### PR TITLE
Add SQLite-backed session persistence and resume flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ htmlcov/
 .pre-commit-cache/
 .playwright-mcp/
 .coverage
+.voidcode/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,8 @@ uv run pre-commit install
 
 ## Code style and quality gates
 
+See [`docs/coding-standards.md`](./docs/coding-standards.md) for the repository coding standards.
+
 VoidCode currently uses:
 
 ### Python

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ uv run voidcode --help
 # Prove the deterministic read-only slice
 uv run voidcode run "read README.md" --workspace .
 
+# List persisted sessions
+uv run voidcode sessions list --workspace .
+
+# Resume a persisted session
+uv run voidcode sessions resume local-cli-session --workspace .
+
 # Start the web frontend (mock-backed)
 mise run frontend:dev
 ```

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -1,0 +1,31 @@
+# Coding Standards
+
+VoidCode is still pre-MVP. Favor clarity, small changes, and repeatable verification over cleverness.
+
+## General expectations
+
+- Keep changes focused and reviewable.
+- Avoid unrelated refactors in feature branches.
+- Update documentation when behavior, workflows, or CLI surfaces change.
+- Prefer explicit, typed code over implicit behavior.
+
+## Python
+
+- Match the existing runtime/graph/tools boundaries.
+- Keep functions small and deterministic where practical.
+- Use Ruff formatting/linting and keep mypy clean.
+- Add or update tests when behavior changes.
+- Avoid introducing new dependencies unless they are necessary.
+
+## Frontend
+
+- Keep the Bun/Vite/React stack consistent with the current shell.
+- Preserve EN/zh-CN support when changing user-facing text.
+- Keep state flows simple and explicit.
+- Do not commit generated frontend artifacts.
+
+## Pull requests
+
+- Run the relevant checks before opening a PR.
+- Include manual QA evidence for CLI or workflow changes.
+- Keep commits atomic so they can be reviewed and reverted independently.

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,6 +2,8 @@
 
 This guide summarizes the local workflow for contributing to VoidCode.
 
+For repository coding expectations, see [`docs/coding-standards.md`](./coding-standards.md).
+
 ## Tooling baseline
 
 VoidCode uses:

--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import argparse
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import cast
+from typing import Protocol, cast
 
 from . import __version__
 from .runtime.contracts import RuntimeRequest
 from .runtime.service import VoidCodeRuntime
+from .runtime.session import StoredSessionSummary
 
 Handler = Callable[[argparse.Namespace], int]
 
@@ -23,16 +24,65 @@ def _handle_run_command(args: argparse.Namespace) -> int:
     workspace = cast(Path, args.workspace)
     request_text = cast(str, args.request)
     runtime = VoidCodeRuntime(workspace=workspace)
-    result = runtime.run(RuntimeRequest(prompt=request_text))
+    result = runtime.run(
+        RuntimeRequest(prompt=request_text, session_id=cast(str | None, args.session_id))
+    )
 
-    for event in result.events:
+    _print_runtime_response(result)
+    return 0
+
+
+def _print_runtime_response(result: object) -> None:
+    typed_result = cast("RuntimeResponseLike", result)
+
+    for event in typed_result.events:
         print(_format_event(event.event_type, event.source, event.payload))
 
     print("RESULT")
-    print(result.output or "", end="")
-    if result.output and not result.output.endswith("\n"):
+    print(typed_result.output or "", end="")
+    if typed_result.output and not typed_result.output.endswith("\n"):
         print()
+
+
+def _handle_sessions_list_command(args: argparse.Namespace) -> int:
+    workspace = cast(Path, args.workspace)
+    runtime = VoidCodeRuntime(workspace=workspace)
+    sessions = runtime.list_sessions()
+
+    for session in sessions:
+        print(_format_session_summary(session))
+
     return 0
+
+
+def _format_session_summary(session: StoredSessionSummary) -> str:
+    return (
+        f"SESSION id={session.session.id} status={session.status} "
+        f"turn={session.turn} updated_at={session.updated_at} prompt={session.prompt!r}"
+    )
+
+
+def _handle_sessions_resume_command(args: argparse.Namespace) -> int:
+    workspace = cast(Path, args.workspace)
+    session_id = cast(str, args.session_id)
+    runtime = VoidCodeRuntime(workspace=workspace)
+    result = runtime.resume(session_id)
+
+    _print_runtime_response(result)
+    return 0
+
+
+class EventLikeProtocol(Protocol):
+    event_type: str
+    source: str
+    payload: dict[str, object]
+
+
+class RuntimeResponseLike(Protocol):
+    events: tuple[EventLikeProtocol, ...]
+    output: str | None
+
+    session: object
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -61,7 +111,35 @@ def build_parser() -> argparse.ArgumentParser:
         default=Path.cwd(),
         help="Workspace root used to resolve relative read paths.",
     )
+    _ = run_parser.add_argument(
+        "--session-id",
+        help="Optional session identifier used for persisted runs.",
+    )
     run_parser.set_defaults(handler=_handle_run_command)
+
+    sessions_parser = subparsers.add_parser("sessions", help="Inspect persisted local sessions.")
+    sessions_subparsers = sessions_parser.add_subparsers(dest="sessions_command")
+
+    list_parser = sessions_subparsers.add_parser("list", help="List persisted sessions.")
+    _ = list_parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd(),
+        help="Workspace root used to resolve the local session database.",
+    )
+    list_parser.set_defaults(handler=_handle_sessions_list_command)
+
+    resume_parser = sessions_subparsers.add_parser(
+        "resume", help="Replay a persisted session response."
+    )
+    _ = resume_parser.add_argument("session_id", help="Persisted session identifier to load.")
+    _ = resume_parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd(),
+        help="Workspace root used to resolve the local session database.",
+    )
+    resume_parser.set_defaults(handler=_handle_sessions_resume_command)
     return parser
 
 

--- a/src/voidcode/runtime/__init__.py
+++ b/src/voidcode/runtime/__init__.py
@@ -1,7 +1,8 @@
 from .contracts import RuntimeEntrypoint, RuntimeRequest, RuntimeResponse
 from .events import EventEnvelope, EventSource
 from .service import ToolRegistry, VoidCodeRuntime
-from .session import SessionRef, SessionState, SessionStatus
+from .session import SessionRef, SessionState, SessionStatus, StoredSessionSummary
+from .storage import SessionStore
 
 __all__ = [
     "EventEnvelope",
@@ -12,6 +13,8 @@ __all__ = [
     "SessionRef",
     "SessionState",
     "SessionStatus",
+    "SessionStore",
+    "StoredSessionSummary",
     "ToolRegistry",
     "VoidCodeRuntime",
 ]

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -1,5 +1,3 @@
-"""In-memory runtime entrypoint for the deterministic read-only slice."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -12,7 +10,8 @@ from ..tools.contracts import ToolDefinition
 from ..tools.read_file import ReadFileTool
 from .contracts import RuntimeRequest, RuntimeResponse
 from .events import EventEnvelope
-from .session import SessionRef, SessionState
+from .session import SessionRef, SessionState, StoredSessionSummary
+from .storage import SessionStore, SqliteSessionStore
 
 
 @dataclass(slots=True)
@@ -43,16 +42,19 @@ class VoidCodeRuntime:
     _workspace: Path
     _tool_registry: ToolRegistry
     _graph: DeterministicReadOnlyGraph
+    _session_store: SessionStore
 
     def __init__(
         self,
         *,
         workspace: Path,
         tool_registry: ToolRegistry | None = None,
+        session_store: SessionStore | None = None,
     ) -> None:
         self._workspace = workspace.resolve()
         self._tool_registry = tool_registry or ToolRegistry.with_defaults()
         self._graph = DeterministicReadOnlyGraph()
+        self._session_store = session_store or SqliteSessionStore()
 
     def run(self, request: RuntimeRequest) -> RuntimeResponse:
         session = SessionState(
@@ -133,8 +135,16 @@ class VoidCodeRuntime:
             tool_result,
             session=completed_session,
         )
-        return RuntimeResponse(
+        response = RuntimeResponse(
             session=graph_result.session,
             events=tuple(events) + graph_result.events,
             output=graph_result.output,
         )
+        self._session_store.save_run(workspace=self._workspace, request=request, response=response)
+        return response
+
+    def list_sessions(self) -> tuple[StoredSessionSummary, ...]:
+        return self._session_store.list_sessions(workspace=self._workspace)
+
+    def resume(self, session_id: str) -> RuntimeResponse:
+        return self._session_store.load_session(workspace=self._workspace, session_id=session_id)

--- a/src/voidcode/runtime/session.py
+++ b/src/voidcode/runtime/session.py
@@ -17,3 +17,12 @@ class SessionState:
     status: SessionStatus = "idle"
     turn: int = 0
     metadata: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class StoredSessionSummary:
+    session: SessionRef
+    status: SessionStatus
+    turn: int
+    prompt: str
+    updated_at: int

--- a/src/voidcode/runtime/storage.py
+++ b/src/voidcode/runtime/storage.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+import json
+import sqlite3
+from pathlib import Path
+from typing import Protocol, cast, final, runtime_checkable
+
+from .contracts import RuntimeRequest, RuntimeResponse
+from .events import EventEnvelope, EventSource
+from .session import SessionRef, SessionState, SessionStatus, StoredSessionSummary
+
+
+@runtime_checkable
+class SessionStore(Protocol):
+    def save_run(
+        self, *, workspace: Path, request: RuntimeRequest, response: RuntimeResponse
+    ) -> None: ...
+
+    def list_sessions(self, *, workspace: Path) -> tuple[StoredSessionSummary, ...]: ...
+
+    def load_session(self, *, workspace: Path, session_id: str) -> RuntimeResponse: ...
+
+
+@final
+class SqliteSessionStore:
+    _database_path: Path | None
+
+    def __init__(self, *, database_path: Path | None = None) -> None:
+        self._database_path = database_path
+
+    def _resolve_database_path(self, workspace: Path) -> Path:
+        if self._database_path is not None:
+            return self._database_path
+        return workspace / ".voidcode" / "sessions.sqlite3"
+
+    @contextmanager
+    def _connect(self, workspace: Path) -> Iterator[sqlite3.Connection]:
+        database_path = self._resolve_database_path(workspace)
+        database_path.parent.mkdir(parents=True, exist_ok=True)
+        connection = sqlite3.connect(database_path)
+        try:
+            connection.row_factory = sqlite3.Row
+            self._ensure_schema(connection)
+            yield connection
+        finally:
+            connection.close()
+
+    def _ensure_schema(self, connection: sqlite3.Connection) -> None:
+        _ = connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS sessions (
+                session_id TEXT PRIMARY KEY,
+                workspace TEXT NOT NULL,
+                status TEXT NOT NULL,
+                turn INTEGER NOT NULL,
+                prompt TEXT NOT NULL,
+                output TEXT,
+                metadata_json TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                last_event_sequence INTEGER NOT NULL
+            )
+            """
+        )
+        _ = connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS session_events (
+                session_id TEXT NOT NULL,
+                sequence INTEGER NOT NULL,
+                event_type TEXT NOT NULL,
+                source TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                PRIMARY KEY (session_id, sequence)
+            )
+            """
+        )
+        _ = connection.execute("PRAGMA user_version = 1")
+        connection.commit()
+
+    @staticmethod
+    def _parse_session_status(value: str) -> SessionStatus:
+        allowed: tuple[SessionStatus, ...] = ("idle", "running", "waiting", "completed", "failed")
+        if value not in allowed:
+            raise ValueError(f"invalid session status: {value}")
+        return value
+
+    @staticmethod
+    def _parse_event_source(value: str) -> EventSource:
+        allowed: tuple[EventSource, ...] = ("runtime", "graph", "tool")
+        if value not in allowed:
+            raise ValueError(f"invalid event source: {value}")
+        return value
+
+    def save_run(
+        self, *, workspace: Path, request: RuntimeRequest, response: RuntimeResponse
+    ) -> None:
+        session_id = response.session.session.id
+        with self._connect(workspace) as connection:
+            created_at = self._read_created_at(connection=connection, session_id=session_id)
+            updated_at = self._next_timestamp(connection=connection)
+            _ = connection.execute(
+                """
+                INSERT OR REPLACE INTO sessions (
+                    session_id, workspace, status, turn, prompt, output,
+                    metadata_json, created_at, updated_at, last_event_sequence
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    session_id,
+                    str(workspace),
+                    response.session.status,
+                    response.session.turn,
+                    request.prompt,
+                    response.output,
+                    json.dumps(response.session.metadata, sort_keys=True),
+                    created_at,
+                    updated_at,
+                    response.events[-1].sequence if response.events else 0,
+                ),
+            )
+            _ = connection.execute("DELETE FROM session_events WHERE session_id = ?", (session_id,))
+            _ = connection.executemany(
+                """
+                INSERT INTO session_events (session_id, sequence, event_type, source, payload_json)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        event.session_id,
+                        event.sequence,
+                        event.event_type,
+                        event.source,
+                        json.dumps(event.payload, sort_keys=True),
+                    )
+                    for event in response.events
+                ],
+            )
+            connection.commit()
+
+    def list_sessions(self, *, workspace: Path) -> tuple[StoredSessionSummary, ...]:
+        with self._connect(workspace) as connection:
+            rows = cast(
+                list[sqlite3.Row],
+                connection.execute(
+                    """
+                SELECT session_id, status, turn, prompt, updated_at
+                FROM sessions
+                WHERE workspace = ?
+                ORDER BY updated_at DESC, session_id ASC
+                """,
+                    (str(workspace),),
+                ).fetchall(),
+            )
+        return tuple(
+            StoredSessionSummary(
+                session=SessionRef(id=cast(str, row["session_id"])),
+                status=self._parse_session_status(cast(str, row["status"])),
+                turn=cast(int, row["turn"]),
+                prompt=cast(str, row["prompt"]),
+                updated_at=cast(int, row["updated_at"]),
+            )
+            for row in rows
+        )
+
+    def load_session(self, *, workspace: Path, session_id: str) -> RuntimeResponse:
+        with self._connect(workspace) as connection:
+            session_row = cast(
+                sqlite3.Row | None,
+                connection.execute(
+                    """
+                SELECT session_id, status, turn, output, metadata_json
+                FROM sessions
+                WHERE workspace = ? AND session_id = ?
+                """,
+                    (str(workspace), session_id),
+                ).fetchone(),
+            )
+            if session_row is None:
+                raise ValueError(f"unknown session: {session_id}")
+            event_rows = cast(
+                list[sqlite3.Row],
+                connection.execute(
+                    """
+                SELECT sequence, event_type, source, payload_json
+                FROM session_events
+                WHERE session_id = ?
+                ORDER BY sequence ASC
+                """,
+                    (session_id,),
+                ).fetchall(),
+            )
+        session = SessionState(
+            session=SessionRef(id=cast(str, session_row["session_id"])),
+            status=self._parse_session_status(cast(str, session_row["status"])),
+            turn=cast(int, session_row["turn"]),
+            metadata=cast(dict[str, object], json.loads(cast(str, session_row["metadata_json"]))),
+        )
+        events = tuple(
+            EventEnvelope(
+                session_id=session_id,
+                sequence=cast(int, row["sequence"]),
+                event_type=cast(str, row["event_type"]),
+                source=self._parse_event_source(cast(str, row["source"])),
+                payload=cast(dict[str, object], json.loads(cast(str, row["payload_json"]))),
+            )
+            for row in event_rows
+        )
+        return RuntimeResponse(
+            session=session, events=events, output=cast(str | None, session_row["output"])
+        )
+
+    def _read_created_at(self, *, connection: sqlite3.Connection, session_id: str) -> int:
+        row = cast(
+            sqlite3.Row | None,
+            connection.execute(
+                "SELECT created_at FROM sessions WHERE session_id = ?",
+                (session_id,),
+            ).fetchone(),
+        )
+        if row is not None:
+            return cast(int, row["created_at"])
+        return self._next_timestamp(connection=connection)
+
+    def _next_timestamp(self, *, connection: sqlite3.Connection) -> int:
+        row = cast(
+            sqlite3.Row,
+            connection.execute(
+                "SELECT COALESCE(MAX(updated_at), 0) + 1 AS next_ts FROM sessions"
+            ).fetchone(),
+        )
+        return cast(int, row["next_ts"])

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -15,7 +15,16 @@ class EventLike(Protocol):
 
 
 class SessionLike(Protocol):
+    session: object
     status: str
+
+
+class SessionRefLike(Protocol):
+    id: str
+
+
+class StoredSessionSummaryLike(Protocol):
+    session: SessionRefLike
 
 
 class RuntimeResponseLike(Protocol):
@@ -29,11 +38,15 @@ class RuntimeRequestLike(Protocol):
 
 
 class RuntimeRequestFactory(Protocol):
-    def __call__(self, *, prompt: str) -> RuntimeRequestLike: ...
+    def __call__(self, *, prompt: str, session_id: str | None = None) -> RuntimeRequestLike: ...
 
 
 class RuntimeRunner(Protocol):
     def run(self, request: RuntimeRequestLike) -> RuntimeResponseLike: ...
+
+    def list_sessions(self) -> tuple[StoredSessionSummaryLike, ...]: ...
+
+    def resume(self, session_id: str) -> RuntimeResponseLike: ...
 
 
 class RuntimeFactory(Protocol):
@@ -99,3 +112,93 @@ def test_cli_run_command_prints_events_and_file_contents(tmp_path: Path) -> None
     assert "EVENT runtime.tool_completed" in result.stdout
     assert "RESULT" in result.stdout
     assert "slice proof" in result.stdout
+
+
+def test_runtime_persists_and_resumes_session_across_instances(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    _ = sample_file.write_text("persisted slice\n", encoding="utf-8")
+    runtime_request, runtime_class = _load_runtime_types()
+
+    first_runtime = runtime_class(workspace=tmp_path)
+    first_result = first_runtime.run(
+        runtime_request(prompt="read sample.txt", session_id="demo-session")
+    )
+
+    second_runtime = runtime_class(workspace=tmp_path)
+    sessions = second_runtime.list_sessions()
+    resumed = second_runtime.resume("demo-session")
+
+    assert [summary.session.id for summary in sessions] == ["demo-session"]
+    assert first_result.output == resumed.output
+    assert [event.event_type for event in resumed.events] == [
+        "runtime.request_received",
+        "graph.tool_request_created",
+        "runtime.tool_lookup_succeeded",
+        "runtime.permission_resolved",
+        "runtime.tool_completed",
+        "graph.response_ready",
+    ]
+
+
+def test_cli_lists_and_resumes_persisted_session(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    _ = sample_file.write_text("resume proof\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "src")
+
+    first_result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "voidcode",
+            "run",
+            "read sample.txt",
+            "--workspace",
+            str(tmp_path),
+            "--session-id",
+            "demo-session",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    list_result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "voidcode",
+            "sessions",
+            "list",
+            "--workspace",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    resume_result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "voidcode",
+            "sessions",
+            "resume",
+            "demo-session",
+            "--workspace",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert first_result.returncode == 0
+    assert list_result.returncode == 0
+    assert resume_result.returncode == 0
+    assert "SESSION id=demo-session status=completed" in list_result.stdout
+    assert "RESULT" in resume_result.stdout
+    assert "resume proof" in resume_result.stdout

--- a/tests/unit/test_backend_contracts.py
+++ b/tests/unit/test_backend_contracts.py
@@ -47,6 +47,13 @@ def test_contract_modules_export_expected_symbols() -> None:
     runtime_request = runtime.RuntimeRequest(
         prompt="Inspect the repo", session_id=session.session.id
     )
+    session_summary = runtime.StoredSessionSummary(
+        session=session.session,
+        status="completed",
+        turn=1,
+        prompt=runtime_request.prompt,
+        updated_at=1,
+    )
     runtime_response = runtime.RuntimeResponse(session=session, events=(event,), output="done")
     graph_request = graph.GraphRunRequest(session=session, prompt=runtime_request.prompt)
     graph_result = graph.GraphRunResult(session=session, events=(event,), tool_results=(result,))
@@ -56,6 +63,7 @@ def test_contract_modules_export_expected_symbols() -> None:
     assert tool.read_only is True
     assert call.arguments == {"path": "README.md"}
     assert runtime_response.events == (event,)
+    assert session_summary.session.id == "session-1"
     assert graph_request.available_tools == ()
     assert graph_result.tool_results == (result,)
 


### PR DESCRIPTION
Closes #6

## Summary
- persist deterministic runtime sessions and events in workspace-local SQLite
- add `voidcode sessions list` and `voidcode sessions resume <session-id>` for the current read-only slice
- add a concise repository coding standards guide and link it from contributor docs

## Verification
- manual CLI proof: `voidcode run \"read README.md\" --workspace . --session-id demo-session`
- manual CLI proof: `voidcode sessions list --workspace .`
- manual CLI proof: `voidcode sessions resume demo-session --workspace .`
- targeted runtime tests passed earlier during local issue-6 verification