### PR TITLE
feat(runtime): add context window management for single-agent runs

### DIFF
--- a/src/voidcode/graph/contracts.py
+++ b/src/voidcode/graph/contracts.py
@@ -4,6 +4,7 @@ import operator
 from dataclasses import dataclass, field
 from typing import Annotated, Protocol, TypedDict, runtime_checkable
 
+from ..runtime.context_window import RuntimeContextWindow
 from ..runtime.events import EventEnvelope, EventSource
 from ..runtime.session import SessionState
 from ..tools.contracts import ToolCall, ToolDefinition, ToolResult
@@ -40,6 +41,7 @@ class GraphRunRequest:
     prompt: str
     available_tools: tuple[ToolDefinition, ...] = ()
     applied_skills: tuple[AppliedSkill, ...] = ()
+    context_window: RuntimeContextWindow | None = None
     metadata: dict[str, object] = field(default_factory=dict)
 
 

--- a/src/voidcode/graph/single_agent_slice.py
+++ b/src/voidcode/graph/single_agent_slice.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from ..runtime.context_window import RuntimeContextWindow
 from ..runtime.events import GRAPH_LOOP_STEP, GRAPH_MODEL_TURN, GRAPH_RESPONSE_READY
 from ..runtime.model_provider import ResolvedProviderModel
 from ..runtime.session import SessionState
@@ -66,6 +67,8 @@ class ProviderSingleAgentGraph:
                 prompt=request.prompt,
                 available_tools=request.available_tools,
                 tool_results=tool_results,
+                context_window=request.context_window
+                or RuntimeContextWindow(prompt=request.prompt),
                 applied_skills=request.applied_skills,
                 raw_model=self._provider_model.selection.raw_model,
                 provider_name=self._provider_model.selection.provider,

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..tools.contracts import ToolResult
+
+
+@dataclass(frozen=True, slots=True)
+class ContextWindowPolicy:
+    max_tool_results: int = 4
+
+    def __post_init__(self) -> None:
+        if self.max_tool_results < 0:
+            raise ValueError("max_tool_results must be >= 0")
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeContextWindow:
+    prompt: str
+    tool_results: tuple[ToolResult, ...] = ()
+    compacted: bool = False
+    compaction_reason: str | None = None
+    original_tool_result_count: int = 0
+    retained_tool_result_count: int = 0
+
+    def metadata_payload(self) -> dict[str, object]:
+        return {
+            "compacted": self.compacted,
+            "compaction_reason": self.compaction_reason,
+            "original_tool_result_count": self.original_tool_result_count,
+            "retained_tool_result_count": self.retained_tool_result_count,
+        }
+
+
+def prepare_single_agent_context(
+    *,
+    prompt: str,
+    tool_results: tuple[ToolResult, ...],
+    session_metadata: dict[str, object],
+    policy: ContextWindowPolicy | None = None,
+) -> RuntimeContextWindow:
+    _ = session_metadata
+    effective_policy = policy or ContextWindowPolicy()
+    original_count = len(tool_results)
+
+    if effective_policy.max_tool_results == 0:
+        retained_results: tuple[ToolResult, ...] = ()
+    else:
+        retained_results = tool_results[-effective_policy.max_tool_results :]
+
+    retained_count = len(retained_results)
+    compacted = retained_count < original_count
+
+    return RuntimeContextWindow(
+        prompt=prompt,
+        tool_results=retained_results,
+        compacted=compacted,
+        compaction_reason="tool_result_window" if compacted else None,
+        original_tool_result_count=original_count,
+        retained_tool_result_count=retained_count,
+    )

--- a/src/voidcode/runtime/provider_errors.py
+++ b/src/voidcode/runtime/provider_errors.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+
+class SingleAgentProviderError(ValueError):
+    """Base runtime-classified provider error."""
+
+
+class SingleAgentContextLimitError(SingleAgentProviderError):
+    """Provider failure caused by context window exhaustion."""
+
+
+def classify_provider_error(exc: Exception) -> SingleAgentProviderError | None:
+    message = str(exc).lower()
+    context_limit_markers = (
+        "context window",
+        "context limit",
+        "maximum context",
+        "maximum context length",
+        "token limit",
+    )
+    if any(marker in message for marker in context_limit_markers):
+        return SingleAgentContextLimitError(str(exc))
+    return None

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -14,6 +14,7 @@ from ..graph.single_agent_slice import ProviderSingleAgentGraph
 from ..tools.contracts import Tool, ToolCall, ToolDefinition, ToolResult
 from .acp import AcpAdapter, AcpRequestEnvelope, AcpResponseEnvelope, build_acp_adapter
 from .config import ExecutionEngineName, RuntimeConfig, load_runtime_config
+from .context_window import ContextWindowPolicy, RuntimeContextWindow, prepare_single_agent_context
 from .contracts import RuntimeRequest, RuntimeResponse, RuntimeStreamChunk, validate_session_id
 from .events import (
     RUNTIME_ACP_CONNECTED,
@@ -22,6 +23,7 @@ from .events import (
     RUNTIME_LSP_SERVER_FAILED,
     RUNTIME_LSP_SERVER_STARTED,
     RUNTIME_LSP_SERVER_STOPPED,
+    RUNTIME_MEMORY_REFRESHED,
     RUNTIME_SKILLS_APPLIED,
     RUNTIME_SKILLS_LOADED,
     RUNTIME_TOOL_HOOK_POST,
@@ -37,6 +39,7 @@ from .permission import (
     PermissionResolution,
     resolve_permission,
 )
+from .provider_errors import SingleAgentContextLimitError, classify_provider_error
 from .session import SessionRef, SessionState, SessionStatus, StoredSessionSummary
 from .skills import SkillRegistry, SkillRuntimeContext
 from .storage import SessionStore, SqliteSessionStore
@@ -110,6 +113,7 @@ class VoidCodeRuntime:
     _acp_adapter: AcpAdapter
     _graph_cache: dict[tuple[ExecutionEngineName, str], RuntimeGraph]
     _hook_recursion_env_var = "VOIDCODE_RUNNING_TOOL_HOOK"
+    _default_context_window_policy = ContextWindowPolicy()
 
     def __init__(
         self,
@@ -395,6 +399,11 @@ class VoidCodeRuntime:
             prompt=request.prompt,
             available_tools=self._tool_registry.definitions(),
             applied_skills=self._graph_applied_skills(session.metadata),
+            context_window=self._prepare_single_agent_context_window(
+                prompt=request.prompt,
+                tool_results=(),
+                session_metadata=session.metadata,
+            ),
             metadata=request.metadata,
         )
         tool_results: list[ToolResult] = []
@@ -422,6 +431,38 @@ class VoidCodeRuntime:
     ) -> Iterator[RuntimeStreamChunk]:
         active_permission_policy = permission_policy or self._permission_policy
         while True:
+            context_window = self._prepare_single_agent_context_window(
+                prompt=graph_request.prompt,
+                tool_results=tuple(tool_results),
+                session_metadata=session.metadata,
+            )
+            session = self._session_with_context_window_metadata(session, context_window)
+            graph_request = GraphRunRequest(
+                session=session,
+                prompt=graph_request.prompt,
+                available_tools=graph_request.available_tools,
+                applied_skills=graph_request.applied_skills,
+                context_window=context_window,
+                metadata=graph_request.metadata,
+            )
+            if context_window.compacted:
+                sequence += 1
+                yield RuntimeStreamChunk(
+                    kind="event",
+                    session=session,
+                    event=EventEnvelope(
+                        session_id=session.session.id,
+                        sequence=sequence,
+                        event_type=RUNTIME_MEMORY_REFRESHED,
+                        source="runtime",
+                        payload={
+                            "reason": context_window.compaction_reason,
+                            "original_tool_result_count": context_window.original_tool_result_count,
+                            "retained_tool_result_count": context_window.retained_tool_result_count,
+                            "compacted": True,
+                        },
+                    ),
+                )
             try:
                 graph_step = graph.step(
                     graph_request,
@@ -429,7 +470,19 @@ class VoidCodeRuntime:
                     session=session,
                 )
             except Exception as exc:
-                yield self._failed_chunk(session=session, sequence=sequence + 1, error=str(exc))
+                classified_error = classify_provider_error(exc)
+                yield self._failed_chunk(
+                    session=session,
+                    sequence=sequence + 1,
+                    error=str(exc),
+                    kind=(
+                        "provider_context_limit"
+                        if isinstance(classified_error, SingleAgentContextLimitError)
+                        else None
+                    ),
+                )
+                if isinstance(classified_error, SingleAgentContextLimitError):
+                    return
                 raise
 
             is_final_step = (
@@ -684,7 +737,7 @@ class VoidCodeRuntime:
         return _HookOutcome(chunks=tuple(emitted_chunks), last_sequence=last_sequence)
 
     def _failed_chunk(
-        self, *, session: SessionState, sequence: int, error: str
+        self, *, session: SessionState, sequence: int, error: str, kind: str | None = None
     ) -> RuntimeStreamChunk:
         failed_session = SessionState(
             session=session.session,
@@ -692,6 +745,9 @@ class VoidCodeRuntime:
             turn=session.turn,
             metadata=session.metadata,
         )
+        payload: dict[str, object] = {"error": error}
+        if kind is not None:
+            payload["kind"] = kind
         return RuntimeStreamChunk(
             kind="event",
             session=failed_session,
@@ -700,7 +756,7 @@ class VoidCodeRuntime:
                 sequence=sequence,
                 event_type="runtime.failed",
                 source="runtime",
-                payload={"error": error},
+                payload=payload,
             ),
         )
 
@@ -1015,6 +1071,11 @@ class VoidCodeRuntime:
             prompt=self._prompt_from_events(stored.events),
             available_tools=self._tool_registry.definitions(),
             applied_skills=self._graph_applied_skills(session.metadata),
+            context_window=self._prepare_single_agent_context_window(
+                prompt=self._prompt_from_events(stored.events),
+                tool_results=tuple(tool_results),
+                session_metadata=session.metadata,
+            ),
             metadata=session.metadata,
         )
         graph = self._graph_for_session_metadata(session.metadata)
@@ -1141,6 +1202,35 @@ class VoidCodeRuntime:
         if isinstance(prompt, str):
             return prompt
         return ""
+
+    def _prepare_single_agent_context_window(
+        self,
+        *,
+        prompt: str,
+        tool_results: tuple[ToolResult, ...],
+        session_metadata: dict[str, object],
+        policy: ContextWindowPolicy | None = None,
+    ) -> RuntimeContextWindow:
+        return prepare_single_agent_context(
+            prompt=prompt,
+            tool_results=tool_results,
+            session_metadata=session_metadata,
+            policy=policy or self._default_context_window_policy,
+        )
+
+    @staticmethod
+    def _session_with_context_window_metadata(
+        session: SessionState, context_window: RuntimeContextWindow
+    ) -> SessionState:
+        return SessionState(
+            session=session.session,
+            status=session.status,
+            turn=session.turn,
+            metadata={
+                **session.metadata,
+                "context_window": context_window.metadata_payload(),
+            },
+        )
 
     @staticmethod
     def _renumber_events(

--- a/src/voidcode/runtime/single_agent_provider.py
+++ b/src/voidcode/runtime/single_agent_provider.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
 from ..tools.contracts import ToolCall, ToolDefinition, ToolResult
+from .context_window import RuntimeContextWindow
 
 type AppliedSkill = dict[str, str]
 
@@ -19,6 +20,7 @@ class SingleAgentTurnRequest:
     prompt: str
     available_tools: tuple[ToolDefinition, ...]
     tool_results: tuple[ToolResult, ...]
+    context_window: RuntimeContextWindow
     applied_skills: tuple[AppliedSkill, ...]
     raw_model: str | None
     provider_name: str | None
@@ -50,9 +52,9 @@ class StubSingleAgentProvider:
 
         step_index = len(request.tool_results)
         if step_index >= len(commands):
-            if not request.tool_results:
+            if not request.context_window.tool_results:
                 raise ValueError("request must contain at least one actionable command")
-            last_result = request.tool_results[-1]
+            last_result = request.context_window.tool_results[-1]
             return SingleAgentTurnResult(output=last_result.content if last_result.content else "")
 
         trimmed_prompt = commands[step_index]

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -228,6 +228,45 @@ def _single_agent_runtime(
     return runtime_request, runtime
 
 
+def test_single_agent_runtime_surfaces_provider_context_limit_failure_kind(tmp_path: Path) -> None:
+    runtime_request, _ = _single_agent_runtime(tmp_path, mode="allow")
+
+    service_module = importlib.import_module("voidcode.runtime.service")
+
+    class FailingGraph:
+        def step(
+            self,
+            request: object,
+            tool_results: tuple[object, ...],
+            *,
+            session: object,
+        ) -> object:
+            _ = request, tool_results, session
+            raise ValueError("provider context window exceeded")
+
+    failing_runtime = cast(
+        RuntimeRunner,
+        service_module.VoidCodeRuntime(
+            workspace=tmp_path,
+            graph=FailingGraph(),
+            config=importlib.import_module("voidcode.runtime.config").RuntimeConfig(
+                approval_mode="allow",
+                execution_engine="single_agent",
+                model="opencode/gpt-5.4",
+            ),
+        ),
+    )
+
+    failed = failing_runtime.run(runtime_request(prompt="read sample.txt", session_id="ctx-limit"))
+
+    assert failed.session.status == "failed"
+    assert failed.events[-1].event_type == "runtime.failed"
+    assert failed.events[-1].payload == {
+        "error": "provider context window exceeded",
+        "kind": "provider_context_limit",
+    }
+
+
 def _multi_step_prompt() -> str:
     return "read source.txt\nwrite copied.txt copied marker\ngrep copied copied.txt"
 
@@ -1428,7 +1467,15 @@ def test_runtime_resume_accepts_legacy_sessions_without_runtime_config_metadata(
 
     assert replay.session.status == response.session.status
     assert replay.output == response.output
-    assert replay.session.metadata == {"workspace": str(tmp_path)}
+    assert replay.session.metadata == {
+        "workspace": str(tmp_path),
+        "context_window": {
+            "compacted": False,
+            "compaction_reason": None,
+            "original_tool_result_count": 1,
+            "retained_tool_result_count": 1,
+        },
+    }
 
 
 def test_runtime_denies_non_read_only_tool_on_resume(tmp_path: Path) -> None:

--- a/tests/unit/graph/test_single_agent_slice.py
+++ b/tests/unit/graph/test_single_agent_slice.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from voidcode.graph.contracts import GraphRunRequest
 from voidcode.graph.single_agent_slice import ProviderSingleAgentGraph
+from voidcode.runtime.context_window import RuntimeContextWindow
 from voidcode.runtime.model_provider import ModelProviderRegistry, resolve_provider_model
 from voidcode.runtime.session import SessionRef, SessionState
 from voidcode.runtime.single_agent_provider import (
@@ -49,6 +50,7 @@ def test_provider_single_agent_graph_requests_tool_on_first_turn() -> None:
             session=_session(),
             prompt="read sample.txt",
             available_tools=_tool_definitions(),
+            context_window=RuntimeContextWindow(prompt="read sample.txt"),
         ),
         tool_results=(),
         session=_session(),
@@ -84,6 +86,17 @@ def test_provider_single_agent_graph_finalizes_after_tool_result() -> None:
             session=_session(),
             prompt="read sample.txt",
             available_tools=_tool_definitions(),
+            context_window=RuntimeContextWindow(
+                prompt="read sample.txt",
+                tool_results=(
+                    ToolResult(
+                        tool_name="read_file",
+                        content="alpha\n",
+                        status="ok",
+                        data={"path": "sample.txt", "content": "alpha\n"},
+                    ),
+                ),
+            ),
         ),
         tool_results=(
             ToolResult(
@@ -130,6 +143,7 @@ def test_provider_single_agent_graph_passes_applied_skill_context_to_provider() 
             session=_session(),
             prompt="read sample.txt",
             available_tools=_tool_definitions(),
+            context_window=RuntimeContextWindow(prompt="read sample.txt"),
             applied_skills=(
                 {
                     "name": "summarize",
@@ -150,3 +164,51 @@ def test_provider_single_agent_graph_passes_applied_skill_context_to_provider() 
             "content": "# Summarize\nUse concise bullet points.",
         },
     )
+    assert provider.requests[0].context_window.prompt == "read sample.txt"
+
+
+def test_provider_single_agent_graph_forwards_bounded_context_window_to_provider() -> None:
+    provider_model = resolve_provider_model(
+        "opencode/gpt-5.4",
+        registry=ModelProviderRegistry.with_defaults(),
+    )
+    provider = _CapturingSingleAgentProvider()
+    graph = ProviderSingleAgentGraph(provider=provider, provider_model=provider_model)
+
+    bounded_context = RuntimeContextWindow(
+        prompt="read sample.txt",
+        tool_results=(
+            ToolResult(
+                tool_name="read_file",
+                content="new\n",
+                status="ok",
+                data={"path": "sample.txt", "content": "new\n"},
+            ),
+        ),
+        compacted=True,
+        compaction_reason="tool_result_window",
+        original_tool_result_count=3,
+        retained_tool_result_count=1,
+    )
+
+    _ = graph.step(
+        request=GraphRunRequest(
+            session=_session(),
+            prompt="read sample.txt",
+            available_tools=_tool_definitions(),
+            context_window=bounded_context,
+        ),
+        tool_results=(
+            ToolResult(
+                tool_name="read_file",
+                content="old\n",
+                status="ok",
+                data={"path": "sample.txt", "content": "old\n"},
+            ),
+        ),
+        session=_session(),
+    )
+
+    assert provider.requests[0].context_window is bounded_context
+    assert provider.requests[0].context_window.compacted is True
+    assert provider.requests[0].context_window.retained_tool_result_count == 1

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from voidcode.runtime.context_window import ContextWindowPolicy, prepare_single_agent_context
+from voidcode.tools.contracts import ToolResult
+
+
+def _tool_result(index: int) -> ToolResult:
+    return ToolResult(
+        tool_name="read_file",
+        content=f"content-{index}",
+        status="ok",
+        data={"index": index},
+    )
+
+
+def test_prepare_single_agent_context_keeps_results_within_limit() -> None:
+    context = prepare_single_agent_context(
+        prompt="read sample.txt",
+        tool_results=(_tool_result(1), _tool_result(2)),
+        session_metadata={},
+        policy=ContextWindowPolicy(max_tool_results=3),
+    )
+
+    assert context.prompt == "read sample.txt"
+    assert tuple(result.data["index"] for result in context.tool_results) == (1, 2)
+    assert context.compacted is False
+    assert context.compaction_reason is None
+    assert context.original_tool_result_count == 2
+    assert context.retained_tool_result_count == 2
+
+
+def test_prepare_single_agent_context_compacts_old_results_and_reports_metadata() -> None:
+    context = prepare_single_agent_context(
+        prompt="read sample.txt",
+        tool_results=(_tool_result(1), _tool_result(2), _tool_result(3), _tool_result(4)),
+        session_metadata={},
+        policy=ContextWindowPolicy(max_tool_results=2),
+    )
+
+    assert tuple(result.data["index"] for result in context.tool_results) == (3, 4)
+    assert context.compacted is True
+    assert context.compaction_reason == "tool_result_window"
+    assert context.original_tool_result_count == 4
+    assert context.retained_tool_result_count == 2

--- a/tests/unit/runtime/test_provider_errors.py
+++ b/tests/unit/runtime/test_provider_errors.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from voidcode.runtime.provider_errors import SingleAgentContextLimitError, classify_provider_error
+
+
+def test_classify_provider_error_returns_context_limit_error_for_limit_messages() -> None:
+    classified = classify_provider_error(ValueError("context window exceeded for provider"))
+
+    assert isinstance(classified, SingleAgentContextLimitError)
+    assert str(classified) == "context window exceeded for provider"
+
+
+def test_classify_provider_error_returns_none_for_unrelated_errors() -> None:
+    assert classify_provider_error(ValueError("network timeout")) is None

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -92,6 +92,18 @@ class _ApprovalThenCaptureSkillGraph:
         return _StubStep(output="done", is_finished=True)
 
 
+class _FailingProviderGraph:
+    def step(
+        self,
+        request: GraphRunRequest,
+        tool_results: tuple[object, ...],
+        *,
+        session: SessionState,
+    ) -> _StubStep:
+        _ = request, tool_results, session
+        raise ValueError("provider context window exceeded")
+
+
 def _write_demo_skill(skill_dir: Path, *, description: str = "Demo skill", content: str) -> None:
     skill_dir.mkdir(parents=True, exist_ok=True)
     (skill_dir / "SKILL.md").write_text(
@@ -896,6 +908,43 @@ def test_runtime_initializes_single_agent_graph_from_config(tmp_path: Path) -> N
     graph = _private_attr(runtime, "_graph")
 
     assert graph.__class__.__name__ == "ProviderSingleAgentGraph"
+
+
+def test_runtime_classifies_provider_context_limit_failures(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_FailingProviderGraph(),
+        config=RuntimeConfig(execution_engine="single_agent", model="opencode/gpt-5.4"),
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="read sample.txt", session_id="provider-limit"))
+
+    assert response.session.status == "failed"
+    assert response.events[-1].event_type == "runtime.failed"
+    assert response.events[-1].payload == {
+        "error": "provider context window exceeded",
+        "kind": "provider_context_limit",
+    }
+
+
+def test_runtime_single_agent_compaction_emits_memory_refresh_and_persists_metadata(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_SkillCapturingStubGraph(),
+        config=RuntimeConfig(execution_engine="single_agent", model="opencode/gpt-5.4"),
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="hello", metadata={}))
+
+    assert response.session.status == "completed"
+    assert response.session.metadata["context_window"] == {
+        "compacted": False,
+        "compaction_reason": None,
+        "original_tool_result_count": 0,
+        "retained_tool_result_count": 0,
+    }
 
 
 def test_runtime_rejects_single_agent_engine_without_model(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_single_agent_provider.py
+++ b/tests/unit/runtime/test_single_agent_provider.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from voidcode.runtime.context_window import RuntimeContextWindow
 from voidcode.runtime.model_provider import ModelProviderRegistry, resolve_provider_model
 from voidcode.runtime.single_agent_provider import (
     SingleAgentTurnRequest,
@@ -30,6 +31,7 @@ def test_stub_single_agent_provider_proposes_tool_call_for_first_turn() -> None:
             prompt="read sample.txt",
             available_tools=_tool_definitions(),
             tool_results=(),
+            context_window=RuntimeContextWindow(prompt="read sample.txt"),
             applied_skills=(),
             raw_model=provider_model.selection.raw_model,
             provider_name=provider_model.selection.provider,
@@ -61,6 +63,17 @@ def test_stub_single_agent_provider_finalizes_from_last_tool_result() -> None:
                     data={"path": "sample.txt", "content": "alpha\nbeta\n"},
                 ),
             ),
+            context_window=RuntimeContextWindow(
+                prompt="read sample.txt",
+                tool_results=(
+                    ToolResult(
+                        tool_name="read_file",
+                        content="alpha\nbeta\n",
+                        status="ok",
+                        data={"path": "sample.txt", "content": "alpha\nbeta\n"},
+                    ),
+                ),
+            ),
             applied_skills=(),
             raw_model=provider_model.selection.raw_model,
             provider_name=provider_model.selection.provider,
@@ -84,9 +97,59 @@ def test_stub_single_agent_provider_rejects_unsupported_requests() -> None:
                 prompt="summarize sample.txt",
                 available_tools=_tool_definitions(),
                 tool_results=(),
+                context_window=RuntimeContextWindow(prompt="summarize sample.txt"),
                 applied_skills=(),
                 raw_model=provider_model.selection.raw_model,
                 provider_name=provider_model.selection.provider,
                 model_name=provider_model.selection.model,
             )
         )
+
+
+def test_stub_single_agent_provider_uses_bounded_context_window_results_for_finalize() -> None:
+    provider_model = resolve_provider_model(
+        "opencode/gpt-5.4",
+        registry=ModelProviderRegistry.with_defaults(),
+    )
+
+    result = StubSingleAgentProvider(name="opencode").propose_turn(
+        SingleAgentTurnRequest(
+            prompt="read sample.txt",
+            available_tools=_tool_definitions(),
+            tool_results=(
+                ToolResult(
+                    tool_name="read_file",
+                    content="old\n",
+                    status="ok",
+                    data={"path": "sample.txt", "content": "old\n"},
+                ),
+                ToolResult(
+                    tool_name="read_file",
+                    content="new\n",
+                    status="ok",
+                    data={"path": "sample.txt", "content": "new\n"},
+                ),
+            ),
+            context_window=RuntimeContextWindow(
+                prompt="read sample.txt",
+                tool_results=(
+                    ToolResult(
+                        tool_name="read_file",
+                        content="new\n",
+                        status="ok",
+                        data={"path": "sample.txt", "content": "new\n"},
+                    ),
+                ),
+                compacted=True,
+                compaction_reason="tool_result_window",
+                original_tool_result_count=2,
+                retained_tool_result_count=1,
+            ),
+            applied_skills=(),
+            raw_model=provider_model.selection.raw_model,
+            provider_name=provider_model.selection.provider,
+            model_name=provider_model.selection.model,
+        )
+    )
+
+    assert result.output == "new\n"


### PR DESCRIPTION
## 描述

为 provider-backed single-agent 路径引入 runtime-owned 的 context window 管理与 compaction 钩子，避免 execution engine 继续直接依赖无界历史输入。这个 PR 先实现最小的 count-based context window、compaction metadata、以及 provider context-limit failure 的统一 runtime 分类，同时保持 runtime 仍然是 session truth、恢复和事件流的控制面。

close #67

## 变更类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 破坏性变更
- [x] 文档更新
- [ ] 重构
- [ ] 仅测试变更
- [ ] CI / 工具链变更

## 测试

- `uv run pytest tests/unit/runtime/test_context_window.py tests/unit/runtime/test_provider_errors.py tests/unit/runtime/test_single_agent_provider.py tests/unit/graph/test_single_agent_slice.py tests/unit/runtime/test_runtime_service_extensions.py -q`
- `uv run pytest tests/integration/test_read_only_slice.py -q`
- `mise run typecheck`
- `mise run test`
- 手工 QA：single-agent provider context-limit 场景会返回 `runtime.failed`，payload 含 `kind = \"provider_context_limit\"`，同时 session metadata 带出 `context_window`

## 核对清单

- [x] 本地测试通过
- [x] 如有必要，已更新相关文档
- [x] 相关的 lint 检查和类型检查已通过
- [x] 未包含无关的变更