### PR TITLE
feat(tools): expand tool registry, normalize tool paths, and make shell_exec cross-platform

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # PROJECT KNOWLEDGE BASE
 
-**Generated:** 2026-04-04
-**Commit:** d6157c7
+**Generated:** 2026-04-09
+**Commit:** e6c0a98
 **Branch:** master
 
 ## OVERVIEW
@@ -30,7 +30,7 @@ voidcode/
 | Session persistence | `src/voidcode/runtime/storage.py` | SQLite-backed local session store |
 | Runtime contracts | `src/voidcode/runtime/contracts.py` | request/response boundary types |
 | Graph planning/finalization | `src/voidcode/graph/read_only_slice.py` | current deterministic slice |
-| Tool behavior | `src/voidcode/tools/read_file.py` | only real built-in tool today |
+| Tool behavior | `src/voidcode/tools/` | builtin tools include read/write/edit/glob/grep/list/web_fetch/web_search/apply_patch/code_search/multi_edit/todo_write/lsp |
 | Unit tests | `tests/unit/` | contracts, metadata, import, CLI smoke |
 | Integration tests | `tests/integration/test_read_only_slice.py` | full deterministic slice + session persistence |
 | Dev workflow | `mise.toml` | canonical task runner |
@@ -64,7 +64,7 @@ voidcode/
 ## UNIQUE STYLES
 - Backend architecture is intentionally split into `runtime/`, `graph/`, and `tools/` with contract files marking boundaries.
 - Session recovery is local and SQLite-backed under `.voidcode/`.
-- The only real backend slice today is deterministic read-only file access.
+- The backend now exposes a broader tool surface including read/write/edit/search/web and patch workflows under `src/voidcode/tools/`.
 - Frontend source is intentionally small and flatter than the aspirational structure described in `frontend/README.md`.
 
 ## COMMANDS

--- a/src/voidcode/runtime/tool_provider.py
+++ b/src/voidcode/runtime/tool_provider.py
@@ -2,8 +2,35 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from ..tools import GrepTool, ReadFileTool, ShellExecTool, WriteFileTool
+from ..tools import (
+    EditTool,
+    GlobTool,
+    GrepTool,
+    ListTool,
+    ReadFileTool,
+    ShellExecTool,
+    WebFetchTool,
+    WebSearchTool,
+    WriteFileTool,
+)
 from ..tools.contracts import Tool
+
+# Import optional tools that may not exist
+try:
+    from ..tools.apply_patch import ApplyPatchTool as _ApplyPatchTool
+    from ..tools.code_search import CodeSearchTool as _CodeSearchTool
+    from ..tools.lsp import LspTool as _LspTool
+    from ..tools.multi_edit import MultiEditTool as _MultiEditTool
+    from ..tools.todo_write import TodoWriteTool as _TodoWriteTool
+
+    _HAS_OPTIONAL_TOOLS = True
+except ImportError:
+    _ApplyPatchTool = None
+    _CodeSearchTool = None
+    _LspTool = None
+    _MultiEditTool = None
+    _TodoWriteTool = None
+    _HAS_OPTIONAL_TOOLS = False
 
 
 class ToolProvider(Protocol):
@@ -12,4 +39,29 @@ class ToolProvider(Protocol):
 
 class BuiltinToolProvider:
     def provide_tools(self) -> tuple[Tool, ...]:
-        return (GrepTool(), ReadFileTool(), ShellExecTool(), WriteFileTool())
+        tools: list[Tool] = [
+            EditTool(),
+            GlobTool(),
+            GrepTool(),
+            ListTool(),
+            ReadFileTool(),
+            ShellExecTool(),
+            WebFetchTool(),
+            WebSearchTool(),
+            WriteFileTool(),
+        ]
+
+        # Add optional tools if available
+        if _HAS_OPTIONAL_TOOLS:
+            if _ApplyPatchTool:
+                tools.append(_ApplyPatchTool())
+            if _CodeSearchTool:
+                tools.append(_CodeSearchTool())
+            if _LspTool:
+                tools.append(_LspTool())
+            if _MultiEditTool:
+                tools.append(_MultiEditTool())
+            if _TodoWriteTool:
+                tools.append(_TodoWriteTool())
+
+        return tuple(tools)

--- a/src/voidcode/runtime/tool_provider.py
+++ b/src/voidcode/runtime/tool_provider.py
@@ -16,6 +16,7 @@ from ..tools import (
 from ..tools.contracts import Tool
 
 # Import optional tools that may not exist
+_has_optional_tools = False
 try:
     from ..tools.apply_patch import ApplyPatchTool as _ApplyPatchTool
     from ..tools.code_search import CodeSearchTool as _CodeSearchTool
@@ -23,14 +24,13 @@ try:
     from ..tools.multi_edit import MultiEditTool as _MultiEditTool
     from ..tools.todo_write import TodoWriteTool as _TodoWriteTool
 
-    _HAS_OPTIONAL_TOOLS = True
+    _has_optional_tools = True
 except ImportError:
     _ApplyPatchTool = None
     _CodeSearchTool = None
     _LspTool = None
     _MultiEditTool = None
     _TodoWriteTool = None
-    _HAS_OPTIONAL_TOOLS = False
 
 
 class ToolProvider(Protocol):
@@ -52,7 +52,7 @@ class BuiltinToolProvider:
         ]
 
         # Add optional tools if available
-        if _HAS_OPTIONAL_TOOLS:
+        if _has_optional_tools:
             if _ApplyPatchTool:
                 tools.append(_ApplyPatchTool())
             if _CodeSearchTool:

--- a/src/voidcode/runtime/tool_provider.py
+++ b/src/voidcode/runtime/tool_provider.py
@@ -2,34 +2,36 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from ..tools import (
-    EditTool,
-    GlobTool,
-    GrepTool,
-    ListTool,
-    ReadFileTool,
-    ShellExecTool,
-    WebFetchTool,
-    WebSearchTool,
-    WriteFileTool,
-)
 from ..tools.contracts import Tool
+from ..tools.edit import EditTool
+from ..tools.glob import GlobTool
+from ..tools.grep import GrepTool
+from ..tools.list_dir import ListTool
+from ..tools.read_file import ReadFileTool
+from ..tools.shell_exec import ShellExecTool
+from ..tools.web_fetch import WebFetchTool
+from ..tools.web_search import WebSearchTool
+from ..tools.write_file import WriteFileTool
 
-# Import optional tools that may not exist
-_has_optional_tools = False
+# Import optional tools independently so one failure doesn't hide others.
 try:
     from ..tools.apply_patch import ApplyPatchTool as _ApplyPatchTool
-    from ..tools.code_search import CodeSearchTool as _CodeSearchTool
-    from ..tools.lsp import LspTool as _LspTool
-    from ..tools.multi_edit import MultiEditTool as _MultiEditTool
-    from ..tools.todo_write import TodoWriteTool as _TodoWriteTool
-
-    _has_optional_tools = True
 except ImportError:
     _ApplyPatchTool = None
+
+try:
+    from ..tools.code_search import CodeSearchTool as _CodeSearchTool
+except ImportError:
     _CodeSearchTool = None
-    _LspTool = None
+
+try:
+    from ..tools.multi_edit import MultiEditTool as _MultiEditTool
+except ImportError:
     _MultiEditTool = None
+
+try:
+    from ..tools.todo_write import TodoWriteTool as _TodoWriteTool
+except ImportError:
     _TodoWriteTool = None
 
 
@@ -51,17 +53,15 @@ class BuiltinToolProvider:
             WriteFileTool(),
         ]
 
-        # Add optional tools if available
-        if _has_optional_tools:
-            if _ApplyPatchTool:
-                tools.append(_ApplyPatchTool())
-            if _CodeSearchTool:
-                tools.append(_CodeSearchTool())
-            if _LspTool:
-                tools.append(_LspTool())
-            if _MultiEditTool:
-                tools.append(_MultiEditTool())
-            if _TodoWriteTool:
-                tools.append(_TodoWriteTool())
+        # Add optional tools if available.
+        # NOTE: LSP is intentionally NOT part of builtin tool defaults.
+        if _ApplyPatchTool is not None:
+            tools.append(_ApplyPatchTool())
+        if _CodeSearchTool is not None:
+            tools.append(_CodeSearchTool())
+        if _MultiEditTool is not None:
+            tools.append(_MultiEditTool())
+        if _TodoWriteTool is not None:
+            tools.append(_TodoWriteTool())
 
         return tuple(tools)

--- a/src/voidcode/tools/__init__.py
+++ b/src/voidcode/tools/__init__.py
@@ -1,4 +1,5 @@
 from .apply_patch import ApplyPatchTool
+from .code_search import CodeSearchTool
 from .contracts import ToolCall, ToolDefinition, ToolResult, ToolResultStatus
 from .edit import EditTool
 from .glob import GlobTool
@@ -26,6 +27,7 @@ __all__ = [
     "LspTool",
     "MultiEditTool",
     "ApplyPatchTool",
+    "CodeSearchTool",
     "TodoWriteTool",
     "ToolCall",
     "ToolDefinition",

--- a/src/voidcode/tools/__init__.py
+++ b/src/voidcode/tools/__init__.py
@@ -5,8 +5,10 @@ from .glob import GlobTool
 from .grep import GrepTool
 from .list_dir import ListTool
 from .lsp import LspTool
+from .multi_edit import MultiEditTool
 from .read_file import ReadFileTool
 from .shell_exec import ShellExecTool
+from .todo_write import TodoWriteTool
 from .web_fetch import WebFetchTool
 from .web_search import WebSearchTool
 from .write_file import WriteFileTool
@@ -22,7 +24,9 @@ __all__ = [
     "WebSearchTool",
     "WriteFileTool",
     "LspTool",
+    "MultiEditTool",
     "ApplyPatchTool",
+    "TodoWriteTool",
     "ToolCall",
     "ToolDefinition",
     "ToolResult",

--- a/src/voidcode/tools/__init__.py
+++ b/src/voidcode/tools/__init__.py
@@ -1,15 +1,15 @@
+from .apply_patch import ApplyPatchTool
 from .contracts import ToolCall, ToolDefinition, ToolResult, ToolResultStatus
 from .edit import EditTool
 from .glob import GlobTool
 from .grep import GrepTool
 from .list_dir import ListTool
+from .lsp import LspTool
 from .read_file import ReadFileTool
 from .shell_exec import ShellExecTool
 from .web_fetch import WebFetchTool
 from .web_search import WebSearchTool
 from .write_file import WriteFileTool
-from .lsp import LspTool
-from .apply_patch import ApplyPatchTool
 
 __all__ = [
     "EditTool",

--- a/src/voidcode/tools/__init__.py
+++ b/src/voidcode/tools/__init__.py
@@ -1,14 +1,28 @@
 from .contracts import ToolCall, ToolDefinition, ToolResult, ToolResultStatus
+from .edit import EditTool
+from .glob import GlobTool
 from .grep import GrepTool
+from .list_dir import ListTool
 from .read_file import ReadFileTool
 from .shell_exec import ShellExecTool
+from .web_fetch import WebFetchTool
+from .web_search import WebSearchTool
 from .write_file import WriteFileTool
+from .lsp import LspTool
+from .apply_patch import ApplyPatchTool
 
 __all__ = [
+    "EditTool",
+    "GlobTool",
     "GrepTool",
+    "ListTool",
     "ReadFileTool",
     "ShellExecTool",
+    "WebFetchTool",
+    "WebSearchTool",
     "WriteFileTool",
+    "LspTool",
+    "ApplyPatchTool",
     "ToolCall",
     "ToolDefinition",
     "ToolResult",

--- a/src/voidcode/tools/apply_patch.py
+++ b/src/voidcode/tools/apply_patch.py
@@ -29,82 +29,82 @@ class ApplyPatchTool:
 
         patch_path = workspace / ".voidcode_apply_patch.patch"
         patch_path.write_text(patch_text, encoding="utf-8")
-
-        check = subprocess.run(
-            ["git", "apply", "--check", str(patch_path)],
-            cwd=str(workspace),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-        )
-        if check.returncode != 0:
-            error = check.stdout or "Patch check failed"
-            raise ValueError(error)
-
-        # Apply patch
-        apply = subprocess.run(
-            ["git", "apply", str(patch_path)],
-            cwd=str(workspace),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-        )
-        if apply.returncode != 0:
-            error = apply.stdout or "Patch apply failed"
-            raise ValueError(error)
-
-        diff = subprocess.run(
-            ["git", "diff", "--name-status"],
-            cwd=str(workspace),
-            stdout=subprocess.PIPE,
-            text=True,
-        )
-
-        changes: list[dict[str, object]] = []
-        for line in diff.stdout.splitlines():
-            if not line.strip():
-                continue
-            if line.startswith("R"):
-                parts = line.split("\t")
-                if len(parts) >= 3:
-                    old_path, new_path = parts[1], parts[2]
-                    changes.append({"path": new_path, "old_path": old_path, "status": "R"})
-            else:
-                parts = line.split("\t")
-                if len(parts) != 2:
-                    continue
-                status, path = parts[0], parts[1]
-                changes.append({"path": path, "status": status})
-
-        summary_lines: list[str] = []
-        for c in changes:
-            if c.get("status") == "R":
-                summary_lines.append(f"M {c['old_path']} -> {c['path']}")
-            else:
-                summary_lines.append(f"{c['status']} {c['path']}")
-
-        content = "\n".join(summary_lines) if summary_lines else "patch applied"
-
-        # Validate that all affected paths are inside the workspace
-        for c in changes:
-            path_value = c.get("path")
-            if isinstance(path_value, str):
-                _assert_within_workspace(workspace, Path(path_value))
-            old_path_value = c.get("old_path")
-            if isinstance(old_path_value, str):
-                _assert_within_workspace(workspace, Path(old_path_value))
-
         try:
-            patch_path.unlink(missing_ok=True)
-        except Exception:
-            pass
+            check = subprocess.run(
+                ["git", "apply", "--check", str(patch_path)],
+                cwd=str(workspace),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            if check.returncode != 0:
+                error = check.stdout or "Patch check failed"
+                raise ValueError(error)
 
-        return ToolResult(
-            tool_name=self.definition.name,
-            status="ok",
-            content=content,
-            data={"changes": changes, "count": len(changes)},
-        )
+            # Apply patch
+            apply = subprocess.run(
+                ["git", "apply", str(patch_path)],
+                cwd=str(workspace),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            if apply.returncode != 0:
+                error = apply.stdout or "Patch apply failed"
+                raise ValueError(error)
+
+            diff = subprocess.run(
+                ["git", "diff", "--name-status"],
+                cwd=str(workspace),
+                stdout=subprocess.PIPE,
+                text=True,
+            )
+
+            changes: list[dict[str, object]] = []
+            for line in diff.stdout.splitlines():
+                if not line.strip():
+                    continue
+                if line.startswith("R"):
+                    parts = line.split("\t")
+                    if len(parts) >= 3:
+                        old_path, new_path = parts[1], parts[2]
+                        changes.append({"path": new_path, "old_path": old_path, "status": "R"})
+                else:
+                    parts = line.split("\t")
+                    if len(parts) != 2:
+                        continue
+                    status, path = parts[0], parts[1]
+                    changes.append({"path": path, "status": status})
+
+            summary_lines: list[str] = []
+            for c in changes:
+                if c.get("status") == "R":
+                    summary_lines.append(f"M {c['old_path']} -> {c['path']}")
+                else:
+                    summary_lines.append(f"{c['status']} {c['path']}")
+
+            content = "\n".join(summary_lines) if summary_lines else "patch applied"
+
+            # Validate that all affected paths are inside the workspace
+            for c in changes:
+                path_value = c.get("path")
+                if isinstance(path_value, str):
+                    _assert_within_workspace(workspace, Path(path_value))
+                old_path_value = c.get("old_path")
+                if isinstance(old_path_value, str):
+                    _assert_within_workspace(workspace, Path(old_path_value))
+
+            return ToolResult(
+                tool_name=self.definition.name,
+                status="ok",
+                content=content,
+                data={"changes": changes, "count": len(changes)},
+            )
+        finally:
+            try:
+                patch_path.unlink(missing_ok=True)
+            except Exception:
+                pass
 
 
 __all__ = ["ApplyPatchTool"]

--- a/src/voidcode/tools/apply_patch.py
+++ b/src/voidcode/tools/apply_patch.py
@@ -91,10 +91,12 @@ class ApplyPatchTool:
 
         # Validate that all affected paths are inside the workspace
         for c in changes:
-            if "path" in c and isinstance(c["path"], str):
-                _assert_within_workspace(workspace, Path(c["path"]))
-            if "old_path" in c and isinstance(c.get("old_path"), str):
-                _assert_within_workspace(workspace, Path(c["old_path"]))
+            path_value = c.get("path")
+            if isinstance(path_value, str):
+                _assert_within_workspace(workspace, Path(path_value))
+            old_path_value = c.get("old_path")
+            if isinstance(old_path_value, str):
+                _assert_within_workspace(workspace, Path(old_path_value))
 
         try:
             patch_path.unlink(missing_ok=True)

--- a/src/voidcode/tools/apply_patch.py
+++ b/src/voidcode/tools/apply_patch.py
@@ -14,6 +14,101 @@ def _assert_within_workspace(workspace: Path, rel_path: Path) -> None:
         raise ValueError("patch operation must affect paths inside the workspace")
 
 
+def _strip_diff_prefix(path_text: str) -> str:
+    if path_text.startswith("a/") or path_text.startswith("b/"):
+        return path_text[2:]
+    return path_text
+
+
+def _parse_diff_git_paths(line: str) -> tuple[str, str] | None:
+    quoted_prefix = 'diff --git "a/'
+    if line.startswith(quoted_prefix):
+        quoted_marker = '" "b/'
+        split_index = line.find(quoted_marker, len(quoted_prefix))
+        if split_index == -1 or not line.endswith('"'):
+            return None
+        old_path = line[len(quoted_prefix) : split_index]
+        new_path = line[split_index + len(quoted_marker) : -1]
+        return old_path, new_path
+
+    plain_prefix = "diff --git a/"
+    if not line.startswith(plain_prefix):
+        return None
+
+    split_index = line.rfind(" b/")
+    if split_index == -1 or split_index < len(plain_prefix):
+        return None
+
+    old_path = line[len(plain_prefix) : split_index]
+    new_path = line[split_index + len(" b/") :]
+    return old_path, new_path
+
+
+def _changes_from_patch(patch_text: str) -> list[dict[str, object]]:
+    changes: list[dict[str, object]] = []
+    block_old_path: str | None = None
+    block_new_path: str | None = None
+    patch_old_path: str | None = None
+
+    def flush_block() -> None:
+        if block_old_path is None and block_new_path is None:
+            return
+        if block_old_path is None and block_new_path is not None:
+            changes.append({"path": block_new_path, "status": "A"})
+        elif block_old_path is not None and block_new_path is None:
+            changes.append({"path": block_old_path, "status": "D"})
+        elif block_old_path == block_new_path:
+            changes.append({"path": block_new_path, "status": "M"})
+        else:
+            changes.append({"path": block_new_path, "old_path": block_old_path, "status": "R"})
+
+    for line in patch_text.splitlines():
+        if line.startswith("diff --git "):
+            flush_block()
+            diff_paths = _parse_diff_git_paths(line)
+            if diff_paths is None:
+                block_old_path = None
+                block_new_path = None
+            else:
+                block_old_path, block_new_path = diff_paths
+            patch_old_path = None
+            continue
+
+        if line.startswith("rename from "):
+            block_old_path = line[len("rename from ") :].strip()
+            continue
+
+        if line.startswith("rename to "):
+            block_new_path = line[len("rename to ") :].strip()
+            continue
+
+        if line.startswith("--- "):
+            old_marker = line[4:].strip()
+            patch_old_path = None if old_marker == "/dev/null" else _strip_diff_prefix(old_marker)
+            continue
+
+        if not line.startswith("+++ "):
+            continue
+
+        new_marker = line[4:].strip()
+        patch_new_path = None if new_marker == "/dev/null" else _strip_diff_prefix(new_marker)
+        block_old_path = patch_old_path
+        block_new_path = patch_new_path
+        patch_old_path = None
+
+    flush_block()
+
+    deduped: list[dict[str, object]] = []
+    seen: set[tuple[object, ...]] = set()
+    for change in changes:
+        key = (change.get("status"), change.get("old_path"), change.get("path"))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(change)
+    return deduped
+
+
 class ApplyPatchTool:
     definition: ClassVar[ToolDefinition] = ToolDefinition(
         name="apply_patch",
@@ -53,28 +148,7 @@ class ApplyPatchTool:
                 error = apply.stdout or "Patch apply failed"
                 raise ValueError(error)
 
-            diff = subprocess.run(
-                ["git", "diff", "--name-status"],
-                cwd=str(workspace),
-                stdout=subprocess.PIPE,
-                text=True,
-            )
-
-            changes: list[dict[str, object]] = []
-            for line in diff.stdout.splitlines():
-                if not line.strip():
-                    continue
-                if line.startswith("R"):
-                    parts = line.split("\t")
-                    if len(parts) >= 3:
-                        old_path, new_path = parts[1], parts[2]
-                        changes.append({"path": new_path, "old_path": old_path, "status": "R"})
-                else:
-                    parts = line.split("\t")
-                    if len(parts) != 2:
-                        continue
-                    status, path = parts[0], parts[1]
-                    changes.append({"path": path, "status": status})
+            changes = _changes_from_patch(patch_text)
 
             summary_lines: list[str] = []
             for c in changes:

--- a/src/voidcode/tools/apply_patch.py
+++ b/src/voidcode/tools/apply_patch.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import ClassVar
+
+from .contracts import ToolCall, ToolDefinition, ToolResult
+
+
+def _assert_within_workspace(workspace: Path, rel_path: Path) -> None:
+    root = workspace.resolve()
+    candidate = (root / rel_path).resolve()
+    if not candidate.is_relative_to(root):
+        raise ValueError("patch operation must affect paths inside the workspace")
+
+
+class ApplyPatchTool:
+    definition: ClassVar[ToolDefinition] = ToolDefinition(
+        name="apply_patch",
+        description="Apply unified diff patches to files inside the current workspace.",
+        input_schema={"patch": {"type": "string"}},
+        read_only=False,
+    )
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        patch_text = call.arguments.get("patch")
+        if not isinstance(patch_text, str):
+            raise ValueError("apply_patch requires a string 'patch' argument")
+
+        patch_path = workspace / ".voidcode_apply_patch.patch"
+        patch_path.write_text(patch_text, encoding="utf-8")
+
+        check = subprocess.run(
+            ["git", "apply", "--check", str(patch_path)],
+            cwd=str(workspace),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        if check.returncode != 0:
+            error = check.stdout or "Patch check failed"
+            return ToolResult(
+                tool_name=self.definition.name, status="error", error=error, content=None
+            )
+
+        # Apply patch
+        apply = subprocess.run(
+            ["git", "apply", str(patch_path)],
+            cwd=str(workspace),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        if apply.returncode != 0:
+            error = apply.stdout or "Patch apply failed"
+            return ToolResult(
+                tool_name=self.definition.name, status="error", error=error, content=None
+            )
+
+        diff = subprocess.run(
+            ["git", "diff", "--name-status"],
+            cwd=str(workspace),
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+
+        changes: list[dict[str, object]] = []
+        for line in diff.stdout.splitlines():
+            if not line.strip():
+                continue
+            if line.startswith("R"):
+                parts = line.split("\t")
+                if len(parts) >= 3:
+                    old_path, new_path = parts[1], parts[2]
+                    changes.append({"path": new_path, "old_path": old_path, "status": "R"})
+            else:
+                parts = line.split("\t")
+                if len(parts) != 2:
+                    continue
+                status, path = parts[0], parts[1]
+                changes.append({"path": path, "status": status})
+
+        summary_lines: list[str] = []
+        for c in changes:
+            if c.get("status") == "R":
+                summary_lines.append(f"M {c['old_path']} -> {c['path']}")
+            else:
+                summary_lines.append(f"{c['status']} {c['path']}")
+
+        content = "\n".join(summary_lines) if summary_lines else "patch applied"
+
+        # Validate that all affected paths are inside the workspace
+        for c in changes:
+            if "path" in c and isinstance(c["path"], str):
+                _assert_within_workspace(workspace, Path(c["path"]))
+            if "old_path" in c and isinstance(c.get("old_path"), str):
+                _assert_within_workspace(workspace, Path(c["old_path"]))
+
+        try:
+            patch_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+
+        return ToolResult(
+            tool_name=self.definition.name,
+            status="ok",
+            content=content,
+            data={"changes": changes, "count": len(changes)},
+        )
+
+
+__all__ = ["ApplyPatchTool"]

--- a/src/voidcode/tools/apply_patch.py
+++ b/src/voidcode/tools/apply_patch.py
@@ -39,9 +39,7 @@ class ApplyPatchTool:
         )
         if check.returncode != 0:
             error = check.stdout or "Patch check failed"
-            return ToolResult(
-                tool_name=self.definition.name, status="error", error=error, content=None
-            )
+            raise ValueError(error)
 
         # Apply patch
         apply = subprocess.run(
@@ -53,9 +51,7 @@ class ApplyPatchTool:
         )
         if apply.returncode != 0:
             error = apply.stdout or "Patch apply failed"
-            return ToolResult(
-                tool_name=self.definition.name, status="error", error=error, content=None
-            )
+            raise ValueError(error)
 
         diff = subprocess.run(
             ["git", "diff", "--name-status"],

--- a/src/voidcode/tools/code_search.py
+++ b/src/voidcode/tools/code_search.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from pathlib import Path
 from typing import ClassVar
 
@@ -31,5 +32,7 @@ class CodeSearchTool:
         return ToolResult(
             tool_name=self.definition.name,
             status="ok",
-            content=f"Code search for '{query}' with {tokens_num} tokens - MCP integration available",
+            content=(
+                f"Code search for '{query}' with {tokens_num} tokens - MCP integration available"
+            ),
         )

--- a/src/voidcode/tools/code_search.py
+++ b/src/voidcode/tools/code_search.py
@@ -1,20 +1,91 @@
 from __future__ import annotations
 
+import json
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, cast
 
 from .contracts import ToolCall, ToolDefinition, ToolResult
+
+DEFAULT_NUM_RESULTS = 5
+DEFAULT_CONTEXT_MAX_CHARACTERS = 10000
+
+
+def _fallback_search(query: str, num_results: int) -> str:
+    encoded_query = urllib.parse.quote(query)
+    url = f"https://html.duckduckgo.com/html/?q={encoded_query}&kl=wt-wt"
+
+    try:
+        req = urllib.request.Request(
+            url,
+            headers={
+                "User-Agent": "Mozilla/5.0 (compatible; VoidCode/1.0)",
+            },
+        )
+
+        with urllib.request.urlopen(req, timeout=30) as response:
+            html = response.read().decode("utf-8", errors="replace")
+
+            results: list[tuple[str, str, str]] = []
+            pattern = r'<a class="result__a" href="([^"]+)"[^>]*>([^<]+)</a>'
+            snippet_pattern = r'<a class="result__snippet"[^>]*>([^<]+)</a>'
+
+            for match in re.finditer(pattern, html):
+                url_match = match.group(1)
+                title = match.group(2).strip()
+                snippet_match = re.search(
+                    snippet_pattern,
+                    html[match.start() : match.start() + 500],
+                )
+                snippet = snippet_match.group(1).strip() if snippet_match else ""
+
+                results.append((title, url_match, snippet))
+                if len(results) >= num_results:
+                    break
+
+            if results:
+                output_lines: list[str] = []
+                for i, (title, result_url, snippet) in enumerate(results, 1):
+                    output_lines.append(f"{i}. {title}")
+                    output_lines.append(f"   {result_url}")
+                    if snippet:
+                        clean_snippet = re.sub(r"<[^>]+>", "", snippet)
+                        output_lines.append(f"   {clean_snippet[:200]}...")
+                    output_lines.append("")
+                return "\n".join(output_lines)
+
+    except Exception:
+        pass
+
+    return "No search results found. Please try a different query."
 
 
 class CodeSearchTool:
     definition: ClassVar[ToolDefinition] = ToolDefinition(
-        name="codesearch",
-        description="Search code examples and documentation using Exa AI.",
+        name="code_search",
+        description="Search programming examples via Exa MCP web_search_exa.",
         input_schema={
             "query": {"type": "string", "description": "The search query"},
-            "tokensNum": {
+            "numResults": {
                 "type": "integer",
-                "description": "Max tokens (1000-50000, default 5000)",
+                "description": "Number of results to return (default: 5)",
+            },
+            "livecrawl": {
+                "type": "string",
+                "enum": ["fallback", "preferred"],
+                "description": "Live crawl strategy",
+            },
+            "type": {
+                "type": "string",
+                "enum": ["auto", "fast", "deep"],
+                "description": "Search depth mode",
+            },
+            "contextMaxCharacters": {
+                "type": "integer",
+                "description": "Maximum context characters for extracted snippets",
             },
         },
         read_only=True,
@@ -23,16 +94,215 @@ class CodeSearchTool:
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
         query = call.arguments.get("query")
         if not isinstance(query, str):
-            raise ValueError("codesearch requires a string query argument")
+            raise ValueError("code_search requires a string query argument")
+        if not query.strip():
+            raise ValueError("code_search query must not be empty")
 
-        tokens_num = call.arguments.get("tokensNum", 5000)
-        if not isinstance(tokens_num, int):
-            tokens_num = 5000
+        num_results = call.arguments.get("numResults", DEFAULT_NUM_RESULTS)
+        if isinstance(num_results, (int, float)):
+            num_results = min(max(int(num_results), 1), 20)
+        else:
+            num_results = DEFAULT_NUM_RESULTS
+
+        livecrawl = call.arguments.get("livecrawl", "fallback")
+        if not isinstance(livecrawl, str) or livecrawl not in {"fallback", "preferred"}:
+            livecrawl = "fallback"
+
+        search_type = call.arguments.get("type", "auto")
+        if not isinstance(search_type, str) or search_type not in {"auto", "fast", "deep"}:
+            search_type = "auto"
+
+        context_max_characters = call.arguments.get(
+            "contextMaxCharacters",
+            call.arguments.get("tokensNum", DEFAULT_CONTEXT_MAX_CHARACTERS),
+        )
+        if isinstance(context_max_characters, (int, float)):
+            context_max_characters = min(max(int(context_max_characters), 1000), 50000)
+        else:
+            context_max_characters = DEFAULT_CONTEXT_MAX_CHARACTERS
+
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "web_search_exa",
+                "arguments": {
+                    "query": query,
+                    "numResults": num_results,
+                    "livecrawl": livecrawl,
+                    "type": search_type,
+                    "contextMaxCharacters": context_max_characters,
+                },
+            },
+        }
+
+        request = urllib.request.Request(
+            "https://mcp.exa.ai/mcp",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json, text/event-stream",
+            },
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                text = response.read().decode("utf-8", errors="replace")
+        except urllib.error.HTTPError as exc:
+            if exc.code == 429:
+                fallback = _fallback_search(query, num_results)
+                return ToolResult(
+                    tool_name=self.definition.name,
+                    status="ok",
+                    content=fallback,
+                    data={
+                        "query": query,
+                        "num_results": num_results,
+                        "livecrawl": livecrawl,
+                        "type": search_type,
+                        "context_max_characters": context_max_characters,
+                        "source": "duckduckgo_fallback",
+                        "snippet_count": 0,
+                        "sources": [],
+                        "fallback_reason": f"HTTP 429 from Exa MCP: {exc.reason}",
+                    },
+                )
+            raise ValueError(f"code_search HTTP error {exc.code}: {exc.reason}") from exc
+        except urllib.error.URLError as exc:
+            fallback = _fallback_search(query, num_results)
+            return ToolResult(
+                tool_name=self.definition.name,
+                status="ok",
+                content=fallback,
+                data={
+                    "query": query,
+                    "num_results": num_results,
+                    "livecrawl": livecrawl,
+                    "type": search_type,
+                    "context_max_characters": context_max_characters,
+                    "source": "duckduckgo_fallback",
+                    "snippet_count": 0,
+                    "sources": [],
+                    "fallback_reason": f"code_search request failed: {exc.reason}",
+                },
+            )
+
+        snippets: list[str] = []
+        sources: list[str] = []
+
+        lines = text.splitlines()
+        for line in lines:
+            if not line.startswith("data: "):
+                continue
+            raw = line[6:].strip()
+            if not raw or raw == "[DONE]":
+                continue
+
+            try:
+                data = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+
+            if not isinstance(data, dict):
+                continue
+            data_dict = cast(dict[str, object], data)
+
+            error_obj = data_dict.get("error")
+            if isinstance(error_obj, dict):
+                error_dict = cast(dict[str, object], error_obj)
+                message = error_dict.get("message")
+                raise ValueError(
+                    str(message)
+                    if isinstance(message, str)
+                    else f"code_search MCP error: {error_obj}"
+                )
+
+            result = data_dict.get("result")
+            if not isinstance(result, dict):
+                continue
+            result_dict = cast(dict[str, object], result)
+            content = result_dict.get("content")
+            if isinstance(content, list) and content:
+                content_items = cast(list[object], content)
+                for item_obj in content_items:
+                    if not isinstance(item_obj, dict):
+                        continue
+                    item_dict = cast(dict[str, object], item_obj)
+                    text_value = item_dict.get("text")
+                    if isinstance(text_value, str) and text_value.strip():
+                        snippets.append(text_value.strip())
+
+                    source_url = item_dict.get("url")
+                    if isinstance(source_url, str) and source_url.strip():
+                        sources.append(source_url.strip())
+
+        deduped_snippets: list[str] = []
+        seen: set[str] = set()
+        for snippet in snippets:
+            key = snippet.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped_snippets.append(snippet)
+
+        if not deduped_snippets:
+            fallback = _fallback_search(query, num_results)
+            urls = re.findall(r"https?://\S+", fallback)
+            fallback_sources: list[str] = []
+            seen_urls: set[str] = set()
+            for url in urls:
+                clean = url.strip().rstrip(")].,;")
+                if clean in seen_urls:
+                    continue
+                seen_urls.add(clean)
+                fallback_sources.append(clean)
+
+            return ToolResult(
+                tool_name=self.definition.name,
+                status="ok",
+                content=fallback,
+                data={
+                    "query": query,
+                    "num_results": num_results,
+                    "livecrawl": livecrawl,
+                    "type": search_type,
+                    "context_max_characters": context_max_characters,
+                    "source": "duckduckgo_fallback",
+                    "snippet_count": 0,
+                    "sources": fallback_sources,
+                    "fallback_reason": "No usable snippets returned by web_search_exa",
+                },
+            )
+
+        output_parts: list[str] = []
+        for index, snippet in enumerate(deduped_snippets[:5], start=1):
+            output_parts.append(f"Snippet {index}:\n{snippet}")
+
+        unique_sources: list[str] = []
+        seen_source: set[str] = set()
+        for source in sources:
+            if source in seen_source:
+                continue
+            seen_source.add(source)
+            unique_sources.append(source)
+
+        if unique_sources:
+            output_parts.append("Sources:\n" + "\n".join(f"- {url}" for url in unique_sources[:10]))
 
         return ToolResult(
             tool_name=self.definition.name,
             status="ok",
-            content=(
-                f"Code search for '{query}' with {tokens_num} tokens - MCP integration available"
-            ),
+            content="\n\n".join(output_parts),
+            data={
+                "query": query,
+                "num_results": num_results,
+                "livecrawl": livecrawl,
+                "type": search_type,
+                "context_max_characters": context_max_characters,
+                "source": "exa_mcp_web_search_exa",
+                "snippet_count": len(deduped_snippets),
+                "sources": unique_sources,
+            },
         )

--- a/src/voidcode/tools/code_search.py
+++ b/src/voidcode/tools/code_search.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import ClassVar
+
+from .contracts import ToolCall, ToolDefinition, ToolResult
+
+
+class CodeSearchTool:
+    definition: ClassVar[ToolDefinition] = ToolDefinition(
+        name="codesearch",
+        description="Search code examples and documentation using Exa AI.",
+        input_schema={
+            "query": {"type": "string", "description": "The search query"},
+            "tokensNum": {
+                "type": "integer",
+                "description": "Max tokens (1000-50000, default 5000)",
+            },
+        },
+        read_only=True,
+    )
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        query = call.arguments.get("query")
+        if not isinstance(query, str):
+            raise ValueError("codesearch requires a string query argument")
+
+        tokens_num = call.arguments.get("tokensNum", 5000)
+        if not isinstance(tokens_num, int):
+            tokens_num = 5000
+
+        return ToolResult(
+            tool_name=self.definition.name,
+            status="ok",
+            content=f"Code search for '{query}' with {tokens_num} tokens - MCP integration available",
+        )

--- a/src/voidcode/tools/edit.py
+++ b/src/voidcode/tools/edit.py
@@ -103,6 +103,9 @@ class LineTrimmedReplacer:
 
 
 class BlockAnchorReplacer:
+    _MAX_ANCHOR_LENGTH = 200
+    _MAX_LINES_SCAN = 2000
+
     @staticmethod
     def find(content: str, old: str) -> list[str]:
         # Enhanced: use anchors with simple Levenshtein similarity
@@ -118,8 +121,16 @@ class BlockAnchorReplacer:
         first_anchor = search_lines[0].strip()
         last_anchor = search_lines[-1].strip()
 
-        # simple Levenshtein distance implementation
+        # simple Levenshtein distance implementation (bounded)
         def _lev(a: str, b: str) -> int:
+            if abs(len(a) - len(b)) > max(1, max(len(a), len(b)) // 4):
+                return max(len(a), len(b))
+
+            if len(a) > BlockAnchorReplacer._MAX_ANCHOR_LENGTH:
+                a = a[: BlockAnchorReplacer._MAX_ANCHOR_LENGTH]
+            if len(b) > BlockAnchorReplacer._MAX_ANCHOR_LENGTH:
+                b = b[: BlockAnchorReplacer._MAX_ANCHOR_LENGTH]
+
             m, n = len(a), len(b)
             dp = [[0] * (n + 1) for _ in range(m + 1)]
             for x in range(m + 1):
@@ -145,11 +156,13 @@ class BlockAnchorReplacer:
             return d <= max(1, max_len // 4)
 
         # Try to locate blocks bounded by anchors with similarity tolerance
-        for i in range(len(original_lines)):
+        max_scan = min(len(original_lines), BlockAnchorReplacer._MAX_LINES_SCAN)
+        for i in range(max_scan):
             if not similar(original_lines[i].strip(), first_anchor):
                 continue
             # search a corresponding end line with similarity to last_anchor
-            for j in range(i + 2, len(original_lines)):
+            upper = min(len(original_lines), i + BlockAnchorReplacer._MAX_LINES_SCAN)
+            for j in range(i + 2, upper):
                 if similar(original_lines[j].strip(), last_anchor):
                     # extract the block from i to j inclusive
                     block = "\n".join(original_lines[i : j + 1])

--- a/src/voidcode/tools/edit.py
+++ b/src/voidcode/tools/edit.py
@@ -433,7 +433,8 @@ class EditTool:
             raise ValueError(f"edit target is not a file: {path_value}")
 
         try:
-            content_old = candidate.read_text(encoding="utf-8")
+            with candidate.open("r", encoding="utf-8", newline="") as handle:
+                content_old = handle.read()
         except UnicodeDecodeError as exc:
             raise ValueError("edit only supports UTF-8 text files") from exc
 
@@ -478,7 +479,7 @@ class EditTool:
             1 for line in diff.splitlines() if line.startswith("-") and not line.startswith("---")
         )
 
-        candidate.write_text(new_content, encoding="utf-8")
+        candidate.write_bytes(new_content.encode("utf-8"))
 
         output = "Edit applied successfully."
         if match_count > 1:

--- a/src/voidcode/tools/edit.py
+++ b/src/voidcode/tools/edit.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import difflib
 import re
 from pathlib import Path
-from typing import ClassVar, List
+from typing import ClassVar
 
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
@@ -170,7 +170,7 @@ class WhitespaceNormalizedReplacer:
         lines = content.split("\n")
         find_lines = old.split("\n")
 
-        for i, line in enumerate(lines):
+        for _i, line in enumerate(lines):
             if WhitespaceNormalizedReplacer.normalize(line) == normalized_old:
                 results.append(line)
 
@@ -260,9 +260,6 @@ def _replace(
             replacers.append(globals()[name])
 
     # Helper to perform a replacement given a matched substring
-    def _do_replace_once(src: str, match: str) -> str:
-        return src.replace(match, new_string, 1)
-
     # If replace_all is requested we attempt to replace all occurrences found by any replacer
     total_replacements = 0
     current = content
@@ -279,7 +276,7 @@ def _replace(
 
         # If replaceAll, replace all occurrences found by this replacer
         if replace_all:
-            seen = set()
+            seen: set[str] = set()
             for m in matches:
                 if m in seen:
                     continue
@@ -383,7 +380,10 @@ class ContextAwareReplacer:
 class EditTool:
     definition: ClassVar[ToolDefinition] = ToolDefinition(
         name="edit",
-        description="Edit a file by replacing text. Supports multiple replacement strategies for flexible matching.",
+        description=(
+            "Edit a file by replacing text. Supports multiple replacement strategies "
+            "for flexible matching."
+        ),
         input_schema={
             "path": {
                 "type": "string",

--- a/src/voidcode/tools/edit.py
+++ b/src/voidcode/tools/edit.py
@@ -1,0 +1,498 @@
+from __future__ import annotations
+
+import difflib
+import re
+from pathlib import Path
+from typing import ClassVar, List
+
+from .contracts import ToolCall, ToolDefinition, ToolResult
+
+
+def _normalize_line_endings(text: str) -> str:
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _detect_line_ending(text: str) -> str:
+    if "\r\n" in text:
+        return "\r\n"
+    return "\n"
+
+
+def _convert_line_endings(text: str, ending: str) -> str:
+    if ending == "\n":
+        return _normalize_line_endings(text)
+    return text.replace("\n", "\r\n")
+
+
+def _trim_diff(diff: str) -> str:
+    lines = diff.split("\n")
+    content_lines = [
+        line
+        for line in lines
+        if (line.startswith("+") or line.startswith("-") or line.startswith(" "))
+        and not line.startswith("---")
+        and not line.startswith("+++")
+    ]
+
+    if not content_lines:
+        return diff
+
+    min_indent = float("inf")
+    for line in content_lines:
+        content = line[1:]
+        if content.strip():
+            match = re.match(r"^(\s*)", content)
+            if match and match.group(1):
+                min_indent = min(min_indent, len(match.group(1)))
+
+    if min_indent == float("inf") or min_indent == 0:
+        return diff
+
+    trimmed_lines: list[str] = []
+    for line in lines:
+        if (
+            (line.startswith("+") or line.startswith("-") or line.startswith(" "))
+            and not line.startswith("---")
+            and not line.startswith("+++")
+        ):
+            prefix = line[0]
+            content = line[1:]
+            trimmed_lines.append(
+                prefix + content[min_indent:] if len(content) > min_indent else line
+            )
+        else:
+            trimmed_lines.append(line)
+
+    return "\n".join(trimmed_lines)
+
+
+class SimpleReplacer:
+    @staticmethod
+    def find(content: str, old: str) -> list[str]:
+        if old in content:
+            return [old]
+        return []
+
+
+class LineTrimmedReplacer:
+    @staticmethod
+    def find(content: str, old: str) -> list[str]:
+        # Find blocks where each corresponding line, after trimming whitespace, matches
+        results: list[str] = []
+        original_lines = content.split("\n")
+        search_lines = old.split("\n")
+
+        if search_lines and search_lines[-1] == "":
+            search_lines = search_lines[:-1]
+
+        L = len(search_lines)
+        if L == 0:
+            return results
+
+        for i in range(len(original_lines) - L + 1):
+            good = True
+            for j in range(L):
+                if original_lines[i + j].strip() != search_lines[j].strip():
+                    good = False
+                    break
+            if good:
+                # reconstruct the exact block from the original content
+                block = "\n".join(original_lines[i : i + L])
+                results.append(block)
+        return results
+
+
+class BlockAnchorReplacer:
+    @staticmethod
+    def find(content: str, old: str) -> list[str]:
+        # Enhanced: use anchors with simple Levenshtein similarity
+        results: list[str] = []
+        original_lines = content.split("\n")
+        search_lines = old.split("\n")
+        if len(search_lines) < 3:
+            return results
+
+        if search_lines and search_lines[-1] == "":
+            search_lines = search_lines[:-1]
+
+        first_anchor = search_lines[0].strip()
+        last_anchor = search_lines[-1].strip()
+
+        # simple Levenshtein distance implementation
+        def _lev(a: str, b: str) -> int:
+            m, n = len(a), len(b)
+            dp = [[0] * (n + 1) for _ in range(m + 1)]
+            for x in range(m + 1):
+                dp[x][0] = x
+            for y in range(n + 1):
+                dp[0][y] = y
+            for i in range(1, m + 1):
+                for j in range(1, n + 1):
+                    cost = 0 if a[i - 1] == b[j - 1] else 1
+                    dp[i][j] = min(
+                        dp[i - 1][j] + 1,  # delete
+                        dp[i][j - 1] + 1,  # insert
+                        dp[i - 1][j - 1] + cost,  # substitute
+                    )
+            return dp[m][n]
+
+        # Thresholds: allow small differences based on length
+        def similar(x: str, y: str) -> bool:
+            d = _lev(x, y)
+            max_len = max(len(x), len(y))
+            if max_len == 0:
+                return True
+            return d <= max(1, max_len // 4)
+
+        # Try to locate blocks bounded by anchors with similarity tolerance
+        for i in range(len(original_lines)):
+            if not similar(original_lines[i].strip(), first_anchor):
+                continue
+            # search a corresponding end line with similarity to last_anchor
+            for j in range(i + 2, len(original_lines)):
+                if similar(original_lines[j].strip(), last_anchor):
+                    # extract the block from i to j inclusive
+                    block = "\n".join(original_lines[i : j + 1])
+                    results.append(block)
+                    break
+        return results
+
+
+class WhitespaceNormalizedReplacer:
+    @staticmethod
+    def normalize(text: str) -> str:
+        return re.sub(r"\s+", " ", text).strip()
+
+    @staticmethod
+    def find(content: str, old: str) -> list[str]:
+        results: list[str] = []
+        normalized_old = WhitespaceNormalizedReplacer.normalize(old)
+        lines = content.split("\n")
+        find_lines = old.split("\n")
+
+        for i, line in enumerate(lines):
+            if WhitespaceNormalizedReplacer.normalize(line) == normalized_old:
+                results.append(line)
+
+        if len(find_lines) > 1:
+            for i in range(len(lines) - len(find_lines) + 1):
+                block = "\n".join(lines[i : i + len(find_lines)])
+                if WhitespaceNormalizedReplacer.normalize(block) == normalized_old:
+                    results.append(block)
+
+        return results
+
+
+class IndentationFlexibleReplacer:
+    @staticmethod
+    def remove_indentation(text: str) -> str:
+        lines = text.split("\n")
+        non_empty = [line for line in lines if line.strip()]
+        if not non_empty:
+            return text
+
+        min_indent = float("inf")
+        for line in non_empty:
+            match = re.match(r"^(\s*)", line)
+            if match and match.group(1):
+                min_indent = min(min_indent, len(match.group(1)))
+
+        dedented = [line[min_indent:] if len(line) >= min_indent else line for line in lines]
+        return "\n".join(dedented)
+
+    @staticmethod
+    def find(content: str, old: str) -> list[str]:
+        results: list[str] = []
+        normalized_old = IndentationFlexibleReplacer.remove_indentation(old)
+        content_lines = content.split("\n")
+        find_lines = old.split("\n")
+        if not find_lines:
+            return results
+
+        for i in range(len(content_lines) - len(find_lines) + 1):
+            block = "\n".join(content_lines[i : i + len(find_lines)])
+            if IndentationFlexibleReplacer.remove_indentation(block) == normalized_old:
+                results.append(block)
+
+        return results
+
+
+def _replace(
+    content: str,
+    old_string: str,
+    new_string: str,
+    *,
+    replace_all: bool = False,
+) -> tuple[str, int]:
+    # Smart replacement pipeline using 9 replacers in order
+    if old_string == new_string:
+        raise ValueError("No changes to apply: oldString and newString are identical.")
+
+    if not content:
+        raise ValueError("Content is empty; nothing to edit.")
+
+    if replace_all:
+        # For replaceAll we still need to verify at least one match exists via smart replacers
+        pass
+
+    replacers = [
+        SimpleReplacer,
+        LineTrimmedReplacer,
+        BlockAnchorReplacer,
+        WhitespaceNormalizedReplacer,
+        IndentationFlexibleReplacer,
+        # EscapeNormalizedReplacer to be added below after class definitions
+        # MultiOccurrenceReplacer, TrimmedBoundaryReplacer, ContextAwareReplacer
+    ]
+
+    # The actual smart replacers will be defined later in file; to avoid forward reference issues,
+    # we attempt to import them lazily from globals() after their definitions. If not yet defined,
+    # we will skip them for the initial pass.
+    smart_names = [
+        "EscapeNormalizedReplacer",
+        "MultiOccurrenceReplacer",
+        "TrimmedBoundaryReplacer",
+        "ContextAwareReplacer",
+    ]
+    # Build dynamic replacer list by checking their presence in globals
+    for name in smart_names:
+        if name in globals():
+            replacers.append(globals()[name])
+
+    # Helper to perform a replacement given a matched substring
+    def _do_replace_once(src: str, match: str) -> str:
+        return src.replace(match, new_string, 1)
+
+    # If replace_all is requested we attempt to replace all occurrences found by any replacer
+    total_replacements = 0
+    current = content
+
+    # Try each replacer in order until we find at least one match
+    for replacer in replacers:
+        matches = []
+        try:
+            matches = replacer.find(current, old_string)
+        except Exception:
+            matches = []
+        if not matches:
+            continue
+
+        # If replaceAll, replace all occurrences found by this replacer
+        if replace_all:
+            seen = set()
+            for m in matches:
+                if m in seen:
+                    continue
+                seen.add(m)
+                if m:
+                    count = current.count(m)
+                    if count:
+                        current = current.replace(m, new_string)
+                        total_replacements += count
+            return current, total_replacements
+
+        # If not replacing all, enforce single-match constraint per problem statement
+        if len(matches) > 1:
+            raise ValueError("Multiple matches found. Use replaceAll to replace all occurrences.")
+        # Exactly one match; replace that exact substring in the current content
+        m = matches[0]
+        if m:
+            current = current.replace(m, new_string, 1)
+            total_replacements += 1
+            return current, total_replacements
+
+    # If we reach here, no replacer found any match
+    raise ValueError("Could not find oldString in the file using replacers.")
+
+
+class EscapeNormalizedReplacer:
+    @staticmethod
+    def find(content: str, old: str) -> list[str]:
+        results: list[str] = []
+        # interpret escapes in old
+        try:
+            old_unescaped = bytes(old, "utf-8").decode("unicode_escape")
+        except Exception:
+            old_unescaped = old
+        variants = [old, old_unescaped]
+        for v in variants:
+            if not v:
+                continue
+            start = 0
+            while True:
+                idx = content.find(v, start)
+                if idx == -1:
+                    break
+                results.append(content[idx : idx + len(v)])
+                start = idx + 1
+        return results
+
+
+class MultiOccurrenceReplacer:
+    @staticmethod
+    def find(content: str, old: str) -> list[str]:
+        results: list[str] = []
+        if old == "":
+            return results
+        start = 0
+        while True:
+            idx = content.find(old, start)
+            if idx == -1:
+                break
+            results.append(content[idx : idx + len(old)])
+            start = idx + 1
+        return results
+
+
+class TrimmedBoundaryReplacer:
+    @staticmethod
+    def find(content: str, old: str) -> list[str]:
+        results: list[str] = []
+        old_lines = old.split("\n")
+        if not old_lines:
+            return results
+        lines = content.split("\n")
+        n = len(old_lines)
+        for i in range(len(lines) - n + 1):
+            block = "\n".join(lines[i : i + n])
+            if block.strip() == old.strip():
+                results.append(block)
+        return results
+
+
+class ContextAwareReplacer:
+    @staticmethod
+    def find(content: str, old: str) -> list[str]:
+        results: list[str] = []
+        old_lines = old.split("\n")
+        if len(old_lines) < 3:
+            return results
+        lines = content.split("\n")
+        n = len(old_lines)
+        for i in range(len(lines) - n + 1):
+            match = True
+            for k in range(n):
+                if lines[i + k].strip() != old_lines[k].strip():
+                    match = False
+                    break
+            if match:
+                results.append("\n".join(lines[i : i + n]))
+        return results
+
+
+class EditTool:
+    definition: ClassVar[ToolDefinition] = ToolDefinition(
+        name="edit",
+        description="Edit a file by replacing text. Supports multiple replacement strategies for flexible matching.",
+        input_schema={
+            "path": {
+                "type": "string",
+                "description": "The path to the file to edit (relative to workspace)",
+            },
+            "oldString": {
+                "type": "string",
+                "description": "The text to replace (must match exactly)",
+            },
+            "newString": {"type": "string", "description": "The text to replace it with"},
+            "replaceAll": {
+                "type": "boolean",
+                "description": "Replace all occurrences of oldString (default: false)",
+            },
+        },
+        read_only=False,
+    )
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        path_value = call.arguments.get("path")
+        if not isinstance(path_value, str):
+            raise ValueError("edit requires a string path argument")
+
+        old_string = call.arguments.get("oldString")
+        if not isinstance(old_string, str):
+            raise ValueError("edit requires a string oldString argument")
+
+        new_string = call.arguments.get("newString")
+        if not isinstance(new_string, str):
+            raise ValueError("edit requires a string newString argument")
+
+        replace_all = call.arguments.get("replaceAll", False)
+        if not isinstance(replace_all, bool):
+            raise ValueError("edit replaceAll must be a boolean")
+
+        relative_path = Path(path_value)
+        workspace_root = workspace.resolve()
+        candidate = (workspace_root / relative_path).resolve()
+
+        if not candidate.is_relative_to(workspace_root):
+            raise ValueError("edit only allows paths inside the workspace")
+
+        if not candidate.exists():
+            raise ValueError(f"edit target does not exist: {path_value}")
+
+        if not candidate.is_file():
+            raise ValueError(f"edit target is not a file: {path_value}")
+
+        try:
+            content_old = candidate.read_text(encoding="utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError("edit only supports UTF-8 text files") from exc
+
+        ending = _detect_line_ending(content_old)
+        normalized_old = _normalize_line_endings(old_string)
+        normalized_new = _normalize_line_endings(new_string)
+        normalized_content = _normalize_line_endings(content_old)
+
+        try:
+            new_content, match_count = _replace(
+                normalized_content,
+                normalized_old,
+                normalized_new,
+                replace_all=replace_all,
+            )
+        except ValueError:
+            raise
+
+        new_content = _convert_line_endings(new_content, ending)
+
+        def _ensure_newlines(lines: list[str]) -> list[str]:
+            return [line + "\n" for line in lines]
+
+        old_lines = content_old.splitlines()
+        new_lines = new_content.splitlines()
+
+        diff = _trim_diff(
+            "".join(
+                difflib.unified_diff(
+                    _ensure_newlines(old_lines) if old_lines else [],
+                    _ensure_newlines(new_lines) if new_lines else [],
+                    fromfile=str(candidate),
+                    tofile=str(candidate),
+                )
+            )
+        )
+
+        additions = sum(
+            1 for line in diff.splitlines() if line.startswith("+") and not line.startswith("+++")
+        )
+        deletions = sum(
+            1 for line in diff.splitlines() if line.startswith("-") and not line.startswith("---")
+        )
+
+        candidate.write_text(new_content, encoding="utf-8")
+
+        output = "Edit applied successfully."
+        if match_count > 1:
+            output += f" ({match_count} occurrences replaced)"
+
+        return ToolResult(
+            tool_name=self.definition.name,
+            status="ok",
+            content=output,
+            data={
+                "path": candidate.relative_to(workspace_root).as_posix(),
+                "additions": additions,
+                "deletions": deletions,
+                "match_count": match_count,
+                "diff": diff,
+            },
+        )

--- a/src/voidcode/tools/edit.py
+++ b/src/voidcode/tools/edit.py
@@ -69,9 +69,18 @@ def _trim_diff(diff: str) -> str:
 class SimpleReplacer:
     @staticmethod
     def find(content: str, old: str) -> list[str]:
-        if old in content:
-            return [old]
-        return []
+        results: list[str] = []
+        if not old:
+            return results
+
+        start = 0
+        while True:
+            idx = content.find(old, start)
+            if idx == -1:
+                break
+            results.append(content[idx : idx + len(old)])
+            start = idx + 1
+        return results
 
 
 class LineTrimmedReplacer:

--- a/src/voidcode/tools/glob.py
+++ b/src/voidcode/tools/glob.py
@@ -64,8 +64,8 @@ class GlobTool:
         try:
             for match in search_dir.glob(pattern):
                 if match.is_file():
-                    parts = match.parts
-                    if any(ignore in parts for ignore in DEFAULT_IGNORE_PATTERNS):
+                    relative_parts = match.relative_to(workspace_root).parts
+                    if any(ignore in relative_parts for ignore in DEFAULT_IGNORE_PATTERNS):
                         continue
 
                     matched.append(match)

--- a/src/voidcode/tools/glob.py
+++ b/src/voidcode/tools/glob.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import ClassVar
+
+from .contracts import ToolCall, ToolDefinition, ToolResult
+
+DEFAULT_IGNORE_PATTERNS = frozenset(
+    [
+        "node_modules",
+        "__pycache__",
+        ".git",
+        "dist",
+        "build",
+        "target",
+        "vendor",
+        ".venv",
+        "venv",
+        ".idea",
+        ".vscode",
+        ".coverage",
+        "coverage",
+        "tmp",
+        "temp",
+        ".cache",
+        "logs",
+    ]
+)
+
+LIMIT = 100
+
+
+class GlobTool:
+    definition: ClassVar[ToolDefinition] = ToolDefinition(
+        name="glob",
+        description="Find files matching a glob pattern inside the workspace.",
+        input_schema={
+            "pattern": {"type": "string", "description": "The glob pattern to match files against"},
+            "path": {
+                "type": "string",
+                "description": "The directory to search in (relative to workspace). Defaults to workspace root.",
+            },
+        },
+        read_only=True,
+    )
+
+    @staticmethod
+    def _find_files(
+        workspace_root: Path,
+        pattern: str,
+        search_path: Path | None = None,
+    ) -> tuple[list[Path], bool]:
+        search_dir = search_path if search_path else workspace_root
+
+        if not search_dir.is_relative_to(workspace_root):
+            raise ValueError("glob search path must be inside the workspace")
+
+        matched: list[Path] = []
+        truncated = False
+
+        try:
+            for match in search_dir.glob(pattern):
+                if match.is_file():
+                    parts = match.parts
+                    if any(ignore in parts for ignore in DEFAULT_IGNORE_PATTERNS):
+                        continue
+
+                    matched.append(match)
+
+                    if len(matched) >= LIMIT:
+                        truncated = True
+                        break
+        except Exception:
+            pass
+
+        return matched, truncated
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        pattern_value = call.arguments.get("pattern")
+        if not isinstance(pattern_value, str):
+            raise ValueError("glob requires a string pattern argument")
+
+        if not pattern_value.strip():
+            raise ValueError("glob pattern must not be empty")
+
+        path_value = call.arguments.get("path")
+        search_path: Path | None = None
+        if isinstance(path_value, str):
+            relative_path = Path(path_value)
+            workspace_root = workspace.resolve()
+            search_path = (workspace_root / relative_path).resolve()
+
+            if not search_path.is_relative_to(workspace_root):
+                raise ValueError("glob path must be inside the workspace")
+
+            if not search_path.exists():
+                raise ValueError(f"glob path does not exist: {path_value}")
+
+        workspace_root = workspace.resolve()
+        matched, truncated = self._find_files(workspace_root, pattern_value, search_path)
+
+        try:
+            matched.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+        except OSError:
+            matched.sort()
+
+        relative_matches = [m.relative_to(workspace_root).as_posix() for m in matched]
+
+        if not relative_matches:
+            output = "No files found"
+        else:
+            output_lines = relative_matches
+            if truncated:
+                output_lines.append("")
+                output_lines.append(
+                    f"(Results are truncated: showing first {LIMIT} results. Consider using a more specific path or pattern.)"
+                )
+            output = "\n".join(output_lines)
+
+        return ToolResult(
+            tool_name=self.definition.name,
+            status="ok",
+            content=output,
+            data={
+                "pattern": pattern_value,
+                "path": search_path.relative_to(workspace_root).as_posix() if search_path else ".",
+                "count": len(relative_matches),
+                "truncated": truncated,
+                "matches": relative_matches,
+            },
+        )

--- a/src/voidcode/tools/glob.py
+++ b/src/voidcode/tools/glob.py
@@ -38,7 +38,10 @@ class GlobTool:
             "pattern": {"type": "string", "description": "The glob pattern to match files against"},
             "path": {
                 "type": "string",
-                "description": "The directory to search in (relative to workspace). Defaults to workspace root.",
+                "description": (
+                    "The directory to search in (relative to workspace). "
+                    "Defaults to workspace root."
+                ),
             },
         },
         read_only=True,
@@ -113,7 +116,8 @@ class GlobTool:
             if truncated:
                 output_lines.append("")
                 output_lines.append(
-                    f"(Results are truncated: showing first {LIMIT} results. Consider using a more specific path or pattern.)"
+                    "(Results are truncated: showing first "
+                    f"{LIMIT} results. Consider using a more specific path or pattern.)"
                 )
             output = "\n".join(output_lines)
 

--- a/src/voidcode/tools/grep.py
+++ b/src/voidcode/tools/grep.py
@@ -71,7 +71,7 @@ class GrepTool:
                     }
                 )
 
-        relative_result_path = str(candidate.relative_to(workspace_root))
+        relative_result_path = candidate.relative_to(workspace_root).as_posix()
         if matches:
             preview_lines = [f"{match['line']}: {match['text']}" for match in matches[:10]]
             summary = (

--- a/src/voidcode/tools/list_dir.py
+++ b/src/voidcode/tools/list_dir.py
@@ -113,7 +113,11 @@ class ListTool:
                 if sum(len(v) for v in files_by_dir.values()) >= LIMIT:
                     break
 
-                if any(ignore in item.parts for ignore in all_ignore):
+                try:
+                    relative_parts = item.relative_to(workspace_root).parts
+                except ValueError:
+                    relative_parts = item.parts
+                if any(ignore in relative_parts for ignore in all_ignore):
                     continue
 
                 item_str = item.as_posix()

--- a/src/voidcode/tools/list_dir.py
+++ b/src/voidcode/tools/list_dir.py
@@ -76,8 +76,12 @@ def _is_ignored(
             return True
 
         # Support directory-style glob ignores like "build/**"
-        if p.endswith("/**") and rel_posix.startswith(p[:-3].rstrip("/")):
-            return True
+        if p.endswith("/**"):
+            prefix = p[:-3].rstrip("/")
+            if not prefix:
+                continue
+            if rel_posix == prefix or rel_posix.startswith(f"{prefix}/"):
+                return True
     return False
 
 

--- a/src/voidcode/tools/list_dir.py
+++ b/src/voidcode/tools/list_dir.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fnmatch
 from pathlib import Path
 from typing import ClassVar, cast
 
@@ -53,6 +54,31 @@ def _render_tree(
         lines.append(f"{child_indent}{file}")
 
     return lines
+
+
+def _is_ignored(
+    *,
+    relative_path: Path,
+    all_ignore_patterns: set[str],
+) -> bool:
+    rel_posix = relative_path.as_posix()
+    relative_parts = relative_path.parts
+    for pattern in all_ignore_patterns:
+        p = pattern.strip()
+        if not p:
+            continue
+
+        # Keep backward-compatible simple name ignores (e.g. "node_modules")
+        if p in relative_parts:
+            return True
+
+        if fnmatch.fnmatch(rel_posix, p):
+            return True
+
+        # Support directory-style glob ignores like "build/**"
+        if p.endswith("/**") and rel_posix.startswith(p[:-3].rstrip("/")):
+            return True
+    return False
 
 
 class ListTool:
@@ -114,10 +140,11 @@ class ListTool:
                     break
 
                 try:
-                    relative_parts = item.relative_to(workspace_root).parts
+                    relative_path = item.relative_to(workspace_root)
                 except ValueError:
-                    relative_parts = item.parts
-                if any(ignore in relative_parts for ignore in all_ignore):
+                    relative_path = item
+
+                if _is_ignored(relative_path=relative_path, all_ignore_patterns=all_ignore):
                     continue
 
                 item_str = item.as_posix()

--- a/src/voidcode/tools/list_dir.py
+++ b/src/voidcode/tools/list_dir.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import ClassVar, cast
+
+from .contracts import ToolCall, ToolDefinition, ToolResult
+
+IGNORE_PATTERNS = frozenset(
+    [
+        "node_modules",
+        "__pycache__",
+        ".git",
+        "dist",
+        "build",
+        "target",
+        "vendor",
+        ".venv",
+        "venv",
+        ".idea",
+        ".vscode",
+        ".coverage",
+        "coverage",
+        "tmp",
+        "temp",
+        ".cache",
+        "logs",
+    ]
+)
+
+LIMIT = 100
+
+
+def _render_tree(
+    dirs: set[str],
+    files_by_dir: dict[str, list[str]],
+    dir_path: str,
+    depth: int,
+) -> list[str]:
+    lines: list[str] = []
+    indent = "  " * depth
+
+    if depth > 0:
+        lines.append(f"{indent}{Path(dir_path).name}/")
+
+    child_indent = "  " * (depth + 1)
+    child_dirs = sorted(d for d in dirs if Path(d).parent.as_posix() == dir_path and d != dir_path)
+
+    for child in child_dirs:
+        lines.extend(_render_tree(dirs, files_by_dir, child, depth + 1))
+
+    files = sorted(files_by_dir.get(dir_path, []))
+    for file in files:
+        lines.append(f"{child_indent}{file}")
+
+    return lines
+
+
+class ListTool:
+    definition: ClassVar[ToolDefinition] = ToolDefinition(
+        name="list",
+        description="List files and directories in a workspace path.",
+        input_schema={
+            "path": {
+                "type": "string",
+                "description": "The directory to list (relative to workspace). Defaults to root.",
+            },
+            "ignore": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Additional glob patterns to ignore",
+            },
+        },
+        read_only=True,
+    )
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        path_value = call.arguments.get("path")
+        search_path: Path
+
+        if isinstance(path_value, str):
+            relative_path = Path(path_value)
+            workspace_root = workspace.resolve()
+            search_path = (workspace_root / relative_path).resolve()
+
+            if not search_path.is_relative_to(workspace_root):
+                raise ValueError("list path must be inside the workspace")
+
+            if not search_path.exists():
+                raise ValueError(f"list path does not exist: {path_value}")
+
+            if not search_path.is_dir():
+                raise ValueError(f"list path is not a directory: {path_value}")
+        else:
+            search_path = workspace.resolve()
+
+        workspace_root = workspace.resolve()
+
+        extra_ignore_raw = call.arguments.get("ignore")
+        if extra_ignore_raw is not None and not isinstance(extra_ignore_raw, list):
+            raise ValueError("list ignore must be an array of strings")
+
+        all_ignore: set[str] = set(IGNORE_PATTERNS)
+        if isinstance(extra_ignore_raw, list):
+            extra_list = cast(list[str], extra_ignore_raw)
+            for item_raw in extra_list:
+                all_ignore.add(item_raw)
+
+        dirs: set[str] = {search_path.as_posix()}
+        files_by_dir: dict[str, list[str]] = {}
+
+        try:
+            for item in search_path.rglob("*"):
+                if sum(len(v) for v in files_by_dir.values()) >= LIMIT:
+                    break
+
+                if any(ignore in item.parts for ignore in all_ignore):
+                    continue
+
+                item_str = item.as_posix()
+                parent_str = item.parent.as_posix()
+
+                if parent_str not in dirs:
+                    dirs.add(parent_str)
+
+                if item.is_dir():
+                    dirs.add(item_str)
+                elif item.is_file():
+                    if parent_str not in files_by_dir:
+                        files_by_dir[parent_str] = []
+                    files_by_dir[parent_str].append(item.name)
+        except PermissionError:
+            pass
+
+        tree_lines = _render_tree(dirs, files_by_dir, search_path.as_posix(), 0)
+        file_count = sum(len(v) for v in files_by_dir.values())
+        truncated = file_count >= LIMIT
+
+        # Start output with the absolute root path, following with a trailing '/'
+        output_lines = [f"{search_path.as_posix()}/"]
+        output_lines.extend(tree_lines)
+
+        if truncated:
+            output_lines.append("")
+            output_lines.append(f"(Results truncated: showing first {LIMIT} files)")
+
+        return ToolResult(
+            tool_name=self.definition.name,
+            status="ok",
+            content="\n".join(output_lines),
+            data={
+                # Expose absolute path in metadata for consistency with the output root
+                "path": str(search_path.as_posix()),
+                "count": file_count,
+                "truncated": truncated,
+            },
+        )

--- a/src/voidcode/tools/lsp.py
+++ b/src/voidcode/tools/lsp.py
@@ -68,6 +68,7 @@ class LspTool:
     def __init__(self) -> None:
         # Cached server address; resolved on first use
         self._host, self._port = self._resolve_server_address()
+        self._initialized = False
 
     # Public API expected by the runtime
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
@@ -129,19 +130,41 @@ class LspTool:
         if not self._server_is_available():
             raise ValueError(f"LSP server not available at {self._host}:{self._port}")
 
+        self._ensure_initialized(workspace=workspace_root)
+
         # Prepare a minimal JSON-RPC payload for the requested operation
         position = {"line": line_value - 1, "character": character_value - 1}
         textDocument = {"uri": candidate.as_uri()}
         params: dict[str, Any] = {"textDocument": textDocument, "position": position}
         if operation == LspOperation.WORKSPACE_SYMBOL:
             params = {"query": ""}
-        if operation in (
-            LspOperation.PREPARE_CALL_HIERARCHY,
-            LspOperation.INCOMING_CALLS,
-            LspOperation.OUTGOING_CALLS,
-        ):
-            # Minimal default for call hierarchy related requests
+        if operation == LspOperation.PREPARE_CALL_HIERARCHY:
             params = {"textDocument": textDocument, "position": position}
+
+        if operation in (LspOperation.INCOMING_CALLS, LspOperation.OUTGOING_CALLS):
+            prepare_response = self._send_request(
+                LspOperation.PREPARE_CALL_HIERARCHY.value,
+                {"textDocument": textDocument, "position": position},
+            )
+            if prepare_response is None:
+                raise ValueError("No response from LSP server for call hierarchy prepare")
+            prepare_error = prepare_response.get("error")
+            if prepare_error is not None:
+                raise ValueError(f"LSP prepareCallHierarchy error: {prepare_error}")
+
+            prepare_result = prepare_response.get("result")
+            item: dict[str, object] | None = None
+            if isinstance(prepare_result, list) and prepare_result:
+                first = cast(object, prepare_result[0])
+                if isinstance(first, dict):
+                    item = cast(dict[str, object], first)
+            elif isinstance(prepare_result, dict):
+                item = cast(dict[str, object], prepare_result)
+
+            if item is None:
+                raise ValueError("LSP prepareCallHierarchy returned no item")
+
+            params = {"item": item}
 
         # Send the request
         response = self._send_request(operation.value, params)
@@ -229,6 +252,50 @@ class LspTool:
                 return json.loads(body_bytes.decode("utf-8"))
         except Exception:
             return None
+
+    def _ensure_initialized(self, *, workspace: Path) -> None:
+        if self._initialized:
+            return
+
+        init_params: dict[str, object] = {
+            "processId": os.getpid(),
+            "clientInfo": {"name": "voidcode", "version": "0.1.0"},
+            "locale": "zh-CN",
+            "rootUri": workspace.as_uri(),
+            "workspaceFolders": [
+                {
+                    "uri": workspace.as_uri(),
+                    "name": workspace.name or str(workspace),
+                }
+            ],
+            "capabilities": {},
+        }
+
+        init_response = self._send_request("initialize", init_params)
+        if init_response is None:
+            raise ValueError("LSP initialize failed: no response")
+
+        init_error = init_response.get("error")
+        if init_error is not None:
+            raise ValueError(f"LSP initialize failed: {init_error}")
+
+        # initialized is a notification (no response expected)
+        self._send_notification("initialized", {})
+        self._initialized = True
+
+    def _send_notification(self, method: str, params: dict[str, object]) -> None:
+        if not self._host or not self._port:
+            return
+
+        payload = json.dumps({"jsonrpc": "2.0", "method": method, "params": params})
+        body = payload.encode("utf-8")
+        header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+        try:
+            with socket.create_connection((self._host, int(self._port)), timeout=3) as s:
+                s.sendall(header + body)
+        except OSError:
+            # Notification failure should not crash process unless it blocks requests later.
+            return
 
     # Expose a convenient alias for the interface elsewhere if needed
     def __repr__(self) -> str:  # pragma: no cover

--- a/src/voidcode/tools/lsp.py
+++ b/src/voidcode/tools/lsp.py
@@ -26,7 +26,7 @@ import json
 import os
 import socket
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
@@ -39,9 +39,9 @@ class LspOperation(enum.Enum):
     DOCUMENT_SYMBOL = "textDocument/documentSymbol"
     WORKSPACE_SYMBOL = "workspace/symbol"
     GO_TO_IMPLEMENTATION = "textDocument/implementation"
-    PREPARE_CALL_HIERARCHY = "textDocument/callHierarchy/prepareCallHierarchy"
-    INCOMING_CALLS = "textDocument/callHierarchy/incomingCalls"
-    OUTGOING_CALLS = "textDocument/callHierarchy/outgoingCalls"
+    PREPARE_CALL_HIERARCHY = "textDocument/prepareCallHierarchy"
+    INCOMING_CALLS = "callHierarchy/incomingCalls"
+    OUTGOING_CALLS = "callHierarchy/outgoingCalls"
 
 
 class LspTool:
@@ -131,7 +131,7 @@ class LspTool:
 
         # Prepare a minimal JSON-RPC payload for the requested operation
         position = {"line": line_value - 1, "character": character_value - 1}
-        textDocument = {"uri": f"file://{str(candidate)}"}
+        textDocument = {"uri": candidate.as_uri()}
         params: dict[str, Any] = {"textDocument": textDocument, "position": position}
         if operation == LspOperation.WORKSPACE_SYMBOL:
             params = {"query": ""}
@@ -147,10 +147,17 @@ class LspTool:
         response = self._send_request(operation.value, params)
         if response is None:
             raise ValueError("No response from LSP server")
-        # If the LSP server returns an error-like payload, surface it
-        if "error" in response or "code" in response:
-            error_value = response.get("error")
-            raise ValueError(str(error_value) if isinstance(error_value, str) else str(response))
+        # If the LSP server returns a JSON-RPC error payload, surface it
+        error_value = response.get("error")
+        if isinstance(error_value, dict):
+            error_dict = cast(dict[str, object], error_value)
+            code = error_dict.get("code")
+            message = error_dict.get("message")
+            if code is not None or message is not None:
+                raise ValueError(f"LSP error: code={code}, message={message}")
+            raise ValueError(f"LSP error: {error_dict}")
+        if error_value is not None:
+            raise ValueError(f"LSP error: {error_value}")
 
         return ToolResult(
             tool_name=self.definition.name,

--- a/src/voidcode/tools/lsp.py
+++ b/src/voidcode/tools/lsp.py
@@ -21,12 +21,12 @@ convention.
 
 from __future__ import annotations
 
+import enum
 import json
 import os
 import socket
 from pathlib import Path
-from typing import ClassVar, Optional, Any
-import enum
+from typing import Any, ClassVar
 
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
@@ -142,7 +142,10 @@ class LspTool:
             return ToolResult(
                 tool_name=self.definition.name,
                 status="error",
-                error="LSP server host/port not configured. Set VOIDCODE_LSP_HOST and VOIDCODE_LSP_PORT.",
+                error=(
+                    "LSP server host/port not configured. Set VOIDCODE_LSP_HOST "
+                    "and VOIDCODE_LSP_PORT."
+                ),
             )
         if not self._server_is_available():
             return ToolResult(
@@ -174,13 +177,12 @@ class LspTool:
                 error="No response from LSP server",
             )
         # If the LSP server returns an error-like payload, surface it
-        if isinstance(response, dict) and ("error" in response or "code" in response):
+        if "error" in response or "code" in response:
+            error_value = response.get("error")
             return ToolResult(
                 tool_name=self.definition.name,
                 status="error",
-                error=str(response.get("error"))
-                if isinstance(response.get("error"), str)
-                else str(response),
+                error=str(error_value) if isinstance(error_value, str) else str(response),
                 data={"lsp_response": response},
             )
 
@@ -206,12 +208,12 @@ class LspTool:
         if not self._host or not self._port:
             return False
         try:
-            with socket.create_connection((self._host, int(self._port)), timeout=0.5) as s:
+            with socket.create_connection((self._host, int(self._port)), timeout=0.5):
                 return True
         except Exception:
             return False
 
-    def _send_request(self, method: str, params: dict) -> Optional[dict[str, Any]]:
+    def _send_request(self, method: str, params: dict[str, object]) -> dict[str, object] | None:
         if not self._host or not self._port:
             return None
         # Prepare a lightweight JSON-RPC 2.0 request

--- a/src/voidcode/tools/lsp.py
+++ b/src/voidcode/tools/lsp.py
@@ -79,8 +79,20 @@ class LspTool:
 
         if not isinstance(file_path, str):
             raise ValueError("lsp requires a string 'filePath' argument")
-        if not isinstance(line, int) or not isinstance(character, int):
-            raise ValueError("lsp requires integer 'line' and 'character' arguments (1-based)")
+        if isinstance(line, (int, float)):
+            line_value = int(line)
+        else:
+            line_value = None
+
+        if isinstance(character, (int, float)):
+            character_value = int(character)
+        else:
+            character_value = None
+
+        if line_value is None or character_value is None:
+            raise ValueError("lsp requires numeric 'line' and 'character' arguments (1-based)")
+        if line_value < 1 or character_value < 1:
+            raise ValueError("lsp line and character must be >= 1")
         if op_value is None:
             raise ValueError("lsp invocation requires 'operation' argument")
 
@@ -118,7 +130,7 @@ class LspTool:
             raise ValueError(f"LSP server not available at {self._host}:{self._port}")
 
         # Prepare a minimal JSON-RPC payload for the requested operation
-        position = {"line": max(0, int(line) - 1), "character": max(0, int(character) - 1)}
+        position = {"line": line_value - 1, "character": character_value - 1}
         textDocument = {"uri": f"file://{str(candidate)}"}
         params: dict[str, Any] = {"textDocument": textDocument, "position": position}
         if operation == LspOperation.WORKSPACE_SYMBOL:

--- a/src/voidcode/tools/lsp.py
+++ b/src/voidcode/tools/lsp.py
@@ -1,0 +1,260 @@
+"""LSP Tool: basic client for Language Server Protocol queries.
+
+This tool provides a minimal, read-only interface to an external LSP server
+via a simple JSON-RPC over TCP/localhost. It supports a subset of common LSP
+operations requested by the system:
+- goToDefinition
+- findReferences
+- hover
+- documentSymbol
+- workspaceSymbol
+- goToImplementation
+- prepareCallHierarchy
+- incomingCalls
+- outgoingCalls
+
+Note: This is intentionally lightweight. It performs a best-effort available
+check and will return a helpful error message if no LSP server is configured or
+reachable. The actual JSON-RPC framing follows the LSP Content-Length header
+convention.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+from pathlib import Path
+from typing import ClassVar, Optional, Any
+import enum
+
+from .contracts import ToolCall, ToolDefinition, ToolResult
+
+
+@enum.unique
+class LspOperation(enum.Enum):
+    GO_TO_DEFINITION = "textDocument/definition"
+    FIND_REFERENCES = "textDocument/references"
+    HOVER = "textDocument/hover"
+    DOCUMENT_SYMBOL = "textDocument/documentSymbol"
+    WORKSPACE_SYMBOL = "workspace/symbol"
+    GO_TO_IMPLEMENTATION = "textDocument/implementation"
+    PREPARE_CALL_HIERARCHY = "textDocument/callHierarchy/prepareCallHierarchy"
+    INCOMING_CALLS = "textDocument/callHierarchy/incomingCalls"
+    OUTGOING_CALLS = "textDocument/callHierarchy/outgoingCalls"
+
+
+class LspTool:
+    """Tool to interact with an external LSP server.
+
+    The tool validates that an LSP server is reachable via environment
+    configuration and then issues a single JSON-RPC request corresponding to the
+    selected operation.
+    """
+
+    # Tool contract definition
+    definition: ClassVar[ToolDefinition] = ToolDefinition(
+        name="lsp",
+        description="LSP client for basic code intelligence lookups.",
+        input_schema={
+            "operation": {"type": "string"},
+            "filePath": {"type": "string"},
+            "line": {"type": "integer"},
+            "character": {"type": "integer"},
+        },
+        read_only=True,
+    )
+
+    def __init__(self) -> None:
+        # Cached server address; resolved on first use
+        self._host, self._port = self._resolve_server_address()
+
+    # Public API expected by the runtime
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        # Extract args
+        op_value = call.arguments.get("operation")
+        file_path = call.arguments.get("filePath")
+        line = call.arguments.get("line")
+        character = call.arguments.get("character")
+
+        if not isinstance(file_path, str):
+            return ToolResult(
+                tool_name=self.definition.name,
+                status="error",
+                error="lsp requires a string 'filePath' argument",
+            )
+        if not isinstance(line, int) or not isinstance(character, int):
+            return ToolResult(
+                tool_name=self.definition.name,
+                status="error",
+                error="lsp requires integer 'line' and 'character' arguments (1-based)",
+            )
+        if op_value is None:
+            return ToolResult(
+                tool_name=self.definition.name,
+                status="error",
+                error="lsp invocation requires 'operation' argument",
+            )
+
+        # Normalize operation
+        try:
+            if isinstance(op_value, LspOperation):
+                operation = op_value
+            else:
+                operation = LspOperation(op_value)
+        except Exception:
+            # Be permissive: allow a string key like "GO_TO_DEFINITION" to map to enum
+            if isinstance(op_value, str):
+                try:
+                    operation = LspOperation[op_value]
+                except Exception:
+                    return ToolResult(
+                        tool_name=self.definition.name,
+                        status="error",
+                        error=f"Unsupported LSP operation: {op_value}",
+                    )
+            else:
+                return ToolResult(
+                    tool_name=self.definition.name,
+                    status="error",
+                    error=f"Unsupported LSP operation: {op_value}",
+                )
+
+        # Resolve file path and ensure it's inside workspace (mirror read_file.py)
+        relative_path = Path(file_path)
+        workspace_root = workspace.resolve()
+        candidate = (workspace_root / relative_path).resolve()
+        if not candidate.is_relative_to(workspace_root):
+            return ToolResult(
+                tool_name=self.definition.name,
+                status="error",
+                error="lsp target must be inside the current workspace",
+            )
+        if not candidate.is_file():
+            return ToolResult(
+                tool_name=self.definition.name,
+                status="error",
+                error=f"lsp target does not exist: {file_path}",
+            )
+
+        # Ensure server is available
+        if not self._host or not self._port:
+            return ToolResult(
+                tool_name=self.definition.name,
+                status="error",
+                error="LSP server host/port not configured. Set VOIDCODE_LSP_HOST and VOIDCODE_LSP_PORT.",
+            )
+        if not self._server_is_available():
+            return ToolResult(
+                tool_name=self.definition.name,
+                status="error",
+                error=f"LSP server not available at {self._host}:{self._port}",
+            )
+
+        # Prepare a minimal JSON-RPC payload for the requested operation
+        position = {"line": max(0, int(line) - 1), "character": max(0, int(character) - 1)}
+        textDocument = {"uri": f"file://{str(candidate)}"}
+        params: dict[str, Any] = {"textDocument": textDocument, "position": position}
+        if operation == LspOperation.WORKSPACE_SYMBOL:
+            params = {"query": ""}
+        if operation in (
+            LspOperation.PREPARE_CALL_HIERARCHY,
+            LspOperation.INCOMING_CALLS,
+            LspOperation.OUTGOING_CALLS,
+        ):
+            # Minimal default for call hierarchy related requests
+            params = {"textDocument": textDocument, "position": position}
+
+        # Send the request
+        response = self._send_request(operation.value, params)
+        if response is None:
+            return ToolResult(
+                tool_name=self.definition.name,
+                status="error",
+                error="No response from LSP server",
+            )
+        # If the LSP server returns an error-like payload, surface it
+        if isinstance(response, dict) and ("error" in response or "code" in response):
+            return ToolResult(
+                tool_name=self.definition.name,
+                status="error",
+                error=str(response.get("error"))
+                if isinstance(response.get("error"), str)
+                else str(response),
+                data={"lsp_response": response},
+            )
+
+        return ToolResult(
+            tool_name=self.definition.name,
+            status="ok",
+            data={"lsp_response": response},
+        )
+
+    # Internal helpers
+    @staticmethod
+    def _resolve_server_address() -> tuple[str, int | None]:
+        host = os.environ.get("VOIDCODE_LSP_HOST", "127.0.0.1")
+        port = os.environ.get("VOIDCODE_LSP_PORT")
+        if port is None:
+            return host, None
+        try:
+            return host, int(port)
+        except ValueError:
+            return host, None
+
+    def _server_is_available(self) -> bool:
+        if not self._host or not self._port:
+            return False
+        try:
+            with socket.create_connection((self._host, int(self._port)), timeout=0.5) as s:
+                return True
+        except Exception:
+            return False
+
+    def _send_request(self, method: str, params: dict) -> Optional[dict[str, Any]]:
+        if not self._host or not self._port:
+            return None
+        # Prepare a lightweight JSON-RPC 2.0 request
+        payload = json.dumps({"jsonrpc": "2.0", "id": 1, "method": method, "params": params})
+        body = payload.encode("utf-8")
+        header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+        try:
+            with socket.create_connection((self._host, int(self._port)), timeout=3) as s:
+                s.sendall(header + body)
+                # Read response header
+                resp_header = b""
+                while b"\r\n\r\n" not in resp_header:
+                    chunk = s.recv(1)
+                    if not chunk:
+                        break
+                    resp_header += chunk
+                # Parse Content-Length
+                header_text = resp_header.decode("ascii", errors="ignore")
+                cl = None
+                for line in header_text.split("\r\n"):
+                    if line.lower().startswith("content-length:"):
+                        try:
+                            cl = int(line.split(":", 1)[1].strip())
+                        except Exception:
+                            cl = None
+                        break
+                if cl is None:
+                    return None
+                # Read body
+                body_bytes = b""
+                remaining = cl
+                while remaining > 0:
+                    chunk = s.recv(remaining)
+                    if not chunk:
+                        break
+                    body_bytes += chunk
+                    remaining -= len(chunk)
+                if not body_bytes:
+                    return None
+                return json.loads(body_bytes.decode("utf-8"))
+        except Exception:
+            return None
+
+    # Expose a convenient alias for the interface elsewhere if needed
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<LspTool host={self._host} port={self._port}>"

--- a/src/voidcode/tools/lsp.py
+++ b/src/voidcode/tools/lsp.py
@@ -78,23 +78,11 @@ class LspTool:
         character = call.arguments.get("character")
 
         if not isinstance(file_path, str):
-            return ToolResult(
-                tool_name=self.definition.name,
-                status="error",
-                error="lsp requires a string 'filePath' argument",
-            )
+            raise ValueError("lsp requires a string 'filePath' argument")
         if not isinstance(line, int) or not isinstance(character, int):
-            return ToolResult(
-                tool_name=self.definition.name,
-                status="error",
-                error="lsp requires integer 'line' and 'character' arguments (1-based)",
-            )
+            raise ValueError("lsp requires integer 'line' and 'character' arguments (1-based)")
         if op_value is None:
-            return ToolResult(
-                tool_name=self.definition.name,
-                status="error",
-                error="lsp invocation requires 'operation' argument",
-            )
+            raise ValueError("lsp invocation requires 'operation' argument")
 
         # Normalize operation
         try:
@@ -107,52 +95,27 @@ class LspTool:
             if isinstance(op_value, str):
                 try:
                     operation = LspOperation[op_value]
-                except Exception:
-                    return ToolResult(
-                        tool_name=self.definition.name,
-                        status="error",
-                        error=f"Unsupported LSP operation: {op_value}",
-                    )
+                except Exception as exc:
+                    raise ValueError(f"Unsupported LSP operation: {op_value}") from exc
             else:
-                return ToolResult(
-                    tool_name=self.definition.name,
-                    status="error",
-                    error=f"Unsupported LSP operation: {op_value}",
-                )
+                raise ValueError(f"Unsupported LSP operation: {op_value}") from None
 
         # Resolve file path and ensure it's inside workspace (mirror read_file.py)
         relative_path = Path(file_path)
         workspace_root = workspace.resolve()
         candidate = (workspace_root / relative_path).resolve()
         if not candidate.is_relative_to(workspace_root):
-            return ToolResult(
-                tool_name=self.definition.name,
-                status="error",
-                error="lsp target must be inside the current workspace",
-            )
+            raise ValueError("lsp target must be inside the current workspace")
         if not candidate.is_file():
-            return ToolResult(
-                tool_name=self.definition.name,
-                status="error",
-                error=f"lsp target does not exist: {file_path}",
-            )
+            raise ValueError(f"lsp target does not exist: {file_path}")
 
         # Ensure server is available
         if not self._host or not self._port:
-            return ToolResult(
-                tool_name=self.definition.name,
-                status="error",
-                error=(
-                    "LSP server host/port not configured. Set VOIDCODE_LSP_HOST "
-                    "and VOIDCODE_LSP_PORT."
-                ),
+            raise ValueError(
+                "LSP server host/port not configured. Set VOIDCODE_LSP_HOST and VOIDCODE_LSP_PORT."
             )
         if not self._server_is_available():
-            return ToolResult(
-                tool_name=self.definition.name,
-                status="error",
-                error=f"LSP server not available at {self._host}:{self._port}",
-            )
+            raise ValueError(f"LSP server not available at {self._host}:{self._port}")
 
         # Prepare a minimal JSON-RPC payload for the requested operation
         position = {"line": max(0, int(line) - 1), "character": max(0, int(character) - 1)}
@@ -171,20 +134,11 @@ class LspTool:
         # Send the request
         response = self._send_request(operation.value, params)
         if response is None:
-            return ToolResult(
-                tool_name=self.definition.name,
-                status="error",
-                error="No response from LSP server",
-            )
+            raise ValueError("No response from LSP server")
         # If the LSP server returns an error-like payload, surface it
         if "error" in response or "code" in response:
             error_value = response.get("error")
-            return ToolResult(
-                tool_name=self.definition.name,
-                status="error",
-                error=str(error_value) if isinstance(error_value, str) else str(response),
-                data={"lsp_response": response},
-            )
+            raise ValueError(str(error_value) if isinstance(error_value, str) else str(response))
 
         return ToolResult(
             tool_name=self.definition.name,

--- a/src/voidcode/tools/multi_edit.py
+++ b/src/voidcode/tools/multi_edit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
+
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, cast
 
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
@@ -21,7 +22,10 @@ class MultiEditTool:
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
         path_value = call.arguments.get("filePath")
-        edits = call.arguments.get("edits", [])
+        edits_value = call.arguments.get("edits", [])
+        edits: list[object] = []
+        if isinstance(edits_value, list):
+            edits = cast(list[object], edits_value)
 
         return ToolResult(
             tool_name=self.definition.name,

--- a/src/voidcode/tools/multi_edit.py
+++ b/src/voidcode/tools/multi_edit.py
@@ -35,7 +35,7 @@ class MultiEditTool:
         if not target.exists() or not target.is_file():
             raise ValueError(f"multi_edit target does not exist: {path_value}")
 
-        relative_target = str(target.relative_to(workspace_root))
+        relative_target = target.relative_to(workspace_root).as_posix()
         edits_value = call.arguments.get("edits", [])
         edits: list[object] = []
         if isinstance(edits_value, list):

--- a/src/voidcode/tools/multi_edit.py
+++ b/src/voidcode/tools/multi_edit.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import ClassVar, cast
+from typing import Any, ClassVar, cast
 
 from .contracts import ToolCall, ToolDefinition, ToolResult
+from .edit import EditTool
 
 
 class MultiEditTool:
     definition: ClassVar[ToolDefinition] = ToolDefinition(
-        name="multiedit",
+        name="multi_edit",
         description="Apply multiple edits to a file sequentially.",
         input_schema={
-            "filePath": {"type": "string", "description": "Path to file"},
+            "path": {"type": "string", "description": "Path to file"},
             "edits": {
                 "type": "array",
                 "description": "Array of {oldString, newString, replaceAll}",
@@ -21,14 +22,67 @@ class MultiEditTool:
     )
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
-        path_value = call.arguments.get("filePath")
+        path_value = call.arguments.get("path")
+        if path_value is None:
+            path_value = call.arguments.get("filePath")
+        if not isinstance(path_value, str) or not path_value.strip():
+            raise ValueError("multi_edit requires a string path argument")
+
+        workspace_root = workspace.resolve()
+        target = (workspace_root / Path(path_value)).resolve()
+        if not target.is_relative_to(workspace_root):
+            raise ValueError("multi_edit only allows paths inside the workspace")
+        if not target.exists() or not target.is_file():
+            raise ValueError(f"multi_edit target does not exist: {path_value}")
+
+        relative_target = str(target.relative_to(workspace_root))
         edits_value = call.arguments.get("edits", [])
         edits: list[object] = []
         if isinstance(edits_value, list):
             edits = cast(list[object], edits_value)
+        else:
+            raise ValueError("multi_edit requires an array edits argument")
+
+        if not edits:
+            raise ValueError("multi_edit requires at least one edit entry")
+
+        edit_tool = EditTool()
+        applied = 0
+        details: list[dict[str, object]] = []
+        for idx, item in enumerate(edits, start=1):
+            if not isinstance(item, dict):
+                raise ValueError(f"multi_edit edit #{idx} must be an object")
+            item_dict = cast(dict[str, Any], item)
+
+            old_string = item_dict.get("oldString")
+            new_string = item_dict.get("newString")
+            replace_all = item_dict.get("replaceAll", False)
+
+            if not isinstance(old_string, str):
+                raise ValueError(f"multi_edit edit #{idx} requires string oldString")
+            if not isinstance(new_string, str):
+                raise ValueError(f"multi_edit edit #{idx} requires string newString")
+            if not isinstance(replace_all, bool):
+                raise ValueError(f"multi_edit edit #{idx} replaceAll must be boolean")
+
+            result = edit_tool.invoke(
+                ToolCall(
+                    tool_name="edit",
+                    arguments={
+                        "path": relative_target,
+                        "oldString": old_string,
+                        "newString": new_string,
+                        "replaceAll": replace_all,
+                    },
+                ),
+                workspace=workspace,
+            )
+            applied += 1
+            details.append({"index": idx, "result": result.data})
 
         return ToolResult(
             tool_name=self.definition.name,
             status="ok",
-            content=f"Applied {len(edits)} edits to {path_value}",
+            content=f"Applied {applied} edits to {relative_target}",
+            data={"path": relative_target, "applied": applied, "edits": details},
         )

--- a/src/voidcode/tools/multi_edit.py
+++ b/src/voidcode/tools/multi_edit.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import ClassVar
+
+from .contracts import ToolCall, ToolDefinition, ToolResult
+
+
+class MultiEditTool:
+    definition: ClassVar[ToolDefinition] = ToolDefinition(
+        name="multiedit",
+        description="Apply multiple edits to a file sequentially.",
+        input_schema={
+            "filePath": {"type": "string", "description": "Path to file"},
+            "edits": {
+                "type": "array",
+                "description": "Array of {oldString, newString, replaceAll}",
+            },
+        },
+        read_only=False,
+    )
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        path_value = call.arguments.get("filePath")
+        edits = call.arguments.get("edits", [])
+
+        return ToolResult(
+            tool_name=self.definition.name,
+            status="ok",
+            content=f"Applied {len(edits)} edits to {path_value}",
+        )

--- a/src/voidcode/tools/read_file.py
+++ b/src/voidcode/tools/read_file.py
@@ -40,7 +40,7 @@ class ReadFileTool:
             status="ok",
             content=content,
             data={
-                "path": str(candidate.relative_to(workspace_root)),
+                "path": candidate.relative_to(workspace_root).as_posix(),
                 "line_count": len(content.splitlines()),
             },
         )

--- a/src/voidcode/tools/shell_exec.py
+++ b/src/voidcode/tools/shell_exec.py
@@ -7,13 +7,29 @@ from typing import ClassVar, final
 
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
+DEFAULT_TIMEOUT_SECONDS = 30
+MAX_TIMEOUT_SECONDS = 120
+MAX_OUTPUT_CHARS = 200_000
+
+
+def _truncate(text: str) -> tuple[str, bool]:
+    if len(text) <= MAX_OUTPUT_CHARS:
+        return text, False
+    return text[:MAX_OUTPUT_CHARS], True
+
 
 @final
 class ShellExecTool:
     definition: ClassVar[ToolDefinition] = ToolDefinition(
         name="shell_exec",
         description="Execute a command inside the current workspace.",
-        input_schema={"command": {"type": "string"}},
+        input_schema={
+            "command": {"type": "string"},
+            "timeout": {
+                "type": "integer",
+                "description": "Timeout in seconds (max 120)",
+            },
+        },
         read_only=False,
     )
 
@@ -30,27 +46,45 @@ class ShellExecTool:
         if not command_parts:
             raise ValueError("shell_exec command must not be empty")
 
-        completed = subprocess.run(
-            command_parts,
-            cwd=workspace.resolve(),
-            capture_output=True,
-            text=True,
-            check=False,
-            shell=False,
-        )
+        timeout_value = call.arguments.get("timeout", DEFAULT_TIMEOUT_SECONDS)
+        if isinstance(timeout_value, (int, float)) and timeout_value > 0:
+            timeout_seconds = min(int(timeout_value), MAX_TIMEOUT_SECONDS)
+        else:
+            timeout_seconds = DEFAULT_TIMEOUT_SECONDS
+
+        try:
+            completed = subprocess.run(
+                command_parts,
+                cwd=workspace.resolve(),
+                capture_output=True,
+                text=True,
+                check=False,
+                shell=False,
+                timeout=timeout_seconds,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise ValueError(f"shell_exec command timed out after {timeout_seconds}s") from exc
+        except OSError as exc:
+            raise ValueError(f"shell_exec failed to execute command: {exc}") from exc
 
         output = completed.stdout
         if completed.stderr:
             output = f"{output}{completed.stderr}" if output else completed.stderr
 
+        content, content_truncated = _truncate(output)
+        stdout, stdout_truncated = _truncate(completed.stdout)
+        stderr, stderr_truncated = _truncate(completed.stderr)
+
         return ToolResult(
             tool_name=self.definition.name,
             status="ok",
-            content=output,
+            content=content,
             data={
                 "command": command_text,
                 "exit_code": completed.returncode,
-                "stdout": completed.stdout,
-                "stderr": completed.stderr,
+                "stdout": stdout,
+                "stderr": stderr,
+                "timeout": timeout_seconds,
+                "truncated": content_truncated or stdout_truncated or stderr_truncated,
             },
         )

--- a/src/voidcode/tools/shell_exec.py
+++ b/src/voidcode/tools/shell_exec.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shlex
 import subprocess
 from pathlib import Path
 from typing import ClassVar, final
@@ -25,13 +26,17 @@ class ShellExecTool:
         if not command_text:
             raise ValueError("shell_exec command must not be empty")
 
+        command_parts = shlex.split(command_text, posix=True)
+        if not command_parts:
+            raise ValueError("shell_exec command must not be empty")
+
         completed = subprocess.run(
-            command_text,
+            command_parts,
             cwd=workspace.resolve(),
             capture_output=True,
             text=True,
             check=False,
-            shell=True,
+            shell=False,
         )
 
         output = completed.stdout

--- a/src/voidcode/tools/shell_exec.py
+++ b/src/voidcode/tools/shell_exec.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import shlex
 import subprocess
 from pathlib import Path
 from typing import ClassVar, final
@@ -27,12 +26,12 @@ class ShellExecTool:
             raise ValueError("shell_exec command must not be empty")
 
         completed = subprocess.run(
-            shlex.split(command_text),
+            command_text,
             cwd=workspace.resolve(),
             capture_output=True,
             text=True,
             check=False,
-            shell=False,
+            shell=True,
         )
 
         output = completed.stdout

--- a/src/voidcode/tools/todo_write.py
+++ b/src/voidcode/tools/todo_write.py
@@ -1,19 +1,20 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
-from typing import ClassVar, cast
+from typing import Any, ClassVar, cast
 
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 
 class TodoWriteTool:
     definition: ClassVar[ToolDefinition] = ToolDefinition(
-        name="todowrite",
+        name="todo_write",
         description="Manage todo list with status and priority.",
         input_schema={
             "todos": {"type": "array", "description": "Array of {content, status, priority}"},
         },
-        read_only=True,
+        read_only=False,
     )
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
@@ -21,8 +22,53 @@ class TodoWriteTool:
         todos: list[object] = []
         if isinstance(todos_value, list):
             todos = cast(list[object], todos_value)
+        else:
+            raise ValueError("todo_write requires todos array")
+
+        allowed_status = {"pending", "in_progress", "completed", "cancelled"}
+        allowed_priority = {"high", "medium", "low"}
+
+        normalized: list[dict[str, str]] = []
+        for idx, item in enumerate(todos, start=1):
+            if not isinstance(item, dict):
+                raise ValueError(f"todo_write item #{idx} must be an object")
+            item_dict = cast(dict[str, Any], item)
+
+            content = item_dict.get("content")
+            status = item_dict.get("status")
+            priority = item_dict.get("priority")
+
+            if not isinstance(content, str) or not content.strip():
+                raise ValueError(f"todo_write item #{idx} content must be non-empty string")
+            if not isinstance(status, str) or status not in allowed_status:
+                raise ValueError(f"todo_write item #{idx} invalid status: {status}")
+            if not isinstance(priority, str) or priority not in allowed_priority:
+                raise ValueError(f"todo_write item #{idx} invalid priority: {priority}")
+
+            normalized.append({"content": content.strip(), "status": status, "priority": priority})
+
+        store_dir = workspace / ".voidcode"
+        store_dir.mkdir(parents=True, exist_ok=True)
+        store_path = store_dir / "todos.json"
+        store_path.write_text(
+            json.dumps(normalized, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+        summary = {
+            "total": len(normalized),
+            "pending": sum(1 for t in normalized if t["status"] == "pending"),
+            "in_progress": sum(1 for t in normalized if t["status"] == "in_progress"),
+            "completed": sum(1 for t in normalized if t["status"] == "completed"),
+            "cancelled": sum(1 for t in normalized if t["status"] == "cancelled"),
+        }
+
         return ToolResult(
             tool_name=self.definition.name,
             status="ok",
-            content=f"Updated {len(todos)} todos",
+            content=f"Updated {len(normalized)} todos",
+            data={
+                "path": str(store_path.relative_to(workspace.resolve())),
+                "summary": summary,
+            },
         )

--- a/src/voidcode/tools/todo_write.py
+++ b/src/voidcode/tools/todo_write.py
@@ -68,7 +68,7 @@ class TodoWriteTool:
             status="ok",
             content=f"Updated {len(normalized)} todos",
             data={
-                "path": str(store_path.relative_to(workspace.resolve())),
+                "path": store_path.relative_to(workspace.resolve()).as_posix(),
                 "summary": summary,
             },
         )

--- a/src/voidcode/tools/todo_write.py
+++ b/src/voidcode/tools/todo_write.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
+
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, cast
 
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
@@ -16,7 +17,10 @@ class TodoWriteTool:
     )
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
-        todos = call.arguments.get("todos", [])
+        todos_value = call.arguments.get("todos", [])
+        todos: list[object] = []
+        if isinstance(todos_value, list):
+            todos = cast(list[object], todos_value)
         return ToolResult(
             tool_name=self.definition.name,
             status="ok",

--- a/src/voidcode/tools/todo_write.py
+++ b/src/voidcode/tools/todo_write.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import ClassVar
+
+from .contracts import ToolCall, ToolDefinition, ToolResult
+
+
+class TodoWriteTool:
+    definition: ClassVar[ToolDefinition] = ToolDefinition(
+        name="todowrite",
+        description="Manage todo list with status and priority.",
+        input_schema={
+            "todos": {"type": "array", "description": "Array of {content, status, priority}"},
+        },
+        read_only=True,
+    )
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        todos = call.arguments.get("todos", [])
+        return ToolResult(
+            tool_name=self.definition.name,
+            status="ok",
+            content=f"Updated {len(todos)} todos",
+        )

--- a/src/voidcode/tools/web_fetch.py
+++ b/src/voidcode/tools/web_fetch.py
@@ -7,8 +7,9 @@ import socket
 import urllib.error
 import urllib.parse
 import urllib.request
+from http.client import HTTPMessage
 from pathlib import Path
-from typing import ClassVar
+from typing import IO, ClassVar, cast
 
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
@@ -72,6 +73,27 @@ def _validate_fetch_url(url_value: str) -> None:
 
     if _is_private_or_loopback_host(parsed.hostname):
         raise ValueError("web_fetch target host is blocked for security reasons")
+
+
+class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: object,
+        code: int,
+        msg: str,
+        headers: object,
+        newurl: str,
+    ) -> urllib.request.Request | None:
+        _validate_fetch_url(newurl)
+        return super().redirect_request(
+            req,
+            cast(IO[bytes], fp),
+            code,
+            msg,
+            cast(HTTPMessage, headers),
+            newurl,
+        )
 
 
 def _extract_text_from_html(html: str) -> str:
@@ -208,6 +230,7 @@ class WebFetchTool:
         content: str = ""
         data: bytes = b""
         mime: str = ""
+        opener = urllib.request.build_opener(_SafeRedirectHandler())
 
         try:
             # Build Accept header according to requested format to be friendlier for servers
@@ -240,7 +263,9 @@ class WebFetchTool:
                 },
             )
 
-            with urllib.request.urlopen(req, timeout=timeout) as response:
+            with opener.open(req, timeout=timeout) as response:
+                final_url = response.geturl()
+                _validate_fetch_url(final_url)
                 content_type = response.headers.get("Content-Type", "")
                 content_length = response.headers.get("Content-Length")
 
@@ -253,12 +278,20 @@ class WebFetchTool:
                         limit_mb = MAX_RESPONSE_SIZE // 1024 // 1024
                         raise ValueError(f"Response too large (exceeds {limit_mb}MB limit)")
 
-                data = response.read()
+                chunks: list[bytes] = []
+                total = 0
+                chunk_size = 64 * 1024
+                while True:
+                    chunk = response.read(chunk_size)
+                    if not chunk:
+                        break
+                    total += len(chunk)
+                    if total > MAX_RESPONSE_SIZE:
+                        limit_mb = MAX_RESPONSE_SIZE // 1024 // 1024
+                        raise ValueError(f"Response too large (exceeds {limit_mb}MB limit)")
+                    chunks.append(chunk)
 
-                if len(data) > MAX_RESPONSE_SIZE:
-                    raise ValueError(
-                        f"Response too large (exceeds {MAX_RESPONSE_SIZE // 1024 // 1024}MB limit)"
-                    )
+                data = b"".join(chunks)
 
                 content = data.decode("utf-8", errors="replace")
                 mime = content_type.split(";")[0].strip().lower() if content_type else ""

--- a/src/voidcode/tools/web_fetch.py
+++ b/src/voidcode/tools/web_fetch.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import base64
+import ipaddress
 import re
+import socket
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import ClassVar
@@ -11,6 +14,64 @@ from .contracts import ToolCall, ToolDefinition, ToolResult
 
 MAX_RESPONSE_SIZE = 5 * 1024 * 1024
 DEFAULT_TIMEOUT = 30
+
+
+def _is_private_or_loopback_host(hostname: str) -> bool:
+    blocked_hostnames = {
+        "localhost",
+        "metadata.google.internal",
+        "metadata",
+    }
+    lower = hostname.lower().strip(".")
+    if lower in blocked_hostnames:
+        return True
+
+    try:
+        ip = ipaddress.ip_address(lower)
+        return bool(
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+            or ip.is_unspecified
+        )
+    except ValueError:
+        pass
+
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror:
+        return False
+
+    for info in infos:
+        address = info[4][0]
+        try:
+            ip = ipaddress.ip_address(address)
+        except ValueError:
+            continue
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+            or ip.is_unspecified
+        ):
+            return True
+    return False
+
+
+def _validate_fetch_url(url_value: str) -> None:
+    parsed = urllib.parse.urlparse(url_value)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError("web_fetch url must start with http:// or https://")
+
+    if not parsed.hostname:
+        raise ValueError("web_fetch url must include a hostname")
+
+    if _is_private_or_loopback_host(parsed.hostname):
+        raise ValueError("web_fetch target host is blocked for security reasons")
 
 
 def _extract_text_from_html(html: str) -> str:
@@ -132,8 +193,7 @@ class WebFetchTool:
         if not isinstance(url_value, str):
             raise ValueError("web_fetch requires a string url argument")
 
-        if not url_value.startswith("http://") and not url_value.startswith("https://"):
-            raise ValueError("web_fetch url must start with http:// or https://")
+        _validate_fetch_url(url_value)
 
         format_value = call.arguments.get("format", "markdown")
         if not isinstance(format_value, str) or format_value not in ("text", "markdown", "html"):
@@ -184,10 +244,14 @@ class WebFetchTool:
                 content_type = response.headers.get("Content-Type", "")
                 content_length = response.headers.get("Content-Length")
 
-                if content_length and int(content_length) > MAX_RESPONSE_SIZE:
-                    raise ValueError(
-                        f"Response too large (exceeds {MAX_RESPONSE_SIZE // 1024 // 1024}MB limit)"
-                    )
+                if content_length:
+                    try:
+                        parsed_length = int(content_length)
+                    except (TypeError, ValueError):
+                        parsed_length = None
+                    if parsed_length is not None and parsed_length > MAX_RESPONSE_SIZE:
+                        limit_mb = MAX_RESPONSE_SIZE // 1024 // 1024
+                        raise ValueError(f"Response too large (exceeds {limit_mb}MB limit)")
 
                 data = response.read()
 

--- a/src/voidcode/tools/web_fetch.py
+++ b/src/voidcode/tools/web_fetch.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import base64
 import re
 import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import ClassVar
-import base64
 
 from .contracts import ToolCall, ToolDefinition, ToolResult
 

--- a/src/voidcode/tools/web_fetch.py
+++ b/src/voidcode/tools/web_fetch.py
@@ -23,8 +23,28 @@ def _extract_text_from_html(html: str) -> str:
     i = 0
     while i < len(html):
         if html[i] == "<":
-            j = html.index(">", i)
-            tag = html[i + 1 : j].split()[0].lower().rstrip("/")
+            if html.startswith("<!--", i):
+                end_comment = html.find("-->", i + 4)
+                if end_comment == -1:
+                    break
+                i = end_comment + 3
+                continue
+
+            j = html.find(">", i)
+            if j == -1:
+                text.append(html[i:])
+                break
+
+            tag_raw = html[i + 1 : j].strip()
+            if not tag_raw:
+                i = j + 1
+                continue
+
+            parts = tag_raw.split()
+            if not parts:
+                i = j + 1
+                continue
+            tag = parts[0].lower().rstrip("/")
 
             if tag.startswith("!"):
                 i = j + 1
@@ -180,25 +200,35 @@ class WebFetchTool:
                 mime = content_type.split(";")[0].strip().lower() if content_type else ""
 
         except urllib.error.HTTPError as exc:
-            return ToolResult(
-                tool_name=self.definition.name,
-                status="error",
-                error=f"HTTP error {exc.code}: {exc.reason}",
-                data={"url": url_value, "status_code": exc.code},
-            )
+            raise ValueError(f"HTTP error {exc.code}: {exc.reason}") from exc
         except urllib.error.URLError as exc:
-            return ToolResult(
-                tool_name=self.definition.name,
-                status="error",
-                error=f"Failed to fetch URL: {exc.reason}",
-                data={"url": url_value},
-            )
+            raise ValueError(f"Failed to fetch URL: {exc.reason}") from exc
 
         # Normal post-fetch processing (outside of except blocks)
         if format_value == "html":
             output = content
-        elif format_value == "text" or "text/html" in mime:
+        elif format_value == "text":
             output = _extract_text_from_html(content)
+        elif format_value == "markdown":
+            if mime and mime.startswith("image/"):
+                b64 = base64.b64encode(data).decode("ascii")
+                data_uri = f"data:{mime};base64,{b64}"
+                return ToolResult(
+                    tool_name=self.definition.name,
+                    status="ok",
+                    content="",
+                    data={
+                        "url": url_value,
+                        "content_type": mime,
+                        "format": format_value,
+                        "byte_count": len(data),
+                        "attachment": {"mime": mime, "data_uri": data_uri},
+                    },
+                )
+            if "text/html" in mime:
+                output = _convert_html_to_markdown(content)
+            else:
+                output = content
         else:
             if mime and mime.startswith("image/"):
                 # Image handling: return as base64 attachment instead of text output

--- a/src/voidcode/tools/web_fetch.py
+++ b/src/voidcode/tools/web_fetch.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import re
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import ClassVar
+import base64
+
+from .contracts import ToolCall, ToolDefinition, ToolResult
+
+MAX_RESPONSE_SIZE = 5 * 1024 * 1024
+DEFAULT_TIMEOUT = 30
+
+
+def _extract_text_from_html(html: str) -> str:
+    text: list[str] = []
+    skip_content = False
+
+    script_style_tags = {"script", "style", "noscript", "iframe", "object", "embed"}
+    tag_stack: list[str] = []
+
+    i = 0
+    while i < len(html):
+        if html[i] == "<":
+            j = html.index(">", i)
+            tag = html[i + 1 : j].split()[0].lower().rstrip("/")
+
+            if tag.startswith("!"):
+                i = j + 1
+                continue
+
+            is_closing = tag.startswith("/")
+            clean_tag = tag.lstrip("/")
+
+            if is_closing and tag_stack and tag_stack[-1] == clean_tag:
+                tag_stack.pop()
+                if clean_tag in script_style_tags:
+                    skip_content = False
+            elif not is_closing:
+                tag_stack.append(clean_tag)
+                if clean_tag in script_style_tags:
+                    skip_content = True
+
+            if not skip_content:
+                if (
+                    html[i : i + 7] == "<br"
+                    or html[i : i + 9] == "<br/>"
+                    or html[i : i + 10] == "<br />"
+                ):
+                    text.append("\n")
+
+            i = j + 1
+            continue
+
+        if not skip_content and i < len(html):
+            text.append(html[i])
+
+        i += 1
+
+    result = "".join(text)
+    result = re.sub(r"\n{3,}", "\n\n", result)
+    result = re.sub(r"[ \t]+", " ", result)
+    return result.strip()
+
+
+def _convert_html_to_markdown(html: str) -> str:
+    # Improve HTML->Markdown conversion by applying simple heuristics on extracted text
+    lines = _extract_text_from_html(html).split("\n")
+    markdown_lines: list[str] = []
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            markdown_lines.append("")
+            continue
+
+        # Normalize emphasis markers already present
+        line = re.sub(r"\*\*(.+?)\*\*", r"**\1**", line)
+        line = re.sub(r"\*(.+?)\*", r"*\1*", line)
+        line = re.sub(r"__(.+?)__", r"_\1_", line)
+        line = re.sub(r"_(.+?)_", r"_\1_", line)
+
+        # Heuristic: treat all-uppercase lines as headings
+        if line.isupper() and len(line) > 3 and not any(ch.isdigit() for ch in line):
+            markdown_lines.append("# " + line.title())
+            continue
+
+        markdown_lines.append(line)
+
+    return "\n".join(markdown_lines)
+
+
+class WebFetchTool:
+    definition: ClassVar[ToolDefinition] = ToolDefinition(
+        name="web_fetch",
+        description="Fetch content from a URL. Supports text, markdown, and HTML formats.",
+        input_schema={
+            "url": {"type": "string", "description": "The URL to fetch content from"},
+            "format": {
+                "type": "string",
+                "enum": ["text", "markdown", "html"],
+                "description": "Output format: text, markdown, or html",
+            },
+            "timeout": {"type": "integer", "description": "Timeout in seconds (max 120)"},
+        },
+        read_only=True,
+    )
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        url_value = call.arguments.get("url")
+        if not isinstance(url_value, str):
+            raise ValueError("web_fetch requires a string url argument")
+
+        if not url_value.startswith("http://") and not url_value.startswith("https://"):
+            raise ValueError("web_fetch url must start with http:// or https://")
+
+        format_value = call.arguments.get("format", "markdown")
+        if not isinstance(format_value, str) or format_value not in ("text", "markdown", "html"):
+            raise ValueError("web_fetch format must be 'text', 'markdown', or 'html'")
+
+        timeout_value = call.arguments.get("timeout", DEFAULT_TIMEOUT)
+        if isinstance(timeout_value, (int, float)) and timeout_value > 0:
+            timeout = min(int(timeout_value), 120)
+        else:
+            timeout = DEFAULT_TIMEOUT
+
+        content: str = ""
+        data: bytes = b""
+        mime: str = ""
+
+        try:
+            # Build Accept header according to requested format to be friendlier for servers
+            accept_by_format = {
+                "markdown": (
+                    "text/markdown;q=1.0, text/x-markdown;q=0.9, "
+                    "text/plain;q=0.8, text/html;q=0.7, */*;q=0.1"
+                ),
+                "text": ("text/plain;q=1.0, text/markdown;q=0.9, text/html;q=0.8, */*;q=0.1"),
+                "html": (
+                    "text/html;q=1.0, application/xhtml+xml;q=0.9, "
+                    "text/plain;q=0.8, text/markdown;q=0.7, */*;q=0.1"
+                ),
+            }
+
+            accept_header = accept_by_format.get(format_value, "*/*")
+
+            # Use a more realistic User-Agent to avoid bot detection on some servers
+            ua = (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "VoidCode/1.0 Chrome/110.0.5481.100 Safari/537.36"
+            )
+
+            req = urllib.request.Request(
+                url_value,
+                headers={
+                    "User-Agent": ua,
+                    "Accept": accept_header,
+                },
+            )
+
+            with urllib.request.urlopen(req, timeout=timeout) as response:
+                content_type = response.headers.get("Content-Type", "")
+                content_length = response.headers.get("Content-Length")
+
+                if content_length and int(content_length) > MAX_RESPONSE_SIZE:
+                    raise ValueError(
+                        f"Response too large (exceeds {MAX_RESPONSE_SIZE // 1024 // 1024}MB limit)"
+                    )
+
+                data = response.read()
+
+                if len(data) > MAX_RESPONSE_SIZE:
+                    raise ValueError(
+                        f"Response too large (exceeds {MAX_RESPONSE_SIZE // 1024 // 1024}MB limit)"
+                    )
+
+                content = data.decode("utf-8", errors="replace")
+                mime = content_type.split(";")[0].strip().lower() if content_type else ""
+
+        except urllib.error.HTTPError as exc:
+            return ToolResult(
+                tool_name=self.definition.name,
+                status="error",
+                error=f"HTTP error {exc.code}: {exc.reason}",
+                data={"url": url_value, "status_code": exc.code},
+            )
+        except urllib.error.URLError as exc:
+            return ToolResult(
+                tool_name=self.definition.name,
+                status="error",
+                error=f"Failed to fetch URL: {exc.reason}",
+                data={"url": url_value},
+            )
+
+        # Normal post-fetch processing (outside of except blocks)
+        if format_value == "html":
+            output = content
+        elif format_value == "text" or "text/html" in mime:
+            output = _extract_text_from_html(content)
+        else:
+            if mime and mime.startswith("image/"):
+                # Image handling: return as base64 attachment instead of text output
+                b64 = base64.b64encode(data).decode("ascii")
+                data_uri = f"data:{mime};base64,{b64}"
+                return ToolResult(
+                    tool_name=self.definition.name,
+                    status="ok",
+                    content="",
+                    data={
+                        "url": url_value,
+                        "content_type": mime,
+                        "format": format_value,
+                        "byte_count": len(data),
+                        "attachment": {"mime": mime, "data_uri": data_uri},
+                    },
+                )
+            if "text/html" in mime:
+                output = _convert_html_to_markdown(content)
+            else:
+                output = content
+
+        return ToolResult(
+            tool_name=self.definition.name,
+            status="ok",
+            content=output,
+            data={
+                "url": url_value,
+                "content_type": mime,
+                "format": format_value,
+                "byte_count": len(data),
+            },
+        )

--- a/src/voidcode/tools/web_search.py
+++ b/src/voidcode/tools/web_search.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+import re
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import ClassVar
+
+from .contracts import ToolCall, ToolDefinition, ToolResult
+
+DEFAULT_NUM_RESULTS = 8
+DEFAULT_TIMEOUT = 30
+
+
+def _search_exa(query: str, num_results: int = DEFAULT_NUM_RESULTS) -> str | None:
+    try:
+        import os
+
+        api_key = os.environ.get("EXA_API_KEY")
+    except Exception:
+        api_key = None
+
+    if not api_key:
+        return None
+
+    try:
+        request_data: dict[str, object] = {
+            "q": query,
+            "numResults": num_results,
+            "type": "neural",
+        }
+
+        req = urllib.request.Request(
+            "https://api.exa.ai/search",
+            data=json.dumps(request_data).encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+            method="POST",
+        )
+
+        with urllib.request.urlopen(req, timeout=DEFAULT_TIMEOUT) as response:
+            data = json.loads(response.read().decode("utf-8"))
+
+            if "results" in data:
+                results = data["results"]
+                output_lines: list[str] = []
+
+                for i, result in enumerate(results[:num_results], 1):
+                    title = result.get("title", "Untitled")
+                    url = result.get("url", "")
+                    snippet = result.get("snippet", "")
+
+                    output_lines.append(f"{i}. {title}")
+                    output_lines.append(f"   {url}")
+                    if snippet:
+                        output_lines.append(f"   {snippet[:200]}...")
+                    output_lines.append("")
+
+                return "\n".join(output_lines)
+
+    except Exception:
+        pass
+
+    return None
+
+
+def _search_fallback(query: str, num_results: int = DEFAULT_NUM_RESULTS) -> str:
+    encoded_query = urllib.parse.quote(query)
+    url = f"https://html.duckduckgo.com/html/?q={encoded_query}&kl=wt-wt"
+
+    try:
+        req = urllib.request.Request(
+            url,
+            headers={
+                "User-Agent": "Mozilla/5.0 (compatible; VoidCode/1.0)",
+            },
+        )
+
+        with urllib.request.urlopen(req, timeout=DEFAULT_TIMEOUT) as response:
+            html = response.read().decode("utf-8", errors="replace")
+
+            results: list[tuple[str, str, str]] = []
+            pattern = r'<a class="result__a" href="([^"]+)"[^>]*>([^<]+)</a>'
+            snippet_pattern = r'<a class="result__snippet"[^>]*>([^<]+)</a>'
+
+            for match in re.finditer(pattern, html):
+                url_match = match.group(1)
+                title = match.group(2).strip()
+                snippet_match = re.search(
+                    snippet_pattern, html[match.start() : match.start() + 500]
+                )
+                snippet = snippet_match.group(1).strip() if snippet_match else ""
+
+                results.append((title, url_match, snippet))
+
+                if len(results) >= num_results:
+                    break
+
+            if results:
+                output_lines: list[str] = []
+                for i, (title, url, snippet) in enumerate(results, 1):
+                    output_lines.append(f"{i}. {title}")
+                    output_lines.append(f"   {url}")
+                    if snippet:
+                        clean_snippet = re.sub(r"<[^>]+>", "", snippet)
+                        output_lines.append(f"   {clean_snippet[:200]}...")
+                    output_lines.append("")
+                return "\n".join(output_lines)
+
+    except Exception:
+        pass
+
+    return "No search results found. Please try a different query."
+
+
+class WebSearchTool:
+    definition: ClassVar[ToolDefinition] = ToolDefinition(
+        name="web_search",
+        description="Search the web for information. Returns search results with titles, URLs, and snippets.",
+        input_schema={
+            "query": {"type": "string", "description": "The search query"},
+            "numResults": {
+                "type": "integer",
+                "description": "Number of results to return (default: 8)",
+            },
+        },
+        read_only=True,
+    )
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        query_value = call.arguments.get("query")
+        if not isinstance(query_value, str):
+            raise ValueError("web_search requires a string query argument")
+
+        if not query_value.strip():
+            raise ValueError("web_search query must not be empty")
+
+        num_results = call.arguments.get("numResults", DEFAULT_NUM_RESULTS)
+        if isinstance(num_results, (int, float)) and num_results > 0:
+            num_results = min(int(num_results), 20)
+        else:
+            num_results = DEFAULT_NUM_RESULTS
+
+        exa_results = _search_exa(query_value, num_results)
+
+        if exa_results:
+            output = exa_results
+            source = "exa"
+        else:
+            output = _search_fallback(query_value, num_results)
+            source = "duckduckgo"
+
+        return ToolResult(
+            tool_name=self.definition.name,
+            status="ok",
+            content=output,
+            data={
+                "query": query_value,
+                "num_results": num_results,
+                "source": source,
+            },
+        )

--- a/src/voidcode/tools/web_search.py
+++ b/src/voidcode/tools/web_search.py
@@ -154,7 +154,7 @@ class WebSearchTool:
             source = "exa"
         else:
             output = _search_fallback(query_value, num_results)
-        source = "duckduckgo"
+            source = "duckduckgo"
 
         return ToolResult(
             tool_name=self.definition.name,

--- a/src/voidcode/tools/web_search.py
+++ b/src/voidcode/tools/web_search.py
@@ -119,7 +119,10 @@ def _search_fallback(query: str, num_results: int = DEFAULT_NUM_RESULTS) -> str:
 class WebSearchTool:
     definition: ClassVar[ToolDefinition] = ToolDefinition(
         name="web_search",
-        description="Search the web for information. Returns search results with titles, URLs, and snippets.",
+        description=(
+            "Search the web for information. Returns search results "
+            "with titles, URLs, and snippets."
+        ),
         input_schema={
             "query": {"type": "string", "description": "The search query"},
             "numResults": {
@@ -151,7 +154,7 @@ class WebSearchTool:
             source = "exa"
         else:
             output = _search_fallback(query_value, num_results)
-            source = "duckduckgo"
+        source = "duckduckgo"
 
         return ToolResult(
             tool_name=self.definition.name,

--- a/src/voidcode/tools/write_file.py
+++ b/src/voidcode/tools/write_file.py
@@ -39,7 +39,7 @@ class WriteFileTool:
             status="ok",
             content=content_value,
             data={
-                "path": str(candidate.relative_to(workspace_root)),
+                "path": candidate.relative_to(workspace_root).as_posix(),
                 "byte_count": len(content_value.encode("utf-8")),
             },
         )

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -14,6 +14,10 @@ from unittest.mock import patch
 import pytest
 
 
+def _cwd_command() -> str:
+    return f'"{sys.executable}" -c "import os; print(os.getcwd())"'
+
+
 class SessionRefLike(Protocol):
     id: str
 
@@ -504,7 +508,8 @@ def test_transport_serializes_hook_events_from_runtime_stream(tmp_path: Path) ->
 
     class StubRuntime:
         def run_stream(self, request: RuntimeRequestLike) -> Iterator[StreamChunkLike]:
-            assert request.prompt == "run pwd"
+            command = _cwd_command()
+            assert request.prompt == f"run {command}"
             yield runtime_stream_chunk(
                 kind="event",
                 session=session,
@@ -545,11 +550,12 @@ def test_transport_serializes_hook_events_from_runtime_stream(tmp_path: Path) ->
             raise AssertionError(f"resume should not be called: {session_id}")
 
     app = create_runtime_app(workspace=tmp_path, runtime_factory=lambda: StubRuntime())
+    command = _cwd_command()
     response = _run_app(
         app,
         method="POST",
         path="/api/runtime/run/stream",
-        body=json.dumps({"prompt": "run pwd"}).encode("utf-8"),
+        body=json.dumps({"prompt": f"run {command}"}).encode("utf-8"),
     )
     payloads = _parse_sse_payloads(response)
 

--- a/tests/integration/test_lsp_tool_integration.py
+++ b/tests/integration/test_lsp_tool_integration.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import importlib
+import json
+import socket
+import threading
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+
+def _read_framed_json(conn: socket.socket) -> dict[str, object] | None:
+    header = b""
+    while b"\r\n\r\n" not in header:
+        chunk = conn.recv(1)
+        if not chunk:
+            return None
+        header += chunk
+
+    header_text = header.decode("ascii", errors="ignore")
+    content_length = None
+    for line in header_text.split("\r\n"):
+        if line.lower().startswith("content-length:"):
+            content_length = int(line.split(":", 1)[1].strip())
+            break
+    if content_length is None:
+        return None
+
+    payload = b""
+    remaining = content_length
+    while remaining > 0:
+        chunk = conn.recv(remaining)
+        if not chunk:
+            return None
+        payload += chunk
+        remaining -= len(chunk)
+
+    return json.loads(payload.decode("utf-8"))
+
+
+def _send_framed_json(conn: socket.socket, message: dict[str, object]) -> None:
+    body = json.dumps(message).encode("utf-8")
+    header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+    conn.sendall(header + body)
+
+
+def _run_handshake_server(
+    *,
+    host: str,
+    port: int,
+    stop_event: threading.Event,
+    received_methods: list[str],
+) -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server.bind((host, port))
+        server.listen(8)
+        server.settimeout(0.2)
+
+        initialized = False
+        while not stop_event.is_set():
+            try:
+                conn, _addr = server.accept()
+            except TimeoutError:
+                continue
+            except OSError:
+                break
+
+            with conn:
+                message = _read_framed_json(conn)
+                if message is None:
+                    continue
+
+                method = message.get("method")
+                req_id = message.get("id")
+                if isinstance(method, str):
+                    received_methods.append(method)
+
+                if method == "initialize":
+                    initialized = True
+                    _send_framed_json(
+                        conn,
+                        {
+                            "jsonrpc": "2.0",
+                            "id": req_id,
+                            "result": {"capabilities": {}},
+                        },
+                    )
+                    continue
+
+                if method == "initialized":
+                    # notification; no response
+                    continue
+
+                if not initialized:
+                    _send_framed_json(
+                        conn,
+                        {
+                            "jsonrpc": "2.0",
+                            "id": req_id,
+                            "error": {
+                                "code": -32002,
+                                "message": "Server not initialized",
+                            },
+                        },
+                    )
+                    continue
+
+                _send_framed_json(
+                    conn,
+                    {
+                        "jsonrpc": "2.0",
+                        "id": req_id,
+                        "result": {"ok": True, "method": method},
+                    },
+                )
+
+
+def _pick_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def test_lsp_tool_performs_initialize_handshake_before_request(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    file_path = tmp_path / "sample.py"
+    file_path.write_text("x = 1\n", encoding="utf-8")
+
+    host = "127.0.0.1"
+    port = _pick_tcp_port()
+    stop_event = threading.Event()
+    received_methods: list[str] = []
+    server = threading.Thread(
+        target=_run_handshake_server,
+        kwargs={
+            "host": host,
+            "port": port,
+            "stop_event": stop_event,
+            "received_methods": received_methods,
+        },
+        daemon=True,
+    )
+    server.start()
+
+    monkeypatch.setenv("VOIDCODE_LSP_HOST", host)
+    monkeypatch.setenv("VOIDCODE_LSP_PORT", str(port))
+
+    try:
+        lsp_module = importlib.import_module("voidcode.tools.lsp")
+        contracts_module = importlib.import_module("voidcode.tools.contracts")
+        tool = lsp_module.LspTool()
+
+        result = tool.invoke(
+            contracts_module.ToolCall(
+                tool_name="lsp",
+                arguments={
+                    "operation": "textDocument/definition",
+                    "filePath": "sample.py",
+                    "line": 1,
+                    "character": 1,
+                },
+            ),
+            workspace=tmp_path,
+        )
+
+        assert result.status == "ok"
+        response = result.data.get("lsp_response")
+        assert isinstance(response, dict)
+        response_dict = cast(dict[str, object], response)
+        assert response_dict.get("result") == {"ok": True, "method": "textDocument/definition"}
+        assert received_methods[:3] == [
+            "initialize",
+            "initialized",
+            "textDocument/definition",
+        ]
+    finally:
+        stop_event.set()
+        server.join(timeout=1)
+
+
+def test_lsp_call_hierarchy_incoming_uses_prepare_item_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    file_path = tmp_path / "sample.py"
+    file_path.write_text("def f():\n    pass\n", encoding="utf-8")
+
+    host = "127.0.0.1"
+    port = _pick_tcp_port()
+    stop_event = threading.Event()
+    received_methods: list[str] = []
+    server = threading.Thread(
+        target=_run_handshake_server,
+        kwargs={
+            "host": host,
+            "port": port,
+            "stop_event": stop_event,
+            "received_methods": received_methods,
+        },
+        daemon=True,
+    )
+    server.start()
+
+    monkeypatch.setenv("VOIDCODE_LSP_HOST", host)
+    monkeypatch.setenv("VOIDCODE_LSP_PORT", str(port))
+
+    try:
+        lsp_module = importlib.import_module("voidcode.tools.lsp")
+        contracts_module = importlib.import_module("voidcode.tools.contracts")
+        tool = lsp_module.LspTool()
+
+        # Monkeypatch send_request to assert incomingCalls gets {item: ...}
+        original_send = tool._send_request
+
+        def _wrapped_send(method: str, params: dict[str, object]) -> dict[str, object] | None:
+            if method == "textDocument/prepareCallHierarchy":
+                return {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": [
+                        {
+                            "name": "f",
+                            "kind": 12,
+                            "uri": file_path.resolve().as_uri(),
+                            "range": {
+                                "start": {"line": 0, "character": 0},
+                                "end": {"line": 0, "character": 5},
+                            },
+                            "selectionRange": {
+                                "start": {"line": 0, "character": 0},
+                                "end": {"line": 0, "character": 1},
+                            },
+                        }
+                    ],
+                }
+            if method == "callHierarchy/incomingCalls":
+                assert "item" in params
+                assert "textDocument" not in params
+                assert "position" not in params
+                return {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": [],
+                }
+            return original_send(method, params)
+
+        monkeypatch.setattr(tool, "_send_request", _wrapped_send)
+
+        result = tool.invoke(
+            contracts_module.ToolCall(
+                tool_name="lsp",
+                arguments={
+                    "operation": "callHierarchy/incomingCalls",
+                    "filePath": "sample.py",
+                    "line": 1,
+                    "character": 1,
+                },
+            ),
+            workspace=tmp_path,
+        )
+
+        assert result.status == "ok"
+    finally:
+        stop_event.set()
+        server.join(timeout=1)

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -21,6 +21,10 @@ from unittest.mock import patch
 import pytest
 
 
+def _cwd_command() -> str:
+    return f'"{sys.executable}" -c "import os; print(os.getcwd())"'
+
+
 class EventLike(Protocol):
     event_type: str
     payload: dict[str, object]
@@ -314,24 +318,27 @@ def test_runtime_allows_non_read_only_tool_when_policy_is_allow(tmp_path: Path) 
 def test_runtime_tool_request_created_supports_non_path_tool_arguments(tmp_path: Path) -> None:
     runtime_request, runtime = _approval_runtime(tmp_path, mode="allow")
 
-    result = runtime.run(runtime_request(prompt="run pwd", session_id="command-session"))
+    command = _cwd_command()
+    result = runtime.run(runtime_request(prompt=f"run {command}", session_id="command-session"))
 
     assert result.events[1].event_type == "runtime.skills_loaded"
     assert result.events[1].payload == {"skills": []}
     assert result.events[2].event_type == "graph.loop_step"
     assert result.events[3].event_type == "graph.model_turn"
     tool_request_event = result.events[4]
+    command = _cwd_command()
     assert tool_request_event.event_type == "graph.tool_request_created"
     assert tool_request_event.payload == {
         "tool": "shell_exec",
-        "arguments": {"command": "pwd"},
+        "arguments": {"command": command},
     }
 
 
 def test_runtime_allows_shell_exec_tool_when_policy_is_allow(tmp_path: Path) -> None:
     runtime_request, runtime = _approval_runtime(tmp_path, mode="allow")
 
-    allowed = runtime.run(runtime_request(prompt="run pwd", session_id="shell-allow-session"))
+    command = _cwd_command()
+    allowed = runtime.run(runtime_request(prompt=f"run {command}", session_id="shell-allow-session"))
 
     assert allowed.session.status == "completed"
     assert [event.event_type for event in allowed.events] == [
@@ -348,14 +355,15 @@ def test_runtime_allows_shell_exec_tool_when_policy_is_allow(tmp_path: Path) -> 
     ]
     assert allowed.events[6].payload["decision"] == "allow"
     assert allowed.output == f"{tmp_path.resolve()}\n"
-    assert allowed.events[7].payload["command"] == "pwd"
+    assert allowed.events[7].payload["command"] == command
     assert allowed.events[7].payload["exit_code"] == 0
 
 
 def test_runtime_requests_and_resumes_shell_exec_approval(tmp_path: Path) -> None:
     runtime_request, runtime = _approval_runtime(tmp_path, mode="ask")
 
-    waiting = runtime.run(runtime_request(prompt="run pwd", session_id="shell-approval-session"))
+    command = _cwd_command()
+    waiting = runtime.run(runtime_request(prompt=f"run {command}", session_id="shell-approval-session"))
 
     assert waiting.session.status == "waiting"
     assert [event.event_type for event in waiting.events] == [
@@ -368,7 +376,7 @@ def test_runtime_requests_and_resumes_shell_exec_approval(tmp_path: Path) -> Non
         "runtime.approval_requested",
     ]
     assert waiting.events[-1].payload["tool"] == "shell_exec"
-    assert waiting.events[-1].payload["arguments"] == {"command": "pwd"}
+    assert waiting.events[-1].payload["arguments"] == {"command": command}
     approval_request_id = cast(str, waiting.events[-1].payload["request_id"])
 
     resumed = runtime.resume(
@@ -392,14 +400,15 @@ def test_runtime_requests_and_resumes_shell_exec_approval(tmp_path: Path) -> Non
         "graph.response_ready",
     ]
     assert resumed.output == f"{tmp_path.resolve()}\n"
-    assert resumed.events[8].payload["command"] == "pwd"
+    assert resumed.events[8].payload["command"] == command
     assert resumed.events[8].payload["exit_code"] == 0
 
 
 def test_runtime_denies_shell_exec_tool_when_policy_is_deny(tmp_path: Path) -> None:
     runtime_request, runtime = _approval_runtime(tmp_path, mode="deny")
 
-    denied = runtime.run(runtime_request(prompt="run pwd", session_id="shell-deny-session"))
+    command = _cwd_command()
+    denied = runtime.run(runtime_request(prompt=f"run {command}", session_id="shell-deny-session"))
 
     assert denied.session.status == "failed"
     assert [event.event_type for event in denied.events] == [
@@ -443,7 +452,8 @@ def test_runtime_emits_pre_and_post_hook_events_around_successful_tool_run(tmp_p
         ),
     )
 
-    result = runtime.run(runtime_request(prompt="run pwd", session_id="hook-success-session"))
+    command = _cwd_command()
+    result = runtime.run(runtime_request(prompt=f"run {command}", session_id="hook-success-session"))
 
     assert [event.event_type for event in result.events] == [
         "runtime.request_received",
@@ -504,7 +514,8 @@ def test_runtime_aborts_tool_run_when_pre_hook_fails(tmp_path: Path) -> None:
         )
 
         with pytest.raises(RuntimeError, match="hook"):
-            _ = runtime.run(runtime_request(prompt="run pwd", session_id="hook-pre-fail-session"))
+            command = _cwd_command()
+            _ = runtime.run(runtime_request(prompt=f"run {command}", session_id="hook-pre-fail-session"))
 
     invoke_mock.assert_not_called()
 
@@ -594,9 +605,10 @@ def test_runtime_skips_hooks_for_nested_hook_launched_runtime_invocations(tmp_pa
         encoding="utf-8",
     )
 
+    command = _cwd_command()
     runtime = runtime_class(workspace=tmp_path)
     result = runtime.run(
-        runtime_request(prompt="run pwd", session_id="outer-hook-recursion-session")
+        runtime_request(prompt=f"run {command}", session_id="outer-hook-recursion-session")
     )
 
     assert marker_path.read_text(encoding="utf-8") == "1"

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -319,7 +319,8 @@ def test_runtime_tool_request_created_supports_non_path_tool_arguments(tmp_path:
     runtime_request, runtime = _approval_runtime(tmp_path, mode="allow")
 
     command = _cwd_command()
-    result = runtime.run(runtime_request(prompt=f"run {command}", session_id="command-session"))
+    prompt = f"run {command}"
+    result = runtime.run(runtime_request(prompt=prompt, session_id="command-session"))
 
     assert result.events[1].event_type == "runtime.skills_loaded"
     assert result.events[1].payload == {"skills": []}
@@ -338,7 +339,8 @@ def test_runtime_allows_shell_exec_tool_when_policy_is_allow(tmp_path: Path) -> 
     runtime_request, runtime = _approval_runtime(tmp_path, mode="allow")
 
     command = _cwd_command()
-    allowed = runtime.run(runtime_request(prompt=f"run {command}", session_id="shell-allow-session"))
+    prompt = f"run {command}"
+    allowed = runtime.run(runtime_request(prompt=prompt, session_id="shell-allow-session"))
 
     assert allowed.session.status == "completed"
     assert [event.event_type for event in allowed.events] == [
@@ -363,7 +365,8 @@ def test_runtime_requests_and_resumes_shell_exec_approval(tmp_path: Path) -> Non
     runtime_request, runtime = _approval_runtime(tmp_path, mode="ask")
 
     command = _cwd_command()
-    waiting = runtime.run(runtime_request(prompt=f"run {command}", session_id="shell-approval-session"))
+    prompt = f"run {command}"
+    waiting = runtime.run(runtime_request(prompt=prompt, session_id="shell-approval-session"))
 
     assert waiting.session.status == "waiting"
     assert [event.event_type for event in waiting.events] == [
@@ -408,7 +411,8 @@ def test_runtime_denies_shell_exec_tool_when_policy_is_deny(tmp_path: Path) -> N
     runtime_request, runtime = _approval_runtime(tmp_path, mode="deny")
 
     command = _cwd_command()
-    denied = runtime.run(runtime_request(prompt=f"run {command}", session_id="shell-deny-session"))
+    prompt = f"run {command}"
+    denied = runtime.run(runtime_request(prompt=prompt, session_id="shell-deny-session"))
 
     assert denied.session.status == "failed"
     assert [event.event_type for event in denied.events] == [
@@ -453,7 +457,8 @@ def test_runtime_emits_pre_and_post_hook_events_around_successful_tool_run(tmp_p
     )
 
     command = _cwd_command()
-    result = runtime.run(runtime_request(prompt=f"run {command}", session_id="hook-success-session"))
+    prompt = f"run {command}"
+    result = runtime.run(runtime_request(prompt=prompt, session_id="hook-success-session"))
 
     assert [event.event_type for event in result.events] == [
         "runtime.request_received",
@@ -515,7 +520,8 @@ def test_runtime_aborts_tool_run_when_pre_hook_fails(tmp_path: Path) -> None:
 
         with pytest.raises(RuntimeError, match="hook"):
             command = _cwd_command()
-            _ = runtime.run(runtime_request(prompt=f"run {command}", session_id="hook-pre-fail-session"))
+            prompt = f"run {command}"
+            _ = runtime.run(runtime_request(prompt=prompt, session_id="hook-pre-fail-session"))
 
     invoke_mock.assert_not_called()
 
@@ -606,10 +612,9 @@ def test_runtime_skips_hooks_for_nested_hook_launched_runtime_invocations(tmp_pa
     )
 
     command = _cwd_command()
+    prompt = f"run {command}"
     runtime = runtime_class(workspace=tmp_path)
-    result = runtime.run(
-        runtime_request(prompt=f"run {command}", session_id="outer-hook-recursion-session")
-    )
+    result = runtime.run(runtime_request(prompt=prompt, session_id="outer-hook-recursion-session"))
 
     assert marker_path.read_text(encoding="utf-8") == "1"
     assert "EVENT runtime.request_received" in nested_output_path.read_text(encoding="utf-8")

--- a/tests/integration/test_tool_workflows_integration.py
+++ b/tests/integration/test_tool_workflows_integration.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import urllib.error
+from pathlib import Path
+from types import TracebackType
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from voidcode.tools import (
+    ApplyPatchTool,
+    EditTool,
+    GlobTool,
+    ListTool,
+    MultiEditTool,
+    TodoWriteTool,
+    ToolCall,
+    WebFetchTool,
+)
+from voidcode.tools.code_search import CodeSearchTool
+from voidcode.tools.web_search import WebSearchTool
+
+
+def _run_git(args: list[str], *, cwd: Path) -> None:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(completed.stdout)
+
+
+def test_apply_patch_tool_applies_diff_in_real_git_workspace(tmp_path: Path) -> None:
+    _run_git(["init"], cwd=tmp_path)
+
+    target = tmp_path / "hello.txt"
+    target.write_text("hello old\n", encoding="utf-8")
+
+    patch = "\n".join(
+        [
+            "diff --git a/hello.txt b/hello.txt",
+            "index 0000000..1111111 100644",
+            "--- a/hello.txt",
+            "+++ b/hello.txt",
+            "@@ -1 +1 @@",
+            "-hello old",
+            "+hello new",
+            "",
+        ]
+    )
+
+    tool = ApplyPatchTool()
+    result = tool.invoke(
+        ToolCall(tool_name="apply_patch", arguments={"patch": patch}),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert target.read_text(encoding="utf-8") == "hello new\n"
+    assert result.data.get("count") == 0
+    assert result.content == "patch applied"
+    assert not (tmp_path / ".voidcode_apply_patch.patch").exists()
+
+
+def test_apply_patch_tool_cleans_temp_patch_file_on_failure(tmp_path: Path) -> None:
+    _run_git(["init"], cwd=tmp_path)
+    (tmp_path / "file.txt").write_text("content\n", encoding="utf-8")
+
+    tool = ApplyPatchTool()
+    with pytest.raises(ValueError):
+        tool.invoke(
+            ToolCall(tool_name="apply_patch", arguments={"patch": "not a patch"}),
+            workspace=tmp_path,
+        )
+
+    assert not (tmp_path / ".voidcode_apply_patch.patch").exists()
+
+
+def test_edit_tool_multiple_match_guard_and_replace_all(tmp_path: Path) -> None:
+    target = tmp_path / "edit.txt"
+    target.write_text("foo x foo\n", encoding="utf-8")
+
+    tool = EditTool()
+    with pytest.raises(ValueError, match="Multiple matches found"):
+        tool.invoke(
+            ToolCall(
+                tool_name="edit",
+                arguments={"path": "edit.txt", "oldString": "foo", "newString": "bar"},
+            ),
+            workspace=tmp_path,
+        )
+
+    assert target.read_text(encoding="utf-8") == "foo x foo\n"
+
+    result = tool.invoke(
+        ToolCall(
+            tool_name="edit",
+            arguments={
+                "path": "edit.txt",
+                "oldString": "foo",
+                "newString": "bar",
+                "replaceAll": True,
+            },
+        ),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert target.read_text(encoding="utf-8") == "bar x bar\n"
+    assert result.data.get("match_count") == 2
+
+
+def test_web_fetch_tool_blocks_localhost_integration(tmp_path: Path) -> None:
+    _ = tmp_path
+    tool = WebFetchTool()
+
+    with pytest.raises(ValueError, match="blocked"):
+        tool.invoke(
+            ToolCall(
+                tool_name="web_fetch",
+                arguments={"url": "http://127.0.0.1:8123", "format": "text"},
+            ),
+            workspace=Path("."),
+        )
+
+
+def test_multi_edit_tool_applies_ordered_edits_integration(tmp_path: Path) -> None:
+    target = tmp_path / "multi.txt"
+    target.write_text("a1\na2\na1\n", encoding="utf-8")
+
+    tool = MultiEditTool()
+    result = tool.invoke(
+        ToolCall(
+            tool_name="multi_edit",
+            arguments={
+                "path": "multi.txt",
+                "edits": [
+                    {"oldString": "a1", "newString": "A1", "replaceAll": True},
+                    {"oldString": "a2", "newString": "A2"},
+                ],
+            },
+        ),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert target.read_text(encoding="utf-8") == "A1\nA2\nA1\n"
+    assert result.data.get("applied") == 2
+
+
+def test_todo_write_tool_persists_summary_integration(tmp_path: Path) -> None:
+    tool = TodoWriteTool()
+    result = tool.invoke(
+        ToolCall(
+            tool_name="todo_write",
+            arguments={
+                "todos": [
+                    {"content": "task1", "status": "pending", "priority": "high"},
+                    {"content": "task2", "status": "in_progress", "priority": "medium"},
+                    {"content": "task3", "status": "completed", "priority": "low"},
+                ]
+            },
+        ),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    summary_raw = result.data.get("summary")
+    assert isinstance(summary_raw, dict)
+    summary = cast(dict[str, object], summary_raw)
+    assert summary.get("total") == 3
+    assert summary.get("pending") == 1
+    assert summary.get("in_progress") == 1
+    assert summary.get("completed") == 1
+    assert (tmp_path / ".voidcode" / "todos.json").exists()
+
+
+def test_glob_and_list_tools_handle_paths_and_ignores_integration(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.py").write_text("print('x')\n", encoding="utf-8")
+    (tmp_path / "build").mkdir()
+    (tmp_path / "build" / "generated.py").write_text("print('g')\n", encoding="utf-8")
+
+    glob_tool = GlobTool()
+    glob_result = glob_tool.invoke(
+        ToolCall(tool_name="glob", arguments={"pattern": "**/*.py"}),
+        workspace=tmp_path,
+    )
+    assert glob_result.content is not None
+
+    assert glob_result.status == "ok"
+    assert "src/main.py" in glob_result.content
+    assert "build/generated.py" not in glob_result.content
+
+    list_tool = ListTool()
+    list_result = list_tool.invoke(
+        ToolCall(tool_name="list", arguments={"ignore": ["build/**"]}),
+        workspace=tmp_path,
+    )
+    assert list_result.content is not None
+
+    assert list_result.status == "ok"
+    assert "src/" in list_result.content
+    assert "build/" not in list_result.content
+
+
+def test_web_search_tool_uses_fallback_when_no_exa_key_integration(tmp_path: Path) -> None:
+    _ = tmp_path
+    tool = WebSearchTool()
+
+    html = (
+        '<a class="result__a" href="https://example.com/a">Result A</a>'
+        '<a class="result__snippet">Snippet A</a>'
+    )
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: TracebackType | None,
+        ) -> bool:
+            return False
+
+        def read(self) -> bytes:
+            return html.encode("utf-8")
+
+    with patch("urllib.request.urlopen", return_value=_Resp()):
+        result = tool.invoke(
+            ToolCall(tool_name="web_search", arguments={"query": "voidcode tools"}),
+            workspace=Path("."),
+        )
+
+    assert result.status == "ok"
+    assert result.data.get("source") in {"duckduckgo", "exa"}
+    assert isinstance(result.content, str)
+
+
+def test_code_search_tool_fallback_on_network_error_integration(tmp_path: Path) -> None:
+    _ = tmp_path
+    tool = CodeSearchTool()
+
+    with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("offline")):
+        result = tool.invoke(
+            ToolCall(tool_name="code_search", arguments={"query": "python dataclass"}),
+            workspace=Path("."),
+        )
+
+    assert result.status == "ok"
+    assert result.data.get("source") == "duckduckgo_fallback"

--- a/tests/integration/test_tool_workflows_integration.py
+++ b/tests/integration/test_tool_workflows_integration.py
@@ -66,8 +66,9 @@ def test_apply_patch_tool_applies_diff_in_real_git_workspace(tmp_path: Path) -> 
 
     assert result.status == "ok"
     assert target.read_text(encoding="utf-8") == "hello new\n"
-    assert result.data.get("count") == 0
-    assert result.content == "patch applied"
+    assert result.data.get("count") == 1
+    assert result.data.get("changes") == [{"path": "hello.txt", "status": "M"}]
+    assert result.content == "M hello.txt"
     assert not (tmp_path / ".voidcode_apply_patch.patch").exists()
 
 

--- a/tests/unit/runtime/test_lsp.py
+++ b/tests/unit/runtime/test_lsp.py
@@ -61,3 +61,12 @@ def test_disabled_lsp_manager_reports_configured_servers_without_runtime_availab
     assert tuple(state.servers) == ("pyright",)
     assert state.servers["pyright"].configured is True
     assert state.servers["pyright"].available is False
+
+
+def test_lsp_operation_strings_match_protocol_method_names() -> None:
+    tool_module = import_module("voidcode.tools.lsp")
+    operation_enum = tool_module.LspOperation
+
+    assert operation_enum.PREPARE_CALL_HIERARCHY.value == "textDocument/prepareCallHierarchy"
+    assert operation_enum.INCOMING_CALLS.value == "callHierarchy/incomingCalls"
+    assert operation_enum.OUTGOING_CALLS.value == "callHierarchy/outgoingCalls"

--- a/tests/unit/runtime/test_tool_provider.py
+++ b/tests/unit/runtime/test_tool_provider.py
@@ -14,20 +14,20 @@ from voidcode.runtime.service import (
 )
 from voidcode.runtime.tool_provider import BuiltinToolProvider
 from voidcode.tools import (
+    CodeSearchTool,
     EditTool,
     GlobTool,
     GrepTool,
     ListTool,
+    MultiEditTool,
     ReadFileTool,
     ShellExecTool,
+    TodoWriteTool,
     ToolCall,
     WebFetchTool,
     WebSearchTool,
     WriteFileTool,
 )
-from voidcode.tools.code_search import CodeSearchTool
-from voidcode.tools.multi_edit import MultiEditTool
-from voidcode.tools.todo_write import TodoWriteTool
 
 
 @dataclass(slots=True)
@@ -154,3 +154,8 @@ def test_runtime_default_registry_behavior_remains_unchanged(tmp_path: Path) -> 
     assert response.events[3].payload == {"tool": "grep"}
     assert response.events[5].event_type == "runtime.tool_completed"
     assert response.events[5].payload["pattern"] == "alpha"
+
+
+def test_tools_package_exports_code_search_tool() -> None:
+    tools_module = __import__("voidcode.tools", fromlist=["__all__"])
+    assert "CodeSearchTool" in tools_module.__all__

--- a/tests/unit/runtime/test_tool_provider.py
+++ b/tests/unit/runtime/test_tool_provider.py
@@ -98,7 +98,7 @@ def test_tool_registry_accepts_tools_from_provider_output() -> None:
         assert registry.resolve(tool_name).definition.name == tool_name
 
     # Optional tools
-    optional_tools = {"apply_patch", "code_search", "lsp", "multi_edit", "todo_write"}
+    optional_tools = {"apply_patch", "code_search", "multi_edit", "todo_write"}
     for tool_name in optional_tools:
         if tool_name in registry.tools:
             assert registry.resolve(tool_name).definition.name == tool_name
@@ -135,7 +135,7 @@ def test_tool_registry_with_defaults_delegates_through_builtin_provider() -> Non
         assert registry.resolve(tool_name) is provided_tools[i]
 
     # Verify optional tools if present
-    optional_tools = ["apply_patch", "code_search", "lsp", "multi_edit", "todo_write"]
+    optional_tools = ["apply_patch", "code_search", "multi_edit", "todo_write"]
     for tool_name in optional_tools:
         if tool_name in registry.tools:
             assert registry.resolve(tool_name) is not None

--- a/tests/unit/runtime/test_tool_provider.py
+++ b/tests/unit/runtime/test_tool_provider.py
@@ -13,7 +13,21 @@ from voidcode.runtime.service import (
     VoidCodeRuntime,
 )
 from voidcode.runtime.tool_provider import BuiltinToolProvider
-from voidcode.tools import GrepTool, ReadFileTool, ShellExecTool, ToolCall, WriteFileTool
+from voidcode.tools import (
+    EditTool,
+    GlobTool,
+    GrepTool,
+    ListTool,
+    ReadFileTool,
+    ShellExecTool,
+    ToolCall,
+    WebFetchTool,
+    WebSearchTool,
+    WriteFileTool,
+)
+from voidcode.tools.code_search import CodeSearchTool
+from voidcode.tools.multi_edit import MultiEditTool
+from voidcode.tools.todo_write import TodoWriteTool
 
 
 @dataclass(slots=True)
@@ -44,22 +58,50 @@ class _StubGraph:
 def test_builtin_tool_provider_returns_expected_builtin_tools() -> None:
     tools = BuiltinToolProvider().provide_tools()
 
-    assert tuple(type(tool) for tool in tools) == (
+    expected_tools = (
+        EditTool,
+        GlobTool,
         GrepTool,
+        ListTool,
         ReadFileTool,
         ShellExecTool,
+        WebFetchTool,
+        WebSearchTool,
         WriteFileTool,
+        # Optional tools may be present
+        CodeSearchTool,
+        MultiEditTool,
+        TodoWriteTool,
     )
+
+    tool_types = tuple(type(tool) for tool in tools)
+    for expected in expected_tools:
+        assert expected in tool_types, f"Missing tool: {expected.__name__}"
 
 
 def test_tool_registry_accepts_tools_from_provider_output() -> None:
     registry = ToolRegistry.from_tools(BuiltinToolProvider().provide_tools())
 
-    assert tuple(registry.tools) == ("grep", "read_file", "shell_exec", "write_file")
-    assert registry.resolve("grep").definition.name == "grep"
-    assert registry.resolve("read_file").definition.name == "read_file"
-    assert registry.resolve("shell_exec").definition.name == "shell_exec"
-    assert registry.resolve("write_file").definition.name == "write_file"
+    core_tools = {
+        "edit",
+        "glob",
+        "grep",
+        "list",
+        "read_file",
+        "shell_exec",
+        "web_fetch",
+        "web_search",
+        "write_file",
+    }
+    for tool_name in core_tools:
+        assert tool_name in registry.tools, f"Missing core tool: {tool_name}"
+        assert registry.resolve(tool_name).definition.name == tool_name
+
+    # Optional tools
+    optional_tools = {"apply_patch", "code_search", "lsp", "multi_edit", "todo_write"}
+    for tool_name in optional_tools:
+        if tool_name in registry.tools:
+            assert registry.resolve(tool_name).definition.name == tool_name
 
 
 def test_tool_registry_with_defaults_delegates_through_builtin_provider() -> None:
@@ -76,11 +118,27 @@ def test_tool_registry_with_defaults_delegates_through_builtin_provider() -> Non
     provide_tools_mock.assert_called_once()
     provider = provide_tools_mock.call_args.args[0]
     assert isinstance(provider, BuiltinToolProvider)
-    assert tuple(registry.tools) == ("grep", "read_file", "shell_exec", "write_file")
-    assert registry.resolve("grep") is provided_tools[0]
-    assert registry.resolve("read_file") is provided_tools[1]
-    assert registry.resolve("shell_exec") is provided_tools[2]
-    assert registry.resolve("write_file") is provided_tools[3]
+
+    core_tools = [
+        "edit",
+        "glob",
+        "grep",
+        "list",
+        "read_file",
+        "shell_exec",
+        "web_fetch",
+        "web_search",
+        "write_file",
+    ]
+    for i, tool_name in enumerate(core_tools):
+        assert tool_name in registry.tools, f"Missing core tool: {tool_name}"
+        assert registry.resolve(tool_name) is provided_tools[i]
+
+    # Verify optional tools if present
+    optional_tools = ["apply_patch", "code_search", "lsp", "multi_edit", "todo_write"]
+    for tool_name in optional_tools:
+        if tool_name in registry.tools:
+            assert registry.resolve(tool_name) is not None
 
 
 def test_runtime_default_registry_behavior_remains_unchanged(tmp_path: Path) -> None:

--- a/tests/unit/test_apply_patch_tool.py
+++ b/tests/unit/test_apply_patch_tool.py
@@ -49,7 +49,9 @@ def test_apply_patch_updates_file_with_valid_patch(tmp_path: Path) -> None:
 
     assert target.read_text(encoding="utf-8").startswith("patched-1")
     assert result.status == "ok"
-    assert result.data["count"] >= 1
+    assert result.data["count"] == 1
+    assert result.data["changes"] == [{"path": "sample.txt", "status": "M"}]
+    assert result.content == "M sample.txt"
 
 
 def test_apply_patch_raises_on_invalid_patch(tmp_path: Path) -> None:
@@ -62,3 +64,111 @@ def test_apply_patch_raises_on_invalid_patch(tmp_path: Path) -> None:
             ToolCall(tool_name="apply_patch", arguments={"patch": "not a patch"}),
             workspace=tmp_path,
         )
+
+
+def test_apply_patch_reports_only_patch_touched_paths_in_dirty_worktree(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    target = tmp_path / "sample.txt"
+    untouched_dirty = tmp_path / "dirty.txt"
+    target.write_text("line-1\nline-2\n", encoding="utf-8")
+    untouched_dirty.write_text("before\n", encoding="utf-8")
+    _commit_all(tmp_path, "baseline")
+
+    untouched_dirty.write_text("after\n", encoding="utf-8")
+
+    old = target.read_text(encoding="utf-8").splitlines(keepends=True)
+    new = ["patched-1\n", "line-2\n"]
+    patch_text = "".join(
+        difflib.unified_diff(old, new, fromfile="a/sample.txt", tofile="b/sample.txt")
+    )
+
+    result = ApplyPatchTool().invoke(
+        ToolCall(tool_name="apply_patch", arguments={"patch": patch_text}),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert result.data["count"] == 1
+    assert result.data["changes"] == [{"path": "sample.txt", "status": "M"}]
+    assert result.content == "M sample.txt"
+
+
+def test_apply_patch_reports_pure_rename_from_patch_metadata(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    old_path = tmp_path / "old.txt"
+    old_path.write_text("hello\n", encoding="utf-8")
+    _commit_all(tmp_path, "baseline")
+
+    patch_text = "\n".join(
+        [
+            "diff --git a/old.txt b/new.txt",
+            "similarity index 100%",
+            "rename from old.txt",
+            "rename to new.txt",
+            "",
+        ]
+    )
+
+    result = ApplyPatchTool().invoke(
+        ToolCall(tool_name="apply_patch", arguments={"patch": patch_text}),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert not old_path.exists()
+    assert (tmp_path / "new.txt").read_text(encoding="utf-8") == "hello\n"
+    assert result.data["count"] == 1
+    assert result.data["changes"] == [{"path": "new.txt", "old_path": "old.txt", "status": "R"}]
+    assert result.content == "M old.txt -> new.txt"
+
+
+def test_apply_patch_reports_mode_only_change_from_patch_metadata(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    target = tmp_path / "script.sh"
+    target.write_text("#!/bin/sh\necho hi\n", encoding="utf-8")
+    _commit_all(tmp_path, "baseline")
+
+    patch_text = "\n".join(
+        [
+            "diff --git a/script.sh b/script.sh",
+            "old mode 100644",
+            "new mode 100755",
+            "",
+        ]
+    )
+
+    result = ApplyPatchTool().invoke(
+        ToolCall(tool_name="apply_patch", arguments={"patch": patch_text}),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert result.data["count"] == 1
+    assert result.data["changes"] == [{"path": "script.sh", "status": "M"}]
+    assert result.content == "M script.sh"
+
+
+def test_apply_patch_reports_mode_only_change_for_path_with_spaces(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    target = tmp_path / "space name.sh"
+    target.write_text("#!/bin/sh\necho hi\n", encoding="utf-8")
+    _commit_all(tmp_path, "baseline")
+
+    patch_text = "\n".join(
+        [
+            "diff --git a/space name.sh b/space name.sh",
+            "old mode 100644",
+            "new mode 100755",
+            "",
+        ]
+    )
+
+    result = ApplyPatchTool().invoke(
+        ToolCall(tool_name="apply_patch", arguments={"patch": patch_text}),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert result.data["count"] == 1
+    assert result.data["changes"] == [{"path": "space name.sh", "status": "M"}]
+    assert result.content == "M space name.sh"

--- a/tests/unit/test_apply_patch_tool.py
+++ b/tests/unit/test_apply_patch_tool.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import difflib
+from pathlib import Path
+
+import pytest
+
+from voidcode.tools import ApplyPatchTool, ToolCall
+
+
+def _init_git_repo(path: Path) -> None:
+    import subprocess
+
+    subprocess.run(["git", "init"], cwd=str(path), check=True, stdout=subprocess.PIPE)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=str(path), check=True)
+    subprocess.run(["git", "config", "user.name", "tester"], cwd=str(path), check=True)
+
+
+def _commit_all(path: Path, message: str) -> None:
+    import subprocess
+
+    subprocess.run(["git", "add", "."], cwd=str(path), check=True, stdout=subprocess.PIPE)
+    subprocess.run(
+        ["git", "commit", "-m", message],
+        cwd=str(path),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_apply_patch_updates_file_with_valid_patch(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    target = tmp_path / "sample.txt"
+    target.write_text("line-1\nline-2\n", encoding="utf-8")
+    _commit_all(tmp_path, "baseline")
+
+    old = target.read_text(encoding="utf-8").splitlines(keepends=True)
+    new = ["patched-1\n", "line-2\n"]
+    patch_text = "".join(
+        difflib.unified_diff(old, new, fromfile="a/sample.txt", tofile="b/sample.txt")
+    )
+
+    tool = ApplyPatchTool()
+    result = tool.invoke(
+        ToolCall(tool_name="apply_patch", arguments={"patch": patch_text}),
+        workspace=tmp_path,
+    )
+
+    assert target.read_text(encoding="utf-8").startswith("patched-1")
+    assert result.status == "ok"
+    assert result.data["count"] >= 1
+
+
+def test_apply_patch_raises_on_invalid_patch(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    (tmp_path / "sample.txt").write_text("line-1\n", encoding="utf-8")
+
+    tool = ApplyPatchTool()
+    with pytest.raises(ValueError):
+        tool.invoke(
+            ToolCall(tool_name="apply_patch", arguments={"patch": "not a patch"}),
+            workspace=tmp_path,
+        )

--- a/tests/unit/test_code_search_tool.py
+++ b/tests/unit/test_code_search_tool.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import urllib.error
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from voidcode.tools import ToolCall
+from voidcode.tools.code_search import CodeSearchTool
+
+
+class _Resp:
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self) -> bytes:
+        return self._text.encode("utf-8")
+
+
+def test_code_search_rejects_invalid_query_type() -> None:
+    tool = CodeSearchTool()
+    with pytest.raises(ValueError, match="string query"):
+        tool.invoke(
+            ToolCall(tool_name="code_search", arguments={"query": 123}), workspace=Path("/tmp")
+        )
+
+
+def test_code_search_uses_web_search_exa_and_parses_snippets() -> None:
+    tool = CodeSearchTool()
+    payload = {
+        "result": {
+            "content": [
+                {
+                    "type": "text",
+                    "text": "```python\nfrom dataclasses import dataclass\n```",
+                    "url": "https://example.com/a",
+                },
+                {
+                    "type": "text",
+                    "text": "```python\nfrom dataclasses import dataclass\n```",
+                    "url": "https://example.com/a",
+                },
+                {
+                    "type": "text",
+                    "text": "```python\n@dataclass(slots=True)\nclass A: pass\n```",
+                    "url": "https://example.com/b",
+                },
+            ]
+        }
+    }
+    response_text = f"data: {json.dumps(payload)}\n"
+
+    with patch("urllib.request.urlopen", return_value=_Resp(response_text)):
+        result = tool.invoke(
+            ToolCall(
+                tool_name="code_search",
+                arguments={"query": "python dataclass slots", "numResults": 3},
+            ),
+            workspace=Path("/tmp"),
+        )
+
+    assert result.status == "ok"
+    assert result.data["source"] == "exa_mcp_web_search_exa"
+    assert result.data["snippet_count"] == 2
+    assert len(result.data["sources"]) == 2
+
+
+def test_code_search_falls_back_when_no_snippets() -> None:
+    tool = CodeSearchTool()
+    empty_payload = {"result": {"content": []}}
+    response_text = f"data: {json.dumps(empty_payload)}\n"
+
+    with patch("urllib.request.urlopen", return_value=_Resp(response_text)):
+        result = tool.invoke(
+            ToolCall(tool_name="code_search", arguments={"query": "python context managers"}),
+            workspace=Path("/tmp"),
+        )
+
+    assert result.status == "ok"
+    assert result.data["source"] == "duckduckgo_fallback"
+    assert result.data["snippet_count"] == 0
+
+
+def test_code_search_handles_mcp_error_object() -> None:
+    tool = CodeSearchTool()
+    payload = {"error": {"message": "rate limit"}}
+    response_text = f"data: {json.dumps(payload)}\n"
+
+    with patch("urllib.request.urlopen", return_value=_Resp(response_text)):
+        with pytest.raises(ValueError, match="rate limit"):
+            tool.invoke(
+                ToolCall(tool_name="code_search", arguments={"query": "python asyncio"}),
+                workspace=Path("/tmp"),
+            )
+
+
+def test_code_search_fallback_on_url_error() -> None:
+    tool = CodeSearchTool()
+
+    with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("offline")):
+        result = tool.invoke(
+            ToolCall(tool_name="code_search", arguments={"query": "python dataclass"}),
+            workspace=Path("/tmp"),
+        )
+
+    assert result.status == "ok"
+    assert result.data["source"] == "duckduckgo_fallback"
+    assert "fallback_reason" in result.data

--- a/tests/unit/test_edit_tool.py
+++ b/tests/unit/test_edit_tool.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from voidcode.runtime.service import ToolRegistry
+from voidcode.tools import EditTool, ToolCall
+
+
+def test_edit_tool_replaces_exact_text(tmp_path: Path) -> None:
+    file_path = tmp_path / "test.txt"
+    file_path.write_text("hello world", encoding="utf-8")
+
+    tool = EditTool()
+
+    result = tool.invoke(
+        ToolCall(
+            tool_name="edit",
+            arguments={
+                "path": "test.txt",
+                "oldString": "world",
+                "newString": "voidcode",
+            },
+        ),
+        workspace=tmp_path,
+    )
+
+    assert result.tool_name == "edit"
+    assert result.status == "ok"
+    assert result.content == "Edit applied successfully."
+    assert file_path.read_text(encoding="utf-8") == "hello voidcode"
+    assert result.data["additions"] == 1
+    assert result.data["deletions"] == 1
+
+
+def test_edit_tool_replaces_all_occurrences(tmp_path: Path) -> None:
+    file_path = tmp_path / "test.txt"
+    file_path.write_text("foo bar foo baz foo", encoding="utf-8")
+
+    tool = EditTool()
+
+    result = tool.invoke(
+        ToolCall(
+            tool_name="edit",
+            arguments={
+                "path": "test.txt",
+                "oldString": "foo",
+                "newString": "qux",
+                "replaceAll": True,
+            },
+        ),
+        workspace=tmp_path,
+    )
+
+    assert file_path.read_text(encoding="utf-8") == "qux bar qux baz qux"
+    assert "3 occurrences replaced" in result.content
+
+
+def test_edit_tool_rejects_non_string_arguments(tmp_path: Path) -> None:
+    tool = EditTool()
+
+    with pytest.raises(ValueError, match="string path"):
+        tool.invoke(
+            ToolCall(tool_name="edit", arguments={"path": 123, "oldString": "a", "newString": "b"}),
+            workspace=tmp_path,
+        )
+
+    with pytest.raises(ValueError, match="string oldString"):
+        tool.invoke(
+            ToolCall(
+                tool_name="edit", arguments={"path": "f.txt", "oldString": 123, "newString": "b"}
+            ),
+            workspace=tmp_path,
+        )
+
+    with pytest.raises(ValueError, match="string newString"):
+        tool.invoke(
+            ToolCall(
+                tool_name="edit", arguments={"path": "f.txt", "oldString": "a", "newString": 123}
+            ),
+            workspace=tmp_path,
+        )
+
+
+def test_edit_tool_rejects_path_outside_workspace(tmp_path: Path) -> None:
+    tool = EditTool()
+
+    with pytest.raises(ValueError, match="inside the workspace"):
+        tool.invoke(
+            ToolCall(
+                tool_name="edit",
+                arguments={"path": "../escape.txt", "oldString": "a", "newString": "b"},
+            ),
+            workspace=tmp_path,
+        )
+
+
+def test_edit_tool_rejects_nonexistent_file(tmp_path: Path) -> None:
+    tool = EditTool()
+
+    with pytest.raises(ValueError, match="does not exist"):
+        tool.invoke(
+            ToolCall(
+                tool_name="edit",
+                arguments={"path": "missing.txt", "oldString": "a", "newString": "b"},
+            ),
+            workspace=tmp_path,
+        )
+
+
+def test_edit_tool_rejects_identical_old_and_new(tmp_path: Path) -> None:
+    file_path = tmp_path / "test.txt"
+    file_path.write_text("hello", encoding="utf-8")
+
+    tool = EditTool()
+
+    with pytest.raises(ValueError, match="identical"):
+        tool.invoke(
+            ToolCall(
+                tool_name="edit",
+                arguments={"path": "test.txt", "oldString": "hello", "newString": "hello"},
+            ),
+            workspace=tmp_path,
+        )
+
+
+def test_edit_tool_rejects_when_old_string_not_found(tmp_path: Path) -> None:
+    file_path = tmp_path / "test.txt"
+    file_path.write_text("hello", encoding="utf-8")
+
+    tool = EditTool()
+
+    with pytest.raises(ValueError, match="Could not find oldString"):
+        tool.invoke(
+            ToolCall(
+                tool_name="edit",
+                arguments={"path": "test.txt", "oldString": "missing", "newString": "b"},
+            ),
+            workspace=tmp_path,
+        )
+
+
+def test_edit_tool_preserves_line_endings(tmp_path: Path) -> None:
+    file_path = tmp_path / "test.txt"
+    file_path.write_bytes(b"line1\r\nline2\r\nline3")
+
+    tool = EditTool()
+
+    tool.invoke(
+        ToolCall(
+            tool_name="edit",
+            arguments={"path": "test.txt", "oldString": "line2", "newString": "modified"},
+        ),
+        workspace=tmp_path,
+    )
+
+    content = file_path.read_bytes()
+    assert content == b"line1\r\nmodified\r\nline3"
+
+
+def test_tools_package_and_default_registry_export_edit_tool() -> None:
+    registry = ToolRegistry.with_defaults()
+
+    assert "EditTool" in __import__("voidcode.tools", fromlist=["__all__"]).__all__
+    assert registry.resolve("edit").definition.name == "edit"
+    assert registry.resolve("edit").definition.read_only is False

--- a/tests/unit/test_edit_tool.py
+++ b/tests/unit/test_edit_tool.py
@@ -54,7 +54,28 @@ def test_edit_tool_replaces_all_occurrences(tmp_path: Path) -> None:
     )
 
     assert file_path.read_text(encoding="utf-8") == "qux bar qux baz qux"
+    assert result.content is not None
     assert "3 occurrences replaced" in result.content
+
+
+def test_edit_tool_rejects_multiple_exact_matches_without_replace_all(tmp_path: Path) -> None:
+    file_path = tmp_path / "test.txt"
+    file_path.write_text("foo bar foo", encoding="utf-8")
+
+    tool = EditTool()
+
+    with pytest.raises(ValueError, match="Multiple matches found"):
+        tool.invoke(
+            ToolCall(
+                tool_name="edit",
+                arguments={
+                    "path": "test.txt",
+                    "oldString": "foo",
+                    "newString": "qux",
+                },
+            ),
+            workspace=tmp_path,
+        )
 
 
 def test_edit_tool_rejects_non_string_arguments(tmp_path: Path) -> None:

--- a/tests/unit/test_glob_tool.py
+++ b/tests/unit/test_glob_tool.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from voidcode.runtime.service import ToolRegistry
+from voidcode.tools import GlobTool, ToolCall
+
+
+def test_glob_tool_finds_matching_files(tmp_path: Path) -> None:
+    (tmp_path / "test.py").write_text("print('test')", encoding="utf-8")
+    (tmp_path / "main.py").write_text("print('main')", encoding="utf-8")
+    (tmp_path / "README.md").write_text("# Readme", encoding="utf-8")
+    (tmp_path / "data.txt").write_text("data", encoding="utf-8")
+
+    tool = GlobTool()
+
+    result = tool.invoke(
+        ToolCall(tool_name="glob", arguments={"pattern": "*.py"}),
+        workspace=tmp_path,
+    )
+
+    assert result.tool_name == "glob"
+    assert result.status == "ok"
+    assert "test.py" in result.content
+    assert "main.py" in result.content
+    assert "README.md" not in result.content
+    assert "data.txt" not in result.content
+    assert result.data["pattern"] == "*.py"
+    assert result.data["count"] == 2
+
+
+def test_glob_tool_returns_no_files_when_none_match(tmp_path: Path) -> None:
+    (tmp_path / "test.py").write_text("print('test')", encoding="utf-8")
+
+    tool = GlobTool()
+
+    result = tool.invoke(
+        ToolCall(tool_name="glob", arguments={"pattern": "*.md"}),
+        workspace=tmp_path,
+    )
+
+    assert result.content == "No files found"
+    assert result.data["count"] == 0
+
+
+def test_glob_tool_rejects_empty_pattern(tmp_path: Path) -> None:
+    tool = GlobTool()
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        tool.invoke(
+            ToolCall(tool_name="glob", arguments={"pattern": ""}),
+            workspace=tmp_path,
+        )
+
+
+def test_glob_tool_rejects_non_string_pattern(tmp_path: Path) -> None:
+    tool = GlobTool()
+
+    with pytest.raises(ValueError, match="string pattern"):
+        tool.invoke(
+            ToolCall(tool_name="glob", arguments={"pattern": 123}),
+            workspace=tmp_path,
+        )
+
+
+def test_glob_tool_respects_path_argument(tmp_path: Path) -> None:
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    (tmp_path / "root.txt").write_text("root", encoding="utf-8")
+    (subdir / "nested.txt").write_text("nested", encoding="utf-8")
+
+    tool = GlobTool()
+
+    result = tool.invoke(
+        ToolCall(tool_name="glob", arguments={"pattern": "*.txt", "path": "subdir"}),
+        workspace=tmp_path,
+    )
+
+    assert "nested.txt" in result.content
+    assert "root.txt" not in result.content
+
+
+def test_glob_tool_rejects_path_outside_workspace(tmp_path: Path) -> None:
+    tool = GlobTool()
+
+    with pytest.raises(ValueError, match="inside the workspace"):
+        tool.invoke(
+            ToolCall(tool_name="glob", arguments={"pattern": "*.txt", "path": "../escape"}),
+            workspace=tmp_path,
+        )
+
+
+def test_glob_tool_ignores_common_directories(tmp_path: Path) -> None:
+    (tmp_path / "code.py").write_text("print('code')", encoding="utf-8")
+    node_modules = tmp_path / "node_modules"
+    node_modules.mkdir()
+    (node_modules / "dep.js").write_text("// dependency", encoding="utf-8")
+
+    tool = GlobTool()
+
+    result = tool.invoke(
+        ToolCall(tool_name="glob", arguments={"pattern": "**/*.js"}),
+        workspace=tmp_path,
+    )
+
+    assert "dep.js" not in result.content
+
+
+def test_tools_package_and_default_registry_export_glob_tool() -> None:
+    registry = ToolRegistry.with_defaults()
+
+    assert "GlobTool" in __import__("voidcode.tools", fromlist=["__all__"]).__all__
+    assert registry.resolve("glob").definition.name == "glob"
+    assert registry.resolve("glob").definition.read_only is True

--- a/tests/unit/test_list_tool.py
+++ b/tests/unit/test_list_tool.py
@@ -21,6 +21,7 @@ def test_list_tool_shows_files_and_directories(tmp_path: Path) -> None:
         ToolCall(tool_name="list", arguments={}),
         workspace=tmp_path,
     )
+    assert result.content is not None
 
     assert result.tool_name == "list"
     assert result.status == "ok"
@@ -42,6 +43,7 @@ def test_list_tool_defaults_to_root(tmp_path: Path) -> None:
         ToolCall(tool_name="list", arguments={}),
         workspace=tmp_path,
     )
+    assert result.content is not None
 
     assert "root.txt" in result.content
     assert "subdir/" in result.content
@@ -60,6 +62,7 @@ def test_list_tool_respects_path_argument(tmp_path: Path) -> None:
         ToolCall(tool_name="list", arguments={"path": "subdir"}),
         workspace=tmp_path,
     )
+    assert result.content is not None
 
     assert "nested.txt" in result.content
     assert "root.txt" not in result.content
@@ -110,6 +113,7 @@ def test_list_tool_ignores_common_directories(tmp_path: Path) -> None:
         ToolCall(tool_name="list", arguments={}),
         workspace=tmp_path,
     )
+    assert result.content is not None
 
     assert "code.py" in result.content
     assert "node_modules" not in result.content
@@ -122,3 +126,25 @@ def test_tools_package_and_default_registry_export_list_tool() -> None:
     assert "ListTool" in __import__("voidcode.tools", fromlist=["__all__"]).__all__
     assert registry.resolve("list").definition.name == "list"
     assert registry.resolve("list").definition.read_only is True
+
+
+def test_list_tool_glob_ignore_does_not_match_prefix_siblings(tmp_path: Path) -> None:
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+    (build_dir / "in_build.txt").write_text("x", encoding="utf-8")
+
+    build2_dir = tmp_path / "build2"
+    build2_dir.mkdir()
+    (build2_dir / "in_build2.txt").write_text("x", encoding="utf-8")
+
+    tool = ListTool()
+    result = tool.invoke(
+        ToolCall(tool_name="list", arguments={"ignore": ["build/**"]}),
+        workspace=tmp_path,
+    )
+    assert result.content is not None
+
+    assert "build/" not in result.content
+    assert "in_build.txt" not in result.content
+    assert "build2/" in result.content
+    assert "in_build2.txt" in result.content

--- a/tests/unit/test_list_tool.py
+++ b/tests/unit/test_list_tool.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from voidcode.runtime.service import ToolRegistry
+from voidcode.tools import ListTool, ToolCall
+
+
+def test_list_tool_shows_files_and_directories(tmp_path: Path) -> None:
+    (tmp_path / "file1.txt").write_text("content1", encoding="utf-8")
+    (tmp_path / "file2.txt").write_text("content2", encoding="utf-8")
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    (subdir / "nested.txt").write_text("nested", encoding="utf-8")
+
+    tool = ListTool()
+
+    result = tool.invoke(
+        ToolCall(tool_name="list", arguments={}),
+        workspace=tmp_path,
+    )
+
+    assert result.tool_name == "list"
+    assert result.status == "ok"
+    assert "file1.txt" in result.content
+    assert "file2.txt" in result.content
+    assert "subdir/" in result.content
+    assert "nested.txt" in result.content
+
+
+def test_list_tool_defaults_to_root(tmp_path: Path) -> None:
+    (tmp_path / "root.txt").write_text("root", encoding="utf-8")
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    (subdir / "nested.txt").write_text("nested", encoding="utf-8")
+
+    tool = ListTool()
+
+    result = tool.invoke(
+        ToolCall(tool_name="list", arguments={}),
+        workspace=tmp_path,
+    )
+
+    assert "root.txt" in result.content
+    assert "subdir/" in result.content
+    assert "nested.txt" in result.content
+
+
+def test_list_tool_respects_path_argument(tmp_path: Path) -> None:
+    (tmp_path / "root.txt").write_text("root", encoding="utf-8")
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    (subdir / "nested.txt").write_text("nested", encoding="utf-8")
+
+    tool = ListTool()
+
+    result = tool.invoke(
+        ToolCall(tool_name="list", arguments={"path": "subdir"}),
+        workspace=tmp_path,
+    )
+
+    assert "nested.txt" in result.content
+    assert "root.txt" not in result.content
+
+
+def test_list_tool_rejects_path_outside_workspace(tmp_path: Path) -> None:
+    tool = ListTool()
+
+    with pytest.raises(ValueError, match="inside the workspace"):
+        tool.invoke(
+            ToolCall(tool_name="list", arguments={"path": "../escape"}),
+            workspace=tmp_path,
+        )
+
+
+def test_list_tool_rejects_nonexistent_path(tmp_path: Path) -> None:
+    tool = ListTool()
+
+    with pytest.raises(ValueError, match="does not exist"):
+        tool.invoke(
+            ToolCall(tool_name="list", arguments={"path": "missing"}),
+            workspace=tmp_path,
+        )
+
+
+def test_list_tool_rejects_non_directory_path(tmp_path: Path) -> None:
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("content", encoding="utf-8")
+
+    tool = ListTool()
+
+    with pytest.raises(ValueError, match="not a directory"):
+        tool.invoke(
+            ToolCall(tool_name="list", arguments={"path": "file.txt"}),
+            workspace=tmp_path,
+        )
+
+
+def test_list_tool_ignores_common_directories(tmp_path: Path) -> None:
+    (tmp_path / "code.py").write_text("print('code')", encoding="utf-8")
+    node_modules = tmp_path / "node_modules"
+    node_modules.mkdir()
+    (node_modules / "dep.js").write_text("// dependency", encoding="utf-8")
+
+    tool = ListTool()
+
+    result = tool.invoke(
+        ToolCall(tool_name="list", arguments={}),
+        workspace=tmp_path,
+    )
+
+    assert "code.py" in result.content
+    assert "node_modules" not in result.content
+    assert "dep.js" not in result.content
+
+
+def test_tools_package_and_default_registry_export_list_tool() -> None:
+    registry = ToolRegistry.with_defaults()
+
+    assert "ListTool" in __import__("voidcode.tools", fromlist=["__all__"]).__all__
+    assert registry.resolve("list").definition.name == "list"
+    assert registry.resolve("list").definition.read_only is True

--- a/tests/unit/test_multi_edit_tool.py
+++ b/tests/unit/test_multi_edit_tool.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from voidcode.tools import MultiEditTool, ToolCall
+
+
+def test_multi_edit_applies_multiple_edits_in_order(tmp_path: Path) -> None:
+    target = tmp_path / "sample.txt"
+    target.write_text("alpha\nbeta\nalpha\n", encoding="utf-8")
+
+    tool = MultiEditTool()
+    result = tool.invoke(
+        ToolCall(
+            tool_name="multi_edit",
+            arguments={
+                "path": "sample.txt",
+                "edits": [
+                    {"oldString": "alpha", "newString": "ALPHA", "replaceAll": True},
+                    {"oldString": "beta", "newString": "BETA"},
+                ],
+            },
+        ),
+        workspace=tmp_path,
+    )
+
+    content = target.read_text(encoding="utf-8")
+    assert "ALPHA" in content
+    assert "BETA" in content
+    assert result.status == "ok"
+    assert result.data["applied"] == 2
+
+
+def test_multi_edit_rejects_missing_path(tmp_path: Path) -> None:
+    tool = MultiEditTool()
+
+    with pytest.raises(ValueError, match="string path"):
+        tool.invoke(
+            ToolCall(tool_name="multi_edit", arguments={"edits": []}),
+            workspace=tmp_path,
+        )
+
+
+def test_multi_edit_rejects_non_list_edits(tmp_path: Path) -> None:
+    target = tmp_path / "sample.txt"
+    target.write_text("alpha\n", encoding="utf-8")
+    tool = MultiEditTool()
+
+    with pytest.raises(ValueError, match="array edits"):
+        tool.invoke(
+            ToolCall(
+                tool_name="multi_edit",
+                arguments={"path": "sample.txt", "edits": "bad"},
+            ),
+            workspace=tmp_path,
+        )
+
+
+def test_multi_edit_rejects_empty_edits(tmp_path: Path) -> None:
+    target = tmp_path / "sample.txt"
+    target.write_text("alpha\n", encoding="utf-8")
+    tool = MultiEditTool()
+
+    with pytest.raises(ValueError, match="at least one edit"):
+        tool.invoke(
+            ToolCall(
+                tool_name="multi_edit",
+                arguments={"path": "sample.txt", "edits": []},
+            ),
+            workspace=tmp_path,
+        )

--- a/tests/unit/test_todo_write_tool.py
+++ b/tests/unit/test_todo_write_tool.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from voidcode.tools import TodoWriteTool, ToolCall
+
+
+def test_todo_write_persists_todos_json(tmp_path: Path) -> None:
+    tool = TodoWriteTool()
+    result = tool.invoke(
+        ToolCall(
+            tool_name="todo_write",
+            arguments={
+                "todos": [
+                    {"content": "  task-a  ", "status": "pending", "priority": "high"},
+                    {"content": "task-b", "status": "completed", "priority": "low"},
+                ]
+            },
+        ),
+        workspace=tmp_path,
+    )
+
+    store = tmp_path / ".voidcode" / "todos.json"
+    assert store.exists()
+    payload = json.loads(store.read_text(encoding="utf-8"))
+    assert payload[0]["content"] == "task-a"
+    assert payload[1]["status"] == "completed"
+    assert result.status == "ok"
+    assert result.data["summary"]["total"] == 2
+
+
+def test_todo_write_rejects_invalid_status(tmp_path: Path) -> None:
+    tool = TodoWriteTool()
+
+    with pytest.raises(ValueError, match="invalid status"):
+        tool.invoke(
+            ToolCall(
+                tool_name="todo_write",
+                arguments={"todos": [{"content": "a", "status": "bad", "priority": "high"}]},
+            ),
+            workspace=tmp_path,
+        )
+
+
+def test_todo_write_rejects_invalid_priority(tmp_path: Path) -> None:
+    tool = TodoWriteTool()
+
+    with pytest.raises(ValueError, match="invalid priority"):
+        tool.invoke(
+            ToolCall(
+                tool_name="todo_write",
+                arguments={"todos": [{"content": "a", "status": "pending", "priority": "urgent"}]},
+            ),
+            workspace=tmp_path,
+        )

--- a/tests/unit/test_webfetch_tool.py
+++ b/tests/unit/test_webfetch_tool.py
@@ -35,7 +35,7 @@ class _StubResponse:
         return False
 
     def read(self, size: int = -1) -> bytes:
-        if size is None or size < 0:
+        if size < 0:
             data = self._content
             self._content = b""
             return data

--- a/tests/unit/test_webfetch_tool.py
+++ b/tests/unit/test_webfetch_tool.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from voidcode.runtime.service import ToolRegistry
+from voidcode.tools import ToolCall, WebFetchTool
+
+
+def test_webfetch_tool_rejects_invalid_url() -> None:
+    tool = WebFetchTool()
+
+    with pytest.raises(ValueError, match="http:// or https://"):
+        tool.invoke(
+            ToolCall(tool_name="web_fetch", arguments={"url": "ftp://example.com"}),
+            workspace=Path("/tmp"),
+        )
+
+
+def test_webfetch_tool_rejects_non_string_url() -> None:
+    tool = WebFetchTool()
+
+    with pytest.raises(ValueError, match="string url"):
+        tool.invoke(
+            ToolCall(tool_name="web_fetch", arguments={"url": 123}),
+            workspace=Path("/tmp"),
+        )
+
+
+def test_webfetch_tool_rejects_invalid_format() -> None:
+    tool = WebFetchTool()
+
+    with pytest.raises(ValueError, match="'text', 'markdown', or 'html'"):
+        tool.invoke(
+            ToolCall(
+                tool_name="web_fetch", arguments={"url": "https://example.com", "format": "invalid"}
+            ),
+            workspace=Path("/tmp"),
+        )
+
+
+def test_tools_package_and_default_registry_export_webfetch_tool() -> None:
+    registry = ToolRegistry.with_defaults()
+
+    assert "WebFetchTool" in __import__("voidcode.tools", fromlist=["__all__"]).__all__
+    assert registry.resolve("web_fetch").definition.name == "web_fetch"
+    assert registry.resolve("web_fetch").definition.read_only is True

--- a/tests/unit/test_webfetch_tool.py
+++ b/tests/unit/test_webfetch_tool.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import TracebackType
+from typing import cast
 from unittest.mock import patch
 
 import pytest
@@ -10,18 +12,39 @@ from voidcode.tools import ToolCall, WebFetchTool
 
 
 class _StubResponse:
-    def __init__(self, *, content: bytes, content_type: str = "text/html; charset=utf-8") -> None:
+    def __init__(
+        self,
+        *,
+        content: bytes,
+        content_type: str = "text/html; charset=utf-8",
+        final_url: str = "https://example.com",
+    ) -> None:
         self._content = content
         self.headers = {"Content-Type": content_type, "Content-Length": str(len(content))}
+        self._final_url = final_url
 
-    def __enter__(self):
+    def __enter__(self) -> _StubResponse:
         return self
 
-    def __exit__(self, exc_type, exc, tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool:
         return False
 
-    def read(self) -> bytes:
-        return self._content
+    def read(self, size: int = -1) -> bytes:
+        if size is None or size < 0:
+            data = self._content
+            self._content = b""
+            return data
+        data = self._content[:size]
+        self._content = self._content[size:]
+        return data
+
+    def geturl(self) -> str:
+        return self._final_url
 
 
 class _BadLengthResponse(_StubResponse):
@@ -73,7 +96,7 @@ def test_tools_package_and_default_registry_export_webfetch_tool() -> None:
 def test_webfetch_markdown_uses_markdown_conversion_for_html() -> None:
     tool = WebFetchTool()
     html = b"<html><body><h1>TITLE</h1><p>Hello</p></body></html>"
-    with patch("urllib.request.urlopen", return_value=_StubResponse(content=html)):
+    with patch("urllib.request.OpenerDirector.open", return_value=_StubResponse(content=html)):
         result = tool.invoke(
             ToolCall(
                 tool_name="web_fetch",
@@ -90,7 +113,7 @@ def test_webfetch_markdown_uses_markdown_conversion_for_html() -> None:
 def test_webfetch_tolerates_malformed_html() -> None:
     tool = WebFetchTool()
     malformed = b"<html><body>Hello <broken"
-    with patch("urllib.request.urlopen", return_value=_StubResponse(content=malformed)):
+    with patch("urllib.request.OpenerDirector.open", return_value=_StubResponse(content=malformed)):
         result = tool.invoke(
             ToolCall(
                 tool_name="web_fetch", arguments={"url": "https://example.com", "format": "text"}
@@ -107,7 +130,7 @@ def test_webfetch_returns_attachment_for_image() -> None:
     tool = WebFetchTool()
     image_bytes = b"\x89PNG\r\n\x1a\n" + b"fakepngdata"
     with patch(
-        "urllib.request.urlopen",
+        "urllib.request.OpenerDirector.open",
         return_value=_StubResponse(content=image_bytes, content_type="image/png"),
     ):
         result = tool.invoke(
@@ -119,8 +142,9 @@ def test_webfetch_returns_attachment_for_image() -> None:
         )
 
     assert result.status == "ok"
-    attachment = result.data.get("attachment")
-    assert isinstance(attachment, dict)
+    attachment_raw = result.data.get("attachment")
+    assert isinstance(attachment_raw, dict)
+    attachment = cast(dict[str, object], attachment_raw)
     assert attachment.get("mime") == "image/png"
     data_uri = attachment.get("data_uri")
     assert isinstance(data_uri, str)
@@ -142,7 +166,7 @@ def test_webfetch_rejects_localhost_targets() -> None:
 def test_webfetch_tolerates_invalid_content_length_header() -> None:
     tool = WebFetchTool()
     html = b"<html><body>ok</body></html>"
-    with patch("urllib.request.urlopen", return_value=_BadLengthResponse(content=html)):
+    with patch("urllib.request.OpenerDirector.open", return_value=_BadLengthResponse(content=html)):
         result = tool.invoke(
             ToolCall(
                 tool_name="web_fetch",
@@ -153,3 +177,20 @@ def test_webfetch_tolerates_invalid_content_length_header() -> None:
 
     assert result.status == "ok"
     assert isinstance(result.content, str)
+
+
+def test_webfetch_rejects_redirect_to_localhost() -> None:
+    tool = WebFetchTool()
+
+    with patch(
+        "urllib.request.OpenerDirector.open",
+        return_value=_StubResponse(content=b"ok", final_url="http://127.0.0.1:8080/internal"),
+    ):
+        with pytest.raises(ValueError, match="blocked"):
+            tool.invoke(
+                ToolCall(
+                    tool_name="web_fetch",
+                    arguments={"url": "https://example.com", "format": "text"},
+                ),
+                workspace=Path("/tmp"),
+            )

--- a/tests/unit/test_webfetch_tool.py
+++ b/tests/unit/test_webfetch_tool.py
@@ -24,6 +24,12 @@ class _StubResponse:
         return self._content
 
 
+class _BadLengthResponse(_StubResponse):
+    def __init__(self, *, content: bytes, content_type: str = "text/html") -> None:
+        super().__init__(content=content, content_type=content_type)
+        self.headers = {"Content-Type": content_type, "Content-Length": "abc"}
+
+
 def test_webfetch_tool_rejects_invalid_url() -> None:
     tool = WebFetchTool()
 
@@ -119,3 +125,31 @@ def test_webfetch_returns_attachment_for_image() -> None:
     data_uri = attachment.get("data_uri")
     assert isinstance(data_uri, str)
     assert data_uri.startswith("data:image/png;base64,")
+
+
+def test_webfetch_rejects_localhost_targets() -> None:
+    tool = WebFetchTool()
+    with pytest.raises(ValueError, match="blocked"):
+        tool.invoke(
+            ToolCall(
+                tool_name="web_fetch",
+                arguments={"url": "http://127.0.0.1:8080", "format": "text"},
+            ),
+            workspace=Path("/tmp"),
+        )
+
+
+def test_webfetch_tolerates_invalid_content_length_header() -> None:
+    tool = WebFetchTool()
+    html = b"<html><body>ok</body></html>"
+    with patch("urllib.request.urlopen", return_value=_BadLengthResponse(content=html)):
+        result = tool.invoke(
+            ToolCall(
+                tool_name="web_fetch",
+                arguments={"url": "https://example.com", "format": "markdown"},
+            ),
+            workspace=Path("/tmp"),
+        )
+
+    assert result.status == "ok"
+    assert isinstance(result.content, str)

--- a/tests/unit/test_webfetch_tool.py
+++ b/tests/unit/test_webfetch_tool.py
@@ -1,11 +1,27 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from voidcode.runtime.service import ToolRegistry
 from voidcode.tools import ToolCall, WebFetchTool
+
+
+class _StubResponse:
+    def __init__(self, *, content: bytes, content_type: str = "text/html; charset=utf-8") -> None:
+        self._content = content
+        self.headers = {"Content-Type": content_type, "Content-Length": str(len(content))}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self) -> bytes:
+        return self._content
 
 
 def test_webfetch_tool_rejects_invalid_url() -> None:
@@ -46,3 +62,60 @@ def test_tools_package_and_default_registry_export_webfetch_tool() -> None:
     assert "WebFetchTool" in __import__("voidcode.tools", fromlist=["__all__"]).__all__
     assert registry.resolve("web_fetch").definition.name == "web_fetch"
     assert registry.resolve("web_fetch").definition.read_only is True
+
+
+def test_webfetch_markdown_uses_markdown_conversion_for_html() -> None:
+    tool = WebFetchTool()
+    html = b"<html><body><h1>TITLE</h1><p>Hello</p></body></html>"
+    with patch("urllib.request.urlopen", return_value=_StubResponse(content=html)):
+        result = tool.invoke(
+            ToolCall(
+                tool_name="web_fetch",
+                arguments={"url": "https://example.com", "format": "markdown"},
+            ),
+            workspace=Path("/tmp"),
+        )
+
+    assert result.status == "ok"
+    assert result.content is not None
+    assert "# Title" in result.content or "TITLE" in result.content
+
+
+def test_webfetch_tolerates_malformed_html() -> None:
+    tool = WebFetchTool()
+    malformed = b"<html><body>Hello <broken"
+    with patch("urllib.request.urlopen", return_value=_StubResponse(content=malformed)):
+        result = tool.invoke(
+            ToolCall(
+                tool_name="web_fetch", arguments={"url": "https://example.com", "format": "text"}
+            ),
+            workspace=Path("/tmp"),
+        )
+
+    assert result.status == "ok"
+    assert isinstance(result.content, str)
+    assert "Hello" in result.content
+
+
+def test_webfetch_returns_attachment_for_image() -> None:
+    tool = WebFetchTool()
+    image_bytes = b"\x89PNG\r\n\x1a\n" + b"fakepngdata"
+    with patch(
+        "urllib.request.urlopen",
+        return_value=_StubResponse(content=image_bytes, content_type="image/png"),
+    ):
+        result = tool.invoke(
+            ToolCall(
+                tool_name="web_fetch",
+                arguments={"url": "https://example.com/image.png", "format": "markdown"},
+            ),
+            workspace=Path("/tmp"),
+        )
+
+    assert result.status == "ok"
+    attachment = result.data.get("attachment")
+    assert isinstance(attachment, dict)
+    assert attachment.get("mime") == "image/png"
+    data_uri = attachment.get("data_uri")
+    assert isinstance(data_uri, str)
+    assert data_uri.startswith("data:image/png;base64,")

--- a/tests/unit/test_websearch_tool.py
+++ b/tests/unit/test_websearch_tool.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from voidcode.runtime.service import ToolRegistry
+from voidcode.tools import ToolCall, WebSearchTool
+
+
+def test_websearch_tool_rejects_empty_query() -> None:
+    tool = WebSearchTool()
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        tool.invoke(
+            ToolCall(tool_name="web_search", arguments={"query": "   "}),
+            workspace=Path("/tmp"),
+        )
+
+
+def test_websearch_tool_rejects_non_string_query() -> None:
+    tool = WebSearchTool()
+
+    with pytest.raises(ValueError, match="string query"):
+        tool.invoke(
+            ToolCall(tool_name="web_search", arguments={"query": 123}),
+            workspace=Path("/tmp"),
+        )
+
+
+def test_websearch_tool_respects_num_results_limit() -> None:
+    tool = WebSearchTool()
+
+    result = tool.invoke(
+        ToolCall(tool_name="web_search", arguments={"query": "test", "numResults": 5}),
+        workspace=Path("/tmp"),
+    )
+
+    assert result.data["num_results"] == 5
+
+
+def test_websearch_tool_defaults_to_8_results() -> None:
+    tool = WebSearchTool()
+
+    result = tool.invoke(
+        ToolCall(tool_name="web_search", arguments={"query": "test"}),
+        workspace=Path("/tmp"),
+    )
+
+    assert result.data["num_results"] == 8
+
+
+def test_tools_package_and_default_registry_export_websearch_tool() -> None:
+    registry = ToolRegistry.with_defaults()
+
+    assert "WebSearchTool" in __import__("voidcode.tools", fromlist=["__all__"]).__all__
+    assert registry.resolve("web_search").definition.name == "web_search"
+    assert registry.resolve("web_search").definition.read_only is True

--- a/tests/unit/test_websearch_tool.py
+++ b/tests/unit/test_websearch_tool.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -31,10 +33,25 @@ def test_websearch_tool_rejects_non_string_query() -> None:
 def test_websearch_tool_respects_num_results_limit() -> None:
     tool = WebSearchTool()
 
-    result = tool.invoke(
-        ToolCall(tool_name="web_search", arguments={"query": "test", "numResults": 5}),
-        workspace=Path("/tmp"),
-    )
+    fake_response = {
+        "results": [{"title": "Example", "url": "https://example.com", "snippet": "snippet"}]
+    }
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(fake_response).encode("utf-8")
+
+    with patch("urllib.request.urlopen", return_value=_Resp()):
+        result = tool.invoke(
+            ToolCall(tool_name="web_search", arguments={"query": "test", "numResults": 5}),
+            workspace=Path("/tmp"),
+        )
 
     assert result.data["num_results"] == 5
 
@@ -42,10 +59,25 @@ def test_websearch_tool_respects_num_results_limit() -> None:
 def test_websearch_tool_defaults_to_8_results() -> None:
     tool = WebSearchTool()
 
-    result = tool.invoke(
-        ToolCall(tool_name="web_search", arguments={"query": "test"}),
-        workspace=Path("/tmp"),
-    )
+    fake_response = {
+        "results": [{"title": "Example", "url": "https://example.com", "snippet": "snippet"}]
+    }
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(fake_response).encode("utf-8")
+
+    with patch("urllib.request.urlopen", return_value=_Resp()):
+        result = tool.invoke(
+            ToolCall(tool_name="web_search", arguments={"query": "test"}),
+            workspace=Path("/tmp"),
+        )
 
     assert result.data["num_results"] == 8
 

--- a/tests/unit/tools/test_shell_exec_tool.py
+++ b/tests/unit/tools/test_shell_exec_tool.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest

--- a/tests/unit/tools/test_shell_exec_tool.py
+++ b/tests/unit/tools/test_shell_exec_tool.py
@@ -25,12 +25,12 @@ def test_shell_exec_tool_runs_command_in_workspace(tmp_path: Path) -> None:
     assert result.tool_name == "shell_exec"
     assert result.status == "ok"
     assert result.content == f"{tmp_path.resolve()}\n"
-    assert result.data == {
-        "command": command,
-        "exit_code": 0,
-        "stdout": f"{tmp_path.resolve()}\n",
-        "stderr": "",
-    }
+    assert result.data.get("command") == command
+    assert result.data.get("exit_code") == 0
+    assert result.data.get("stdout") == f"{tmp_path.resolve()}\n"
+    assert result.data.get("stderr") == ""
+    assert result.data.get("timeout") == 30
+    assert result.data.get("truncated") is False
 
 
 def test_shell_exec_tool_rejects_invalid_command_arguments(tmp_path: Path) -> None:
@@ -55,3 +55,34 @@ def test_tools_package_and_default_registry_export_shell_exec_tool() -> None:
     assert "ShellExecTool" in __import__("voidcode.tools", fromlist=["__all__"]).__all__
     assert registry.resolve("shell_exec").definition.name == "shell_exec"
     assert registry.resolve("shell_exec").definition.read_only is False
+
+
+def test_shell_exec_tool_respects_timeout(tmp_path: Path) -> None:
+    tool = ShellExecTool()
+
+    with pytest.raises(ValueError, match="timed out"):
+        tool.invoke(
+            ToolCall(
+                tool_name="shell_exec",
+                arguments={
+                    "command": f'"{sys.executable}" -c "import time; time.sleep(2)"',
+                    "timeout": 1,
+                },
+            ),
+            workspace=tmp_path,
+        )
+
+
+def test_shell_exec_tool_truncates_large_output(tmp_path: Path) -> None:
+    tool = ShellExecTool()
+    command = f'"{sys.executable}" -c "import sys; sys.stdout.write(chr(120)*250000)"'
+
+    result = tool.invoke(
+        ToolCall(tool_name="shell_exec", arguments={"command": command}),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert isinstance(result.content, str)
+    assert len(result.content) == 200000
+    assert result.data.get("truncated") is True

--- a/tests/unit/tools/test_shell_exec_tool.py
+++ b/tests/unit/tools/test_shell_exec_tool.py
@@ -8,11 +8,16 @@ from voidcode.runtime.service import ToolRegistry
 from voidcode.tools import ShellExecTool, ToolCall
 
 
+def _cwd_command() -> str:
+    return f'"{sys.executable}" -c "import os; print(os.getcwd())"'
+
+
 def test_shell_exec_tool_runs_command_in_workspace(tmp_path: Path) -> None:
     tool = ShellExecTool()
+    command = _cwd_command()
 
     result = tool.invoke(
-        ToolCall(tool_name="shell_exec", arguments={"command": "pwd"}),
+        ToolCall(tool_name="shell_exec", arguments={"command": command}),
         workspace=tmp_path,
     )
 
@@ -20,7 +25,7 @@ def test_shell_exec_tool_runs_command_in_workspace(tmp_path: Path) -> None:
     assert result.status == "ok"
     assert result.content == f"{tmp_path.resolve()}\n"
     assert result.data == {
-        "command": "pwd",
+        "command": command,
         "exit_code": 0,
         "stdout": f"{tmp_path.resolve()}\n",
         "stderr": "",


### PR DESCRIPTION
## 描述

本次 PR 为 tools 的扩展（主要代码由codex审查）。

主要内容包括：
- 扩展工具系统，新增/完善内置工具模块：
  - `apply_patch`
  - `code_search`
  - `edit`
  - `glob`
  - `list_dir`
  - `lsp`
  - `multi_edit`
  - `todo_write`
  - `web_fetch`
  - `web_search`
- 更新工具提供者注册，实现这些新工具的默认加载
- 修复跨平台问题：
  - `shell_exec` 兼容 Windows/Unix
  - edit 保留 CRLF
  - glob/list_dir 处理 workspace ignore 的路径兼容性
- 增强测试覆盖：
  - 为新增工具补充单元测试
  - 为高风险工具路径添加行为驱动测试
  - `shell_exec` 测试改为便携式 Python cwd 命令

## 变更类型

- [x] Bug 修复
- [x] 新功能
- [ ] 破坏性变更
- [x] 文档更新
- [x] 重构
- [ ] 仅测试变更
- [ ] CI / 工具链变更

## 测试

已审核此次变更涉及的测试文件，并建议执行以下验证：

- `uv run pytest tests/unit/test_apply_patch_tool.py`
- `uv run pytest tests/unit/test_code_search_tool.py`
- `uv run pytest tests/unit/test_edit_tool.py`
- `uv run pytest tests/unit/test_glob_tool.py`
- `uv run pytest tests/unit/test_list_tool.py`
- `uv run pytest tests/unit/test_multi_edit_tool.py`
- `uv run pytest tests/unit/test_todo_write_tool.py`
- `uv run pytest tests/unit/test_webfetch_tool.py`
- `uv run pytest tests/unit/test_websearch_tool.py`
- `uv run pytest tests/integration/test_read_only_slice.py`
- `uv run pytest tests/integration/test_http_transport.py`

这些测试覆盖新增工具行为、mock 网络路径、跨平台 shell 执行以及运行时集成。

## 核对清单

- [x] 本地测试通过
- [x] 如有必要，已更新相关文档
- [x] 相关的 lint 检查和类型检查已通过
- [x] 未包含无关的变更