### PR TITLE
test: capture the remaining skill execution gap

### DIFF
--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -78,6 +78,27 @@ class _SkillCapturingStubGraph:
         return _StubStep(output=request.prompt, is_finished=True)
 
 
+class _SkillAwareStubGraph:
+    last_request: GraphRunRequest | None = None
+
+    def step(
+        self,
+        request: GraphRunRequest,
+        tool_results: tuple[object, ...],
+        *,
+        session: SessionState,
+    ) -> _StubStep:
+        _ = tool_results, session
+        type(self).last_request = request
+        skill_names = [skill["name"] for skill in request.applied_skills]
+        skill_contents = [skill["content"] for skill in request.applied_skills]
+        if skill_names:
+            output = f"{request.prompt}\n[skills={','.join(skill_names)}]\n{skill_contents[0]}"
+        else:
+            output = request.prompt
+        return _StubStep(output=output, is_finished=True)
+
+
 class _ApprovalThenCaptureSkillGraph:
     last_request: GraphRunRequest | None = None
 
@@ -499,6 +520,83 @@ def test_runtime_persists_explicit_empty_applied_skill_snapshot(tmp_path: Path) 
     assert response.session.metadata["applied_skill_payloads"] == []
     assert _SkillCapturingStubGraph.last_request is not None
     assert _SkillCapturingStubGraph.last_request.applied_skills == ()
+
+
+def test_runtime_skill_payloads_affect_execution_output_when_graph_consumes_them(
+    tmp_path: Path,
+) -> None:
+    skill_dir = tmp_path / ".voidcode" / "skills" / "demo"
+    _write_demo_skill(
+        skill_dir,
+        content="# Demo\nUse concise bullet points.",
+    )
+
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_SkillAwareStubGraph(),
+        config=RuntimeConfig(skills=RuntimeSkillsConfig(enabled=True)),
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="summarize sample.txt"))
+
+    assert response.output == (
+        "summarize sample.txt\n[skills=demo]\n# Demo\nUse concise bullet points."
+    )
+    assert _SkillAwareStubGraph.last_request is not None
+    assert _SkillAwareStubGraph.last_request.applied_skills == (
+        {
+            "name": "demo",
+            "description": "Demo skill",
+            "content": "# Demo\nUse concise bullet points.",
+        },
+    )
+
+
+def test_runtime_resume_reuses_frozen_skill_payloads_for_execution_semantics(
+    tmp_path: Path,
+) -> None:
+    skill_dir = tmp_path / ".voidcode" / "skills" / "demo"
+    _write_demo_skill(
+        skill_dir,
+        content="# Demo\nUse concise bullet points.",
+    )
+
+    initial_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(skills=RuntimeSkillsConfig(enabled=True), approval_mode="ask"),
+    )
+
+    waiting = initial_runtime.run(RuntimeRequest(prompt="go", session_id="skill-exec-resume"))
+    approval_request_id = str(waiting.events[-1].payload["request_id"])
+
+    _write_demo_skill(
+        skill_dir,
+        description="Changed skill",
+        content="# Changed\nDo something else.",
+    )
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_SkillAwareStubGraph(),
+        config=RuntimeConfig(skills=RuntimeSkillsConfig(enabled=True), approval_mode="ask"),
+    )
+
+    resumed = resumed_runtime.resume(
+        session_id="skill-exec-resume",
+        approval_request_id=approval_request_id,
+        approval_decision="allow",
+    )
+
+    assert resumed.output == "go\n[skills=demo]\n# Demo\nUse concise bullet points."
+    assert _SkillAwareStubGraph.last_request is not None
+    assert _SkillAwareStubGraph.last_request.applied_skills == (
+        {
+            "name": "demo",
+            "description": "Demo skill",
+            "content": "# Demo\nUse concise bullet points.",
+        },
+    )
 
 
 class _MultiStepStubGraph:


### PR DESCRIPTION
## 描述

这个 PR 不实现新的 skill runtime 功能，而是为 issue #88 的范围校正保留测试证据。

我最初按“skill execution semantics 尚未实现”的假设推进，但代码与现有测试路径表明：runtime 已经具备 skill discovery、`runtime.skills_loaded` / `runtime.skills_applied`、frozen skill payload persistence、resume/replay 恢复，以及 single-agent path 对 applied skill context 的透传。

本 PR 增加 execution-focused tests，明确证明当前系统已经支持：
- skill payload 进入 graph request 后可被 graph 消费并影响输出
- resume 时继续使用 frozen skill snapshot，而不是读取被修改后的 live skill 内容

因此，#88 后续应聚焦于“跨 engine path 扩展/收口 skill execution semantics”，而不是重复实现 discovery/persistence/forwarding 的既有能力。

## 变更类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 破坏性变更
- [ ] 文档更新
- [ ] 重构
- [x] 仅测试变更
- [ ] CI / 工具链变更

## 测试

- `uv run pytest --no-cov tests/unit/runtime/test_runtime_service_extensions.py::test_runtime_skill_payloads_affect_execution_output_when_graph_consumes_them tests/unit/runtime/test_runtime_service_extensions.py::test_runtime_resume_reuses_frozen_skill_payloads_for_execution_semantics`
- `lsp_diagnostics tests/unit/runtime/test_runtime_service_extensions.py`（仅剩既有 unused-parameter hints，无新增错误）

## 核对清单

- [x] 本地测试通过
- [ ] 如有必要，已更新相关文档
- [ ] 相关的 lint 检查和类型检查已通过
- [x] 未包含无关的变更