### PR TITLE
feat(tui): align the TUI with runtime sessions and events

### DIFF
--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -13,6 +13,7 @@ RUNTIME_CONFIG_FILE_NAME = ".voidcode.json"
 APPROVAL_MODE_ENV_VAR = "VOIDCODE_APPROVAL_MODE"
 MODEL_ENV_VAR = "VOIDCODE_MODEL"
 _VALID_APPROVAL_MODES = ("allow", "deny", "ask")
+_VALID_TUI_COMMANDS = ("command_palette", "session_new", "session_resume")
 
 type ExecutionEngineName = Literal["deterministic", "single_agent"]
 
@@ -61,6 +62,12 @@ class RuntimeAcpConfig:
 
 
 @dataclass(frozen=True, slots=True)
+class RuntimeTuiConfig:
+    leader_key: str = "alt+x"
+    keymap: Mapping[str, str] | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class RuntimeConfig:
     approval_mode: PermissionDecision = "ask"
     model: str | None = None
@@ -70,6 +77,7 @@ class RuntimeConfig:
     skills: RuntimeSkillsConfig | None = None
     lsp: RuntimeLspConfig | None = None
     acp: RuntimeAcpConfig | None = None
+    tui: RuntimeTuiConfig | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -82,6 +90,7 @@ class RuntimeConfigOverrides:
     skills: RuntimeSkillsConfig | None = None
     lsp: RuntimeLspConfig | None = None
     acp: RuntimeAcpConfig | None = None
+    tui: RuntimeTuiConfig | None = None
 
 
 def runtime_config_path(workspace: Path) -> Path:
@@ -116,6 +125,7 @@ def load_runtime_config(
         skills=repo_local.skills,
         lsp=repo_local.lsp,
         acp=repo_local.acp,
+        tui=repo_local.tui,
     )
 
 
@@ -160,6 +170,9 @@ def _load_repo_local_config(workspace: Path) -> RuntimeConfigOverrides:
     raw_acp = payload.get("acp")
     acp = _parse_acp_config(raw_acp)
 
+    raw_tui = payload.get("tui")
+    tui = _parse_tui_config(raw_tui)
+
     raw_approval_mode = payload.get("approval_mode")
     parsed_approval_mode = _parse_approval_mode(
         raw_approval_mode,
@@ -176,6 +189,7 @@ def _load_repo_local_config(workspace: Path) -> RuntimeConfigOverrides:
         skills=skills,
         lsp=lsp,
         acp=acp,
+        tui=tui,
     )
 
 
@@ -289,6 +303,39 @@ def _parse_acp_config(raw_acp: object) -> RuntimeAcpConfig | None:
     acp_payload = cast(dict[str, object], raw_acp)
     enabled = _parse_optional_bool(acp_payload.get("enabled"), field_path="acp.enabled")
     return RuntimeAcpConfig(enabled=enabled)
+
+
+def _parse_tui_config(raw_tui: object) -> RuntimeTuiConfig | None:
+    if raw_tui is None:
+        return None
+    if not isinstance(raw_tui, dict):
+        raise ValueError("runtime config field 'tui' must be an object when provided")
+
+    tui_payload = cast(dict[str, object], raw_tui)
+    leader_key = tui_payload.get("leader_key")
+    if leader_key is not None and not isinstance(leader_key, str):
+        raise ValueError("runtime config field 'tui.leader_key' must be a string when provided")
+
+    keymap: Mapping[str, str] | None = None
+    raw_keymap = tui_payload.get("keymap")
+    if raw_keymap is not None:
+        if not isinstance(raw_keymap, dict):
+            raise ValueError("runtime config field 'tui.keymap' must be an object when provided")
+        dict_keymap = cast(dict[str, object], raw_keymap)
+        for value in dict_keymap.values():
+            if not isinstance(value, str):
+                raise ValueError("runtime config field 'tui.keymap' values must be strings")
+            if value not in _VALID_TUI_COMMANDS:
+                allowed = ", ".join(_VALID_TUI_COMMANDS)
+                raise ValueError(
+                    f"runtime config field 'tui.keymap' values must be one of: {allowed}"
+                )
+        keymap = cast(dict[str, str], raw_keymap)
+
+    return RuntimeTuiConfig(
+        leader_key=leader_key if leader_key is not None else "alt+x",
+        keymap=keymap,
+    )
 
 
 def _parse_optional_bool(raw_value: object, *, field_path: str) -> bool | None:

--- a/src/voidcode/tui/app.py
+++ b/src/voidcode/tui/app.py
@@ -45,10 +45,9 @@ class VoidCodeTUI(App[int]):
         border: solid $panel;
     }
     #current-response {
-        min-height: 3;
-        max-height: 8;
-        border: solid $success;
+        height: 1;
         padding: 0 1;
+        color: $text-muted;
     }
     #composer-input {
         dock: bottom;
@@ -57,6 +56,16 @@ class VoidCodeTUI(App[int]):
         text-style: bold;
         color: $accent;
         margin-top: 1;
+    }
+    Footer > .footer--key {
+        color: $text;
+        background: $surface;
+        text-style: bold;
+    }
+    Footer > .footer--highlight-key {
+        color: $text;
+        background: $surface-lighten-1;
+        text-style: bold;
     }
     """
 

--- a/src/voidcode/tui/app.py
+++ b/src/voidcode/tui/app.py
@@ -24,48 +24,48 @@ class VoidCodeTUI(App[int]):
     CSS = """
     Screen {
         layout: vertical;
-        background: transparent;
+        background: ansi_default;
     }
     #main-layout {
         height: 100%;
         width: 100%;
-        background: transparent;
+        background: ansi_default;
     }
     #transcript-column {
         width: 3fr;
         height: 100%;
         border-right: solid $accent;
-        background: transparent;
+        background: ansi_default;
     }
     #sidebar-column {
         width: 1fr;
         height: 100%;
         padding: 1;
-        background: transparent;
+        background: ansi_default;
     }
     #transcript-log {
         height: 1fr;
         border: solid $panel;
-        background: transparent;
+        background: ansi_default;
     }
     #current-response {
         height: 1;
         padding: 0 1;
         color: $text-muted;
-        background: transparent;
+        background: ansi_default;
     }
     #composer-input {
         dock: bottom;
-        background: transparent;
+        background: ansi_default;
     }
     .sidebar-header {
         text-style: bold;
         color: $accent;
         margin-top: 1;
-        background: transparent;
+        background: ansi_default;
     }
     Footer {
-        background: transparent;
+        background: ansi_default;
     }
     FooterKey {
         background: $surface;
@@ -81,7 +81,7 @@ class VoidCodeTUI(App[int]):
         background: $surface;
     }
     Footer:ansi {
-        background: transparent;
+        background: ansi_default;
     }
     Footer:ansi FooterKey {
         background: $surface;

--- a/src/voidcode/tui/app.py
+++ b/src/voidcode/tui/app.py
@@ -57,15 +57,39 @@ class VoidCodeTUI(App[int]):
         color: $accent;
         margin-top: 1;
     }
-    Footer > .footer--key {
+    Footer {
+        background: transparent;
+    }
+    FooterKey {
+        background: $surface;
+        color: $text;
+    }
+    FooterKey .footer-key--key {
         color: $text;
         background: $surface;
         text-style: bold;
     }
-    Footer > .footer--highlight-key {
+    FooterKey .footer-key--description {
+        color: $text-muted;
+        background: $surface;
+    }
+    Footer:ansi {
+        background: transparent;
+    }
+    Footer:ansi FooterKey {
+        background: $surface;
         color: $text;
-        background: $surface-lighten-1;
-        text-style: bold;
+    }
+    Footer:ansi .footer-key--key {
+        color: $text;
+        background: $surface;
+    }
+    Footer:ansi .footer-key--description {
+        color: $text-muted;
+        background: $surface;
+    }
+    Footer:ansi FooterKey.-command-palette {
+        background: $surface;
     }
     """
 

--- a/src/voidcode/tui/app.py
+++ b/src/voidcode/tui/app.py
@@ -7,7 +7,7 @@ from rich.text import Text
 from textual import work
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
-from textual.widgets import Footer, Header, Input, RichLog, Static
+from textual.widgets import Footer, Input, RichLog, Static
 
 from ..runtime.config import load_runtime_config
 from ..runtime.contracts import RuntimeRequest
@@ -15,14 +15,16 @@ from ..runtime.events import EventEnvelope
 from ..runtime.permission import PermissionDecision
 from ..runtime.service import VoidCodeRuntime
 from .messages import StreamChunkReceived, StreamCompleted, StreamFailed
-from .screens import ApprovalModal
+from .screens import ApprovalModal, CommandPalette, SessionListModal
 
 
 class VoidCodeTUI(App[int]):
-    TITLE = "VoidCode TUI"
+    ansi_color = True
+
     CSS = """
     Screen {
         layout: vertical;
+        background: transparent;
     }
     #main-layout {
         height: 100%;
@@ -68,26 +70,108 @@ class VoidCodeTUI(App[int]):
         self.pending_request_id: str | None = None
         self.current_state = "Idle"
         self._stream_active = False
+        self._session_titles: dict[str, str] = {}
+        self._current_prompt: str | None = None
+
+        leader_key = "alt+x"
+        if config.tui:
+            if config.tui.leader_key:
+                leader_key = config.tui.leader_key
+            if config.tui.keymap:
+                for k, action in config.tui.keymap.items():
+                    self.bind(k, action)
+
+        self.bind(leader_key, "command_palette", description="Command Palette")
 
     def compose(self) -> ComposeResult:
-        yield Header()
         with Horizontal(id="main-layout"):
             with Vertical(id="transcript-column"):
                 yield RichLog(id="transcript-log", markup=False)
-                yield Static("Waiting for input...", id="current-response")
+                yield Static("", id="current-response")
                 yield Input(placeholder="Ask voidcode...", id="composer-input")
             with VerticalScroll(id="sidebar-column"):
                 yield Static("Status", classes="sidebar-header")
                 yield Static("Idle", id="status-panel")
-                yield Static("Tasks", classes="sidebar-header")
-                yield Static("No active tasks.", id="tasks-panel")
-                yield Static("MCP", classes="sidebar-header")
-                yield Static("No tools loaded.", id="mcp-panel")
+                yield Static("Session", classes="sidebar-header")
+                yield Static("None", id="session-panel")
+                yield Static("Workspace", classes="sidebar-header")
+                yield Static("Unknown", id="workspace-panel")
+                yield Static("LSP", classes="sidebar-header")
+                yield Static("Disabled", id="lsp-panel")
+                yield Static("ACP", classes="sidebar-header")
+                yield Static("Disabled", id="acp-panel")
+                yield Static("Tokens", classes="sidebar-header")
+                yield Static("Unavailable", id="tokens-panel")
         yield Footer()
 
     def on_mount(self) -> None:
         self._set_state("Idle")
+        self.query_one("#workspace-panel", Static).update(self.workspace.name)
+
+        lsp_state = self.runtime.current_lsp_state()
+        if lsp_state.mode == "managed":
+            active_servers = [
+                name for name, s in lsp_state.servers.items() if s.status == "running"
+            ]
+            if active_servers:
+                self.query_one("#lsp-panel", Static).update(f"Active: {len(active_servers)}")
+            else:
+                self.query_one("#lsp-panel", Static).update("No active servers")
+        else:
+            self.query_one("#lsp-panel", Static).update("Disabled")
+
+        acp_state = self.runtime.current_acp_state()
+        if acp_state.mode == "managed":
+            self.query_one("#acp-panel", Static).update(acp_state.status.title())
+        else:
+            self.query_one("#acp-panel", Static).update("Disabled")
+
         self.query_one("#composer-input", Input).focus()
+
+    def action_command_palette(self) -> None:
+        self.push_screen(CommandPalette(), self._handle_command)
+
+    def action_session_new(self) -> None:
+        self._handle_command("session: new")
+
+    def action_session_resume(self) -> None:
+        self._handle_command("session: resume")
+
+    def _handle_command(self, command: str | None) -> None:
+        if command == "session: new":
+            self.session_id = None
+            self._current_prompt = None
+            self._set_state("Idle")
+            self.query_one("#session-panel", Static).update("None")
+            self.query_one("#transcript-log", RichLog).clear()
+            self.query_one("#transcript-log", RichLog).write(
+                Text("--- New Session ---", style="bold")
+            )
+            self.query_one("#composer-input", Input).focus()
+        elif command == "session: resume":
+            sessions = self.runtime.list_sessions()
+            self._session_titles = {s.session.id: s.prompt for s in sessions}
+
+            def _handle_session(session_id: str | None) -> None:
+                if session_id:
+                    self.session_id = session_id
+
+                    short_id = session_id.removeprefix("session-")[:8]
+                    title = short_id
+                    if session_id in self._session_titles:
+                        title += f" - {self._session_titles[session_id][:30]}"
+                    self.query_one("#session-panel", Static).update(title)
+
+                    self.query_one("#transcript-log", RichLog).clear()
+                    self.query_one("#transcript-log", RichLog).write(
+                        Text(f"--- Resumed Session {short_id} ---", style="bold")
+                    )
+                    self._set_state("Running")
+                    self._set_stream_active(True)
+                    self._replay_stream(session_id)
+                    self.query_one("#composer-input", Input).focus()
+
+            self.push_screen(SessionListModal(sessions), _handle_session)
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         prompt = event.value.strip()
@@ -100,6 +184,7 @@ class VoidCodeTUI(App[int]):
         self._write_user_prompt(prompt)
         self._set_state("Running")
         self._set_stream_active(True)
+        self._current_prompt = prompt
 
         request = RuntimeRequest(prompt=prompt, allocate_session_id=self.session_id is None)
         self._start_stream(request)
@@ -108,6 +193,15 @@ class VoidCodeTUI(App[int]):
         self.query_one("#transcript-log", RichLog).write(Text(f"User: {prompt}"))
 
     def _write_event_line(self, event: EventEnvelope) -> None:
+        if event.event_type not in (
+            "graph.tool_request_created",
+            "runtime.tool_completed",
+            "runtime.approval_requested",
+            "runtime.failed",
+            "runtime.approval_resolved",
+        ):
+            return
+
         self.query_one("#transcript-log", RichLog).write(
             Text(f"EVENT {event.event_type} source={event.source}", style="dim")
         )
@@ -120,21 +214,36 @@ class VoidCodeTUI(App[int]):
         self.query_one("#status-panel", Static).update(state)
         current = self.query_one("#current-response", Static)
         if state == "Idle":
-            current.update("Waiting for input...")
+            current.update("")
         elif state == "Running":
             current.update("Working...")
         elif state == "Waiting approval":
             current.update("Waiting for approval...")
         elif state == "Completed":
-            current.update("Completed. Waiting for input...")
+            current.update("")
         elif state == "Failed":
-            current.update("Stream failed. Waiting for input...")
+            current.update("Stream failed.")
 
     def _set_stream_active(self, active: bool) -> None:
         self._stream_active = active
         self.query_one("#composer-input", Input).disabled = (
             active or self.pending_request_id is not None
         )
+
+    @work(thread=True)
+    def _replay_stream(self, session_id: str) -> None:
+        last_status = "Idle"
+        saw_chunk = False
+        try:
+            for chunk in self.runtime.resume_stream(session_id=session_id):
+                saw_chunk = True
+                last_status = chunk.session.status
+                self.post_message(StreamChunkReceived(chunk))
+            if not saw_chunk:
+                raise ValueError("runtime stream emitted no chunks")
+            self.post_message(StreamCompleted(last_status))
+        except Exception as error:
+            self.post_message(StreamFailed(error))
 
     @work(thread=True)
     def _start_stream(self, request: RuntimeRequest) -> None:
@@ -177,13 +286,24 @@ class VoidCodeTUI(App[int]):
         self.session_id = chunk.session.session.id
 
         if chunk.kind == "event" and chunk.event is not None:
+            if self.session_id:
+                short_id = self.session_id.removeprefix("session-")[:8]
+                title = short_id
+                if self.session_id in self._session_titles:
+                    title += f" - {self._session_titles[self.session_id][:30]}"
+                elif self._current_prompt:
+                    title += f" - {self._current_prompt[:30]}"
+                self.query_one("#session-panel", Static).update(title)
+
             event = chunk.event
             self._write_event_line(event)
+
             if (
                 chunk.session.status == "waiting"
                 and event.event_type == "runtime.approval_requested"
             ):
-                self.pending_request_id = str(event.payload["request_id"])
+                payload = event.payload or {}
+                self.pending_request_id = str(payload.get("request_id", ""))
                 self._set_state("Waiting approval")
                 self._set_stream_active(False)
 

--- a/src/voidcode/tui/app.py
+++ b/src/voidcode/tui/app.py
@@ -29,33 +29,40 @@ class VoidCodeTUI(App[int]):
     #main-layout {
         height: 100%;
         width: 100%;
+        background: transparent;
     }
     #transcript-column {
         width: 3fr;
         height: 100%;
         border-right: solid $accent;
+        background: transparent;
     }
     #sidebar-column {
         width: 1fr;
         height: 100%;
         padding: 1;
+        background: transparent;
     }
     #transcript-log {
         height: 1fr;
         border: solid $panel;
+        background: transparent;
     }
     #current-response {
         height: 1;
         padding: 0 1;
         color: $text-muted;
+        background: transparent;
     }
     #composer-input {
         dock: bottom;
+        background: transparent;
     }
     .sidebar-header {
         text-style: bold;
         color: $accent;
         margin-top: 1;
+        background: transparent;
     }
     Footer {
         background: transparent;

--- a/src/voidcode/tui/screens.py
+++ b/src/voidcode/tui/screens.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 from typing import Literal
 
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
-from textual.widgets import Button, Label
+from textual.widgets import Button, Label, OptionList, Static
 
 from ..runtime.events import EventEnvelope
+from ..runtime.session import StoredSessionSummary
 
 
 class ApprovalModal(ModalScreen[Literal["allow", "deny"]]):
@@ -17,14 +19,28 @@ class ApprovalModal(ModalScreen[Literal["allow", "deny"]]):
     }
     #dialog {
         padding: 1 2;
-        width: 60;
-        height: 11;
+        width: 80;
+        height: auto;
+        max-height: 80%;
         border: thick $background 80%;
         background: $surface;
     }
     #question {
         content-align: center middle;
         width: 100%;
+        margin-bottom: 1;
+    }
+    #payload-details {
+        border: solid $accent;
+        height: auto;
+        max-height: 15;
+        overflow-y: auto;
+        margin-bottom: 1;
+        padding: 0 1;
+    }
+    #buttons {
+        height: auto;
+        align: center middle;
     }
     """
 
@@ -42,9 +58,101 @@ class ApprovalModal(ModalScreen[Literal["allow", "deny"]]):
 
         with Vertical(id="dialog"):
             yield Label(prompt, id="question")
-            with Horizontal():
+
+            arguments = self.event.payload.get("arguments")
+            if arguments:
+                import json
+
+                try:
+                    formatted_args = json.dumps(arguments, indent=2)
+                    yield Static(formatted_args, id="payload-details")
+                except Exception:
+                    yield Static(str(arguments), id="payload-details")
+
+            with Horizontal(id="buttons"):
                 yield Button("Allow", variant="success", id="allow")
                 yield Button("Deny", variant="error", id="deny")
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         self.dismiss("allow" if event.button.id == "allow" else "deny")
+
+
+class CommandPalette(ModalScreen[str | None]):
+    CSS = """
+    CommandPalette {
+        align: center middle;
+    }
+    #palette-dialog {
+        padding: 1 2;
+        width: 60;
+        height: auto;
+        max-height: 20;
+        border: thick $background 80%;
+        background: $surface;
+    }
+    """
+
+    BINDINGS = [Binding("escape", "dismiss_palette", "Dismiss", show=False)]
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="palette-dialog"):
+            yield Label("Command Palette", classes="sidebar-header")
+            yield OptionList("session: new", "session: resume", id="palette-options")
+
+    def on_mount(self) -> None:
+        self.query_one(OptionList).focus()
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        self.dismiss(str(event.option.prompt))
+
+    def action_dismiss_palette(self) -> None:
+        self.dismiss(None)
+
+
+class SessionListModal(ModalScreen[str | None]):
+    CSS = """
+    SessionListModal {
+        align: center middle;
+    }
+    #session-dialog {
+        padding: 1 2;
+        width: 80;
+        height: auto;
+        max-height: 30;
+        border: thick $background 80%;
+        background: $surface;
+    }
+    """
+
+    BINDINGS = [Binding("escape", "dismiss_modal", "Dismiss", show=False)]
+
+    def __init__(self, sessions: tuple[StoredSessionSummary, ...]) -> None:
+        super().__init__()
+        self.sessions = sessions
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="session-dialog"):
+            yield Label("Select Session to Resume", classes="sidebar-header")
+            if not self.sessions:
+                yield Label("No sessions found.")
+                yield OptionList("Cancel", id="session-options")
+            else:
+                options: list[str] = []
+                for s in self.sessions:
+                    short_id = s.session.id.removeprefix("session-")[:8]
+                    prompt = s.prompt[:50] + ("..." if len(s.prompt) > 50 else "")
+                    options.append(f"{short_id} - {prompt} [{s.status}]")
+                yield OptionList(*options, id="session-options")
+
+    def on_mount(self) -> None:
+        self.query_one(OptionList).focus()
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        if str(event.option.prompt) == "Cancel" or not self.sessions:
+            self.dismiss(None)
+            return
+        idx = event.option_index
+        self.dismiss(self.sessions[idx].session.id)
+
+    def action_dismiss_modal(self) -> None:
+        self.dismiss(None)

--- a/tests/unit/interface/test_tui.py
+++ b/tests/unit/interface/test_tui.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -91,7 +91,7 @@ async def test_tui_waiting_stream_keeps_waiting_state(app_class: Any) -> None:
         )
     )
 
-    with patch("voidcode.tui.app.load_runtime_config", autospec=True, return_value=object()):
+    with patch("voidcode.tui.app.load_runtime_config", autospec=True, return_value=MagicMock()):
         with patch("voidcode.tui.app.VoidCodeRuntime", autospec=True) as runtime_class:
             runtime = runtime_class.return_value
             runtime.run_stream.return_value = waiting_stream
@@ -112,7 +112,7 @@ async def test_tui_waiting_stream_keeps_waiting_state(app_class: Any) -> None:
 async def test_tui_ignores_submission_while_stream_active(app_class: Any) -> None:
     VoidCodeTUI, _, _ = app_class
 
-    with patch("voidcode.tui.app.load_runtime_config", autospec=True, return_value=object()):
+    with patch("voidcode.tui.app.load_runtime_config", autospec=True, return_value=MagicMock()):
         with patch("voidcode.tui.app.VoidCodeRuntime", autospec=True) as runtime_class:
             runtime = runtime_class.return_value
             app = VoidCodeTUI(workspace=Path("."))
@@ -130,7 +130,7 @@ async def test_tui_ignores_submission_while_stream_active(app_class: Any) -> Non
 async def test_tui_renders_output_literally_without_markup(app_class: Any) -> None:
     VoidCodeTUI, StreamChunkReceived, StreamCompleted = app_class
 
-    with patch("voidcode.tui.app.load_runtime_config", autospec=True, return_value=object()):
+    with patch("voidcode.tui.app.load_runtime_config", autospec=True, return_value=MagicMock()):
         with patch("voidcode.tui.app.VoidCodeRuntime", autospec=True):
             app = VoidCodeTUI(workspace=Path("."))
 
@@ -154,7 +154,7 @@ async def test_tui_renders_output_literally_without_markup(app_class: Any) -> No
 async def test_tui_failed_stream_stays_failed(app_class: Any) -> None:
     VoidCodeTUI, StreamChunkReceived, StreamCompleted = app_class
 
-    with patch("voidcode.tui.app.load_runtime_config", autospec=True, return_value=object()):
+    with patch("voidcode.tui.app.load_runtime_config", autospec=True, return_value=MagicMock()):
         with patch("voidcode.tui.app.VoidCodeRuntime", autospec=True):
             app = VoidCodeTUI(workspace=Path("."))
 
@@ -172,3 +172,175 @@ async def test_tui_failed_stream_stays_failed(app_class: Any) -> None:
 
                 assert app.current_state == "Failed"
                 assert app.query_one("#status-panel").content == "Failed"
+
+
+@pytest.mark.anyio
+async def test_tui_sidebar_updates_on_mount(app_class: Any) -> None:
+    VoidCodeTUI, _, _ = app_class
+
+    mock_config = MagicMock()
+    mock_config.tui.leader_key = "alt+y"
+
+    with patch("voidcode.tui.app.load_runtime_config", autospec=True, return_value=mock_config):
+        with patch("voidcode.tui.app.VoidCodeRuntime", autospec=True) as runtime_class:
+            runtime = runtime_class.return_value
+
+            # mock lsp
+            mock_lsp = MagicMock()
+            mock_lsp.mode = "managed"
+            mock_server = MagicMock()
+            mock_server.status = "running"
+            mock_lsp.servers = {"pylsp": mock_server}
+            runtime.current_lsp_state.return_value = mock_lsp
+
+            # mock acp
+            mock_acp = MagicMock()
+            mock_acp.mode = "managed"
+            mock_acp.status = "connected"
+            runtime.current_acp_state.return_value = mock_acp
+
+            app = VoidCodeTUI(workspace=Path("/fake/workspace"))
+
+            async with app.run_test() as pilot:
+                await pilot.pause()
+
+                assert app.query_one("#workspace-panel").content == "workspace"
+                assert app.query_one("#lsp-panel").content == "Active: 1"
+                assert app.query_one("#acp-panel").content == "Connected"
+
+
+@pytest.mark.anyio
+async def test_tui_command_palette_new_session(app_class: Any) -> None:
+    VoidCodeTUI, _, _ = app_class
+
+    mock_config = MagicMock()
+    mock_config.tui.leader_key = "alt+x"
+
+    with patch("voidcode.tui.app.load_runtime_config", autospec=True, return_value=mock_config):
+        with patch("voidcode.tui.app.VoidCodeRuntime", autospec=True):
+            app = VoidCodeTUI(workspace=Path("."))
+            app.session_id = "old-session"
+
+            async with app.run_test() as pilot:
+                await pilot.press("alt+x")
+                await pilot.pause()
+
+                # We should be in command palette
+                from voidcode.tui.screens import CommandPalette
+
+                assert isinstance(app.screen, CommandPalette)
+
+                await pilot.press("enter")  # Selects 'session: new' since it's first
+                await pilot.pause()
+
+                assert app.session_id is None
+                assert app.query_one("#session-panel").content == "None"
+
+
+@pytest.mark.anyio
+async def test_tui_command_palette_resume_session(app_class: Any) -> None:
+    VoidCodeTUI, _, _ = app_class
+
+    mock_config = MagicMock()
+    mock_config.tui.leader_key = "alt+x"
+
+    with patch("voidcode.tui.app.load_runtime_config", autospec=True, return_value=mock_config):
+        with patch("voidcode.tui.app.VoidCodeRuntime", autospec=True) as runtime_class:
+            runtime = runtime_class.return_value
+
+            # Create a mock StoredSessionSummary
+            from voidcode.runtime.session import SessionRef, StoredSessionSummary
+
+            mock_session = StoredSessionSummary(
+                session=SessionRef(id="session-test-id"),
+                status="completed",
+                turn=2,
+                prompt="test prompt",
+                updated_at=0,
+            )
+            runtime.list_sessions.return_value = (mock_session,)
+
+            waiting_stream = iter(
+                (
+                    _make_chunk(
+                        session_id="session-test-id",
+                        status="running",
+                        output="resumed output line 1",
+                    ),
+                    _make_chunk(
+                        session_id="session-test-id",
+                        status="completed",
+                        output="resumed output line 2",
+                    ),
+                )
+            )
+            runtime.resume_stream.return_value = waiting_stream
+
+            app = VoidCodeTUI(workspace=Path("."))
+
+            async with app.run_test() as pilot:
+                await pilot.press("alt+x")
+                await pilot.pause()
+
+                await pilot.press("down", "enter")  # Selects 'session: resume'
+                await pilot.pause()
+
+                from voidcode.tui.screens import SessionListModal
+
+                assert isinstance(app.screen, SessionListModal)
+
+                await pilot.press("enter")
+                await pilot.pause()
+                await pilot.pause()
+
+                assert app.session_id == "session-test-id"
+                assert "test-id" in app.query_one("#session-panel").content
+                assert "test prompt" in app.query_one("#session-panel").content
+
+                runtime.resume_stream.assert_called_once_with(session_id="session-test-id")
+
+                log = app.query_one("#transcript-log")
+                plain_text = "\\n".join(
+                    "".join(segment.text for segment in line) for line in log.lines
+                )
+                assert "resumed output line 1" in plain_text
+                assert "resumed output line 2" in plain_text
+
+
+@pytest.mark.anyio
+async def test_tui_filters_transcript_events(app_class: Any) -> None:
+    VoidCodeTUI, StreamChunkReceived, StreamCompleted = app_class
+
+    with patch("voidcode.tui.app.load_runtime_config", autospec=True, return_value=MagicMock()):
+        with patch("voidcode.tui.app.VoidCodeRuntime", autospec=True):
+            app = VoidCodeTUI(workspace=Path("."))
+
+            async with app.run_test() as pilot:
+                app.on_stream_chunk_received(
+                    StreamChunkReceived(
+                        _make_chunk(
+                            status="running",
+                            event=_runtime_event("graph.tool_request_created", tool="read"),
+                        )
+                    )
+                )
+
+                app.on_stream_chunk_received(
+                    StreamChunkReceived(
+                        _make_chunk(
+                            status="running",
+                            event=_runtime_event("runtime.internal_spam", some_data="ignored"),
+                        )
+                    )
+                )
+
+                app.on_stream_completed(StreamCompleted("completed"))
+                await pilot.pause()
+
+                log = app.query_one("#transcript-log")
+                plain_text = "\\n".join(
+                    "".join(segment.text for segment in line) for line in log.lines
+                )
+
+                assert "graph.tool_request_created" in plain_text
+                assert "runtime.internal_spam" not in plain_text


### PR DESCRIPTION
## 描述

让 TUI 更贴近统一的 runtime session / event truth，并把当前工作关键信息稳定地放到右侧边栏里。这个 PR 为 TUI 增加了可配置的 leader key / keymap（默认 `M-x` / `alt+x`）、command palette / session resume 流程、基于 runtime truth 的侧栏状态、透明背景与 ANSI 颜色支持，以及更有上下文的审批弹窗与更克制的 transcript 事件过滤。

close #62

## 变更类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 破坏性变更
- [ ] 文档更新
- [ ] 重构
- [ ] 仅测试变更
- [ ] CI / 工具链变更

## 测试

- `uv run pytest tests/unit/interface/test_tui.py -q`
- `mise run typecheck`
- `mise run test`
- 手工 QA：验证 `M-x` 打开 command palette，session resume 真实调用 `resume_stream(session_id=...)`，高信号 event 会出现在 transcript 中，透明背景/无 idle 噪音占位生效

## 核对清单

- [x] 本地测试通过
- [ ] 如有必要，已更新相关文档
- [x] 相关的 lint 检查和类型检查已通过
- [x] 未包含无关的变更