### PR TITLE
feat(runtime): add provider fallback handling for single-agent runs

### DIFF
--- a/src/voidcode/graph/single_agent_slice.py
+++ b/src/voidcode/graph/single_agent_slice.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import cast
 
 from ..runtime.context_window import RuntimeContextWindow
 from ..runtime.events import GRAPH_LOOP_STEP, GRAPH_MODEL_TURN, GRAPH_RESPONSE_READY
@@ -57,6 +58,7 @@ class ProviderSingleAgentGraph:
                     "mode": "single_agent",
                     "provider": self._provider.name,
                     "model": self._provider_model.selection.model,
+                    "attempt": request.metadata.get("provider_attempt", 0),
                     "prompt": request.prompt,
                 },
             ),
@@ -73,6 +75,7 @@ class ProviderSingleAgentGraph:
                 raw_model=self._provider_model.selection.raw_model,
                 provider_name=self._provider_model.selection.provider,
                 model_name=self._provider_model.selection.model,
+                attempt=cast(int, request.metadata.get("provider_attempt", 0)),
             )
         )
 

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -68,6 +68,12 @@ class RuntimeTuiConfig:
 
 
 @dataclass(frozen=True, slots=True)
+class RuntimeProviderFallbackConfig:
+    preferred_model: str
+    fallback_models: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
 class RuntimeConfig:
     approval_mode: PermissionDecision = "ask"
     model: str | None = None
@@ -78,6 +84,7 @@ class RuntimeConfig:
     lsp: RuntimeLspConfig | None = None
     acp: RuntimeAcpConfig | None = None
     tui: RuntimeTuiConfig | None = None
+    provider_fallback: RuntimeProviderFallbackConfig | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -91,6 +98,7 @@ class RuntimeConfigOverrides:
     lsp: RuntimeLspConfig | None = None
     acp: RuntimeAcpConfig | None = None
     tui: RuntimeTuiConfig | None = None
+    provider_fallback: RuntimeProviderFallbackConfig | None = None
 
 
 def runtime_config_path(workspace: Path) -> Path:
@@ -126,6 +134,7 @@ def load_runtime_config(
         lsp=repo_local.lsp,
         acp=repo_local.acp,
         tui=repo_local.tui,
+        provider_fallback=repo_local.provider_fallback,
     )
 
 
@@ -173,6 +182,9 @@ def _load_repo_local_config(workspace: Path) -> RuntimeConfigOverrides:
     raw_tui = payload.get("tui")
     tui = _parse_tui_config(raw_tui)
 
+    raw_provider_fallback = payload.get("provider_fallback")
+    provider_fallback = _parse_provider_fallback_config(raw_provider_fallback)
+
     raw_approval_mode = payload.get("approval_mode")
     parsed_approval_mode = _parse_approval_mode(
         raw_approval_mode,
@@ -190,6 +202,7 @@ def _load_repo_local_config(workspace: Path) -> RuntimeConfigOverrides:
         lsp=lsp,
         acp=acp,
         tui=tui,
+        provider_fallback=provider_fallback,
     )
 
 
@@ -335,6 +348,33 @@ def _parse_tui_config(raw_tui: object) -> RuntimeTuiConfig | None:
     return RuntimeTuiConfig(
         leader_key=leader_key if leader_key is not None else "alt+x",
         keymap=keymap,
+    )
+
+
+def _parse_provider_fallback_config(
+    raw_provider_fallback: object,
+) -> RuntimeProviderFallbackConfig | None:
+    if raw_provider_fallback is None:
+        return None
+    if not isinstance(raw_provider_fallback, dict):
+        raise ValueError("runtime config field 'provider_fallback' must be an object when provided")
+
+    payload = cast(dict[str, object], raw_provider_fallback)
+    preferred_model = payload.get("preferred_model")
+    if not isinstance(preferred_model, str):
+        raise ValueError(
+            "runtime config field 'provider_fallback.preferred_model' must be a string"
+        )
+    fallback_models = _parse_string_list(
+        payload.get("fallback_models"),
+        field_path="provider_fallback.fallback_models",
+    )
+    ordered_models = (preferred_model, *fallback_models)
+    if len(set(ordered_models)) != len(ordered_models):
+        raise ValueError("provider fallback chain must not contain duplicate models")
+    return RuntimeProviderFallbackConfig(
+        preferred_model=preferred_model,
+        fallback_models=fallback_models,
     )
 
 

--- a/src/voidcode/runtime/events.py
+++ b/src/voidcode/runtime/events.py
@@ -9,6 +9,7 @@ type ExistingEventType = Literal[
     "runtime.request_received",
     "runtime.skills_loaded",
     "runtime.skills_applied",
+    "runtime.provider_fallback",
     "runtime.acp_connected",
     "runtime.acp_disconnected",
     "runtime.acp_failed",
@@ -34,6 +35,7 @@ type KnownEventType = ExistingEventType | PrototypeAdditiveEventType
 RUNTIME_REQUEST_RECEIVED: Final[ExistingEventType] = "runtime.request_received"
 RUNTIME_SKILLS_LOADED: Final[ExistingEventType] = "runtime.skills_loaded"
 RUNTIME_SKILLS_APPLIED: Final[ExistingEventType] = "runtime.skills_applied"
+RUNTIME_PROVIDER_FALLBACK: Final[ExistingEventType] = "runtime.provider_fallback"
 RUNTIME_ACP_CONNECTED: Final[ExistingEventType] = "runtime.acp_connected"
 RUNTIME_ACP_DISCONNECTED: Final[ExistingEventType] = "runtime.acp_disconnected"
 RUNTIME_ACP_FAILED: Final[ExistingEventType] = "runtime.acp_failed"
@@ -59,6 +61,7 @@ EMITTED_EVENT_TYPES: Final[tuple[ExistingEventType, ...]] = (
     RUNTIME_REQUEST_RECEIVED,
     RUNTIME_SKILLS_LOADED,
     RUNTIME_SKILLS_APPLIED,
+    RUNTIME_PROVIDER_FALLBACK,
     RUNTIME_ACP_CONNECTED,
     RUNTIME_ACP_DISCONNECTED,
     RUNTIME_ACP_FAILED,

--- a/src/voidcode/runtime/model_provider.py
+++ b/src/voidcode/runtime/model_provider.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
+from .config import RuntimeProviderFallbackConfig
 from .single_agent_provider import SingleAgentProvider, StubSingleAgentProvider
 
 
@@ -35,6 +36,18 @@ class ResolvedProviderModel:
     provider: ModelProvider | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class ResolvedProviderChain:
+    preferred: ResolvedProviderModel = ResolvedProviderModel()
+    fallbacks: tuple[ResolvedProviderModel, ...] = ()
+    all_targets: tuple[ResolvedProviderModel, ...] = ()
+
+    def target_at(self, index: int) -> ResolvedProviderModel | None:
+        if index < 0 or index >= len(self.all_targets):
+            return None
+        return self.all_targets[index]
+
+
 @dataclass(slots=True)
 class ModelProviderRegistry:
     providers: dict[str, ModelProvider]
@@ -64,6 +77,26 @@ def resolve_provider_model(
             model=model_name,
         ),
         provider=provider,
+    )
+
+
+def resolve_provider_chain(
+    provider_fallback: RuntimeProviderFallbackConfig | None,
+    *,
+    registry: ModelProviderRegistry,
+) -> ResolvedProviderChain:
+    if provider_fallback is None:
+        return ResolvedProviderChain()
+
+    preferred = resolve_provider_model(provider_fallback.preferred_model, registry=registry)
+    fallbacks = tuple(
+        resolve_provider_model(raw_model, registry=registry)
+        for raw_model in provider_fallback.fallback_models
+    )
+    return ResolvedProviderChain(
+        preferred=preferred,
+        fallbacks=fallbacks,
+        all_targets=(preferred, *fallbacks),
     )
 
 

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -542,6 +542,15 @@ class VoidCodeRuntime:
                             ),
                         )
                         provider_attempt = next_attempt
+                        session = SessionState(
+                            session=session.session,
+                            status=session.status,
+                            turn=session.turn,
+                            metadata={
+                                **session.metadata,
+                                "provider_attempt": provider_attempt,
+                            },
+                        )
                         graph = self._build_graph_for_engine(
                             self._effective_runtime_config_from_metadata(
                                 session.metadata
@@ -1180,9 +1189,22 @@ class VoidCodeRuntime:
                 tool_results=tuple(tool_results),
                 session_metadata=session.metadata,
             ),
-            metadata={**session.metadata, "provider_attempt": 0},
+            metadata={
+                **session.metadata,
+                "provider_attempt": cast(int, session.metadata.get("provider_attempt", 0)),
+            },
         )
+        provider_attempt = cast(int, graph_request.metadata.get("provider_attempt", 0))
         graph = self._graph_for_session_metadata(session.metadata)
+        if provider_attempt > 0:
+            resume_target = self._provider_chain_for_session_metadata(session.metadata).target_at(
+                provider_attempt
+            )
+            if resume_target is not None:
+                graph = self._build_graph_for_engine(
+                    self._effective_runtime_config_from_metadata(session.metadata).execution_engine,
+                    resume_target,
+                )
 
         loop_events: list[EventEnvelope] = []
         output: str | None = None
@@ -1571,6 +1593,7 @@ class VoidCodeRuntime:
         persisted_model = runtime_config.get("model")
         if persisted_model is None or isinstance(persisted_model, str):
             model = persisted_model
+        provider_fallback = None
         persisted_provider_fallback = runtime_config.get("provider_fallback")
         if isinstance(persisted_provider_fallback, dict):
             payload = cast(dict[str, object], persisted_provider_fallback)

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -13,7 +13,12 @@ from ..graph.read_only_slice import DeterministicReadOnlyGraph
 from ..graph.single_agent_slice import ProviderSingleAgentGraph
 from ..tools.contracts import Tool, ToolCall, ToolDefinition, ToolResult
 from .acp import AcpAdapter, AcpRequestEnvelope, AcpResponseEnvelope, build_acp_adapter
-from .config import ExecutionEngineName, RuntimeConfig, load_runtime_config
+from .config import (
+    ExecutionEngineName,
+    RuntimeConfig,
+    RuntimeProviderFallbackConfig,
+    load_runtime_config,
+)
 from .context_window import ContextWindowPolicy, RuntimeContextWindow, prepare_single_agent_context
 from .contracts import RuntimeRequest, RuntimeResponse, RuntimeStreamChunk, validate_session_id
 from .events import (
@@ -31,7 +36,13 @@ from .events import (
     EventEnvelope,
 )
 from .lsp import LspManager, LspManagerState, LspRequest, LspRequestResult, build_lsp_manager
-from .model_provider import ModelProviderRegistry, ResolvedProviderModel, resolve_provider_model
+from .model_provider import (
+    ModelProviderRegistry,
+    ResolvedProviderChain,
+    ResolvedProviderModel,
+    resolve_provider_chain,
+    resolve_provider_model,
+)
 from .permission import (
     PendingApproval,
     PermissionDecision,
@@ -41,6 +52,7 @@ from .permission import (
 )
 from .provider_errors import SingleAgentContextLimitError, classify_provider_error
 from .session import SessionRef, SessionState, SessionStatus, StoredSessionSummary
+from .single_agent_provider import ProviderExecutionError
 from .skills import SkillRegistry, SkillRuntimeContext
 from .storage import SessionStore, SqliteSessionStore
 from .tool_provider import BuiltinToolProvider
@@ -108,6 +120,7 @@ class VoidCodeRuntime:
     _session_store: SessionStore
     _model_provider_registry: ModelProviderRegistry
     _provider_model: ResolvedProviderModel
+    _provider_chain: ResolvedProviderChain
     _skill_registry: SkillRegistry
     _lsp_manager: LspManager
     _acp_adapter: AcpAdapter
@@ -138,6 +151,10 @@ class VoidCodeRuntime:
             self._config.model,
             registry=self._model_provider_registry,
         )
+        self._provider_chain = resolve_provider_chain(
+            self._config.provider_fallback,
+            registry=self._model_provider_registry,
+        )
         self._lsp_manager = lsp_manager or build_lsp_manager(self._config.lsp)
         self._tool_registry = tool_registry or ToolRegistry.with_defaults(
             lsp_tool=self._build_lsp_tool()
@@ -149,6 +166,7 @@ class VoidCodeRuntime:
                 approval_mode=self._config.approval_mode,
                 model=self._config.model,
                 execution_engine=self._config.execution_engine,
+                provider_fallback=self._config.provider_fallback,
             )
         )
         self._permission_policy = permission_policy or PermissionPolicy(
@@ -185,17 +203,39 @@ class VoidCodeRuntime:
     def _build_graph_for_engine_from_config(self, config: EffectiveRuntimeConfig) -> RuntimeGraph:
         # Generate cache key from config
         model_str = config.model if config.model is not None else ""
-        cache_key = (config.execution_engine, model_str)
+        provider_fallback_key = (
+            ""
+            if config.provider_fallback is None
+            else "|".join(
+                (
+                    config.provider_fallback.preferred_model,
+                    *config.provider_fallback.fallback_models,
+                )
+            )
+        )
+        cache_key = (config.execution_engine, f"{model_str}::{provider_fallback_key}")
 
         # Check cache first
         if cache_key in self._graph_cache:
             return self._graph_cache[cache_key]
 
         # Build new graph and cache it
-        provider_model = resolve_provider_model(
-            config.model,
-            registry=self._model_provider_registry,
-        )
+        if config.provider_fallback is not None:
+            provider_chain = resolve_provider_chain(
+                config.provider_fallback,
+                registry=self._model_provider_registry,
+            )
+            provider_model = provider_chain.preferred
+            self._provider_chain = provider_chain
+        else:
+            provider_model = resolve_provider_model(
+                config.model,
+                registry=self._model_provider_registry,
+            )
+            self._provider_chain = ResolvedProviderChain(
+                preferred=provider_model,
+                all_targets=((provider_model,) if provider_model.provider is not None else ()),
+            )
         self._provider_model = provider_model
         graph = self._build_graph_for_engine(config.execution_engine, provider_model)
         self._graph_cache[cache_key] = graph
@@ -404,7 +444,7 @@ class VoidCodeRuntime:
                 tool_results=(),
                 session_metadata=session.metadata,
             ),
-            metadata=request.metadata,
+            metadata={**request.metadata, "provider_attempt": 0},
         )
         tool_results: list[ToolResult] = []
         graph = self._graph_for_session_metadata(session.metadata)
@@ -430,6 +470,7 @@ class VoidCodeRuntime:
         permission_policy: PermissionPolicy | None = None,
     ) -> Iterator[RuntimeStreamChunk]:
         active_permission_policy = permission_policy or self._permission_policy
+        provider_attempt = cast(int, graph_request.metadata.get("provider_attempt", 0))
         while True:
             context_window = self._prepare_single_agent_context_window(
                 prompt=graph_request.prompt,
@@ -470,13 +511,73 @@ class VoidCodeRuntime:
                     session=session,
                 )
             except Exception as exc:
+                if isinstance(exc, ProviderExecutionError):
+                    next_attempt = provider_attempt + 1
+                    provider_chain = self._provider_chain_for_session_metadata(session.metadata)
+                    all_targets = provider_chain.all_targets
+                    next_target = (
+                        all_targets[next_attempt] if next_attempt < len(all_targets) else None
+                    )
+                    if (
+                        exc.kind in {"rate_limit", "invalid_model", "transient_failure"}
+                        and next_target is not None
+                    ):
+                        sequence += 1
+                        yield RuntimeStreamChunk(
+                            kind="event",
+                            session=session,
+                            event=EventEnvelope(
+                                session_id=session.session.id,
+                                sequence=sequence,
+                                event_type="runtime.provider_fallback",
+                                source="runtime",
+                                payload={
+                                    "reason": exc.kind,
+                                    "from_provider": exc.provider_name,
+                                    "from_model": exc.model_name,
+                                    "to_provider": next_target.selection.provider,
+                                    "to_model": next_target.selection.model,
+                                    "attempt": next_attempt,
+                                },
+                            ),
+                        )
+                        provider_attempt = next_attempt
+                        graph = self._build_graph_for_engine(
+                            self._effective_runtime_config_from_metadata(
+                                session.metadata
+                            ).execution_engine,
+                            next_target,
+                        )
+                        graph_request = GraphRunRequest(
+                            session=session,
+                            prompt=graph_request.prompt,
+                            available_tools=graph_request.available_tools,
+                            applied_skills=graph_request.applied_skills,
+                            metadata={
+                                **graph_request.metadata,
+                                "provider_attempt": provider_attempt,
+                            },
+                        )
+                        continue
+                if isinstance(exc, ProviderExecutionError):
+                    yield self._failed_chunk(
+                        session=session,
+                        sequence=sequence + 1,
+                        error=str(exc),
+                        payload={
+                            "provider_error_kind": exc.kind,
+                            "provider": exc.provider_name,
+                            "model": exc.model_name,
+                        },
+                    )
+                    return
                 classified_error = classify_provider_error(exc)
                 yield self._failed_chunk(
                     session=session,
                     sequence=sequence + 1,
                     error=str(exc),
-                    kind=(
-                        "provider_context_limit"
+                    payload=(
+                        {"kind": "provider_context_limit"}
                         if isinstance(classified_error, SingleAgentContextLimitError)
                         else None
                     ),
@@ -737,7 +838,12 @@ class VoidCodeRuntime:
         return _HookOutcome(chunks=tuple(emitted_chunks), last_sequence=last_sequence)
 
     def _failed_chunk(
-        self, *, session: SessionState, sequence: int, error: str, kind: str | None = None
+        self,
+        *,
+        session: SessionState,
+        sequence: int,
+        error: str,
+        payload: dict[str, object] | None = None,
     ) -> RuntimeStreamChunk:
         failed_session = SessionState(
             session=session.session,
@@ -745,9 +851,7 @@ class VoidCodeRuntime:
             turn=session.turn,
             metadata=session.metadata,
         )
-        payload: dict[str, object] = {"error": error}
-        if kind is not None:
-            payload["kind"] = kind
+        failure_payload = {"error": error, **(payload or {})}
         return RuntimeStreamChunk(
             kind="event",
             session=failed_session,
@@ -756,7 +860,7 @@ class VoidCodeRuntime:
                 sequence=sequence,
                 event_type="runtime.failed",
                 source="runtime",
-                payload=payload,
+                payload=failure_payload,
             ),
         )
 
@@ -1076,7 +1180,7 @@ class VoidCodeRuntime:
                 tool_results=tuple(tool_results),
                 session_metadata=session.metadata,
             ),
-            metadata=session.metadata,
+            metadata={**session.metadata, "provider_attempt": 0},
         )
         graph = self._graph_for_session_metadata(session.metadata)
 
@@ -1330,6 +1434,11 @@ class VoidCodeRuntime:
         }
         if self._config.model is not None:
             runtime_config_metadata["model"] = self._config.model
+        if self._config.provider_fallback is not None:
+            runtime_config_metadata["provider_fallback"] = {
+                "preferred_model": self._config.provider_fallback.preferred_model,
+                "fallback_models": list(self._config.provider_fallback.fallback_models),
+            }
         lsp_state = self._lsp_manager.current_state()
         runtime_config_metadata["lsp"] = {
             "mode": lsp_state.mode,
@@ -1437,11 +1546,13 @@ class VoidCodeRuntime:
         approval_mode: PermissionDecision = self._config.approval_mode
         model = self._config.model
         execution_engine = self._config.execution_engine
+        provider_fallback = self._config.provider_fallback
         if metadata is None:
             return EffectiveRuntimeConfig(
                 approval_mode=approval_mode,
                 model=model,
                 execution_engine=execution_engine,
+                provider_fallback=provider_fallback,
             )
 
         persisted_runtime_config = metadata.get("runtime_config")
@@ -1450,6 +1561,7 @@ class VoidCodeRuntime:
                 approval_mode=approval_mode,
                 model=model,
                 execution_engine=execution_engine,
+                provider_fallback=provider_fallback,
             )
 
         runtime_config = cast(dict[str, object], persisted_runtime_config)
@@ -1459,6 +1571,21 @@ class VoidCodeRuntime:
         persisted_model = runtime_config.get("model")
         if persisted_model is None or isinstance(persisted_model, str):
             model = persisted_model
+        persisted_provider_fallback = runtime_config.get("provider_fallback")
+        if isinstance(persisted_provider_fallback, dict):
+            payload = cast(dict[str, object], persisted_provider_fallback)
+            preferred_model = payload.get("preferred_model")
+            fallback_models = payload.get("fallback_models")
+            if isinstance(preferred_model, str) and isinstance(fallback_models, list):
+                raw_fallback_models = cast(list[object], fallback_models)
+                parsed_fallback_models = [
+                    item for item in raw_fallback_models if isinstance(item, str)
+                ]
+                if len(parsed_fallback_models) == len(raw_fallback_models):
+                    provider_fallback = RuntimeProviderFallbackConfig(
+                        preferred_model=preferred_model,
+                        fallback_models=tuple(parsed_fallback_models),
+                    )
         persisted_execution_engine = runtime_config.get("execution_engine")
         if persisted_execution_engine in ("deterministic", "single_agent"):
             execution_engine = persisted_execution_engine
@@ -1466,6 +1593,18 @@ class VoidCodeRuntime:
             approval_mode=approval_mode,
             model=model,
             execution_engine=execution_engine,
+            provider_fallback=provider_fallback,
+        )
+
+    def _provider_chain_for_session_metadata(
+        self, metadata: dict[str, object] | None
+    ) -> ResolvedProviderChain:
+        effective_config = self._effective_runtime_config_from_metadata(metadata)
+        if effective_config.provider_fallback is None:
+            return ResolvedProviderChain()
+        return resolve_provider_chain(
+            effective_config.provider_fallback,
+            registry=self._model_provider_registry,
         )
 
     def _graph_for_session_metadata(self, metadata: dict[str, object] | None) -> RuntimeGraph:
@@ -1478,6 +1617,7 @@ class VoidCodeRuntime:
         if (
             effective_config.execution_engine == self._config.execution_engine
             and effective_config.model == self._config.model
+            and effective_config.provider_fallback == self._config.provider_fallback
         ):
             return self._graph
 
@@ -1497,6 +1637,7 @@ class EffectiveRuntimeConfig:
     approval_mode: PermissionDecision
     model: str | None
     execution_engine: ExecutionEngineName
+    provider_fallback: RuntimeProviderFallbackConfig | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/voidcode/runtime/single_agent_provider.py
+++ b/src/voidcode/runtime/single_agent_provider.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
+from typing import Literal, Protocol, runtime_checkable
 
 from ..tools.contracts import ToolCall, ToolDefinition, ToolResult
 from .context_window import RuntimeContextWindow
@@ -25,12 +25,25 @@ class SingleAgentTurnRequest:
     raw_model: str | None
     provider_name: str | None
     model_name: str | None
+    attempt: int = 0
 
 
 @dataclass(frozen=True, slots=True)
 class SingleAgentTurnResult:
     tool_call: ToolCall | None = None
     output: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderExecutionError(ValueError):
+    kind: Literal["rate_limit", "context_limit", "invalid_model", "transient_failure"]
+    provider_name: str
+    model_name: str
+    message: str
+    retryable: bool = False
+
+    def __str__(self) -> str:
+        return self.message
 
 
 @runtime_checkable

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -1348,6 +1348,66 @@ def test_transport_persists_failed_stream_for_replay(tmp_path: Path) -> None:
     ]
 
 
+def test_transport_serializes_structured_provider_failure_payloads() -> None:
+    create_runtime_app = _load_transport_app_factory()
+    runtime_stream_chunk, session_ref, session_state, event_envelope = _load_stream_types()
+    failed_session = session_state(
+        session=session_ref(id="provider-failed-session"),
+        status="failed",
+        turn=1,
+        metadata={"workspace": "/tmp/workspace"},
+    )
+
+    class FailingStubRuntime:
+        def run_stream(self, request: RuntimeRequestLike) -> Iterator[StreamChunkLike]:
+            assert request.prompt == "fail provider"
+            yield runtime_stream_chunk(
+                kind="event",
+                session=failed_session,
+                event=event_envelope(
+                    session_id="provider-failed-session",
+                    sequence=1,
+                    event_type="runtime.failed",
+                    source="runtime",
+                    payload={
+                        "error": "context exceeded",
+                        "provider_error_kind": "context_limit",
+                        "provider": "opencode",
+                        "model": "gpt-5.4",
+                    },
+                ),
+            )
+
+        def list_sessions(self) -> tuple[StoredSessionSummaryLike, ...]:
+            raise AssertionError("list_sessions should not be called")
+
+        def resume(self, session_id: str) -> RuntimeResponseLike:
+            raise AssertionError(f"resume should not be called: {session_id}")
+
+    app = create_runtime_app(
+        workspace=Path("/tmp/workspace"),
+        runtime_factory=lambda: FailingStubRuntime(),
+    )
+
+    response = _run_app(
+        app,
+        method="POST",
+        path="/api/runtime/run/stream",
+        body=json.dumps({"prompt": "fail provider"}).encode("utf-8"),
+    )
+    payloads = _parse_sse_payloads(response)
+    first_payload = cast(dict[str, object], payloads[0])
+    first_event = cast(dict[str, object], first_payload["event"])
+
+    assert response.status == 200
+    assert first_event["payload"] == {
+        "error": "context exceeded",
+        "provider_error_kind": "context_limit",
+        "provider": "opencode",
+        "model": "gpt-5.4",
+    }
+
+
 def test_transport_logs_unexpected_streaming_errors(caplog: pytest.LogCaptureFixture) -> None:
     create_runtime_app = _load_transport_app_factory()
 

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -267,6 +267,104 @@ def test_single_agent_runtime_surfaces_provider_context_limit_failure_kind(tmp_p
     }
 
 
+@dataclass(frozen=True, slots=True)
+class _ScriptedModelProvider:
+    name: str
+    outcomes: tuple[object, ...]
+
+    def single_agent_provider(self) -> object:
+        outcomes = list(self.outcomes)
+        name = self.name
+
+        class _Provider:
+            def __init__(self) -> None:
+                self.name = name
+
+            def propose_turn(self, request: object) -> object:
+                _ = request
+                if not outcomes:
+                    return importlib.import_module(
+                        "voidcode.runtime.single_agent_provider"
+                    ).SingleAgentTurnResult(output="done")
+                outcome = outcomes.pop(0)
+                if isinstance(outcome, Exception):
+                    raise outcome
+                return outcome
+
+        return _Provider()
+
+
+def test_single_agent_runtime_falls_back_to_next_provider_target(tmp_path: Path) -> None:
+    runtime_request, _ = _load_runtime_types()
+    permission_module = importlib.import_module("voidcode.runtime.permission")
+    config_module = importlib.import_module("voidcode.runtime.config")
+    model_provider_module = importlib.import_module("voidcode.runtime.model_provider")
+    single_agent_provider_module = importlib.import_module("voidcode.runtime.single_agent_provider")
+    service_module = importlib.import_module("voidcode.runtime.service")
+
+    runtime = cast(
+        RuntimeRunner,
+        service_module.VoidCodeRuntime(
+            workspace=tmp_path,
+            config=config_module.RuntimeConfig(
+                approval_mode="allow",
+                execution_engine="single_agent",
+                model="opencode/gpt-5.4",
+                provider_fallback=config_module.RuntimeProviderFallbackConfig(
+                    preferred_model="opencode/gpt-5.4",
+                    fallback_models=("custom/demo",),
+                ),
+            ),
+            permission_policy=permission_module.PermissionPolicy(mode="allow"),
+            model_provider_registry=model_provider_module.ModelProviderRegistry(
+                providers={
+                    "opencode": _ScriptedModelProvider(
+                        name="opencode",
+                        outcomes=(
+                            single_agent_provider_module.ProviderExecutionError(
+                                kind="rate_limit",
+                                provider_name="opencode",
+                                model_name="gpt-5.4",
+                                message="too many requests",
+                            ),
+                        ),
+                    ),
+                    "custom": _ScriptedModelProvider(
+                        name="custom",
+                        outcomes=(
+                            single_agent_provider_module.SingleAgentTurnResult(
+                                output="fallback ok"
+                            ),
+                        ),
+                    ),
+                }
+            ),
+        ),
+    )
+
+    response = runtime.run(runtime_request(prompt="read sample.txt", session_id="fallback-run"))
+
+    assert response.session.status == "completed"
+    assert response.output == "fallback ok"
+    assert [event.event_type for event in response.events] == [
+        "runtime.request_received",
+        "runtime.skills_loaded",
+        "runtime.provider_fallback",
+        "graph.loop_step",
+        "graph.model_turn",
+        "graph.loop_step",
+        "graph.response_ready",
+    ]
+    assert response.events[2].payload == {
+        "reason": "rate_limit",
+        "from_provider": "opencode",
+        "from_model": "gpt-5.4",
+        "to_provider": "custom",
+        "to_model": "demo",
+        "attempt": 1,
+    }
+
+
 def _multi_step_prompt() -> str:
     return "read source.txt\nwrite copied.txt copied marker\ngrep copied copied.txt"
 

--- a/tests/unit/graph/test_single_agent_slice.py
+++ b/tests/unit/graph/test_single_agent_slice.py
@@ -67,6 +67,7 @@ def test_provider_single_agent_graph_requests_tool_on_first_turn() -> None:
         "mode": "single_agent",
         "provider": "opencode",
         "model": "gpt-5.4",
+        "attempt": 0,
         "prompt": "read sample.txt",
     }
 
@@ -124,6 +125,7 @@ def test_provider_single_agent_graph_finalizes_after_tool_result() -> None:
         "mode": "single_agent",
         "provider": "opencode",
         "model": "gpt-5.4",
+        "attempt": 0,
         "prompt": "read sample.txt",
     }
     assert step.events[2].payload == {"step": 3, "phase": "finalize", "max_steps": 4}

--- a/tests/unit/runtime/test_model_provider.py
+++ b/tests/unit/runtime/test_model_provider.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import pytest
 
-from voidcode.runtime.model_provider import ModelProviderRegistry, resolve_provider_model
+from voidcode.runtime.config import RuntimeProviderFallbackConfig
+from voidcode.runtime.model_provider import (
+    ModelProviderRegistry,
+    resolve_provider_chain,
+    resolve_provider_model,
+)
 
 
 def test_resolve_provider_model_accepts_none() -> None:
@@ -12,6 +17,14 @@ def test_resolve_provider_model_accepts_none() -> None:
     assert resolved.selection.provider is None
     assert resolved.selection.model is None
     assert resolved.provider is None
+
+
+def test_resolve_provider_chain_accepts_none() -> None:
+    resolved = resolve_provider_chain(None, registry=ModelProviderRegistry.with_defaults())
+
+    assert resolved.preferred.selection.raw_model is None
+    assert resolved.fallbacks == ()
+    assert resolved.all_targets == ()
 
 
 def test_resolve_provider_model_parses_known_provider_reference() -> None:
@@ -37,6 +50,27 @@ def test_resolve_provider_model_creates_generic_provider_for_unknown_name() -> N
     assert resolved.selection.model == "demo-model"
     assert resolved.provider is not None
     assert resolved.provider.name == "custom"
+
+
+def test_resolve_provider_chain_preserves_ordered_fallback_targets() -> None:
+    resolved = resolve_provider_chain(
+        RuntimeProviderFallbackConfig(
+            preferred_model="opencode/gpt-5.4",
+            fallback_models=("opencode/gpt-5.3", "custom/demo"),
+        ),
+        registry=ModelProviderRegistry.with_defaults(),
+    )
+
+    assert resolved.preferred.selection.raw_model == "opencode/gpt-5.4"
+    assert [target.selection.raw_model for target in resolved.fallbacks] == [
+        "opencode/gpt-5.3",
+        "custom/demo",
+    ]
+    assert [target.selection.raw_model for target in resolved.all_targets] == [
+        "opencode/gpt-5.4",
+        "opencode/gpt-5.3",
+        "custom/demo",
+    ]
 
 
 @pytest.mark.parametrize("raw_model", ["", "provider", "/model", "provider/", "a/b/c"])

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -14,6 +14,7 @@ from voidcode.runtime.config import (
     RuntimeHooksConfig,
     RuntimeLspConfig,
     RuntimeLspServerConfig,
+    RuntimeProviderFallbackConfig,
     RuntimeSkillsConfig,
     RuntimeToolsBuiltinConfig,
     RuntimeToolsConfig,
@@ -104,6 +105,10 @@ def test_runtime_config_parses_extension_domains(tmp_path: Path) -> None:
                     "servers": {"pyright": {"command": ["pyright-langserver", "--stdio"]}},
                 },
                 "acp": {"enabled": False},
+                "provider_fallback": {
+                    "preferred_model": "opencode/gpt-5.4",
+                    "fallback_models": ["opencode/gpt-5.3", "custom/demo"],
+                },
             }
         ),
         encoding="utf-8",
@@ -125,6 +130,10 @@ def test_runtime_config_parses_extension_domains(tmp_path: Path) -> None:
         servers={"pyright": RuntimeLspServerConfig(command=("pyright-langserver", "--stdio"))},
     )
     assert config.acp == RuntimeAcpConfig(enabled=False)
+    assert config.provider_fallback == RuntimeProviderFallbackConfig(
+        preferred_model="opencode/gpt-5.4",
+        fallback_models=("opencode/gpt-5.3", "custom/demo"),
+    )
 
 
 def test_runtime_config_accepts_single_agent_execution_engine(tmp_path: Path) -> None:
@@ -271,6 +280,31 @@ def test_runtime_config_rejects_invalid_repo_local_execution_engine(tmp_path: Pa
             {"lsp": {"servers": {"pyright": {"command": ["pyright"], "languages": [1]}}}},
             "runtime config field 'lsp.servers.pyright.languages\\[0\\]'",
             id="lsp-server-language-item-type",
+        ),
+        pytest.param(
+            {"provider_fallback": []},
+            "runtime config field 'provider_fallback'",
+            id="provider-fallback-shape",
+        ),
+        pytest.param(
+            {"provider_fallback": {"preferred_model": 1}},
+            "runtime config field 'provider_fallback.preferred_model'",
+            id="provider-fallback-preferred-type",
+        ),
+        pytest.param(
+            {"provider_fallback": {"preferred_model": "opencode/gpt-5.4", "fallback_models": [1]}},
+            "runtime config field 'provider_fallback.fallback_models\\[0\\]'",
+            id="provider-fallback-list-item-type",
+        ),
+        pytest.param(
+            {
+                "provider_fallback": {
+                    "preferred_model": "opencode/gpt-5.4",
+                    "fallback_models": ["opencode/gpt-5.4"],
+                }
+            },
+            "provider fallback chain must not contain duplicate models",
+            id="provider-fallback-duplicates",
         ),
         pytest.param({"acp": []}, "runtime config field 'acp'", id="acp-shape"),
         pytest.param(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -27,7 +27,11 @@ from voidcode.runtime.service import (
     SessionState,
     VoidCodeRuntime,
 )
-from voidcode.runtime.single_agent_provider import ProviderExecutionError, SingleAgentTurnResult
+from voidcode.runtime.single_agent_provider import (
+    ProviderExecutionError,
+    SingleAgentTurnRequest,
+    SingleAgentTurnResult,
+)
 from voidcode.runtime.skills import SkillRegistry
 from voidcode.tools import ToolCall
 
@@ -129,6 +133,67 @@ class _ScriptedModelProvider:
 
     def single_agent_provider(self) -> _ScriptedSingleAgentProvider:
         return _ScriptedSingleAgentProvider(name=self.name, outcomes=self.outcomes)
+
+
+class _AlwaysFailingModelProvider:
+    _error_kind: Literal["rate_limit", "context_limit", "invalid_model", "transient_failure"]
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        error_kind: Literal["rate_limit", "context_limit", "invalid_model", "transient_failure"],
+    ) -> None:
+        self.name = name
+        self._error_kind = error_kind
+
+    def single_agent_provider(self) -> _AlwaysFailingSingleAgentProvider:
+        return _AlwaysFailingSingleAgentProvider(name=self.name, error_kind=self._error_kind)
+
+
+@dataclass(slots=True)
+class _AlwaysFailingSingleAgentProvider:
+    name: str
+    error_kind: Literal["rate_limit", "context_limit", "invalid_model", "transient_failure"]
+
+    def propose_turn(self, request: object) -> SingleAgentTurnResult:
+        _ = request
+        raise ProviderExecutionError(
+            kind=self.error_kind,
+            provider_name=self.name,
+            model_name="gpt-5.4",
+            message=f"{self.error_kind} failure",
+        )
+
+
+@dataclass(slots=True)
+class _ApprovalResumeFallbackModelProvider:
+    name: str
+    attempts_seen: list[int]
+
+    def single_agent_provider(self) -> _ApprovalResumeFallbackSingleAgentProvider:
+        return _ApprovalResumeFallbackSingleAgentProvider(
+            name=self.name,
+            attempts_seen=self.attempts_seen,
+        )
+
+
+@dataclass(slots=True)
+class _ApprovalResumeFallbackSingleAgentProvider:
+    name: str
+    attempts_seen: list[int]
+
+    def propose_turn(self, request: object) -> SingleAgentTurnResult:
+        turn_request = cast(SingleAgentTurnRequest, request)
+        self.attempts_seen.append(turn_request.attempt)
+        if not turn_request.tool_results:
+            return SingleAgentTurnResult(
+                tool_call=ToolCall(
+                    tool_name="write_file",
+                    arguments={"path": "alpha.txt", "content": "1"},
+                )
+            )
+        return SingleAgentTurnResult(output="done")
 
 
 def _write_demo_skill(skill_dir: Path, *, description: str = "Demo skill", content: str) -> None:
@@ -1031,6 +1096,135 @@ def test_runtime_effective_runtime_config_recovers_provider_fallback_chain(tmp_p
         preferred_model="opencode/gpt-5.4",
         fallback_models=("opencode/gpt-5.3", "custom/demo"),
     )
+
+
+def test_runtime_effective_runtime_config_treats_missing_persisted_provider_fallback_as_none(
+    tmp_path: Path,
+) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("fallback chain\n", encoding="utf-8")
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            approval_mode="allow",
+            execution_engine="single_agent",
+            model="opencode/gpt-5.4",
+            provider_fallback=RuntimeProviderFallbackConfig(
+                preferred_model="opencode/gpt-5.4",
+                fallback_models=("opencode/gpt-5.3", "custom/demo"),
+            ),
+        ),
+    )
+    _ = runtime.run(
+        RuntimeRequest(prompt="read sample.txt", session_id="fallback-config-missing-key")
+    )
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        row = connection.execute(
+            "SELECT metadata_json FROM sessions WHERE session_id = ?",
+            ("fallback-config-missing-key",),
+        ).fetchone()
+        assert row is not None
+        metadata = json.loads(str(row[0]))
+        assert isinstance(metadata, dict)
+        metadata_dict = cast(dict[str, object], metadata)
+        runtime_config = cast(dict[str, object], metadata_dict["runtime_config"])
+        runtime_config.pop("provider_fallback", None)
+        _ = connection.execute(
+            "UPDATE sessions SET metadata_json = ? WHERE session_id = ?",
+            (
+                json.dumps(metadata_dict, sort_keys=True),
+                "fallback-config-missing-key",
+            ),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            execution_engine="single_agent",
+            model="fresh/model",
+            provider_fallback=RuntimeProviderFallbackConfig(
+                preferred_model="fresh/model",
+                fallback_models=("fresh/fallback",),
+            ),
+        ),
+    )
+    effective = resumed_runtime.effective_runtime_config(session_id="fallback-config-missing-key")
+
+    assert effective.approval_mode == "allow"
+    assert effective.execution_engine == "single_agent"
+    assert effective.model == "opencode/gpt-5.4"
+    assert effective.provider_fallback is None
+
+
+def test_runtime_resume_preserves_provider_attempt_and_target_across_pending_approval(
+    tmp_path: Path,
+) -> None:
+    custom_attempts: list[int] = []
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _AlwaysFailingModelProvider(name="opencode", error_kind="rate_limit"),
+            "custom": _ApprovalResumeFallbackModelProvider(
+                name="custom",
+                attempts_seen=custom_attempts,
+            ),
+        }
+    )
+    config = RuntimeConfig(
+        approval_mode="ask",
+        execution_engine="single_agent",
+        model="opencode/gpt-5.4",
+        provider_fallback=RuntimeProviderFallbackConfig(
+            preferred_model="opencode/gpt-5.4",
+            fallback_models=("custom/demo",),
+        ),
+    )
+    initial_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=config,
+        permission_policy=PermissionPolicy(mode="ask"),
+        model_provider_registry=registry,
+    )
+
+    waiting = initial_runtime.run(
+        RuntimeRequest(prompt="write alpha.txt 1", session_id="resume-provider-attempt")
+    )
+
+    assert waiting.session.status == "waiting"
+    assert custom_attempts == [1]
+    approval_event = waiting.events[-1]
+    assert approval_event.event_type == "runtime.approval_requested"
+    request_id = str(approval_event.payload["request_id"])
+    fallback_events = [
+        event for event in waiting.events if event.event_type == "runtime.provider_fallback"
+    ]
+    assert len(fallback_events) == 1
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=config,
+        permission_policy=PermissionPolicy(mode="ask"),
+        model_provider_registry=registry,
+    )
+    resumed = resumed_runtime.resume(
+        session_id="resume-provider-attempt",
+        approval_request_id=request_id,
+        approval_decision="allow",
+    )
+
+    assert resumed.session.status == "completed"
+    assert resumed.output == "done"
+    assert custom_attempts == [1, 1, 1]
+    assert all(attempt == 1 for attempt in custom_attempts)
+    resumed_fallback_events = [
+        event for event in resumed.events if event.event_type == "runtime.provider_fallback"
+    ]
+    assert len(resumed_fallback_events) == 1
 
 
 @pytest.mark.parametrize("error_kind", ["rate_limit", "invalid_model", "transient_failure"])

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -4,7 +4,7 @@ import json
 import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import pytest
 
@@ -14,10 +14,12 @@ from voidcode.runtime.config import (
     RuntimeConfig,
     RuntimeLspConfig,
     RuntimeLspServerConfig,
+    RuntimeProviderFallbackConfig,
     RuntimeSkillsConfig,
 )
 from voidcode.runtime.events import EventEnvelope
 from voidcode.runtime.lsp import DisabledLspManager
+from voidcode.runtime.model_provider import ModelProviderRegistry
 from voidcode.runtime.permission import PermissionPolicy
 from voidcode.runtime.service import (
     GraphRunRequest,
@@ -25,6 +27,7 @@ from voidcode.runtime.service import (
     SessionState,
     VoidCodeRuntime,
 )
+from voidcode.runtime.single_agent_provider import ProviderExecutionError, SingleAgentTurnResult
 from voidcode.runtime.skills import SkillRegistry
 from voidcode.tools import ToolCall
 
@@ -102,6 +105,30 @@ class _FailingProviderGraph:
     ) -> _StubStep:
         _ = request, tool_results, session
         raise ValueError("provider context window exceeded")
+
+
+class _ScriptedSingleAgentProvider:
+    def __init__(self, *, name: str, outcomes: tuple[object, ...]) -> None:
+        self.name = name
+        self._outcomes = list(outcomes)
+
+    def propose_turn(self, request: object) -> SingleAgentTurnResult:
+        _ = request
+        if not self._outcomes:
+            return SingleAgentTurnResult(output="done")
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return cast(SingleAgentTurnResult, outcome)
+
+
+@dataclass(frozen=True, slots=True)
+class _ScriptedModelProvider:
+    name: str
+    outcomes: tuple[object, ...]
+
+    def single_agent_provider(self) -> _ScriptedSingleAgentProvider:
+        return _ScriptedSingleAgentProvider(name=self.name, outcomes=self.outcomes)
 
 
 def _write_demo_skill(skill_dir: Path, *, description: str = "Demo skill", content: str) -> None:
@@ -978,6 +1005,128 @@ def test_runtime_effective_runtime_config_recovers_single_agent_engine(tmp_path:
     assert effective.approval_mode == "allow"
     assert effective.execution_engine == "single_agent"
     assert effective.model == "opencode/gpt-5.4"
+
+
+def test_runtime_effective_runtime_config_recovers_provider_fallback_chain(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("fallback chain\n", encoding="utf-8")
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            approval_mode="allow",
+            execution_engine="single_agent",
+            model="opencode/gpt-5.4",
+            provider_fallback=RuntimeProviderFallbackConfig(
+                preferred_model="opencode/gpt-5.4",
+                fallback_models=("opencode/gpt-5.3", "custom/demo"),
+            ),
+        ),
+    )
+    _ = runtime.run(RuntimeRequest(prompt="read sample.txt", session_id="fallback-config"))
+
+    resumed_runtime = VoidCodeRuntime(workspace=tmp_path, config=RuntimeConfig())
+    effective = resumed_runtime.effective_runtime_config(session_id="fallback-config")
+
+    assert effective.provider_fallback == RuntimeProviderFallbackConfig(
+        preferred_model="opencode/gpt-5.4",
+        fallback_models=("opencode/gpt-5.3", "custom/demo"),
+    )
+
+
+@pytest.mark.parametrize("error_kind", ["rate_limit", "invalid_model", "transient_failure"])
+def test_runtime_downgrades_to_next_provider_target_on_provider_failures(
+    tmp_path: Path,
+    error_kind: Literal["rate_limit", "invalid_model", "transient_failure"],
+) -> None:
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderExecutionError(
+                        kind=error_kind,
+                        provider_name="opencode",
+                        model_name="gpt-5.4",
+                        message=f"{error_kind} failure",
+                    ),
+                ),
+            ),
+            "custom": _ScriptedModelProvider(
+                name="custom",
+                outcomes=(SingleAgentTurnResult(output="fallback complete"),),
+            ),
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            execution_engine="single_agent",
+            model="opencode/gpt-5.4",
+            provider_fallback=RuntimeProviderFallbackConfig(
+                preferred_model="opencode/gpt-5.4",
+                fallback_models=("custom/demo",),
+            ),
+        ),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="read sample.txt"))
+
+    assert response.session.status == "completed"
+    assert response.output == "fallback complete"
+    fallback_events = [
+        event for event in response.events if event.event_type == "runtime.provider_fallback"
+    ]
+    assert len(fallback_events) == 1
+    assert fallback_events[0].payload == {
+        "reason": error_kind,
+        "from_provider": "opencode",
+        "from_model": "gpt-5.4",
+        "to_provider": "custom",
+        "to_model": "demo",
+        "attempt": 1,
+    }
+
+
+def test_runtime_fails_without_downgrade_on_context_limit(tmp_path: Path) -> None:
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderExecutionError(
+                        kind="context_limit",
+                        provider_name="opencode",
+                        model_name="gpt-5.4",
+                        message="context exceeded",
+                    ),
+                ),
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            execution_engine="single_agent",
+            model="opencode/gpt-5.4",
+            provider_fallback=RuntimeProviderFallbackConfig(
+                preferred_model="opencode/gpt-5.4",
+                fallback_models=("custom/demo",),
+            ),
+        ),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="read sample.txt"))
+
+    assert response.session.status == "failed"
+    assert response.events[-1].event_type == "runtime.failed"
+    assert response.events[-1].payload == {
+        "error": "context exceeded",
+        "provider_error_kind": "context_limit",
+        "provider": "opencode",
+        "model": "gpt-5.4",
+    }
 
 
 def test_runtime_rejects_malformed_model_reference_during_initialization(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_single_agent_provider.py
+++ b/tests/unit/runtime/test_single_agent_provider.py
@@ -5,6 +5,7 @@ import pytest
 from voidcode.runtime.context_window import RuntimeContextWindow
 from voidcode.runtime.model_provider import ModelProviderRegistry, resolve_provider_model
 from voidcode.runtime.single_agent_provider import (
+    ProviderExecutionError,
     SingleAgentTurnRequest,
     StubSingleAgentProvider,
 )
@@ -104,6 +105,18 @@ def test_stub_single_agent_provider_rejects_unsupported_requests() -> None:
                 model_name=provider_model.selection.model,
             )
         )
+
+
+def test_provider_execution_error_requires_supported_kind() -> None:
+    error = ProviderExecutionError(
+        kind="rate_limit",
+        provider_name="opencode",
+        model_name="gpt-5.4",
+        message="too many requests",
+    )
+
+    assert error.kind == "rate_limit"
+    assert str(error) == "too many requests"
 
 
 def test_stub_single_agent_provider_uses_bounded_context_window_results_for_finalize() -> None:


### PR DESCRIPTION
## 描述

为 provider-backed single-agent 路径补上 runtime-owned 的 provider fallback chain 与 provider error taxonomy。这个 PR 让 runtime 能解析 preferred model + ordered fallback chain，在 provider 执行失败时按错误类型做统一处理：对 `rate_limit` / `invalid_model` / `transient_failure` 触发降级到下一个 target，对 `context_limit` 产出结构化 `runtime.failed` 结果，并保持 session persistence / replay / transport 序列化语义稳定。

close #68

## 变更类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 破坏性变更
- [ ] 文档更新
- [ ] 重构
- [ ] 仅测试变更
- [ ] CI / 工具链变更

## 测试

- `uv run pytest tests/unit/runtime/test_runtime_config.py tests/unit/runtime/test_model_provider.py tests/unit/runtime/test_single_agent_provider.py tests/unit/graph/test_single_agent_slice.py tests/unit/runtime/test_runtime_service_extensions.py -q`
- `uv run pytest tests/integration/test_read_only_slice.py tests/integration/test_http_transport.py -q`
- `mise run typecheck`
- `mise run test`
- 手工 QA：验证 `rate_limit` 会触发 `runtime.provider_fallback` 并成功降级；`context_limit` 会产出结构化 `runtime.failed`，payload 含 `provider_error_kind` / `provider` / `model`

## 核对清单

- [x] 本地测试通过
- [ ] 如有必要，已更新相关文档
- [x] 相关的 lint 检查和类型检查已通过
- [x] 未包含无关的变更