### PR TITLE
feat(runtime): manage LSP servers inside the runtime

### DIFF
--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -34,16 +34,19 @@ def _handle_run_command(args: argparse.Namespace) -> int:
         approval_mode=cast(PermissionDecision | None, getattr(args, "approval_mode", None)),
     )
     runtime = VoidCodeRuntime(workspace=workspace, config=config)
-    request = RuntimeRequest(prompt=request_text, session_id=cast(str | None, args.session_id))
-    interactive = sys.stdin.isatty() and sys.stderr.isatty()
-    output = _run_with_inline_approval(
-        runtime,
-        request,
-        interactive=interactive,
-    )
+    try:
+        request = RuntimeRequest(prompt=request_text, session_id=cast(str | None, args.session_id))
+        interactive = sys.stdin.isatty() and sys.stderr.isatty()
+        output = _run_with_inline_approval(
+            runtime,
+            request,
+            interactive=interactive,
+        )
 
-    if not interactive:
-        _print_runtime_output(output)
+        if not interactive:
+            _print_runtime_output(output)
+    finally:
+        _ = runtime.shutdown_lsp()
     return 0
 
 
@@ -154,7 +157,10 @@ def _print_runtime_output(output: str | None) -> None:
 def _handle_sessions_list_command(args: argparse.Namespace) -> int:
     workspace = cast(Path, args.workspace)
     runtime = VoidCodeRuntime(workspace=workspace)
-    sessions = runtime.list_sessions()
+    try:
+        sessions = runtime.list_sessions()
+    finally:
+        _ = runtime.shutdown_lsp()
 
     for session in sessions:
         print(_format_session_summary(session))
@@ -175,13 +181,16 @@ def _handle_sessions_resume_command(args: argparse.Namespace) -> int:
     approval_decision = cast(PermissionResolution | None, getattr(args, "approval_decision", None))
     runtime = VoidCodeRuntime(workspace=workspace)
     try:
-        result = runtime.resume(
-            session_id,
-            approval_request_id=cast(str | None, getattr(args, "approval_request_id", None)),
-            approval_decision=approval_decision,
-        )
-    except ValueError as exc:
-        raise SystemExit(f"error: {exc}") from None
+        try:
+            result = runtime.resume(
+                session_id,
+                approval_request_id=cast(str | None, getattr(args, "approval_request_id", None)),
+                approval_decision=approval_decision,
+            )
+        except ValueError as exc:
+            raise SystemExit(f"error: {exc}") from None
+    finally:
+        _ = runtime.shutdown_lsp()
 
     _print_runtime_response(result)
     return 0
@@ -210,9 +219,12 @@ def _handle_config_show_command(args: argparse.Namespace) -> int:
     session_id = cast(str | None, getattr(args, "session_id", None))
     runtime = VoidCodeRuntime(workspace=workspace)
     try:
-        effective_config = runtime.effective_runtime_config(session_id=session_id)
-    except ValueError as exc:
-        raise SystemExit(f"error: {exc}") from None
+        try:
+            effective_config = runtime.effective_runtime_config(session_id=session_id)
+        except ValueError as exc:
+            raise SystemExit(f"error: {exc}") from None
+    finally:
+        _ = runtime.shutdown_lsp()
 
     print(
         json.dumps(

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -44,9 +44,15 @@ class RuntimeSkillsConfig:
 
 
 @dataclass(frozen=True, slots=True)
+class RuntimeLspServerConfig:
+    command: tuple[str, ...]
+    languages: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
 class RuntimeLspConfig:
     enabled: bool | None = None
-    servers: Mapping[str, object] | None = None
+    servers: Mapping[str, RuntimeLspServerConfig] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -235,8 +241,43 @@ def _parse_lsp_config(raw_lsp: object) -> RuntimeLspConfig | None:
 
     lsp_payload = cast(dict[str, object], raw_lsp)
     enabled = _parse_optional_bool(lsp_payload.get("enabled"), field_path="lsp.enabled")
-    servers = _parse_object_container(lsp_payload.get("servers"), field_path="lsp.servers")
+    servers = _parse_lsp_servers_config(lsp_payload.get("servers"), field_path="lsp.servers")
     return RuntimeLspConfig(enabled=enabled, servers=servers)
+
+
+def _parse_lsp_servers_config(
+    raw_value: object, *, field_path: str
+) -> dict[str, RuntimeLspServerConfig] | None:
+    if raw_value is None:
+        return None
+    if not isinstance(raw_value, dict):
+        raise ValueError(f"runtime config field '{field_path}' must be an object when provided")
+
+    raw_servers = cast(dict[str, object], raw_value)
+    parsed_servers: dict[str, RuntimeLspServerConfig] = {}
+    for server_name, raw_server in raw_servers.items():
+        parsed_servers[server_name] = _parse_lsp_server_config(
+            raw_server,
+            field_path=f"{field_path}.{server_name}",
+        )
+    return parsed_servers
+
+
+def _parse_lsp_server_config(raw_value: object, *, field_path: str) -> RuntimeLspServerConfig:
+    if not isinstance(raw_value, dict):
+        raise ValueError(f"runtime config field '{field_path}' must be an object")
+
+    server_payload = cast(dict[str, object], raw_value)
+    command = _parse_string_list(server_payload.get("command"), field_path=f"{field_path}.command")
+    if not command:
+        raise ValueError(
+            f"runtime config field '{field_path}.command' must contain at least one string"
+        )
+    languages = _parse_string_list(
+        server_payload.get("languages"),
+        field_path=f"{field_path}.languages",
+    )
+    return RuntimeLspServerConfig(command=command, languages=languages)
 
 
 def _parse_acp_config(raw_acp: object) -> RuntimeAcpConfig | None:
@@ -271,14 +312,6 @@ def _parse_string_list(raw_value: object, *, field_path: str) -> tuple[str, ...]
             raise ValueError(f"runtime config field '{field_path}[{index}]' must be a string")
         parsed_items.append(item)
     return tuple(parsed_items)
-
-
-def _parse_object_container(raw_value: object, *, field_path: str) -> dict[str, object] | None:
-    if raw_value is None:
-        return None
-    if not isinstance(raw_value, dict):
-        raise ValueError(f"runtime config field '{field_path}' must be an object when provided")
-    return cast(dict[str, object], raw_value)
 
 
 def _parse_command_list(raw_value: object, *, field_path: str) -> tuple[tuple[str, ...], ...]:

--- a/src/voidcode/runtime/events.py
+++ b/src/voidcode/runtime/events.py
@@ -9,6 +9,9 @@ type ExistingEventType = Literal[
     "runtime.request_received",
     "runtime.skills_loaded",
     "runtime.skills_applied",
+    "runtime.lsp_server_started",
+    "runtime.lsp_server_stopped",
+    "runtime.lsp_server_failed",
     "graph.loop_step",
     "graph.model_turn",
     "graph.tool_request_created",
@@ -28,6 +31,9 @@ type KnownEventType = ExistingEventType | PrototypeAdditiveEventType
 RUNTIME_REQUEST_RECEIVED: Final[ExistingEventType] = "runtime.request_received"
 RUNTIME_SKILLS_LOADED: Final[ExistingEventType] = "runtime.skills_loaded"
 RUNTIME_SKILLS_APPLIED: Final[ExistingEventType] = "runtime.skills_applied"
+RUNTIME_LSP_SERVER_STARTED: Final[ExistingEventType] = "runtime.lsp_server_started"
+RUNTIME_LSP_SERVER_STOPPED: Final[ExistingEventType] = "runtime.lsp_server_stopped"
+RUNTIME_LSP_SERVER_FAILED: Final[ExistingEventType] = "runtime.lsp_server_failed"
 GRAPH_LOOP_STEP: Final[ExistingEventType] = "graph.loop_step"
 GRAPH_MODEL_TURN: Final[ExistingEventType] = "graph.model_turn"
 GRAPH_TOOL_REQUEST_CREATED: Final[ExistingEventType] = "graph.tool_request_created"
@@ -47,6 +53,9 @@ EMITTED_EVENT_TYPES: Final[tuple[ExistingEventType, ...]] = (
     RUNTIME_REQUEST_RECEIVED,
     RUNTIME_SKILLS_LOADED,
     RUNTIME_SKILLS_APPLIED,
+    RUNTIME_LSP_SERVER_STARTED,
+    RUNTIME_LSP_SERVER_STOPPED,
+    RUNTIME_LSP_SERVER_FAILED,
     GRAPH_LOOP_STEP,
     GRAPH_MODEL_TURN,
     GRAPH_TOOL_REQUEST_CREATED,

--- a/src/voidcode/runtime/lsp.py
+++ b/src/voidcode/runtime/lsp.py
@@ -4,6 +4,7 @@ import json
 import os
 import select
 import subprocess
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal, Protocol, cast
@@ -431,13 +432,22 @@ class ManagedLspManager:
         if process.stdout is None:
             raise ValueError("LSP process stdout is unavailable")
 
+        fd = process.stdout.fileno()
+        deadline = time.monotonic() + timeout
+
+        def _wait_for_ready(error_message: str) -> None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(error_message)
+            ready, _, _ = select.select([fd], [], [], remaining)
+            if not ready:
+                raise TimeoutError(error_message)
+
         # Read header with timeout
         header = b""
         while b"\r\n\r\n" not in header:
-            ready, _, _ = select.select([process.stdout], [], [], timeout)
-            if not ready:
-                raise TimeoutError(f"LSP server did not respond within {timeout}s")
-            chunk = process.stdout.read(1)
+            _wait_for_ready(f"LSP server did not respond within {timeout}s")
+            chunk = os.read(fd, 1)
             if not chunk:
                 return None
             header += chunk
@@ -452,12 +462,13 @@ class ManagedLspManager:
             return None
 
         # Read body with timeout
-        ready, _, _ = select.select([process.stdout], [], [], timeout)
-        if not ready:
-            raise TimeoutError(f"LSP server did not send body within {timeout}s")
-        body = process.stdout.read(content_length)
-        if not body:
-            return None
+        body = b""
+        while len(body) < content_length:
+            _wait_for_ready(f"LSP server did not send body within {timeout}s")
+            chunk = os.read(fd, content_length - len(body))
+            if not chunk:
+                return None
+            body += chunk
         return cast(dict[str, object], json.loads(body.decode("utf-8")))
 
 

--- a/src/voidcode/runtime/lsp.py
+++ b/src/voidcode/runtime/lsp.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import select
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -230,7 +231,7 @@ class ManagedLspManager:
                 cwd=workspace,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
             )
         except (FileNotFoundError, OSError) as exc:
             message = f"failed to start LSP server {server_name}: {exc}"
@@ -424,11 +425,18 @@ class ManagedLspManager:
             raise ValueError("LSP server pipe closed unexpectedly") from exc
 
     @staticmethod
-    def _read_message(process: subprocess.Popen[bytes]) -> dict[str, object] | None:
+    def _read_message(
+        process: subprocess.Popen[bytes], *, timeout: float = 30.0
+    ) -> dict[str, object] | None:
         if process.stdout is None:
             raise ValueError("LSP process stdout is unavailable")
+
+        # Read header with timeout
         header = b""
         while b"\r\n\r\n" not in header:
+            ready, _, _ = select.select([process.stdout], [], [], timeout)
+            if not ready:
+                raise TimeoutError(f"LSP server did not respond within {timeout}s")
             chunk = process.stdout.read(1)
             if not chunk:
                 return None
@@ -443,6 +451,10 @@ class ManagedLspManager:
         if content_length is None:
             return None
 
+        # Read body with timeout
+        ready, _, _ = select.select([process.stdout], [], [], timeout)
+        if not ready:
+            raise TimeoutError(f"LSP server did not send body within {timeout}s")
         body = process.stdout.read(content_length)
         if not body:
             return None

--- a/src/voidcode/runtime/lsp.py
+++ b/src/voidcode/runtime/lsp.py
@@ -1,49 +1,84 @@
 from __future__ import annotations
 
+import json
+import os
+import subprocess
 from dataclasses import dataclass, field
-from typing import Literal
+from pathlib import Path
+from typing import Literal, Protocol, cast
 
-from .config import RuntimeLspConfig
-
-
-@dataclass(frozen=True, slots=True)
-class LspServerConfig:
-    name: str
-    definition: object
+from .config import RuntimeLspConfig, RuntimeLspServerConfig
 
 
 @dataclass(frozen=True, slots=True)
 class LspConfigState:
     configured_enabled: bool = False
-    servers: dict[str, LspServerConfig] = field(default_factory=dict)
+    servers: dict[str, RuntimeLspServerConfig] = field(default_factory=dict)
 
     @classmethod
     def from_runtime_config(cls, config: RuntimeLspConfig | None) -> LspConfigState:
         if config is None:
             return cls()
+        return cls(
+            configured_enabled=bool(config.enabled),
+            servers={name: definition for name, definition in (config.servers or {}).items()},
+        )
 
-        servers: dict[str, LspServerConfig] = {
-            name: LspServerConfig(name=name, definition=definition)
-            for name, definition in (config.servers or {}).items()
-        }
-        return cls(configured_enabled=bool(config.enabled), servers=servers)
-
-    def resolve(self, server_name: str) -> LspServerConfig | None:
+    def resolve(self, server_name: str) -> RuntimeLspServerConfig | None:
         return self.servers.get(server_name)
+
+    def default_server_name(self) -> str | None:
+        if not self.servers:
+            return None
+        return next(iter(self.servers))
 
 
 @dataclass(frozen=True, slots=True)
 class LspServerState:
     name: str
     configured: bool = True
+    status: Literal["stopped", "starting", "running", "failed"] = "stopped"
     available: bool = False
+    last_error: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
 class LspManagerState:
-    mode: Literal["disabled"] = "disabled"
+    mode: Literal["disabled", "managed"] = "disabled"
     configuration: LspConfigState = field(default_factory=LspConfigState)
     servers: dict[str, LspServerState] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class LspRuntimeEvent:
+    event_type: str
+    payload: dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class LspRequest:
+    server_name: str | None
+    method: str
+    params: dict[str, object]
+    workspace: Path
+
+
+@dataclass(frozen=True, slots=True)
+class LspRequestResult:
+    response: dict[str, object]
+
+
+class LspManager(Protocol):
+    @property
+    def configuration(self) -> LspConfigState: ...
+
+    def current_state(self) -> LspManagerState: ...
+
+    def request(self, request: LspRequest) -> LspRequestResult: ...
+
+    def shutdown(self) -> tuple[LspRuntimeEvent, ...]: ...
+
+    def drain_events(self) -> tuple[LspRuntimeEvent, ...]: ...
 
 
 class DisabledLspManager:
@@ -54,7 +89,7 @@ class DisabledLspManager:
     def configuration(self) -> LspConfigState:
         return self._configuration
 
-    def resolve(self, server_name: str) -> LspServerConfig | None:
+    def resolve(self, server_name: str) -> RuntimeLspServerConfig | None:
         return self._configuration.resolve(server_name)
 
     def current_state(self) -> LspManagerState:
@@ -62,3 +97,360 @@ class DisabledLspManager:
             name: LspServerState(name=name) for name in self._configuration.servers
         }
         return LspManagerState(configuration=self._configuration, servers=servers)
+
+    def request(self, request: LspRequest) -> LspRequestResult:
+        _ = request
+        raise ValueError("LSP runtime support is disabled")
+
+    def shutdown(self) -> tuple[LspRuntimeEvent, ...]:
+        return ()
+
+    def drain_events(self) -> tuple[LspRuntimeEvent, ...]:
+        return ()
+
+
+@dataclass(slots=True)
+class _RunningLspServer:
+    config: RuntimeLspServerConfig
+    process: subprocess.Popen[bytes]
+    initialized: bool = False
+
+
+class ManagedLspManager:
+    def __init__(self, config: RuntimeLspConfig) -> None:
+        self._configuration = LspConfigState.from_runtime_config(config)
+        self._server_states: dict[str, LspServerState] = {
+            name: LspServerState(name=name) for name in self._configuration.servers
+        }
+        self._running_servers: dict[str, _RunningLspServer] = {}
+        self._pending_events: list[LspRuntimeEvent] = []
+
+    @property
+    def configuration(self) -> LspConfigState:
+        return self._configuration
+
+    def current_state(self) -> LspManagerState:
+        return LspManagerState(
+            mode="managed",
+            configuration=self._configuration,
+            servers=dict(self._server_states),
+        )
+
+    def request(self, request: LspRequest) -> LspRequestResult:
+        server_name = request.server_name or self._configuration.default_server_name()
+        if server_name is None:
+            raise ValueError("no LSP server is configured")
+
+        server_config = self._configuration.resolve(server_name)
+        if server_config is None:
+            raise ValueError(f"unknown LSP server: {server_name}")
+
+        running_server = self._ensure_running(
+            server_name=server_name,
+            server_config=server_config,
+            workspace=request.workspace,
+        )
+        response = self._send_request(
+            running_server,
+            method=request.method,
+            params=request.params,
+            server_name=server_name,
+        )
+        return LspRequestResult(response=response)
+
+    def shutdown(self) -> tuple[LspRuntimeEvent, ...]:
+        for server_name, running_server in list(self._running_servers.items()):
+            process = running_server.process
+            if process.poll() is None:
+                self._send_request(
+                    running_server,
+                    method="shutdown",
+                    params={},
+                    server_name=server_name,
+                )
+                self._send_notification(process, method="exit", params={})
+                try:
+                    process.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    process.terminate()
+                    try:
+                        process.wait(timeout=1)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait(timeout=1)
+
+            self._running_servers.pop(server_name, None)
+            self._server_states[server_name] = LspServerState(
+                name=server_name,
+                status="stopped",
+                available=False,
+            )
+            self._record_event(
+                LspRuntimeEvent(
+                    event_type="runtime.lsp_server_stopped",
+                    payload={
+                        "server": server_name,
+                        "command": list(running_server.config.command),
+                        "state": "stopped",
+                    },
+                )
+            )
+        return self.drain_events()
+
+    def drain_events(self) -> tuple[LspRuntimeEvent, ...]:
+        events = tuple(self._pending_events)
+        self._pending_events.clear()
+        return events
+
+    def _ensure_running(
+        self,
+        *,
+        server_name: str,
+        server_config: RuntimeLspServerConfig,
+        workspace: Path,
+    ) -> _RunningLspServer:
+        running_server = self._running_servers.get(server_name)
+        if running_server is not None and running_server.process.poll() is None:
+            if not running_server.initialized:
+                self._initialize_server(
+                    running_server,
+                    server_name=server_name,
+                    workspace=workspace,
+                )
+            return running_server
+
+        self._server_states[server_name] = LspServerState(
+            name=server_name,
+            status="starting",
+            available=False,
+        )
+        try:
+            process = subprocess.Popen(
+                list(server_config.command),
+                cwd=workspace,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except (FileNotFoundError, OSError) as exc:
+            message = f"failed to start LSP server {server_name}: {exc}"
+            self._mark_failed(server_name=server_name, error=message)
+            self._record_event(
+                self._failed_event(
+                    server_name=server_name, server_config=server_config, error=message
+                )
+            )
+            raise ValueError(message) from exc
+
+        if process.stdin is None or process.stdout is None:
+            process.kill()
+            process.wait(timeout=1)
+            message = f"failed to start LSP server {server_name}: missing stdio pipe"
+            self._mark_failed(server_name=server_name, error=message)
+            self._record_event(
+                self._failed_event(
+                    server_name=server_name, server_config=server_config, error=message
+                )
+            )
+            raise ValueError(message)
+
+        running_server = _RunningLspServer(config=server_config, process=process)
+        self._running_servers[server_name] = running_server
+        self._initialize_server(
+            running_server,
+            server_name=server_name,
+            workspace=workspace,
+        )
+        return running_server
+
+    def _initialize_server(
+        self,
+        running_server: _RunningLspServer,
+        *,
+        server_name: str,
+        workspace: Path,
+    ) -> None:
+        init_params: dict[str, object] = {
+            "processId": os.getpid(),
+            "clientInfo": {"name": "voidcode", "version": "0.1.0"},
+            "locale": "zh-CN",
+            "rootUri": workspace.as_uri(),
+            "workspaceFolders": [
+                {
+                    "uri": workspace.as_uri(),
+                    "name": workspace.name or str(workspace),
+                }
+            ],
+            "capabilities": {},
+        }
+        try:
+            response = self._send_request(
+                running_server,
+                method="initialize",
+                params=init_params,
+                server_name=server_name,
+            )
+        except ValueError as exc:
+            message = str(exc)
+            self._mark_failed(
+                server_name=server_name,
+                error=message,
+            )
+            self._record_event(
+                self._failed_event(
+                    server_name=server_name,
+                    server_config=running_server.config,
+                    error=message,
+                )
+            )
+            raise
+
+        init_error = response.get("error")
+        if init_error is not None:
+            message = f"LSP initialize failed for {server_name}: {init_error}"
+            self._mark_failed(
+                server_name=server_name,
+                error=message,
+            )
+            self._record_event(
+                self._failed_event(
+                    server_name=server_name,
+                    server_config=running_server.config,
+                    error=message,
+                )
+            )
+            raise ValueError(message)
+
+        self._send_notification(running_server.process, method="initialized", params={})
+        running_server.initialized = True
+        self._server_states[server_name] = LspServerState(
+            name=server_name,
+            status="running",
+            available=True,
+        )
+        self._record_event(
+            LspRuntimeEvent(
+                event_type="runtime.lsp_server_started",
+                payload={
+                    "server": server_name,
+                    "command": list(running_server.config.command),
+                    "state": "running",
+                },
+            )
+        )
+
+    def _record_event(self, event: LspRuntimeEvent) -> None:
+        self._pending_events.append(event)
+
+    def _mark_failed(
+        self,
+        *,
+        server_name: str,
+        error: str,
+    ) -> None:
+        running_server = self._running_servers.pop(server_name, None)
+        if running_server is not None and running_server.process.poll() is None:
+            running_server.process.terminate()
+            try:
+                running_server.process.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                running_server.process.kill()
+                running_server.process.wait(timeout=1)
+        self._server_states[server_name] = LspServerState(
+            name=server_name,
+            status="failed",
+            available=False,
+            last_error=error,
+        )
+
+    @staticmethod
+    def _failed_event(
+        *,
+        server_name: str,
+        server_config: RuntimeLspServerConfig,
+        error: str,
+    ) -> LspRuntimeEvent:
+        return LspRuntimeEvent(
+            event_type="runtime.lsp_server_failed",
+            payload={
+                "server": server_name,
+                "command": list(server_config.command),
+                "state": "failed",
+                "error": error,
+            },
+        )
+
+    def _send_request(
+        self,
+        running_server: _RunningLspServer,
+        *,
+        method: str,
+        params: dict[str, object],
+        server_name: str,
+    ) -> dict[str, object]:
+        process = running_server.process
+        self._write_message(
+            process=process,
+            message={"jsonrpc": "2.0", "id": 1, "method": method, "params": params},
+        )
+        response = self._read_message(process=process)
+        while response is not None and response.get("id") != 1:
+            response = self._read_message(process=process)
+        if response is None:
+            raise ValueError(f"No response from LSP server {server_name} for {method}")
+        return response
+
+    def _send_notification(
+        self,
+        process: subprocess.Popen[bytes],
+        *,
+        method: str,
+        params: dict[str, object],
+    ) -> None:
+        self._write_message(
+            process=process, message={"jsonrpc": "2.0", "method": method, "params": params}
+        )
+
+    @staticmethod
+    def _write_message(process: subprocess.Popen[bytes], message: dict[str, object]) -> None:
+        if process.stdin is None:
+            raise ValueError("LSP process stdin is unavailable")
+        body = json.dumps(message).encode("utf-8")
+        header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+        try:
+            process.stdin.write(header + body)
+            process.stdin.flush()
+        except BrokenPipeError as exc:
+            raise ValueError("LSP server pipe closed unexpectedly") from exc
+
+    @staticmethod
+    def _read_message(process: subprocess.Popen[bytes]) -> dict[str, object] | None:
+        if process.stdout is None:
+            raise ValueError("LSP process stdout is unavailable")
+        header = b""
+        while b"\r\n\r\n" not in header:
+            chunk = process.stdout.read(1)
+            if not chunk:
+                return None
+            header += chunk
+
+        header_text = header.decode("ascii", errors="ignore")
+        content_length = None
+        for line in header_text.split("\r\n"):
+            if line.lower().startswith("content-length:"):
+                content_length = int(line.split(":", 1)[1].strip())
+                break
+        if content_length is None:
+            return None
+
+        body = process.stdout.read(content_length)
+        if not body:
+            return None
+        return cast(dict[str, object], json.loads(body.decode("utf-8")))
+
+
+def build_lsp_manager(config: RuntimeLspConfig | None) -> LspManager:
+    configuration = LspConfigState.from_runtime_config(config)
+    if configuration.configured_enabled is not True or not configuration.servers:
+        return DisabledLspManager(config)
+    return ManagedLspManager(config or RuntimeLspConfig())

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -16,13 +16,16 @@ from .acp import DisabledAcpAdapter
 from .config import ExecutionEngineName, RuntimeConfig, load_runtime_config
 from .contracts import RuntimeRequest, RuntimeResponse, RuntimeStreamChunk, validate_session_id
 from .events import (
+    RUNTIME_LSP_SERVER_FAILED,
+    RUNTIME_LSP_SERVER_STARTED,
+    RUNTIME_LSP_SERVER_STOPPED,
     RUNTIME_SKILLS_APPLIED,
     RUNTIME_SKILLS_LOADED,
     RUNTIME_TOOL_HOOK_POST,
     RUNTIME_TOOL_HOOK_PRE,
     EventEnvelope,
 )
-from .lsp import DisabledLspManager
+from .lsp import LspManager, LspManagerState, LspRequest, build_lsp_manager
 from .model_provider import ModelProviderRegistry, ResolvedProviderModel, resolve_provider_model
 from .permission import (
     PendingApproval,
@@ -73,8 +76,8 @@ class ToolRegistry:
         return cls(tools={tool.definition.name: tool for tool in tools})
 
     @classmethod
-    def with_defaults(cls) -> ToolRegistry:
-        return cls.from_tools(BuiltinToolProvider().provide_tools())
+    def with_defaults(cls, *, lsp_tool: Tool | None = None) -> ToolRegistry:
+        return cls.from_tools(BuiltinToolProvider(lsp_tool=lsp_tool).provide_tools())
 
     def definitions(self) -> tuple[ToolDefinition, ...]:
         return tuple(tool.definition for tool in self.tools.values())
@@ -100,7 +103,7 @@ class VoidCodeRuntime:
     _model_provider_registry: ModelProviderRegistry
     _provider_model: ResolvedProviderModel
     _skill_registry: SkillRegistry
-    _lsp_manager: DisabledLspManager
+    _lsp_manager: LspManager
     _acp_adapter: DisabledAcpAdapter
     _graph_cache: dict[tuple[ExecutionEngineName, str], RuntimeGraph]
     _hook_recursion_env_var = "VOIDCODE_RUNNING_TOOL_HOOK"
@@ -116,7 +119,7 @@ class VoidCodeRuntime:
         session_store: SessionStore | None = None,
         model_provider_registry: ModelProviderRegistry | None = None,
         skill_registry: SkillRegistry | None = None,
-        lsp_manager: DisabledLspManager | None = None,
+        lsp_manager: LspManager | None = None,
         acp_adapter: DisabledAcpAdapter | None = None,
     ) -> None:
         self._workspace = workspace.resolve()
@@ -128,7 +131,10 @@ class VoidCodeRuntime:
             self._config.model,
             registry=self._model_provider_registry,
         )
-        self._tool_registry = tool_registry or ToolRegistry.with_defaults()
+        self._lsp_manager = lsp_manager or build_lsp_manager(self._config.lsp)
+        self._tool_registry = tool_registry or ToolRegistry.with_defaults(
+            lsp_tool=self._build_lsp_tool()
+        )
         self._graph_override = graph
         self._graph_cache = {}
         self._graph = graph or self._build_graph_for_engine_from_config(
@@ -143,8 +149,14 @@ class VoidCodeRuntime:
         )
         self._session_store = session_store or SqliteSessionStore()
         self._skill_registry = skill_registry or self._build_skill_registry()
-        self._lsp_manager = lsp_manager or DisabledLspManager(self._config.lsp)
         self._acp_adapter = acp_adapter or DisabledAcpAdapter(self._config.acp)
+
+    def __enter__(self) -> VoidCodeRuntime:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        _ = exc_type, exc, tb
+        _ = self.shutdown_lsp()
 
     @staticmethod
     def _build_graph_for_engine(
@@ -153,14 +165,12 @@ class VoidCodeRuntime:
     ) -> RuntimeGraph:
         if engine_name == "deterministic":
             return DeterministicReadOnlyGraph()
-        if engine_name == "single_agent":
-            if provider_model.provider is None:
-                raise ValueError("single_agent execution engine requires a configured model")
-            return ProviderSingleAgentGraph(
-                provider=provider_model.provider.single_agent_provider(),
-                provider_model=provider_model,
-            )
-        raise ValueError(f"unknown execution engine: {engine_name}")
+        if provider_model.provider is None:
+            raise ValueError("single_agent execution engine requires a configured model")
+        return ProviderSingleAgentGraph(
+            provider=provider_model.provider.single_agent_provider(),
+            provider_model=provider_model,
+        )
 
     def _build_graph_for_engine_from_config(self, config: EffectiveRuntimeConfig) -> RuntimeGraph:
         # Generate cache key from config
@@ -191,6 +201,40 @@ class VoidCodeRuntime:
                 search_paths=skills_config.paths,
             )
         return SkillRegistry.discover(workspace=self._workspace)
+
+    def _build_lsp_tool(self) -> Tool | None:
+        if self._lsp_manager.current_state().mode != "managed":
+            return None
+        from ..tools.lsp import LspTool
+
+        return LspTool(requester=self.request_lsp)
+
+    def current_lsp_state(self) -> LspManagerState:
+        return self._lsp_manager.current_state()
+
+    def request_lsp(
+        self,
+        *,
+        server_name: str | None,
+        method: str,
+        params: dict[str, object],
+        workspace: Path,
+    ):
+        return self._lsp_manager.request(
+            LspRequest(
+                server_name=server_name,
+                method=method,
+                params=params,
+                workspace=workspace,
+            )
+        )
+
+    def shutdown_lsp(self) -> tuple[EventEnvelope, ...]:
+        return self._envelopes_for_lsp_events(
+            session_id="runtime",
+            start_sequence=1,
+            lsp_events=self._lsp_manager.shutdown(),
+        )
 
     def _run_with_persistence(self, request: RuntimeRequest) -> Iterator[RuntimeStreamChunk]:
         request = self._validated_request(request)
@@ -489,8 +533,23 @@ class VoidCodeRuntime:
             try:
                 tool_result = tool.invoke(plan_tool_call, workspace=self._workspace)
             except Exception as exc:
+                for lsp_event in self._envelopes_for_lsp_events(
+                    session_id=session.session.id,
+                    start_sequence=sequence + 1,
+                    lsp_events=self._lsp_manager.drain_events(),
+                ):
+                    sequence = lsp_event.sequence
+                    yield RuntimeStreamChunk(kind="event", session=session, event=lsp_event)
                 yield self._failed_chunk(session=session, sequence=sequence + 1, error=str(exc))
                 raise
+
+            for lsp_event in self._envelopes_for_lsp_events(
+                session_id=session.session.id,
+                start_sequence=sequence + 1,
+                lsp_events=self._lsp_manager.drain_events(),
+            ):
+                sequence = lsp_event.sequence
+                yield RuntimeStreamChunk(kind="event", session=session, event=lsp_event)
 
             sequence += 1
             yield RuntimeStreamChunk(
@@ -1146,7 +1205,49 @@ class VoidCodeRuntime:
         }
         if self._config.model is not None:
             runtime_config_metadata["model"] = self._config.model
+        lsp_state = self._lsp_manager.current_state()
+        runtime_config_metadata["lsp"] = {
+            "mode": lsp_state.mode,
+            "configured_enabled": lsp_state.configuration.configured_enabled,
+            "servers": list(lsp_state.configuration.servers),
+        }
         return runtime_config_metadata
+
+    @staticmethod
+    def _envelopes_for_lsp_events(
+        *,
+        session_id: str,
+        start_sequence: int,
+        lsp_events: tuple[object, ...],
+    ) -> tuple[EventEnvelope, ...]:
+        known_event_types = {
+            RUNTIME_LSP_SERVER_STARTED,
+            RUNTIME_LSP_SERVER_STOPPED,
+            RUNTIME_LSP_SERVER_FAILED,
+        }
+        envelopes: list[EventEnvelope] = []
+        sequence = start_sequence
+        for raw_event in lsp_events:
+            if isinstance(raw_event, dict):
+                raw_event_dict = cast(dict[str, object], raw_event)
+                event_type = raw_event_dict.get("event_type")
+                payload = raw_event_dict.get("payload")
+            else:
+                event_type = getattr(raw_event, "event_type", None)
+                payload = getattr(raw_event, "payload", None)
+            if event_type not in known_event_types or not isinstance(payload, dict):
+                continue
+            envelopes.append(
+                EventEnvelope(
+                    session_id=session_id,
+                    sequence=sequence,
+                    event_type=cast(str, event_type),
+                    source="runtime",
+                    payload=cast(dict[str, object], payload),
+                )
+            )
+            sequence += 1
+        return tuple(envelopes)
 
     def _permission_policy_for_session(
         self, metadata: dict[str, object] | None

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -25,7 +25,7 @@ from .events import (
     RUNTIME_TOOL_HOOK_PRE,
     EventEnvelope,
 )
-from .lsp import LspManager, LspManagerState, LspRequest, build_lsp_manager
+from .lsp import LspManager, LspManagerState, LspRequest, LspRequestResult, build_lsp_manager
 from .model_provider import ModelProviderRegistry, ResolvedProviderModel, resolve_provider_model
 from .permission import (
     PendingApproval,
@@ -165,12 +165,14 @@ class VoidCodeRuntime:
     ) -> RuntimeGraph:
         if engine_name == "deterministic":
             return DeterministicReadOnlyGraph()
-        if provider_model.provider is None:
-            raise ValueError("single_agent execution engine requires a configured model")
-        return ProviderSingleAgentGraph(
-            provider=provider_model.provider.single_agent_provider(),
-            provider_model=provider_model,
-        )
+        if engine_name == "single_agent":
+            if provider_model.provider is None:
+                raise ValueError("single_agent execution engine requires a configured model")
+            return ProviderSingleAgentGraph(
+                provider=provider_model.provider.single_agent_provider(),
+                provider_model=provider_model,
+            )
+        raise ValueError(f"unknown execution engine: {engine_name}")
 
     def _build_graph_for_engine_from_config(self, config: EffectiveRuntimeConfig) -> RuntimeGraph:
         # Generate cache key from config
@@ -219,7 +221,7 @@ class VoidCodeRuntime:
         method: str,
         params: dict[str, object],
         workspace: Path,
-    ):
+    ) -> LspRequestResult:
         return self._lsp_manager.request(
             LspRequest(
                 server_name=server_name,

--- a/src/voidcode/runtime/tool_provider.py
+++ b/src/voidcode/runtime/tool_provider.py
@@ -40,6 +40,9 @@ class ToolProvider(Protocol):
 
 
 class BuiltinToolProvider:
+    def __init__(self, *, lsp_tool: Tool | None = None) -> None:
+        self._lsp_tool = lsp_tool
+
     def provide_tools(self) -> tuple[Tool, ...]:
         tools: list[Tool] = [
             EditTool(),
@@ -53,8 +56,10 @@ class BuiltinToolProvider:
             WriteFileTool(),
         ]
 
+        if self._lsp_tool is not None:
+            tools.append(self._lsp_tool)
+
         # Add optional tools if available.
-        # NOTE: LSP is intentionally NOT part of builtin tool defaults.
         if _ApplyPatchTool is not None:
             tools.append(_ApplyPatchTool())
         if _CodeSearchTool is not None:

--- a/src/voidcode/tools/lsp.py
+++ b/src/voidcode/tools/lsp.py
@@ -136,6 +136,9 @@ class LspTool:
                 params=params,
                 workspace=workspace_root,
             )
+            error_value = response.response.get("error")
+            if error_value is not None:
+                raise ValueError(f"LSP error: {error_value}")
             return ToolResult(
                 tool_name=self.definition.name,
                 status="ok",

--- a/src/voidcode/tools/lsp.py
+++ b/src/voidcode/tools/lsp.py
@@ -1,34 +1,23 @@
-"""LSP Tool: basic client for Language Server Protocol queries.
-
-This tool provides a minimal, read-only interface to an external LSP server
-via a simple JSON-RPC over TCP/localhost. It supports a subset of common LSP
-operations requested by the system:
-- goToDefinition
-- findReferences
-- hover
-- documentSymbol
-- workspaceSymbol
-- goToImplementation
-- prepareCallHierarchy
-- incomingCalls
-- outgoingCalls
-
-Note: This is intentionally lightweight. It performs a best-effort available
-check and will return a helpful error message if no LSP server is configured or
-reachable. The actual JSON-RPC framing follows the LSP Content-Length header
-convention.
-"""
+"""LSP Tool: read-only adapter over the runtime-managed LSP subsystem."""
 
 from __future__ import annotations
 
 import enum
-import json
-import os
-import socket
 from pathlib import Path
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar, Protocol, cast
 
 from .contracts import ToolCall, ToolDefinition, ToolResult
+
+
+class LspRequester(Protocol):
+    def __call__(
+        self,
+        *,
+        server_name: str | None,
+        method: str,
+        params: dict[str, object],
+        workspace: Path,
+    ) -> Any: ...
 
 
 @enum.unique
@@ -45,14 +34,6 @@ class LspOperation(enum.Enum):
 
 
 class LspTool:
-    """Tool to interact with an external LSP server.
-
-    The tool validates that an LSP server is reachable via environment
-    configuration and then issues a single JSON-RPC request corresponding to the
-    selected operation.
-    """
-
-    # Tool contract definition
     definition: ClassVar[ToolDefinition] = ToolDefinition(
         name="lsp",
         description="LSP client for basic code intelligence lookups.",
@@ -61,23 +42,23 @@ class LspTool:
             "filePath": {"type": "string"},
             "line": {"type": "integer"},
             "character": {"type": "integer"},
+            "server": {"type": "string"},
         },
         read_only=True,
     )
 
-    def __init__(self) -> None:
-        # Cached server address; resolved on first use
-        self._host, self._port = self._resolve_server_address()
-        self._initialized = False
+    def __init__(self, *, requester: LspRequester) -> None:
+        self._requester = requester
 
-    # Public API expected by the runtime
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
-        # Extract args
         op_value = call.arguments.get("operation")
         file_path = call.arguments.get("filePath")
         line = call.arguments.get("line")
         character = call.arguments.get("character")
+        server = call.arguments.get("server")
 
+        if server is not None and not isinstance(server, str):
+            raise ValueError("lsp requires a string 'server' argument when provided")
         if not isinstance(file_path, str):
             raise ValueError("lsp requires a string 'filePath' argument")
         if isinstance(line, (int, float)):
@@ -97,14 +78,12 @@ class LspTool:
         if op_value is None:
             raise ValueError("lsp invocation requires 'operation' argument")
 
-        # Normalize operation
         try:
             if isinstance(op_value, LspOperation):
                 operation = op_value
             else:
                 operation = LspOperation(op_value)
         except Exception:
-            # Be permissive: allow a string key like "GO_TO_DEFINITION" to map to enum
             if isinstance(op_value, str):
                 try:
                     operation = LspOperation[op_value]
@@ -113,7 +92,6 @@ class LspTool:
             else:
                 raise ValueError(f"Unsupported LSP operation: {op_value}") from None
 
-        # Resolve file path and ensure it's inside workspace (mirror read_file.py)
         relative_path = Path(file_path)
         workspace_root = workspace.resolve()
         candidate = (workspace_root / relative_path).resolve()
@@ -122,181 +100,62 @@ class LspTool:
         if not candidate.is_file():
             raise ValueError(f"lsp target does not exist: {file_path}")
 
-        # Ensure server is available
-        if not self._host or not self._port:
-            raise ValueError(
-                "LSP server host/port not configured. Set VOIDCODE_LSP_HOST and VOIDCODE_LSP_PORT."
-            )
-        if not self._server_is_available():
-            raise ValueError(f"LSP server not available at {self._host}:{self._port}")
-
-        self._ensure_initialized(workspace=workspace_root)
-
-        # Prepare a minimal JSON-RPC payload for the requested operation
         position = {"line": line_value - 1, "character": character_value - 1}
-        textDocument = {"uri": candidate.as_uri()}
-        params: dict[str, Any] = {"textDocument": textDocument, "position": position}
+        text_document = {"uri": candidate.as_uri()}
+        params: dict[str, object] = {"textDocument": text_document, "position": position}
         if operation == LspOperation.WORKSPACE_SYMBOL:
             params = {"query": ""}
-        if operation == LspOperation.PREPARE_CALL_HIERARCHY:
-            params = {"textDocument": textDocument, "position": position}
 
         if operation in (LspOperation.INCOMING_CALLS, LspOperation.OUTGOING_CALLS):
-            prepare_response = self._send_request(
-                LspOperation.PREPARE_CALL_HIERARCHY.value,
-                {"textDocument": textDocument, "position": position},
+            prepare_result = self._requester(
+                server_name=server,
+                method=LspOperation.PREPARE_CALL_HIERARCHY.value,
+                params={"textDocument": text_document, "position": position},
+                workspace=workspace_root,
             )
-            if prepare_response is None:
-                raise ValueError("No response from LSP server for call hierarchy prepare")
+            prepare_response = prepare_result.response
             prepare_error = prepare_response.get("error")
             if prepare_error is not None:
                 raise ValueError(f"LSP prepareCallHierarchy error: {prepare_error}")
 
-            prepare_result = prepare_response.get("result")
+            prepare_payload = prepare_response.get("result")
             item: dict[str, object] | None = None
-            if isinstance(prepare_result, list) and prepare_result:
-                first = cast(object, prepare_result[0])
+            if isinstance(prepare_payload, list) and prepare_payload:
+                first = cast(object, prepare_payload[0])
                 if isinstance(first, dict):
                     item = cast(dict[str, object], first)
-            elif isinstance(prepare_result, dict):
-                item = cast(dict[str, object], prepare_result)
-
+            elif isinstance(prepare_payload, dict):
+                item = cast(dict[str, object], prepare_payload)
             if item is None:
                 raise ValueError("LSP prepareCallHierarchy returned no item")
-
             params = {"item": item}
 
-        # Send the request
-        response = self._send_request(operation.value, params)
-        if response is None:
-            raise ValueError("No response from LSP server")
-        # If the LSP server returns a JSON-RPC error payload, surface it
-        error_value = response.get("error")
-        if isinstance(error_value, dict):
-            error_dict = cast(dict[str, object], error_value)
-            code = error_dict.get("code")
-            message = error_dict.get("message")
-            if code is not None or message is not None:
-                raise ValueError(f"LSP error: code={code}, message={message}")
-            raise ValueError(f"LSP error: {error_dict}")
+            response = self._requester(
+                server_name=server,
+                method=operation.value,
+                params=params,
+                workspace=workspace_root,
+            )
+            return ToolResult(
+                tool_name=self.definition.name,
+                status="ok",
+                data={"lsp_response": response.response},
+            )
+
+        response = self._requester(
+            server_name=server,
+            method=operation.value,
+            params=params,
+            workspace=workspace_root,
+        )
+        error_value = response.response.get("error")
         if error_value is not None:
             raise ValueError(f"LSP error: {error_value}")
-
         return ToolResult(
             tool_name=self.definition.name,
             status="ok",
-            data={"lsp_response": response},
+            data={"lsp_response": response.response},
         )
 
-    # Internal helpers
-    @staticmethod
-    def _resolve_server_address() -> tuple[str, int | None]:
-        host = os.environ.get("VOIDCODE_LSP_HOST", "127.0.0.1")
-        port = os.environ.get("VOIDCODE_LSP_PORT")
-        if port is None:
-            return host, None
-        try:
-            return host, int(port)
-        except ValueError:
-            return host, None
-
-    def _server_is_available(self) -> bool:
-        if not self._host or not self._port:
-            return False
-        try:
-            with socket.create_connection((self._host, int(self._port)), timeout=0.5):
-                return True
-        except Exception:
-            return False
-
-    def _send_request(self, method: str, params: dict[str, object]) -> dict[str, object] | None:
-        if not self._host or not self._port:
-            return None
-        # Prepare a lightweight JSON-RPC 2.0 request
-        payload = json.dumps({"jsonrpc": "2.0", "id": 1, "method": method, "params": params})
-        body = payload.encode("utf-8")
-        header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
-        try:
-            with socket.create_connection((self._host, int(self._port)), timeout=3) as s:
-                s.sendall(header + body)
-                # Read response header
-                resp_header = b""
-                while b"\r\n\r\n" not in resp_header:
-                    chunk = s.recv(1)
-                    if not chunk:
-                        break
-                    resp_header += chunk
-                # Parse Content-Length
-                header_text = resp_header.decode("ascii", errors="ignore")
-                cl = None
-                for line in header_text.split("\r\n"):
-                    if line.lower().startswith("content-length:"):
-                        try:
-                            cl = int(line.split(":", 1)[1].strip())
-                        except Exception:
-                            cl = None
-                        break
-                if cl is None:
-                    return None
-                # Read body
-                body_bytes = b""
-                remaining = cl
-                while remaining > 0:
-                    chunk = s.recv(remaining)
-                    if not chunk:
-                        break
-                    body_bytes += chunk
-                    remaining -= len(chunk)
-                if not body_bytes:
-                    return None
-                return json.loads(body_bytes.decode("utf-8"))
-        except Exception:
-            return None
-
-    def _ensure_initialized(self, *, workspace: Path) -> None:
-        if self._initialized:
-            return
-
-        init_params: dict[str, object] = {
-            "processId": os.getpid(),
-            "clientInfo": {"name": "voidcode", "version": "0.1.0"},
-            "locale": "zh-CN",
-            "rootUri": workspace.as_uri(),
-            "workspaceFolders": [
-                {
-                    "uri": workspace.as_uri(),
-                    "name": workspace.name or str(workspace),
-                }
-            ],
-            "capabilities": {},
-        }
-
-        init_response = self._send_request("initialize", init_params)
-        if init_response is None:
-            raise ValueError("LSP initialize failed: no response")
-
-        init_error = init_response.get("error")
-        if init_error is not None:
-            raise ValueError(f"LSP initialize failed: {init_error}")
-
-        # initialized is a notification (no response expected)
-        self._send_notification("initialized", {})
-        self._initialized = True
-
-    def _send_notification(self, method: str, params: dict[str, object]) -> None:
-        if not self._host or not self._port:
-            return
-
-        payload = json.dumps({"jsonrpc": "2.0", "method": method, "params": params})
-        body = payload.encode("utf-8")
-        header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
-        try:
-            with socket.create_connection((self._host, int(self._port)), timeout=3) as s:
-                s.sendall(header + body)
-        except OSError:
-            # Notification failure should not crash process unless it blocks requests later.
-            return
-
-    # Expose a convenient alias for the interface elsewhere if needed
     def __repr__(self) -> str:  # pragma: no cover
-        return f"<LspTool host={self._host} port={self._port}>"
+        return "<LspTool runtime-managed>"

--- a/tests/integration/test_lsp_tool_integration.py
+++ b/tests/integration/test_lsp_tool_integration.py
@@ -1,160 +1,183 @@
 from __future__ import annotations
 
-import importlib
-import json
-import socket
-import threading
+import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
 import pytest
 
-
-def _read_framed_json(conn: socket.socket) -> dict[str, object] | None:
-    header = b""
-    while b"\r\n\r\n" not in header:
-        chunk = conn.recv(1)
-        if not chunk:
-            return None
-        header += chunk
-
-    header_text = header.decode("ascii", errors="ignore")
-    content_length = None
-    for line in header_text.split("\r\n"):
-        if line.lower().startswith("content-length:"):
-            content_length = int(line.split(":", 1)[1].strip())
-            break
-    if content_length is None:
-        return None
-
-    payload = b""
-    remaining = content_length
-    while remaining > 0:
-        chunk = conn.recv(remaining)
-        if not chunk:
-            return None
-        payload += chunk
-        remaining -= len(chunk)
-
-    return json.loads(payload.decode("utf-8"))
+from voidcode.runtime.config import RuntimeConfig, RuntimeLspConfig, RuntimeLspServerConfig
+from voidcode.runtime.contracts import RuntimeRequest
+from voidcode.runtime.service import GraphRunRequest, SessionState, VoidCodeRuntime
+from voidcode.tools.contracts import ToolCall
+from voidcode.tools.lsp import LspTool
 
 
-def _send_framed_json(conn: socket.socket, message: dict[str, object]) -> None:
-    body = json.dumps(message).encode("utf-8")
-    header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
-    conn.sendall(header + body)
+def _write_fake_lsp_server(script_path: Path) -> None:
+    script_path.write_text(
+        "import json\n"
+        "import sys\n\n"
+        "def read_message():\n"
+        '    header = b""\n'
+        '    while b"\\r\\n\\r\\n" not in header:\n'
+        "        chunk = sys.stdin.buffer.read(1)\n"
+        "        if not chunk:\n"
+        "            return None\n"
+        "        header += chunk\n"
+        "    content_length = None\n"
+        '    for line in header.decode("ascii", errors="ignore").split("\\r\\n"):\n'
+        '        if line.lower().startswith("content-length:"):\n'
+        '            content_length = int(line.split(":", 1)[1].strip())\n'
+        "            break\n"
+        "    if content_length is None:\n"
+        "        return None\n"
+        "    body = sys.stdin.buffer.read(content_length)\n"
+        "    if not body:\n"
+        "        return None\n"
+        '    return json.loads(body.decode("utf-8"))\n\n'
+        "def send_message(message):\n"
+        '    body = json.dumps(message).encode("utf-8")\n'
+        '    header = f"Content-Length: {len(body)}\\r\\n\\r\\n".encode("ascii")\n'
+        "    sys.stdout.buffer.write(header + body)\n"
+        "    sys.stdout.buffer.flush()\n\n"
+        "while True:\n"
+        "    message = read_message()\n"
+        "    if message is None:\n"
+        "        break\n"
+        '    method = message.get("method")\n'
+        '    request_id = message.get("id")\n'
+        '    if method == "initialize":\n'
+        "        send_message(\n"
+        '            {"jsonrpc": "2.0", "id": request_id, "result": {"capabilities": {}}}\n'
+        "        )\n"
+        "        continue\n"
+        '    if method in {"initialized", "shutdown", "exit"}:\n'
+        '        if method == "shutdown":\n'
+        '            send_message({"jsonrpc": "2.0", "id": request_id, "result": None})\n'
+        '        if method == "exit":\n'
+        "            break\n"
+        "        continue\n"
+        '    if method == "textDocument/prepareCallHierarchy":\n'
+        "        send_message(\n"
+        "            {\n"
+        '                "jsonrpc": "2.0",\n'
+        '                "id": request_id,\n'
+        '                "result": [\n'
+        "                    {\n"
+        '                        "name": "f",\n'
+        '                        "kind": 12,\n'
+        '                        "uri": "file:///tmp/sample.py",\n'
+        '                        "range": {\n'
+        '                            "start": {"line": 0, "character": 0},\n'
+        '                            "end": {"line": 0, "character": 1},\n'
+        "                        },\n"
+        '                        "selectionRange": {\n'
+        '                            "start": {"line": 0, "character": 0},\n'
+        '                            "end": {"line": 0, "character": 1},\n'
+        "                        },\n"
+        "                    }\n"
+        "                ],\n"
+        "            }\n"
+        "        )\n"
+        "        continue\n"
+        "    send_message(\n"
+        '        {"jsonrpc": "2.0", "id": request_id, "result": {"ok": True, "method": method}}\n'
+        "    )\n",
+        encoding="utf-8",
+    )
 
 
-def _run_handshake_server(
-    *,
-    host: str,
-    port: int,
-    stop_event: threading.Event,
-    received_methods: list[str],
-) -> None:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
-        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        server.bind((host, port))
-        server.listen(8)
-        server.settimeout(0.2)
+def _build_runtime_with_lsp(tmp_path: Path, *, command: tuple[str, ...]) -> VoidCodeRuntime:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            lsp=RuntimeLspConfig(
+                enabled=True,
+                servers={"pyright": RuntimeLspServerConfig(command=command)},
+            )
+        ),
+    )
+    return runtime
 
-        initialized = False
-        while not stop_event.is_set():
-            try:
-                conn, _addr = server.accept()
-            except TimeoutError:
-                continue
-            except OSError:
-                break
 
-            with conn:
-                message = _read_framed_json(conn)
-                if message is None:
-                    continue
+@dataclass(slots=True)
+class _StubLspStep:
+    tool_call: ToolCall | None = None
+    output: str | None = None
+    events: tuple[object, ...] = ()
+    is_finished: bool = False
 
-                method = message.get("method")
-                req_id = message.get("id")
-                if isinstance(method, str):
-                    received_methods.append(method)
 
-                if method == "initialize":
-                    initialized = True
-                    _send_framed_json(
-                        conn,
-                        {
-                            "jsonrpc": "2.0",
-                            "id": req_id,
-                            "result": {"capabilities": {}},
-                        },
-                    )
-                    continue
-
-                if method == "initialized":
-                    # notification; no response
-                    continue
-
-                if not initialized:
-                    _send_framed_json(
-                        conn,
-                        {
-                            "jsonrpc": "2.0",
-                            "id": req_id,
-                            "error": {
-                                "code": -32002,
-                                "message": "Server not initialized",
-                            },
-                        },
-                    )
-                    continue
-
-                _send_framed_json(
-                    conn,
-                    {
-                        "jsonrpc": "2.0",
-                        "id": req_id,
-                        "result": {"ok": True, "method": method},
+class _LspGraph:
+    def step(
+        self,
+        request: GraphRunRequest,
+        tool_results: tuple[object, ...],
+        *,
+        session: SessionState,
+    ) -> _StubLspStep:
+        _ = request, session
+        if not tool_results:
+            return _StubLspStep(
+                tool_call=ToolCall(
+                    tool_name="lsp",
+                    arguments={
+                        "operation": "textDocument/definition",
+                        "filePath": "sample.py",
+                        "line": 1,
+                        "character": 1,
                     },
                 )
+            )
+        return _StubLspStep(output="done", is_finished=True)
 
 
-def _pick_tcp_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return int(s.getsockname()[1])
+def test_runtime_managed_lsp_tool_starts_server_and_returns_response(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.py"
+    sample_file.write_text("x = 1\n", encoding="utf-8")
+    server_script = tmp_path / "fake_lsp_server.py"
+    _write_fake_lsp_server(server_script)
 
-
-def test_lsp_tool_performs_initialize_handshake_before_request(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    file_path = tmp_path / "sample.py"
-    file_path.write_text("x = 1\n", encoding="utf-8")
-
-    host = "127.0.0.1"
-    port = _pick_tcp_port()
-    stop_event = threading.Event()
-    received_methods: list[str] = []
-    server = threading.Thread(
-        target=_run_handshake_server,
-        kwargs={
-            "host": host,
-            "port": port,
-            "stop_event": stop_event,
-            "received_methods": received_methods,
-        },
-        daemon=True,
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_LspGraph(),
+        config=RuntimeConfig(
+            lsp=RuntimeLspConfig(
+                enabled=True,
+                servers={
+                    "pyright": RuntimeLspServerConfig(
+                        command=(sys.executable, "-u", str(server_script))
+                    )
+                },
+            )
+        ),
     )
-    server.start()
 
-    monkeypatch.setenv("VOIDCODE_LSP_HOST", host)
-    monkeypatch.setenv("VOIDCODE_LSP_PORT", str(port))
+    result = runtime.run(RuntimeRequest(prompt="lsp please"))
 
-    try:
-        lsp_module = importlib.import_module("voidcode.tools.lsp")
-        contracts_module = importlib.import_module("voidcode.tools.contracts")
-        tool = lsp_module.LspTool()
+    tool_completed = next(
+        event for event in result.events if event.event_type == "runtime.tool_completed"
+    )
+    response = cast(dict[str, object], tool_completed.payload["lsp_response"])
+    assert response["result"] == {"ok": True, "method": "textDocument/definition"}
+    assert any(event.event_type == "runtime.lsp_server_started" for event in result.events)
+    assert runtime.current_lsp_state().servers["pyright"].status == "running"
 
-        result = tool.invoke(
-            contracts_module.ToolCall(
+    shutdown_events = runtime.shutdown_lsp()
+    assert [event.event_type for event in shutdown_events] == ["runtime.lsp_server_stopped"]
+
+
+def test_runtime_managed_lsp_tool_rejects_disabled_manager(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.py"
+    sample_file.write_text("x = 1\n", encoding="utf-8")
+    runtime = VoidCodeRuntime(workspace=tmp_path, config=RuntimeConfig())
+
+    tool = LspTool(requester=runtime.request_lsp)
+
+    with pytest.raises(ValueError, match="disabled"):
+        _ = tool.invoke(
+            ToolCall(
                 tool_name="lsp",
                 arguments={
                     "operation": "textDocument/definition",
@@ -166,93 +189,22 @@ def test_lsp_tool_performs_initialize_handshake_before_request(
             workspace=tmp_path,
         )
 
-        assert result.status == "ok"
-        response = result.data.get("lsp_response")
-        assert isinstance(response, dict)
-        response_dict = cast(dict[str, object], response)
-        assert response_dict.get("result") == {"ok": True, "method": "textDocument/definition"}
-        assert received_methods[:3] == [
-            "initialize",
-            "initialized",
-            "textDocument/definition",
-        ]
-    finally:
-        stop_event.set()
-        server.join(timeout=1)
 
-
-def test_lsp_call_hierarchy_incoming_uses_prepare_item_payload(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    file_path = tmp_path / "sample.py"
-    file_path.write_text("def f():\n    pass\n", encoding="utf-8")
-
-    host = "127.0.0.1"
-    port = _pick_tcp_port()
-    stop_event = threading.Event()
-    received_methods: list[str] = []
-    server = threading.Thread(
-        target=_run_handshake_server,
-        kwargs={
-            "host": host,
-            "port": port,
-            "stop_event": stop_event,
-            "received_methods": received_methods,
-        },
-        daemon=True,
+def test_runtime_managed_lsp_tool_surfaces_failed_startup_state(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.py"
+    sample_file.write_text("x = 1\n", encoding="utf-8")
+    runtime = _build_runtime_with_lsp(
+        tmp_path,
+        command=("definitely-not-a-real-lsp-binary",),
     )
-    server.start()
+    tool = LspTool(requester=runtime.request_lsp)
 
-    monkeypatch.setenv("VOIDCODE_LSP_HOST", host)
-    monkeypatch.setenv("VOIDCODE_LSP_PORT", str(port))
-
-    try:
-        lsp_module = importlib.import_module("voidcode.tools.lsp")
-        contracts_module = importlib.import_module("voidcode.tools.contracts")
-        tool = lsp_module.LspTool()
-
-        # Monkeypatch send_request to assert incomingCalls gets {item: ...}
-        original_send = tool._send_request
-
-        def _wrapped_send(method: str, params: dict[str, object]) -> dict[str, object] | None:
-            if method == "textDocument/prepareCallHierarchy":
-                return {
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "result": [
-                        {
-                            "name": "f",
-                            "kind": 12,
-                            "uri": file_path.resolve().as_uri(),
-                            "range": {
-                                "start": {"line": 0, "character": 0},
-                                "end": {"line": 0, "character": 5},
-                            },
-                            "selectionRange": {
-                                "start": {"line": 0, "character": 0},
-                                "end": {"line": 0, "character": 1},
-                            },
-                        }
-                    ],
-                }
-            if method == "callHierarchy/incomingCalls":
-                assert "item" in params
-                assert "textDocument" not in params
-                assert "position" not in params
-                return {
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "result": [],
-                }
-            return original_send(method, params)
-
-        monkeypatch.setattr(tool, "_send_request", _wrapped_send)
-
-        result = tool.invoke(
-            contracts_module.ToolCall(
+    with pytest.raises(ValueError, match="failed to start LSP server pyright"):
+        _ = tool.invoke(
+            ToolCall(
                 tool_name="lsp",
                 arguments={
-                    "operation": "callHierarchy/incomingCalls",
+                    "operation": "textDocument/definition",
                     "filePath": "sample.py",
                     "line": 1,
                     "character": 1,
@@ -261,7 +213,4 @@ def test_lsp_call_hierarchy_incoming_uses_prepare_item_payload(
             workspace=tmp_path,
         )
 
-        assert result.status == "ok"
-    finally:
-        stop_event.set()
-        server.join(timeout=1)
+    assert runtime.current_lsp_state().servers["pyright"].status == "failed"

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -892,6 +892,7 @@ def test_single_agent_runtime_executes_read_path_and_persists_config(tmp_path: P
     assert result.session.metadata["runtime_config"] == {
         "approval_mode": "allow",
         "execution_engine": "single_agent",
+        "lsp": {"configured_enabled": False, "mode": "disabled", "servers": []},
         "model": "opencode/gpt-5.4",
     }
     assert result.events[3].payload["mode"] == "single_agent"
@@ -1375,6 +1376,7 @@ def test_runtime_resume_uses_persisted_runtime_config_over_fresh_resume_override
     assert replay.session.metadata["runtime_config"] == {
         "approval_mode": "allow",
         "execution_engine": "deterministic",
+        "lsp": {"configured_enabled": False, "mode": "disabled", "servers": []},
         "model": "session/model",
     }
 

--- a/tests/unit/runtime/test_lsp.py
+++ b/tests/unit/runtime/test_lsp.py
@@ -1,19 +1,37 @@
 from __future__ import annotations
 
 from importlib import import_module
+from pathlib import Path
 from typing import Any
 
-from voidcode.runtime.config import RuntimeLspConfig
+import pytest
+
+from voidcode.runtime.config import RuntimeLspConfig, RuntimeLspServerConfig
 
 
-def _load_lsp_symbols() -> tuple[Any, Any]:
+def _load_lsp_symbols() -> tuple[Any, ...]:
     module: Any = import_module("voidcode.runtime.lsp")
-    return module.DisabledLspManager, module.LspConfigState
+    return (
+        module.DisabledLspManager,
+        module.LspConfigState,
+        module.ManagedLspManager,
+        module.LspRequest,
+        module.build_lsp_manager,
+    )
 
 
 DisabledLspManager: Any
 LspConfigState: Any
-DisabledLspManager, LspConfigState = _load_lsp_symbols()
+ManagedLspManager: Any
+LspRequest: Any
+build_lsp_manager: Any
+(
+    DisabledLspManager,
+    LspConfigState,
+    ManagedLspManager,
+    LspRequest,
+    build_lsp_manager,
+) = _load_lsp_symbols()
 
 
 def test_lsp_config_state_defaults_to_disabled_with_no_servers() -> None:
@@ -22,6 +40,7 @@ def test_lsp_config_state_defaults_to_disabled_with_no_servers() -> None:
     assert state.configured_enabled is False
     assert state.servers == {}
     assert state.resolve("pyright") is None
+    assert state.default_server_name() is None
 
 
 def test_lsp_config_state_wraps_runtime_lsp_config_servers() -> None:
@@ -29,8 +48,8 @@ def test_lsp_config_state_wraps_runtime_lsp_config_servers() -> None:
         RuntimeLspConfig(
             enabled=True,
             servers={
-                "pyright": {"command": ["pyright-langserver", "--stdio"]},
-                "ruff": {"command": ["ruff", "server"]},
+                "pyright": RuntimeLspServerConfig(command=("pyright-langserver", "--stdio")),
+                "ruff": RuntimeLspServerConfig(command=("ruff", "server"), languages=("python",)),
             },
         )
     )
@@ -39,8 +58,8 @@ def test_lsp_config_state_wraps_runtime_lsp_config_servers() -> None:
 
     assert state.configured_enabled is True
     assert tuple(state.servers) == ("pyright", "ruff")
-    assert pyright_server is not None
-    assert pyright_server.definition == {"command": ["pyright-langserver", "--stdio"]}
+    assert pyright_server == RuntimeLspServerConfig(command=("pyright-langserver", "--stdio"))
+    assert state.default_server_name() == "pyright"
     assert state.resolve("missing") is None
 
 
@@ -48,7 +67,7 @@ def test_disabled_lsp_manager_reports_configured_servers_without_runtime_availab
     manager = DisabledLspManager(
         RuntimeLspConfig(
             enabled=True,
-            servers={"pyright": {"command": ["pyright-langserver", "--stdio"]}},
+            servers={"pyright": RuntimeLspServerConfig(command=("pyright-langserver", "--stdio"))},
         )
     )
 
@@ -60,7 +79,63 @@ def test_disabled_lsp_manager_reports_configured_servers_without_runtime_availab
     assert state.configuration is manager.configuration
     assert tuple(state.servers) == ("pyright",)
     assert state.servers["pyright"].configured is True
+    assert state.servers["pyright"].status == "stopped"
     assert state.servers["pyright"].available is False
+
+
+def test_disabled_lsp_manager_rejects_requests() -> None:
+    manager = DisabledLspManager()
+
+    with pytest.raises(ValueError, match="disabled"):
+        _ = manager.request(
+            LspRequest(
+                server_name=None,
+                method="textDocument/definition",
+                params={},
+                workspace=Path("."),
+            )
+        )
+
+
+def test_build_lsp_manager_returns_managed_manager_when_enabled_and_configured() -> None:
+    manager = build_lsp_manager(
+        RuntimeLspConfig(
+            enabled=True,
+            servers={"pyright": RuntimeLspServerConfig(command=("pyright-langserver", "--stdio"))},
+        )
+    )
+
+    state = manager.current_state()
+
+    assert isinstance(manager, ManagedLspManager)
+    assert state.mode == "managed"
+    assert state.servers["pyright"].status == "stopped"
+
+
+def test_managed_lsp_manager_marks_failed_startup_when_command_is_missing(tmp_path: Path) -> None:
+    manager = ManagedLspManager(
+        RuntimeLspConfig(
+            enabled=True,
+            servers={
+                "broken": RuntimeLspServerConfig(command=("definitely-not-a-real-lsp-binary",))
+            },
+        )
+    )
+
+    request = LspRequest(
+        server_name="broken",
+        method="textDocument/definition",
+        params={"textDocument": {"uri": (tmp_path / "sample.py").as_uri()}},
+        workspace=tmp_path,
+    )
+
+    with pytest.raises(ValueError, match="failed to start LSP server broken"):
+        _ = manager.request(request)
+
+    state = manager.current_state()
+    assert state.servers["broken"].status == "failed"
+    assert state.servers["broken"].available is False
+    assert state.servers["broken"].last_error is not None
 
 
 def test_lsp_operation_strings_match_protocol_method_names() -> None:

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -13,6 +13,7 @@ from voidcode.runtime.config import (
     RuntimeAcpConfig,
     RuntimeHooksConfig,
     RuntimeLspConfig,
+    RuntimeLspServerConfig,
     RuntimeSkillsConfig,
     RuntimeToolsBuiltinConfig,
     RuntimeToolsConfig,
@@ -121,7 +122,7 @@ def test_runtime_config_parses_extension_domains(tmp_path: Path) -> None:
     )
     assert config.lsp == RuntimeLspConfig(
         enabled=False,
-        servers={"pyright": {"command": ["pyright-langserver", "--stdio"]}},
+        servers={"pyright": RuntimeLspServerConfig(command=("pyright-langserver", "--stdio"))},
     )
     assert config.acp == RuntimeAcpConfig(enabled=False)
 
@@ -250,6 +251,26 @@ def test_runtime_config_rejects_invalid_repo_local_execution_engine(tmp_path: Pa
             {"lsp": {"servers": []}},
             "runtime config field 'lsp.servers'",
             id="lsp-servers-shape",
+        ),
+        pytest.param(
+            {"lsp": {"servers": {"pyright": []}}},
+            "runtime config field 'lsp.servers.pyright'",
+            id="lsp-server-shape",
+        ),
+        pytest.param(
+            {"lsp": {"servers": {"pyright": {"command": []}}}},
+            "runtime config field 'lsp.servers.pyright.command'.*at least one string",
+            id="lsp-server-command-empty",
+        ),
+        pytest.param(
+            {"lsp": {"servers": {"pyright": {"command": [False]}}}},
+            "runtime config field 'lsp.servers.pyright.command\\[0\\]'",
+            id="lsp-server-command-item-type",
+        ),
+        pytest.param(
+            {"lsp": {"servers": {"pyright": {"command": ["pyright"], "languages": [1]}}}},
+            "runtime config field 'lsp.servers.pyright.languages\\[0\\]'",
+            id="lsp-server-language-item-type",
         ),
         pytest.param({"acp": []}, "runtime config field 'acp'", id="acp-shape"),
         pytest.param(

--- a/tests/unit/runtime/test_runtime_events.py
+++ b/tests/unit/runtime/test_runtime_events.py
@@ -5,6 +5,9 @@ from voidcode.runtime.events import (
     GRAPH_LOOP_STEP,
     GRAPH_MODEL_TURN,
     PROTOTYPE_ADDITIVE_EVENT_TYPES,
+    RUNTIME_LSP_SERVER_FAILED,
+    RUNTIME_LSP_SERVER_STARTED,
+    RUNTIME_LSP_SERVER_STOPPED,
     RUNTIME_MEMORY_REFRESHED,
     RUNTIME_SKILLS_APPLIED,
 )
@@ -14,6 +17,9 @@ def test_emitted_event_types_include_stable_graph_protocol_events() -> None:
     assert GRAPH_LOOP_STEP in EMITTED_EVENT_TYPES
     assert GRAPH_MODEL_TURN in EMITTED_EVENT_TYPES
     assert RUNTIME_SKILLS_APPLIED in EMITTED_EVENT_TYPES
+    assert RUNTIME_LSP_SERVER_STARTED in EMITTED_EVENT_TYPES
+    assert RUNTIME_LSP_SERVER_STOPPED in EMITTED_EVENT_TYPES
+    assert RUNTIME_LSP_SERVER_FAILED in EMITTED_EVENT_TYPES
 
 
 def test_future_additive_event_types_keep_memory_refresh_only() -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -13,6 +13,7 @@ from voidcode.runtime.config import (
     RuntimeAcpConfig,
     RuntimeConfig,
     RuntimeLspConfig,
+    RuntimeLspServerConfig,
     RuntimeSkillsConfig,
 )
 from voidcode.runtime.events import EventEnvelope
@@ -130,7 +131,9 @@ def test_runtime_initializes_extension_state_from_config_when_enabled(tmp_path: 
             skills=RuntimeSkillsConfig(enabled=True),
             lsp=RuntimeLspConfig(
                 enabled=True,
-                servers={"pyright": {"command": ["pyright-langserver", "--stdio"]}},
+                servers={
+                    "pyright": RuntimeLspServerConfig(command=("pyright-langserver", "--stdio"))
+                },
             ),
             acp=RuntimeAcpConfig(enabled=True),
         ),
@@ -151,9 +154,10 @@ def test_runtime_initializes_extension_state_from_config_when_enabled(tmp_path: 
     assert provider_model.provider.name == "opencode"
     assert skill.description == "Demo skill"
     assert skill.directory == skill_dir.resolve()
-    assert lsp_state.mode == "disabled"
+    assert lsp_state.mode == "managed"
     assert lsp_state.configuration.configured_enabled is True
     assert tuple(lsp_state.servers) == ("pyright",)
+    assert lsp_state.servers["pyright"].status == "stopped"
     assert lsp_state.servers["pyright"].available is False
     assert acp_state.mode == "disabled"
     assert acp_state.configuration.configured_enabled is True
@@ -191,7 +195,9 @@ def test_runtime_retains_explicit_injected_extension_instances(tmp_path: Path) -
             skills=RuntimeSkillsConfig(enabled=True),
             lsp=RuntimeLspConfig(
                 enabled=True,
-                servers={"pyright": {"command": ["pyright-langserver", "--stdio"]}},
+                servers={
+                    "pyright": RuntimeLspServerConfig(command=("pyright-langserver", "--stdio"))
+                },
             ),
             acp=RuntimeAcpConfig(enabled=True),
         ),


### PR DESCRIPTION
close #60 
## Summary
- type LSP server configuration and add runtime-managed LSP lifecycle/events
- route LSP requests through the runtime boundary so tool execution, failure handling, and persisted runtime metadata stay in one control plane
- shut down managed LSP servers after CLI commands and cover enabled/disabled/failure paths with unit and integration tests

## Verification
- mise run typecheck
- mise run test
- manual runtime-managed LSP QA with a fake stdio server, verifying `runtime.lsp_server_started`, a successful `runtime.tool_completed` payload, and `runtime.lsp_server_stopped`