### PR TITLE
feat(hook): add runtime-owned formatter hook presets (#89)

### DIFF
--- a/src/voidcode/hook/__init__.py
+++ b/src/voidcode/hook/__init__.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from .config import RuntimeFormatterPresetConfig, RuntimeHooksConfig
+from .executor import HookExecutionEvent, HookExecutionOutcome, HookExecutionRequest, run_tool_hooks
+
+__all__ = [
+    "HookExecutionEvent",
+    "HookExecutionOutcome",
+    "HookExecutionRequest",
+    "RuntimeFormatterPresetConfig",
+    "RuntimeHooksConfig",
+    "run_tool_hooks",
+]

--- a/src/voidcode/hook/config.py
+++ b/src/voidcode/hook/config.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+
+def _empty_formatter_presets() -> dict[str, RuntimeFormatterPresetConfig]:
+    return {}
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeFormatterPresetConfig:
+    command: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeHooksConfig:
+    enabled: bool | None = None
+    pre_tool: tuple[tuple[str, ...], ...] = ()
+    post_tool: tuple[tuple[str, ...], ...] = ()
+    formatter_presets: Mapping[str, RuntimeFormatterPresetConfig] = field(
+        default_factory=_empty_formatter_presets
+    )

--- a/src/voidcode/hook/config.py
+++ b/src/voidcode/hook/config.py
@@ -5,7 +5,16 @@ from dataclasses import dataclass, field
 
 
 def _empty_formatter_presets() -> dict[str, RuntimeFormatterPresetConfig]:
-    return {}
+    return {
+        "python": RuntimeFormatterPresetConfig(command=("ruff", "format")),
+        "typescript": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+        "javascript": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+        "json": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+        "markdown": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+        "yaml": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+        "rust": RuntimeFormatterPresetConfig(command=("rustfmt",)),
+        "go": RuntimeFormatterPresetConfig(command=("gofmt",)),
+    }
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/voidcode/hook/executor.py
+++ b/src/voidcode/hook/executor.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from ..runtime.events import RUNTIME_TOOL_HOOK_POST, RUNTIME_TOOL_HOOK_PRE
+from .config import RuntimeHooksConfig
+
+
+@dataclass(frozen=True, slots=True)
+class HookExecutionEvent:
+    sequence: int
+    event_type: str
+    payload: dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class HookExecutionOutcome:
+    events: tuple[HookExecutionEvent, ...]
+    last_sequence: int
+    failed_error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class HookExecutionRequest:
+    hooks: RuntimeHooksConfig | None
+    workspace: Path
+    session_id: str
+    tool_name: str
+    phase: Literal["pre", "post"]
+    recursion_env_var: str
+    environment: Mapping[str, str]
+    sequence_start: int
+
+
+def run_tool_hooks(request: HookExecutionRequest) -> HookExecutionOutcome:
+    hooks = request.hooks
+    if hooks is None or hooks.enabled is not True:
+        return HookExecutionOutcome(events=(), last_sequence=request.sequence_start)
+    if request.environment.get(request.recursion_env_var) == "1":
+        return HookExecutionOutcome(events=(), last_sequence=request.sequence_start)
+
+    commands = hooks.pre_tool if request.phase == "pre" else hooks.post_tool
+    last_sequence = request.sequence_start
+    events: list[HookExecutionEvent] = []
+    for command in commands:
+        last_sequence += 1
+        try:
+            subprocess.run(
+                list(command),
+                cwd=request.workspace,
+                capture_output=True,
+                text=True,
+                check=True,
+                env={**os.environ, **request.environment, request.recursion_env_var: "1"},
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            error_text = f"tool {request.phase}-hook failed for {request.tool_name}: {exc}"
+            return HookExecutionOutcome(
+                events=(
+                    HookExecutionEvent(
+                        sequence=last_sequence,
+                        event_type=_event_type_for_phase(request.phase),
+                        payload={
+                            "phase": request.phase,
+                            "tool_name": request.tool_name,
+                            "session_id": request.session_id,
+                            "status": "error",
+                            "error": error_text,
+                        },
+                    ),
+                ),
+                last_sequence=last_sequence,
+                failed_error=error_text,
+            )
+
+        events.append(
+            HookExecutionEvent(
+                sequence=last_sequence,
+                event_type=_event_type_for_phase(request.phase),
+                payload={
+                    "phase": request.phase,
+                    "tool_name": request.tool_name,
+                    "session_id": request.session_id,
+                    "status": "ok",
+                },
+            )
+        )
+
+    return HookExecutionOutcome(events=tuple(events), last_sequence=last_sequence)
+
+
+def _event_type_for_phase(phase: Literal["pre", "post"]) -> str:
+    return RUNTIME_TOOL_HOOK_PRE if phase == "pre" else RUNTIME_TOOL_HOOK_POST

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -239,13 +239,13 @@ def _parse_hooks_config(raw_hooks: object) -> RuntimeHooksConfig | None:
 def _parse_formatter_presets_config(
     raw_value: object, *, field_path: str
 ) -> dict[str, RuntimeFormatterPresetConfig]:
+    parsed_presets = dict(RuntimeHooksConfig().formatter_presets)
     if raw_value is None:
-        return {}
+        return parsed_presets
     if not isinstance(raw_value, dict):
         raise ValueError(f"runtime config field '{field_path}' must be an object when provided")
 
     raw_presets = cast(dict[str, object], raw_value)
-    parsed_presets: dict[str, RuntimeFormatterPresetConfig] = {}
     for preset_name, raw_preset in raw_presets.items():
         parsed_presets[preset_name] = _parse_formatter_preset_config(
             raw_preset,

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, cast
 
+from ..hook.config import RuntimeFormatterPresetConfig, RuntimeHooksConfig
 from .permission import PermissionDecision
 
 RUNTIME_CONFIG_FILE_NAME = ".voidcode.json"
@@ -18,13 +19,6 @@ _VALID_TUI_COMMANDS = ("command_palette", "session_new", "session_resume")
 type ExecutionEngineName = Literal["deterministic", "single_agent"]
 
 _VALID_EXECUTION_ENGINES: tuple[ExecutionEngineName, ...] = ("deterministic", "single_agent")
-
-
-@dataclass(frozen=True, slots=True)
-class RuntimeHooksConfig:
-    enabled: bool | None = None
-    pre_tool: tuple[tuple[str, ...], ...] = ()
-    post_tool: tuple[tuple[str, ...], ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -229,8 +223,50 @@ def _parse_hooks_config(raw_hooks: object) -> RuntimeHooksConfig | None:
 
     pre_tool = _parse_command_list(hooks_payload.get("pre_tool"), field_path="hooks.pre_tool")
     post_tool = _parse_command_list(hooks_payload.get("post_tool"), field_path="hooks.post_tool")
+    formatter_presets: dict[str, RuntimeFormatterPresetConfig] = _parse_formatter_presets_config(
+        hooks_payload.get("formatter_presets"),
+        field_path="hooks.formatter_presets",
+    )
 
-    return RuntimeHooksConfig(enabled=enabled, pre_tool=pre_tool, post_tool=post_tool)
+    return RuntimeHooksConfig(
+        enabled=enabled,
+        pre_tool=pre_tool,
+        post_tool=post_tool,
+        formatter_presets=formatter_presets,
+    )
+
+
+def _parse_formatter_presets_config(
+    raw_value: object, *, field_path: str
+) -> dict[str, RuntimeFormatterPresetConfig]:
+    if raw_value is None:
+        return {}
+    if not isinstance(raw_value, dict):
+        raise ValueError(f"runtime config field '{field_path}' must be an object when provided")
+
+    raw_presets = cast(dict[str, object], raw_value)
+    parsed_presets: dict[str, RuntimeFormatterPresetConfig] = {}
+    for preset_name, raw_preset in raw_presets.items():
+        parsed_presets[preset_name] = _parse_formatter_preset_config(
+            raw_preset,
+            field_path=f"{field_path}.{preset_name}",
+        )
+    return parsed_presets
+
+
+def _parse_formatter_preset_config(
+    raw_value: object, *, field_path: str
+) -> RuntimeFormatterPresetConfig:
+    if not isinstance(raw_value, dict):
+        raise ValueError(f"runtime config field '{field_path}' must be an object")
+
+    preset_payload = cast(dict[str, object], raw_value)
+    command = _parse_string_list(preset_payload.get("command"), field_path=f"{field_path}.command")
+    if not command:
+        raise ValueError(
+            f"runtime config field '{field_path}.command' must contain at least one string"
+        )
+    return RuntimeFormatterPresetConfig(command=command)
 
 
 def _parse_tools_config(raw_tools: object) -> RuntimeToolsConfig | None:

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
 import os
-import subprocess
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Protocol, cast, final, runtime_checkable
+from typing import Any, Literal, Protocol, cast, final, runtime_checkable
 from uuid import uuid4
 
 from ..graph.contracts import GraphEvent, GraphRunRequest
 from ..graph.read_only_slice import DeterministicReadOnlyGraph
 from ..graph.single_agent_slice import ProviderSingleAgentGraph
+from ..hook.executor import HookExecutionOutcome, HookExecutionRequest, run_tool_hooks
 from ..tools.contracts import Tool, ToolCall, ToolDefinition, ToolResult, ToolResultStatus
 from .acp import AcpAdapter, AcpRequestEnvelope, AcpResponseEnvelope, build_acp_adapter
 from .config import (
@@ -31,8 +31,6 @@ from .events import (
     RUNTIME_MEMORY_REFRESHED,
     RUNTIME_SKILLS_APPLIED,
     RUNTIME_SKILLS_LOADED,
-    RUNTIME_TOOL_HOOK_POST,
-    RUNTIME_TOOL_HOOK_PRE,
     EventEnvelope,
 )
 from .lsp import LspManager, LspManagerState, LspRequest, LspRequestResult, build_lsp_manager
@@ -818,65 +816,39 @@ class VoidCodeRuntime:
         session: SessionState,
         sequence: int,
         tool_name: str,
-        phase: str,
+        phase: Literal["pre", "post"],
     ) -> _HookOutcome:
-        hooks_config = self._config.hooks
-        if hooks_config is None or hooks_config.enabled is not True:
-            return _HookOutcome(chunks=(), last_sequence=sequence)
-        if os.environ.get(self._hook_recursion_env_var) == "1":
-            return _HookOutcome(chunks=(), last_sequence=sequence)
-
-        commands = hooks_config.pre_tool if phase == "pre" else hooks_config.post_tool
-        last_sequence = sequence
-        emitted_chunks: list[RuntimeStreamChunk] = []
-        for command in commands:
-            last_sequence += 1
-            try:
-                subprocess.run(
-                    list(command),
-                    cwd=self._workspace,
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                    env={**os.environ, self._hook_recursion_env_var: "1"},
-                )
-            except (OSError, subprocess.CalledProcessError) as exc:
-                hook_event = EventEnvelope(
-                    session_id=session.session.id,
-                    sequence=last_sequence,
-                    event_type=RUNTIME_TOOL_HOOK_PRE if phase == "pre" else RUNTIME_TOOL_HOOK_POST,
-                    source="runtime",
-                    payload={
-                        "phase": phase,
-                        "tool_name": tool_name,
-                        "session_id": session.session.id,
-                        "status": "error",
-                        "error": f"tool {phase}-hook failed for {tool_name}: {exc}",
-                    },
-                )
-                return _HookOutcome(
-                    chunks=(RuntimeStreamChunk(kind="event", session=session, event=hook_event),),
-                    last_sequence=last_sequence,
-                    failed_error=f"tool {phase}-hook failed for {tool_name}: {exc}",
-                )
-
-            yield_event = EventEnvelope(
+        outcome: HookExecutionOutcome = run_tool_hooks(
+            HookExecutionRequest(
+                hooks=self._config.hooks,
+                workspace=self._workspace,
                 session_id=session.session.id,
-                sequence=last_sequence,
-                event_type=RUNTIME_TOOL_HOOK_PRE if phase == "pre" else RUNTIME_TOOL_HOOK_POST,
-                source="runtime",
-                payload={
-                    "phase": phase,
-                    "tool_name": tool_name,
-                    "session_id": session.session.id,
-                    "status": "ok",
-                },
+                tool_name=tool_name,
+                phase=phase,
+                recursion_env_var=self._hook_recursion_env_var,
+                environment=os.environ,
+                sequence_start=sequence,
             )
-            emitted_chunks.append(
-                RuntimeStreamChunk(kind="event", session=session, event=yield_event)
+        )
+        emitted_chunks = tuple(
+            RuntimeStreamChunk(
+                kind="event",
+                session=session,
+                event=EventEnvelope(
+                    session_id=session.session.id,
+                    sequence=event.sequence,
+                    event_type=event.event_type,
+                    source="runtime",
+                    payload=event.payload,
+                ),
             )
-
-        return _HookOutcome(chunks=tuple(emitted_chunks), last_sequence=last_sequence)
+            for event in outcome.events
+        )
+        return _HookOutcome(
+            chunks=emitted_chunks,
+            last_sequence=outcome.last_sequence,
+            failed_error=outcome.failed_error,
+        )
 
     def _failed_chunk(
         self,

--- a/tests/unit/hook/test_executor.py
+++ b/tests/unit/hook/test_executor.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from voidcode.hook.config import RuntimeHooksConfig
+from voidcode.hook.executor import HookExecutionOutcome, HookExecutionRequest, run_tool_hooks
+
+
+def test_run_tool_hooks_executes_configured_pre_commands_and_reports_success(
+    tmp_path: Path,
+) -> None:
+    hooks = RuntimeHooksConfig(
+        enabled=True,
+        pre_tool=((sys.executable, "-c", "print('pre ok')"),),
+    )
+
+    outcome: HookExecutionOutcome = run_tool_hooks(
+        HookExecutionRequest(
+            hooks=hooks,
+            workspace=tmp_path,
+            session_id="hook-session",
+            tool_name="write_file",
+            phase="pre",
+            recursion_env_var="VOIDCODE_RUNNING_TOOL_HOOK",
+            environment={},
+            sequence_start=7,
+        )
+    )
+
+    assert outcome.failed_error is None
+    assert outcome.last_sequence == 8
+    assert len(outcome.events) == 1
+    event = outcome.events[0]
+    assert event.sequence == 8
+    assert event.event_type == "runtime.tool_hook_pre"
+    assert event.payload == {
+        "phase": "pre",
+        "tool_name": "write_file",
+        "session_id": "hook-session",
+        "status": "ok",
+    }

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -208,7 +208,112 @@ def test_runtime_config_parses_formatter_preset_hooks(tmp_path: Path) -> None:
         enabled=True,
         formatter_presets={
             "python": RuntimeFormatterPresetConfig(command=("ruff", "format")),
+            "javascript": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+            "json": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+            "markdown": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+            "yaml": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+            "rust": RuntimeFormatterPresetConfig(command=("rustfmt",)),
+            "go": RuntimeFormatterPresetConfig(command=("gofmt",)),
             "typescript": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+        },
+    )
+
+
+def test_runtime_hooks_config_defaults_formatter_presets_to_common_language_builtins() -> None:
+    assert RuntimeHooksConfig().formatter_presets == {
+        "python": RuntimeFormatterPresetConfig(command=("ruff", "format")),
+        "typescript": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+        "javascript": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+        "json": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+        "markdown": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+        "yaml": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+        "rust": RuntimeFormatterPresetConfig(command=("rustfmt",)),
+        "go": RuntimeFormatterPresetConfig(command=("gofmt",)),
+    }
+
+
+def test_runtime_config_keeps_builtin_formatter_presets_when_hooks_formatter_presets_missing(
+    tmp_path: Path,
+) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "enabled": True,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.hooks == RuntimeHooksConfig(enabled=True)
+
+
+def test_runtime_config_overrides_builtin_formatter_preset_with_user_value(tmp_path: Path) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "enabled": True,
+                    "formatter_presets": {
+                        "python": {"command": ["uvx", "ruff", "format"]},
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.hooks == RuntimeHooksConfig(
+        enabled=True,
+        formatter_presets={
+            "python": RuntimeFormatterPresetConfig(command=("uvx", "ruff", "format")),
+            "typescript": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+            "javascript": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+            "json": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+            "markdown": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+            "yaml": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+            "rust": RuntimeFormatterPresetConfig(command=("rustfmt",)),
+            "go": RuntimeFormatterPresetConfig(command=("gofmt",)),
+        },
+    )
+
+
+def test_runtime_config_keeps_builtin_formatter_presets_when_adding_custom_user_preset(
+    tmp_path: Path,
+) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "enabled": True,
+                    "formatter_presets": {
+                        "toml": {"command": ["taplo", "fmt"]},
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.hooks == RuntimeHooksConfig(
+        enabled=True,
+        formatter_presets={
+            "python": RuntimeFormatterPresetConfig(command=("ruff", "format")),
+            "typescript": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+            "javascript": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+            "json": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+            "markdown": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+            "yaml": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+            "rust": RuntimeFormatterPresetConfig(command=("rustfmt",)),
+            "go": RuntimeFormatterPresetConfig(command=("gofmt",)),
+            "toml": RuntimeFormatterPresetConfig(command=("taplo", "fmt")),
         },
     )
 
@@ -394,6 +499,26 @@ def test_runtime_config_rejects_invalid_max_steps(
             cast(dict[str, object], {"hooks": {"post_tool": [["echo", "hello"], []]}}),
             "runtime config field 'hooks.post_tool\\[1\\]'.*at least one string",
             id="hooks-post-tool-empty-command",
+        ),
+        pytest.param(
+            {"hooks": {"formatter_presets": []}},
+            "runtime config field 'hooks.formatter_presets'",
+            id="hooks-formatter-presets-shape",
+        ),
+        pytest.param(
+            {"hooks": {"formatter_presets": {"python": []}}},
+            "runtime config field 'hooks.formatter_presets.python'",
+            id="hooks-formatter-preset-shape",
+        ),
+        pytest.param(
+            {"hooks": {"formatter_presets": {"python": {"command": []}}}},
+            "runtime config field 'hooks.formatter_presets.python.command'.*at least one string",
+            id="hooks-formatter-preset-command-empty",
+        ),
+        pytest.param(
+            {"hooks": {"formatter_presets": {"python": {"command": [False]}}}},
+            "runtime config field 'hooks.formatter_presets.python.command\\[0\\]'",
+            id="hooks-formatter-preset-command-item-type",
         ),
     ],
 )

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -11,6 +11,7 @@ from voidcode.runtime.config import (
     MODEL_ENV_VAR,
     RUNTIME_CONFIG_FILE_NAME,
     RuntimeAcpConfig,
+    RuntimeFormatterPresetConfig,
     RuntimeHooksConfig,
     RuntimeLspConfig,
     RuntimeLspServerConfig,
@@ -182,6 +183,33 @@ def test_runtime_config_parses_minimal_hook_commands(tmp_path: Path) -> None:
         enabled=True,
         pre_tool=(("python", "scripts/pre.py"),),
         post_tool=(("python", "scripts/post.py"),),
+    )
+
+
+def test_runtime_config_parses_formatter_preset_hooks(tmp_path: Path) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "enabled": True,
+                    "formatter_presets": {
+                        "python": {"command": ["ruff", "format"]},
+                        "typescript": {"command": ["prettier", "--write"]},
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.hooks == RuntimeHooksConfig(
+        enabled=True,
+        formatter_presets={
+            "python": RuntimeFormatterPresetConfig(command=("ruff", "format")),
+            "typescript": RuntimeFormatterPresetConfig(command=("prettier", "--write")),
+        },
     )
 
 


### PR DESCRIPTION
## 描述

将 #89 收敛为一个窄切片：把 runtime-owned hook 配置抽到 `src/voidcode/hook/`，为 hooks config 增加内置的常见语言 formatter presets，并把现有 tool hook 执行逻辑提取到独立 executor 中，保持现有 pre/post hook 行为不变。

当前 PR 可明确提供的能力：
- 在 hook config 中提供内置 formatter presets：
  - Python → `ruff format`
  - TypeScript / JavaScript / JSON / Markdown / YAML → `prettier --write`
  - Rust → `rustfmt`
  - Go → `gofmt`
- 支持仓库本地 `hooks.formatter_presets` 对这些内置 preset 进行覆盖或扩展
- 将 runtime 中现有的 tool hook 执行逻辑抽到 `src/voidcode/hook/executor.py`

当前 PR **不**声称已经实现自动 formatter 执行、语言检测或文件类型路由；executor 仍只执行显式配置的 `pre_tool` / `post_tool` 命令。

## 变更类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 破坏性变更
- [ ] 文档更新
- [x] 重构
- [ ] 仅测试变更
- [ ] CI / 工具链变更

## 测试

已执行：
- `mise run typecheck`
- `mise run lint`
- `mise run test`
- `uv run pytest --no-cov tests/unit/runtime/test_runtime_config.py`
- `uv run pytest --no-cov tests/unit/hook/test_executor.py`
- `uv run pytest --no-cov tests/integration/test_read_only_slice.py -k hook`

## 核对清单

- [x] 本地测试通过
- [ ] 如有必要，已更新相关文档
- [x] 相关的 lint 检查和类型检查已通过
- [x] 未包含无关的变更