### PR TITLE
feat(tui): replace sidebar with compact status bar and Ctrl+x telescope modal

### DIFF
--- a/src/voidcode/tui/app.py
+++ b/src/voidcode/tui/app.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal
+from typing import ClassVar, Literal, cast
 
 from rich.text import Text
 from textual import work
 from textual.app import App, ComposeResult
-from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.binding import Binding
+from textual.containers import Vertical
 from textual.widgets import Footer, Header, Input, RichLog, Static
 
 from ..runtime.config import load_runtime_config
@@ -14,49 +15,91 @@ from ..runtime.contracts import RuntimeRequest
 from ..runtime.events import EventEnvelope
 from ..runtime.permission import PermissionDecision
 from ..runtime.service import VoidCodeRuntime
+from ..runtime.session import StoredSessionSummary
 from .messages import StreamChunkReceived, StreamCompleted, StreamFailed
-from .screens import ApprovalModal
+from .screens import ApprovalModal, RuntimeDetailScreen
+
+# Internal events that carry no value to the operator; suppress from transcript.
+_SILENT_EVENT_TYPES = frozenset(
+    {
+        "runtime.request_received",
+        "runtime.permission_resolved",
+        "runtime.tool_lookup_succeeded",
+        "runtime.tool_hook_pre",
+        "runtime.tool_hook_post",
+        "runtime.skills_loaded",
+        "graph.loop_step",
+        "graph.response_ready",
+    }
+)
+
+_STATUS_ICONS: dict[str, str] = {
+    "completed": "●",
+    "failed": "✗",
+    "waiting": "◐",
+    "running": "◌",
+    "idle": "○",
+}
+_LSP_ICONS: dict[str, str] = {
+    "running": "●",
+    "starting": "◌",
+    "stopped": "○",
+    "failed": "✗",
+}
+_ACP_ICONS: dict[str, str] = {
+    "connected": "●",
+    "disconnected": "○",
+    "failed": "✗",
+}
+
+
+class StatusBar(Static):
+    """Compact single-line runtime status bar docked at the bottom."""
+
+    DEFAULT_CSS = """
+    StatusBar {
+        dock: bottom;
+        height: 1;
+        background: $panel;
+        color: $text-muted;
+        padding: 0 1;
+    }
+    """
 
 
 class VoidCodeTUI(App[int]):
-    TITLE = "VoidCode TUI"
+    TITLE = "VoidCode"
+    ANSI_COLOR = True
+    COMMAND_PALETTE_BINDING: ClassVar[str] = ""  # type: ignore[assignment]  # disable built-in Ctrl+P
+
     CSS = """
     Screen {
         layout: vertical;
+        background: transparent;
     }
     #main-layout {
-        height: 100%;
+        height: 1fr;
         width: 100%;
-    }
-    #transcript-column {
-        width: 3fr;
-        height: 100%;
-        border-right: solid $accent;
-    }
-    #sidebar-column {
-        width: 1fr;
-        height: 100%;
-        padding: 1;
     }
     #transcript-log {
         height: 1fr;
-        border: solid $panel;
     }
-    #current-response {
-        min-height: 3;
-        max-height: 8;
-        border: solid $success;
+    #status-panel {
+        min-height: 1;
+        max-height: 3;
+        border-top: solid $panel;
         padding: 0 1;
+        color: $text-muted;
     }
     #composer-input {
         dock: bottom;
     }
-    .sidebar-header {
-        text-style: bold;
-        color: $accent;
-        margin-top: 1;
-    }
     """
+
+    BINDINGS = [
+        Binding("ctrl+p", "open_sessions", "Sessions"),
+        Binding("ctrl+x", "open_detail", "Runtime", priority=True),
+    ]
 
     def __init__(self, workspace: Path, approval_mode: PermissionDecision | None = None) -> None:
         super().__init__()
@@ -68,26 +111,26 @@ class VoidCodeTUI(App[int]):
         self.pending_request_id: str | None = None
         self.current_state = "Idle"
         self._stream_active = False
+        self._tokens_in: int = 0
+        self._tokens_out: int = 0
+
+    # ── layout ────────────────────────────────────────────────────────────────
 
     def compose(self) -> ComposeResult:
         yield Header()
-        with Horizontal(id="main-layout"):
-            with Vertical(id="transcript-column"):
-                yield RichLog(id="transcript-log", markup=False)
-                yield Static("Waiting for input...", id="current-response")
-                yield Input(placeholder="Ask voidcode...", id="composer-input")
-            with VerticalScroll(id="sidebar-column"):
-                yield Static("Status", classes="sidebar-header")
-                yield Static("Idle", id="status-panel")
-                yield Static("Tasks", classes="sidebar-header")
-                yield Static("No active tasks.", id="tasks-panel")
-                yield Static("MCP", classes="sidebar-header")
-                yield Static("No tools loaded.", id="mcp-panel")
+        with Vertical(id="main-layout"):
+            yield RichLog(id="transcript-log", markup=False, highlight=False)
+            yield Static("Idle", id="status-panel")
+            yield Input(placeholder="Ask voidcode…", id="composer-input")
+        yield StatusBar(id="runtime-status-bar")
         yield Footer()
 
     def on_mount(self) -> None:
         self._set_state("Idle")
         self.query_one("#composer-input", Input).focus()
+        self._refresh_status_bar()
+
+    # ── input ─────────────────────────────────────────────────────────────────
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         prompt = event.value.strip()
@@ -101,40 +144,174 @@ class VoidCodeTUI(App[int]):
         self._set_state("Running")
         self._set_stream_active(True)
 
+        if self.session_id is None:
+            self._tokens_in = 0
+            self._tokens_out = 0
+
         request = RuntimeRequest(prompt=prompt, allocate_session_id=self.session_id is None)
         self._start_stream(request)
 
+    # ── transcript helpers ────────────────────────────────────────────────────
+
     def _write_user_prompt(self, prompt: str) -> None:
-        self.query_one("#transcript-log", RichLog).write(Text(f"User: {prompt}"))
+        self.query_one("#transcript-log", RichLog).write(Text(f"You: {prompt}", style="bold"))
 
     def _write_event_line(self, event: EventEnvelope) -> None:
-        self.query_one("#transcript-log", RichLog).write(
-            Text(f"EVENT {event.event_type} source={event.source}", style="dim")
-        )
+        if event.event_type in _SILENT_EVENT_TYPES:
+            return
+
+        log = self.query_one("#transcript-log", RichLog)
+        p = event.payload
+
+        if event.event_type == "runtime.skills_applied":
+            skills = p.get("skills")
+            skill_list = cast(list[object], skills) if isinstance(skills, list) else []
+            names = ", ".join(str(s) for s in skill_list)
+            log.write(Text(f"⚡ skills: {names}", style="dim"))
+
+        elif event.event_type == "graph.model_turn":
+            provider = p.get("provider") or ""
+            model = p.get("model") or ""
+            tag = " / ".join(x for x in (str(provider), str(model)) if x)
+            log.write(Text(f"◌ {tag or 'model turn'}", style="dim"))
+
+        elif event.event_type == "graph.tool_request_created":
+            tool = p.get("tool", "")
+            path = p.get("path", "")
+            suffix = f"  {path}" if path else ""
+            log.write(Text(f"→ {tool}{suffix}", style="cyan"))
+
+        elif event.event_type == "runtime.tool_completed":
+            # Covered by the "→ tool" line above; suppress duplicate output.
+            pass
+
+        elif event.event_type == "runtime.approval_resolved":
+            decision = p.get("decision", "")
+            icon, style = ("✓", "green") if decision == "allow" else ("✗", "red")
+            log.write(Text(f"{icon} approval: {decision}", style=style))
+
+        elif event.event_type == "runtime.failed":
+            log.write(Text(f"✗ {p.get('error', 'unknown error')}", style="bold red"))
+
+        elif event.event_type in {
+            "runtime.lsp_server_started",
+            "runtime.lsp_server_stopped",
+            "runtime.lsp_server_failed",
+        }:
+            server = p.get("server", "")
+            state = p.get("state", "")
+            log.write(Text(f"LSP  {server}: {state}", style="dim"))
+
+        elif event.event_type in {
+            "runtime.acp_connected",
+            "runtime.acp_disconnected",
+            "runtime.acp_failed",
+        }:
+            status = p.get("status", "")
+            log.write(Text(f"ACP: {status}", style="dim"))
+
+        else:
+            # Unknown event — show generically per contract requirement.
+            log.write(Text(f"· {event.event_type}", style="dim"))
 
     def _write_output_line(self, output: str) -> None:
         self.query_one("#transcript-log", RichLog).write(Text(output))
 
+    # ── state management ──────────────────────────────────────────────────────
+
     def _set_state(self, state: str) -> None:
         self.current_state = state
         self.query_one("#status-panel", Static).update(state)
-        current = self.query_one("#current-response", Static)
-        if state == "Idle":
-            current.update("Waiting for input...")
-        elif state == "Running":
-            current.update("Working...")
-        elif state == "Waiting approval":
-            current.update("Waiting for approval...")
-        elif state == "Completed":
-            current.update("Completed. Waiting for input...")
-        elif state == "Failed":
-            current.update("Stream failed. Waiting for input...")
+        self._refresh_status_bar()
 
     def _set_stream_active(self, active: bool) -> None:
         self._stream_active = active
         self.query_one("#composer-input", Input).disabled = (
             active or self.pending_request_id is not None
         )
+
+    # ── status bar ────────────────────────────────────────────────────────────
+
+    def _refresh_status_bar(self) -> None:
+        parts: list[str] = []
+
+        # Workspace
+        parts.append(self.workspace.name or str(self.workspace))
+
+        # Session + state
+        if self.session_id:
+            short_id = self.session_id[:8]
+            icon = _STATUS_ICONS.get(self.current_state.lower(), "○")
+            parts.append(f"{short_id}  {icon} {self.current_state}")
+        else:
+            parts.append("new session")
+
+        # Model
+        try:
+            model: object = self.runtime._config.model or self.runtime._config.execution_engine  # type: ignore[reportPrivateUsage]
+            model_str = str(model)
+            if len(model_str) > 24:
+                model_str = model_str[:22] + "…"
+            parts.append(model_str)
+        except Exception:
+            pass
+
+        # LSP
+        try:
+            lsp = self.runtime.current_lsp_state()
+            if lsp.mode != "disabled" and lsp.servers:
+                lsp_parts = [
+                    f"{_LSP_ICONS.get(srv.status, '○')} {name}" for name, srv in lsp.servers.items()
+                ]
+                parts.append("  ".join(lsp_parts))
+        except Exception:
+            pass
+
+        # ACP
+        try:
+            acp = self.runtime.current_acp_state()
+            if acp.mode != "disabled":
+                icon = _ACP_ICONS.get(acp.status, "○")
+                parts.append(f"{icon} MCP")
+        except Exception:
+            pass
+
+        # Tokens
+        if self._tokens_in or self._tokens_out:
+
+            def _fmt(n: int) -> str:
+                return f"{n / 1000:.1f}k" if n >= 1000 else str(n)
+
+            parts.append(f"↑{_fmt(self._tokens_in)} ↓{_fmt(self._tokens_out)}")
+
+        bar = self.query_one("#runtime-status-bar", StatusBar)
+        bar.update("  ·  ".join(parts))
+
+    def _build_runtime_snapshot(self) -> dict[str, object]:
+        snapshot: dict[str, object] = {}
+        try:
+            snapshot["model"] = self.runtime._config.model  # type: ignore[reportPrivateUsage]
+            snapshot["execution_engine"] = self.runtime._config.execution_engine  # type: ignore[reportPrivateUsage]
+            snapshot["approval_mode"] = self.runtime._config.approval_mode  # type: ignore[reportPrivateUsage]
+        except Exception:
+            pass
+        try:
+            snapshot["tools_count"] = len(self.runtime._tool_registry.definitions())  # type: ignore[reportPrivateUsage]
+        except Exception:
+            pass
+        try:
+            lsp = self.runtime.current_lsp_state()
+            snapshot["lsp_servers"] = [(name, srv.status) for name, srv in lsp.servers.items()]
+        except Exception:
+            snapshot["lsp_servers"] = []
+        try:
+            acp = self.runtime.current_acp_state()
+            snapshot["acp_status"] = acp.status
+        except Exception:
+            snapshot["acp_status"] = "—"
+        return snapshot
+
+    # ── stream workers ────────────────────────────────────────────────────────
 
     @work(thread=True)
     def _start_stream(self, request: RuntimeRequest) -> None:
@@ -172,13 +349,39 @@ class VoidCodeTUI(App[int]):
         except Exception as error:
             self.post_message(StreamFailed(error))
 
+    @work(thread=True)
+    def _replay_session(self, summary: StoredSessionSummary) -> None:
+        last_status = "Idle"
+        saw_chunk = False
+        try:
+            for chunk in self.runtime.resume_stream(summary.session.id):
+                saw_chunk = True
+                last_status = chunk.session.status
+                self.post_message(StreamChunkReceived(chunk))
+            if not saw_chunk:
+                raise ValueError("runtime stream emitted no chunks")
+            self.post_message(StreamCompleted(last_status))
+        except Exception as error:
+            self.post_message(StreamFailed(error))
+
+    # ── message handlers ──────────────────────────────────────────────────────
+
     def on_stream_chunk_received(self, message: StreamChunkReceived) -> None:
         chunk = message.chunk
         self.session_id = chunk.session.session.id
 
         if chunk.kind == "event" and chunk.event is not None:
             event = chunk.event
+
+            # Accumulate token counts when available in the event payload.
+            if event.event_type == "graph.model_turn":
+                raw_in = event.payload.get("input_tokens") or 0
+                raw_out = event.payload.get("output_tokens") or 0
+                self._tokens_in += raw_in if isinstance(raw_in, int) else 0
+                self._tokens_out += raw_out if isinstance(raw_out, int) else 0
+
             self._write_event_line(event)
+
             if (
                 chunk.session.status == "waiting"
                 and event.event_type == "runtime.approval_requested"
@@ -199,6 +402,18 @@ class VoidCodeTUI(App[int]):
                     self._resume_stream(self.session_id, request_id, decision)
 
                 self.push_screen(ApprovalModal(event), _handle_decision)
+                return
+
+            # Refresh status bar on runtime infrastructure events.
+            if event.event_type in {
+                "runtime.lsp_server_started",
+                "runtime.lsp_server_stopped",
+                "runtime.lsp_server_failed",
+                "runtime.acp_connected",
+                "runtime.acp_disconnected",
+                "runtime.acp_failed",
+            }:
+                self._refresh_status_bar()
                 return
 
             if event.event_type == "runtime.failed":
@@ -225,8 +440,43 @@ class VoidCodeTUI(App[int]):
 
     def on_stream_failed(self, message: StreamFailed) -> None:
         self.query_one("#transcript-log", RichLog).write(
-            Text(f"Error: {message.error}", style="bold red")
+            Text(f"✗ {message.error}", style="bold red")
         )
         self.pending_request_id = None
         self._set_state("Failed")
         self._set_stream_active(False)
+
+    # ── session / detail picker ───────────────────────────────────────────────
+
+    def action_open_sessions(self) -> None:
+        if self._stream_active:
+            self.notify("Cannot switch sessions while running.", severity="warning")
+            return
+        self._open_detail(initial_tab="sessions")
+
+    def action_open_detail(self) -> None:
+        if self._stream_active:
+            self.notify("Cannot open runtime details while running.", severity="warning")
+            return
+        self._open_detail(initial_tab="sessions")
+
+    def _open_detail(self, *, initial_tab: str = "sessions") -> None:
+        sessions = self.runtime.list_sessions()
+        snapshot = self._build_runtime_snapshot()
+
+        def _handle_selection(summary: StoredSessionSummary | None) -> None:
+            if summary is None or self._stream_active:
+                return
+            self.query_one("#transcript-log", RichLog).clear()
+            self.session_id = summary.session.id
+            self._tokens_in = 0
+            self._tokens_out = 0
+            self._write_user_prompt(f"[resume {summary.session.id[:8]}]")
+            self._set_state("Running")
+            self._set_stream_active(True)
+            self._replay_session(summary)
+
+        self.push_screen(
+            RuntimeDetailScreen(sessions, snapshot, initial_tab=initial_tab),
+            _handle_selection,
+        )

--- a/src/voidcode/tui/screens.py
+++ b/src/voidcode/tui/screens.py
@@ -1,13 +1,35 @@
 from __future__ import annotations
 
-from typing import Literal
+from datetime import datetime
+from typing import Literal, cast
 
 from textual.app import ComposeResult
-from textual.containers import Horizontal, Vertical
+from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
-from textual.widgets import Button, Label
+from textual.widgets import Button, Label, OptionList, Static, TabbedContent, TabPane
+from textual.widgets._option_list import Option
 
 from ..runtime.events import EventEnvelope
+from ..runtime.session import StoredSessionSummary
+
+_STATUS_ICONS: dict[str, str] = {
+    "completed": "●",
+    "failed": "✗",
+    "waiting": "◐",
+    "running": "◌",
+    "idle": "○",
+}
+_LSP_ICONS: dict[str, str] = {
+    "running": "●",
+    "starting": "◌",
+    "stopped": "○",
+    "failed": "✗",
+}
+_ACP_ICONS: dict[str, str] = {
+    "connected": "●",
+    "disconnected": "○",
+    "failed": "✗",
+}
 
 
 class ApprovalModal(ModalScreen[Literal["allow", "deny"]]):
@@ -17,14 +39,22 @@ class ApprovalModal(ModalScreen[Literal["allow", "deny"]]):
     }
     #dialog {
         padding: 1 2;
-        width: 60;
-        height: 11;
+        width: 70;
+        height: auto;
         border: thick $background 80%;
         background: $surface;
     }
     #question {
-        content-align: center middle;
+        text-style: bold;
         width: 100%;
+        margin-bottom: 1;
+    }
+    .approval-detail {
+        color: $text-muted;
+        margin-bottom: 0;
+    }
+    #buttons {
+        margin-top: 1;
     }
     """
 
@@ -33,18 +63,224 @@ class ApprovalModal(ModalScreen[Literal["allow", "deny"]]):
         self.event = event
 
     def compose(self) -> ComposeResult:
-        tool = str(self.event.payload.get("tool", "unknown"))
-        target_summary = self.event.payload.get("target_summary")
+        payload = self.event.payload
+        tool = str(payload.get("tool", "unknown"))
+        target_summary = payload.get("target_summary")
+        reason = payload.get("reason")
+        arguments = payload.get("arguments")
+
         if isinstance(target_summary, str) and target_summary:
-            prompt = f"Approve {tool} for {target_summary}?"
+            heading = f"Approve {tool}  —  {target_summary}"
         else:
-            prompt = f"Approve {tool}?"
+            heading = f"Approve {tool}?"
 
         with Vertical(id="dialog"):
-            yield Label(prompt, id="question")
-            with Horizontal():
+            yield Label(heading, id="question")
+            if isinstance(reason, str) and reason:
+                yield Static(f"Reason: {reason}", classes="approval-detail")
+            if isinstance(arguments, dict) and arguments:
+                items = cast(dict[str, object], arguments)
+                pairs = "  ".join(f"{k}={v}" for k, v in list(items.items())[:4])
+                yield Static(f"Args:   {pairs}", classes="approval-detail")
+            with Horizontal(id="buttons"):
                 yield Button("Allow", variant="success", id="allow")
                 yield Button("Deny", variant="error", id="deny")
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         self.dismiss("allow" if event.button.id == "allow" else "deny")
+
+
+class SessionPickerScreen(ModalScreen[StoredSessionSummary | None]):
+    """Telescope-style session picker.  Ctrl+P opens, Esc closes."""
+
+    BINDINGS = [("escape", "dismiss_none", "Close")]
+
+    CSS = """
+    SessionPickerScreen {
+        align: center middle;
+    }
+    #sp-container {
+        width: 82%;
+        height: 72%;
+        border: thick $background 80%;
+        background: $surface;
+        padding: 1 2;
+    }
+    #sp-title {
+        text-style: bold;
+        color: $accent;
+        height: 1;
+        margin-bottom: 1;
+    }
+    #sp-list {
+        height: 1fr;
+    }
+    #sp-empty {
+        color: $text-muted;
+        height: 1fr;
+        content-align: center middle;
+    }
+    #sp-hint {
+        color: $text-muted;
+        height: 1;
+        margin-top: 1;
+    }
+    """
+
+    def __init__(self, sessions: tuple[StoredSessionSummary, ...]) -> None:
+        super().__init__()
+        self.sessions = sessions
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="sp-container"):
+            yield Label("Sessions", id="sp-title")
+            if not self.sessions:
+                yield Label("No sessions found.", id="sp-empty")
+            else:
+                options: list[Option] = []
+                for s in self.sessions:
+                    ts = datetime.fromtimestamp(s.updated_at / 1000).strftime("%m/%d %H:%M")
+                    icon = _STATUS_ICONS.get(s.status, "○")
+                    sid = s.session.id[:8]
+                    prompt = s.prompt[:52] + "…" if len(s.prompt) > 52 else s.prompt
+                    label = f"{icon}  {ts}  [{sid}]  {prompt}"
+                    options.append(Option(label, id=s.session.id))
+                yield OptionList(*options, id="sp-list")
+            yield Label("↑↓ navigate · enter select · esc close", id="sp-hint")
+
+    def action_dismiss_none(self) -> None:
+        self.dismiss(None)
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        option_id = event.option_id
+        for session in self.sessions:
+            if session.session.id == option_id:
+                self.dismiss(session)
+                return
+        self.dismiss(None)
+
+
+class RuntimeDetailScreen(ModalScreen[StoredSessionSummary | None]):
+    """Ctrl+x / Ctrl+P telescope modal: Sessions | Runtime tabs."""
+
+    BINDINGS = [("escape", "dismiss_none", "Close")]
+
+    CSS = """
+    RuntimeDetailScreen {
+        align: center middle;
+    }
+    #rd-container {
+        width: 82%;
+        height: 78%;
+        border: thick $background 80%;
+        background: $surface;
+        padding: 1 2;
+    }
+    #rd-title {
+        text-style: bold;
+        color: $accent;
+        height: 1;
+        margin-bottom: 1;
+    }
+    #rd-sessions-list {
+        height: 1fr;
+    }
+    #rd-sessions-empty {
+        color: $text-muted;
+        height: 1fr;
+        content-align: center middle;
+    }
+    #rd-runtime-content {
+        height: 1fr;
+    }
+    .rd-section-label {
+        color: $text-muted;
+        text-style: bold;
+        margin-top: 1;
+        height: 1;
+    }
+    .rd-section-value {
+        color: $text;
+        min-height: 1;
+        padding-left: 2;
+    }
+    #rd-hint {
+        color: $text-muted;
+        height: 1;
+        margin-top: 1;
+    }
+    """
+
+    def __init__(
+        self,
+        sessions: tuple[StoredSessionSummary, ...],
+        runtime_snapshot: dict[str, object],
+        initial_tab: str = "sessions",
+    ) -> None:
+        super().__init__()
+        self.sessions = sessions
+        self.runtime_snapshot = runtime_snapshot
+        self._initial_tab = initial_tab
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="rd-container"):
+            yield Label("Runtime", id="rd-title")
+            with TabbedContent(initial=self._initial_tab):
+                with TabPane("Sessions", id="sessions"):
+                    if not self.sessions:
+                        yield Label("No sessions found.", id="rd-sessions-empty")
+                    else:
+                        options: list[Option] = []
+                        for s in self.sessions:
+                            ts = datetime.fromtimestamp(s.updated_at / 1000).strftime("%m/%d %H:%M")
+                            icon = _STATUS_ICONS.get(s.status, "○")
+                            sid = s.session.id[:8]
+                            prompt = s.prompt[:52] + "…" if len(s.prompt) > 52 else s.prompt
+                            label = f"{icon}  {ts}  [{sid}]  {prompt}"
+                            options.append(Option(label, id=s.session.id))
+                        yield OptionList(*options, id="rd-sessions-list")
+                with TabPane("Runtime", id="runtime"):
+                    with VerticalScroll(id="rd-runtime-content"):
+                        model = str(self.runtime_snapshot.get("model") or "—")
+                        engine = str(self.runtime_snapshot.get("execution_engine") or "—")
+                        approval = str(self.runtime_snapshot.get("approval_mode") or "—")
+                        tools_count = self.runtime_snapshot.get("tools_count")
+                        yield Static("MODEL", classes="rd-section-label")
+                        yield Static(f"{model}  ({engine})", classes="rd-section-value")
+                        yield Static("APPROVAL", classes="rd-section-label")
+                        yield Static(approval, classes="rd-section-value")
+                        yield Static("TOOLS", classes="rd-section-label")
+                        yield Static(
+                            f"{tools_count} registered" if tools_count is not None else "—",
+                            classes="rd-section-value",
+                        )
+                        raw_lsp = self.runtime_snapshot.get("lsp_servers")
+                        lsp_entries: list[tuple[str, str]] = (
+                            cast(list[tuple[str, str]], raw_lsp)
+                            if isinstance(raw_lsp, list)
+                            else []
+                        )
+                        if lsp_entries:
+                            yield Static("LSP", classes="rd-section-label")
+                            for name, status in lsp_entries:
+                                lsp_icon = _LSP_ICONS.get(status, "○")
+                                yield Static(
+                                    f"{lsp_icon} {name}  {status}",
+                                    classes="rd-section-value",
+                                )
+                        acp_status = str(self.runtime_snapshot.get("acp_status") or "—")
+                        acp_icon = _ACP_ICONS.get(acp_status, "○")
+                        yield Static("MCP / ACP", classes="rd-section-label")
+                        yield Static(f"{acp_icon} {acp_status}", classes="rd-section-value")
+            yield Label("tab switch tab · ↑↓ navigate · enter select · esc close", id="rd-hint")
+
+    def action_dismiss_none(self) -> None:
+        self.dismiss(None)
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        option_id = event.option_id
+        for session in self.sessions:
+            if session.session.id == option_id:
+                self.dismiss(session)
+                return
+        self.dismiss(None)

--- a/tests/unit/interface/test_tui.py
+++ b/tests/unit/interface/test_tui.py
@@ -172,3 +172,113 @@ async def test_tui_failed_stream_stays_failed(app_class: Any) -> None:
 
                 assert app.current_state == "Failed"
                 assert app.query_one("#status-panel").content == "Failed"
+
+
+@pytest.mark.anyio
+async def test_tui_accumulates_tokens_from_model_turn(app_class: Any) -> None:
+    VoidCodeTUI, StreamChunkReceived, _ = app_class
+
+    with patch("voidcode.tui.app.load_runtime_config", autospec=True, return_value=object()):
+        with patch("voidcode.tui.app.VoidCodeRuntime", autospec=True):
+            app = VoidCodeTUI(workspace=Path("."))
+
+            async with app.run_test() as pilot:
+                app.on_stream_chunk_received(
+                    StreamChunkReceived(
+                        _make_chunk(
+                            status="running",
+                            event=_runtime_event(
+                                "graph.model_turn",
+                                input_tokens=500,
+                                output_tokens=300,
+                            ),
+                        )
+                    )
+                )
+                app.on_stream_chunk_received(
+                    StreamChunkReceived(
+                        _make_chunk(
+                            status="running",
+                            event=_runtime_event(
+                                "graph.model_turn",
+                                input_tokens=200,
+                                output_tokens=100,
+                            ),
+                        )
+                    )
+                )
+                await pilot.pause()
+
+                assert app._tokens_in == 700
+                assert app._tokens_out == 400
+
+
+@pytest.mark.anyio
+async def test_tui_status_bar_shows_workspace_and_session(app_class: Any) -> None:
+    VoidCodeTUI, StreamChunkReceived, _ = app_class
+
+    with patch("voidcode.tui.app.load_runtime_config", autospec=True, return_value=object()):
+        with patch("voidcode.tui.app.VoidCodeRuntime", autospec=True) as runtime_class:
+            runtime = runtime_class.return_value
+            runtime.current_lsp_state.side_effect = Exception("no lsp")
+            runtime.current_acp_state.side_effect = Exception("no acp")
+            app = VoidCodeTUI(workspace=Path("/home/user/myproject"))
+
+            async with app.run_test() as pilot:
+                app.on_stream_chunk_received(
+                    StreamChunkReceived(
+                        _make_chunk(
+                            session_id="abcdef1234567890",
+                            status="running",
+                            event=_runtime_event("graph.model_turn"),
+                        )
+                    )
+                )
+                await pilot.pause()
+
+                bar = app.query_one("#runtime-status-bar")
+                bar_text = str(bar.content)
+                assert "myproject" in bar_text
+                assert "abcdef12" in bar_text
+
+
+@pytest.mark.anyio
+async def test_tui_ctrl_p_opens_runtime_detail_screen(app_class: Any) -> None:
+    VoidCodeTUI, _, _ = app_class
+
+    with patch("voidcode.tui.app.load_runtime_config", autospec=True, return_value=object()):
+        with patch("voidcode.tui.app.VoidCodeRuntime", autospec=True) as runtime_class:
+            runtime = runtime_class.return_value
+            runtime.list_sessions.return_value = ()
+            runtime.current_lsp_state.side_effect = Exception("no lsp")
+            runtime.current_acp_state.side_effect = Exception("no acp")
+            app = VoidCodeTUI(workspace=Path("."))
+
+            async with app.run_test() as pilot:
+                await pilot.press("ctrl+p")
+                await pilot.pause()
+
+                from voidcode.tui.screens import RuntimeDetailScreen
+
+                assert isinstance(app.screen, RuntimeDetailScreen)
+
+
+@pytest.mark.anyio
+async def test_tui_ctrl_x_opens_runtime_detail_screen(app_class: Any) -> None:
+    VoidCodeTUI, _, _ = app_class
+
+    with patch("voidcode.tui.app.load_runtime_config", autospec=True, return_value=object()):
+        with patch("voidcode.tui.app.VoidCodeRuntime", autospec=True) as runtime_class:
+            runtime = runtime_class.return_value
+            runtime.list_sessions.return_value = ()
+            runtime.current_lsp_state.side_effect = Exception("no lsp")
+            runtime.current_acp_state.side_effect = Exception("no acp")
+            app = VoidCodeTUI(workspace=Path("."))
+
+            async with app.run_test() as pilot:
+                await pilot.press("ctrl+x")
+                await pilot.pause()
+
+                from voidcode.tui.screens import RuntimeDetailScreen
+
+                assert isinstance(app.screen, RuntimeDetailScreen)


### PR DESCRIPTION
## 描述

解决 #62 — 让 TUI 的状态展示与 runtime 对齐，同时借鉴 opencode 的风格重新设计信息层级。

**主要变更：**

- 移除 1/4 宽度的 sidebar，transcript 改为全宽布局
- 新增底部单行 `StatusBar` 组件，常驻显示：工作区 / 会话状态 / 模型 / LSP 服务器 / ACP（MCP）状态 / token 用量
- 新增 `RuntimeDetailScreen`：`Ctrl+x`（以及 `Ctrl+P`）唤出类 Neovim telescope 的 tabbed 弹窗
  - **Sessions 标签**：浏览 / 恢复历史会话
  - **Runtime 标签**：模型、approval 模式、工具数量、LSP 服务器、ACP 状态
- 预留 token 累计逻辑，从 `graph.model_turn` 事件中读取 `input_tokens` / `output_tokens`（runtime 有相应 payload 后即可生效）
- 关闭 Textual 内置的 `Ctrl+P` command palette，避免冲突
- 将 `#current-response` 重命名为 `#status-panel`，与现有测试保持一致

## 变更类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 破坏性变更
- [ ] 文档更新
- [ ] 重构
- [ ] 仅测试变更
- [ ] CI / 工具链变更

## 测试

新增 4 条单元测试：

- `test_tui_accumulates_tokens_from_model_turn` — token 累计逻辑
- `test_tui_status_bar_shows_workspace_and_session` — 状态栏内容
- `test_tui_ctrl_p_opens_runtime_detail_screen` — Ctrl+P 唤出弹窗
- `test_tui_ctrl_x_opens_runtime_detail_screen` — Ctrl+x 唤出弹窗

原有 4 条测试全部继续通过（含之前因 `#status-panel` ID 不一致导致失败的 2 条）。

全量单元测试：217 passed。

## 核对清单

- [x] 本地测试通过
- [x] 如有必要，已更新相关文档
- [x] 相关的 lint 检查和类型检查已通过
- [x] 未包含无关的变更