### PR TITLE
fix(runtime): fall back when persisted checkpoints are unreadable

### DIFF
--- a/src/voidcode/runtime/storage.py
+++ b/src/voidcode/runtime/storage.py
@@ -347,9 +347,12 @@ class SqliteSessionStore:
         payload = cast(str | None, row["resume_checkpoint_json"])
         if payload is None:
             return None
-        checkpoint = json.loads(payload)
+        try:
+            checkpoint = json.loads(payload)
+        except json.JSONDecodeError:
+            return None
         if not isinstance(checkpoint, dict):
-            raise ValueError("persisted resume checkpoint must be an object")
+            return None
         return cast(dict[str, object], checkpoint)
 
     def _read_pending_approval_json(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1508,6 +1508,88 @@ def test_runtime_resume_falls_back_when_persisted_checkpoint_is_missing(tmp_path
     assert resumed.output == "done"
 
 
+def test_runtime_resume_falls_back_when_persisted_checkpoint_json_is_corrupt(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    waiting = runtime.run(RuntimeRequest(prompt="go", session_id="checkpoint-corrupt-json-session"))
+    approval_request_id = str(waiting.events[-1].payload["request_id"])
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        _ = connection.execute(
+            "UPDATE sessions SET resume_checkpoint_json = ? WHERE session_id = ?",
+            ("{not valid json", "checkpoint-corrupt-json-session"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    resumed = resumed_runtime.resume(
+        session_id="checkpoint-corrupt-json-session",
+        approval_request_id=approval_request_id,
+        approval_decision="allow",
+    )
+
+    assert resumed.session.status == "completed"
+    assert resumed.output == "done"
+
+
+def test_runtime_resume_falls_back_when_persisted_checkpoint_payload_is_not_object(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    waiting = runtime.run(RuntimeRequest(prompt="go", session_id="checkpoint-non-object-session"))
+    approval_request_id = str(waiting.events[-1].payload["request_id"])
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        _ = connection.execute(
+            "UPDATE sessions SET resume_checkpoint_json = ? WHERE session_id = ?",
+            (json.dumps(["not", "an", "object"]), "checkpoint-non-object-session"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    resumed = resumed_runtime.resume(
+        session_id="checkpoint-non-object-session",
+        approval_request_id=approval_request_id,
+        approval_decision="allow",
+    )
+
+    assert resumed.session.status == "completed"
+    assert resumed.output == "done"
+
+
 @pytest.mark.parametrize("error_kind", ["rate_limit", "invalid_model", "transient_failure"])
 def test_runtime_downgrades_to_next_provider_target_on_provider_failures(
     tmp_path: Path,


### PR DESCRIPTION
## 描述

修复 #83：当 SQLite 中持久化的 `resume_checkpoint_json` 是损坏 JSON 或非 object payload 时，runtime 现在会将其视为不可用 checkpoint，而不是在 storage loader 层直接抛错。

这样 approval resume 就可以继续走已有的 legacy event reconstruction fallback 路径，避免在 fallback 逻辑运行之前就因为不可读 checkpoint 失败。

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 破坏性变更
- [ ] 文档更新
- [ ] 重构
- [ ] 仅测试变更
- [ ] CI / 工具链变更

## 测试

- `uv run pytest tests/unit/runtime/test_runtime_service_extensions.py::test_runtime_resume_falls_back_when_persisted_checkpoint_json_is_corrupt`
- `uv run pytest tests/unit/runtime/test_runtime_service_extensions.py::test_runtime_resume_falls_back_when_persisted_checkpoint_payload_is_not_object`
- `uv run pytest tests/unit/runtime/test_runtime_service_extensions.py::test_runtime_resume_falls_back_when_persisted_checkpoint_is_missing tests/unit/runtime/test_runtime_service_extensions.py::test_runtime_resume_approval_rebuilds_from_persisted_checkpoint_after_restart`
- `mise run lint`
- `mise run typecheck`
- `mise run test`

## 核对清单

- [x] 本地测试通过
- [ ] 如有必要，已更新相关文档
- [x] 相关的 lint 检查和类型检查已通过
- [x] 未包含无关的变更