### PR TITLE
feat(runtime): harden provider config resolution and persistence (#90)

### DIFF
--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -8,9 +8,10 @@ from pathlib import Path
 from typing import Protocol, cast
 
 from . import __version__
-from .runtime.config import load_runtime_config
+from .runtime.config import load_runtime_config, serialize_provider_fallback_config
 from .runtime.contracts import RuntimeRequest, RuntimeStreamChunk
 from .runtime.events import EventEnvelope
+from .runtime.model_provider import resolved_provider_snapshot
 from .runtime.permission import PermissionDecision, PermissionResolution
 from .runtime.service import VoidCodeRuntime
 from .runtime.session import SessionState, StoredSessionSummary
@@ -235,6 +236,12 @@ def _handle_config_show_command(args: argparse.Namespace) -> int:
                 "model": effective_config.model,
                 "execution_engine": effective_config.execution_engine,
                 "max_steps": effective_config.max_steps,
+                "provider_fallback": serialize_provider_fallback_config(
+                    getattr(effective_config, "provider_fallback", None)
+                ),
+                "resolved_provider": resolved_provider_snapshot(
+                    getattr(effective_config, "resolved_provider", None)
+                ),
             }
         )
     )

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -400,20 +400,29 @@ def _parse_tui_config(raw_tui: object) -> RuntimeTuiConfig | None:
 def _parse_provider_fallback_config(
     raw_provider_fallback: object,
 ) -> RuntimeProviderFallbackConfig | None:
+    return parse_provider_fallback_payload(
+        raw_provider_fallback,
+        source="runtime config field 'provider_fallback'",
+    )
+
+
+def parse_provider_fallback_payload(
+    raw_provider_fallback: object,
+    *,
+    source: str,
+) -> RuntimeProviderFallbackConfig | None:
     if raw_provider_fallback is None:
         return None
     if not isinstance(raw_provider_fallback, dict):
-        raise ValueError("runtime config field 'provider_fallback' must be an object when provided")
+        raise ValueError(f"{source} must be an object when provided")
 
     payload = cast(dict[str, object], raw_provider_fallback)
     preferred_model = payload.get("preferred_model")
     if not isinstance(preferred_model, str):
-        raise ValueError(
-            "runtime config field 'provider_fallback.preferred_model' must be a string"
-        )
+        raise ValueError(f"{_nested_config_field(source, 'preferred_model')} must be a string")
     fallback_models = _parse_string_list(
         payload.get("fallback_models"),
-        field_path="provider_fallback.fallback_models",
+        field_path=_nested_config_field(source, "fallback_models"),
     )
     ordered_models = (preferred_model, *fallback_models)
     if len(set(ordered_models)) != len(ordered_models):
@@ -424,6 +433,17 @@ def _parse_provider_fallback_config(
     )
 
 
+def serialize_provider_fallback_config(
+    provider_fallback: RuntimeProviderFallbackConfig | None,
+) -> dict[str, object] | None:
+    if provider_fallback is None:
+        return None
+    return {
+        "preferred_model": provider_fallback.preferred_model,
+        "fallback_models": list(provider_fallback.fallback_models),
+    }
+
+
 def _parse_optional_bool(raw_value: object, *, field_path: str) -> bool | None:
     if raw_value is None:
         return None
@@ -432,17 +452,40 @@ def _parse_optional_bool(raw_value: object, *, field_path: str) -> bool | None:
     return raw_value
 
 
+def _nested_config_field(source: str, nested: str) -> str:
+    runtime_field_prefix = "runtime config field '"
+    if source.startswith(runtime_field_prefix) and source.endswith("'"):
+        base_field = source[len(runtime_field_prefix) : -1]
+        return f"runtime config field '{base_field}.{nested}'"
+    return f"{source}.{nested}"
+
+
+def _format_runtime_config_field_error(field_path: str) -> str:
+    runtime_field_prefix = "runtime config field '"
+    if field_path.startswith(runtime_field_prefix):
+        if field_path.endswith("'"):
+            return field_path
+        if "'[" in field_path:
+            base, suffix = field_path[len(runtime_field_prefix) :].split("'[", maxsplit=1)
+            return f"{runtime_field_prefix}{base}[{suffix}'"
+    return f"runtime config field '{field_path}'"
+
+
 def _parse_string_list(raw_value: object, *, field_path: str) -> tuple[str, ...]:
     if raw_value is None:
         return ()
     if not isinstance(raw_value, list):
-        raise ValueError(f"runtime config field '{field_path}' must be an array when provided")
+        raise ValueError(
+            f"{_format_runtime_config_field_error(field_path)} must be an array when provided"
+        )
 
     raw_items = cast(list[object], raw_value)
     parsed_items: list[str] = []
     for index, item in enumerate(raw_items):
         if not isinstance(item, str):
-            raise ValueError(f"runtime config field '{field_path}[{index}]' must be a string")
+            raise ValueError(
+                f"{_format_runtime_config_field_error(f'{field_path}[{index}]')} must be a string"
+            )
         parsed_items.append(item)
     return tuple(parsed_items)
 

--- a/src/voidcode/runtime/model_provider.py
+++ b/src/voidcode/runtime/model_provider.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
+from typing import Protocol, cast, runtime_checkable
 
 from .config import RuntimeProviderFallbackConfig
+from .provider_errors import format_invalid_provider_config_error
 from .single_agent_provider import SingleAgentProvider, StubSingleAgentProvider
 
 
@@ -46,6 +48,14 @@ class ResolvedProviderChain:
         if index < 0 or index >= len(self.all_targets):
             return None
         return self.all_targets[index]
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedProviderConfig:
+    model: str | None = None
+    provider_fallback: RuntimeProviderFallbackConfig | None = None
+    active_target: ResolvedProviderModel = ResolvedProviderModel()
+    target_chain: ResolvedProviderChain = ResolvedProviderChain()
 
 
 @dataclass(slots=True)
@@ -100,8 +110,215 @@ def resolve_provider_chain(
     )
 
 
+def resolve_provider_config(
+    model: str | None,
+    provider_fallback: RuntimeProviderFallbackConfig | None,
+    *,
+    registry: ModelProviderRegistry,
+) -> ResolvedProviderConfig:
+    if provider_fallback is not None:
+        if model is not None and model != provider_fallback.preferred_model:
+            raise ValueError(
+                format_invalid_provider_config_error(
+                    "provider_fallback.preferred_model",
+                    "must match model when both are configured",
+                )
+            )
+        target_chain = resolve_provider_chain(provider_fallback, registry=registry)
+        return ResolvedProviderConfig(
+            model=provider_fallback.preferred_model,
+            provider_fallback=provider_fallback,
+            active_target=target_chain.preferred,
+            target_chain=target_chain,
+        )
+
+    if model is None:
+        return ResolvedProviderConfig()
+
+    active_target = resolve_provider_model(model, registry=registry)
+    target_chain = ResolvedProviderChain(
+        preferred=active_target,
+        all_targets=(active_target,),
+    )
+    return ResolvedProviderConfig(
+        model=model,
+        provider_fallback=None,
+        active_target=active_target,
+        target_chain=target_chain,
+    )
+
+
+def resolved_provider_snapshot(
+    resolved_provider: ResolvedProviderConfig | Mapping[str, object] | None,
+) -> dict[str, object] | None:
+    if resolved_provider is None:
+        return None
+    if isinstance(resolved_provider, Mapping):
+        return dict(resolved_provider)
+
+    targets: list[dict[str, str]] = []
+    for target in resolved_provider.target_chain.all_targets:
+        snapshot = _resolved_provider_target_snapshot(target)
+        if snapshot is not None:
+            targets.append(snapshot)
+    if not targets:
+        return None
+    active_target = _resolved_provider_target_snapshot(resolved_provider.active_target)
+    if active_target is None:
+        return None
+    return {
+        "active_target": active_target,
+        "targets": targets,
+    }
+
+
+def parse_resolved_provider_snapshot(
+    raw_snapshot: object,
+    *,
+    source: str,
+    registry: ModelProviderRegistry,
+) -> ResolvedProviderConfig:
+    if not isinstance(raw_snapshot, dict):
+        raise ValueError(format_invalid_provider_config_error(source, "must be an object"))
+
+    snapshot = cast(dict[str, object], raw_snapshot)
+    raw_active_target = snapshot.get("active_target")
+    raw_targets = snapshot.get("targets")
+    if not isinstance(raw_active_target, dict):
+        raise ValueError(
+            format_invalid_provider_config_error(f"{source}.active_target", "must be an object")
+        )
+    if not isinstance(raw_targets, list):
+        raise ValueError(
+            format_invalid_provider_config_error(f"{source}.targets", "must be an array")
+        )
+
+    raw_targets_list = cast(list[object], raw_targets)
+    resolved_targets_list = [
+        _resolved_provider_model_from_snapshot(
+            item,
+            source=f"{source}.targets[{index}]",
+            registry=registry,
+        )
+        for index, item in enumerate(raw_targets_list)
+    ]
+    if not resolved_targets_list:
+        raise ValueError(
+            format_invalid_provider_config_error(f"{source}.targets", "must not be empty")
+        )
+    first_target = resolved_targets_list[0]
+    resolved_targets: tuple[ResolvedProviderModel, ...] = tuple(resolved_targets_list)
+
+    resolved_active_target = _resolved_provider_model_from_snapshot(
+        cast(object, raw_active_target),
+        source=f"{source}.active_target",
+        registry=registry,
+    )
+    if resolved_active_target.selection.raw_model != first_target.selection.raw_model:
+        raise ValueError(
+            format_invalid_provider_config_error(
+                f"{source}.active_target",
+                "must match the first resolved provider target",
+            )
+        )
+
+    provider_fallback: RuntimeProviderFallbackConfig | None = None
+    if len(resolved_targets) > 1:
+        first_raw_model = first_target.selection.raw_model
+        if first_raw_model is None:
+            raise ValueError(
+                format_invalid_provider_config_error(
+                    f"{source}.targets[0]",
+                    "must include a raw_model",
+                )
+            )
+        provider_fallback = RuntimeProviderFallbackConfig(
+            preferred_model=first_raw_model,
+            fallback_models=tuple(
+                _require_raw_model(target=target, source=f"{source}.targets[{index}]")
+                for index, target in enumerate(resolved_targets[1:], start=1)
+            ),
+        )
+
+    first_raw_model = first_target.selection.raw_model
+    if first_raw_model is None:
+        raise ValueError(
+            format_invalid_provider_config_error(
+                f"{source}.targets[0]",
+                "must include a raw_model",
+            )
+        )
+
+    return ResolvedProviderConfig(
+        model=first_raw_model,
+        provider_fallback=provider_fallback,
+        active_target=resolved_active_target,
+        target_chain=ResolvedProviderChain(
+            preferred=first_target,
+            fallbacks=resolved_targets[1:],
+            all_targets=resolved_targets,
+        ),
+    )
+
+
 def _parse_model_reference(raw_model: str) -> tuple[str, str]:
     provider_name, separator, model_name = raw_model.partition("/")
     if separator != "/" or "/" in model_name or not provider_name or not model_name:
         raise ValueError("model must use provider/model format")
     return provider_name, model_name
+
+
+def _resolved_provider_target_snapshot(target: ResolvedProviderModel) -> dict[str, str] | None:
+    if (
+        target.selection.raw_model is None
+        or target.selection.provider is None
+        or target.selection.model is None
+    ):
+        return None
+    return {
+        "raw_model": target.selection.raw_model,
+        "provider": target.selection.provider,
+        "model": target.selection.model,
+    }
+
+
+def _resolved_provider_model_from_snapshot(
+    raw_value: object,
+    *,
+    source: str,
+    registry: ModelProviderRegistry,
+) -> ResolvedProviderModel:
+    if not isinstance(raw_value, dict):
+        raise ValueError(format_invalid_provider_config_error(source, "must be an object"))
+    payload = cast(dict[str, object], raw_value)
+    raw_model = payload.get("raw_model")
+    provider = payload.get("provider")
+    model = payload.get("model")
+    if (
+        not isinstance(raw_model, str)
+        or not isinstance(provider, str)
+        or not isinstance(model, str)
+    ):
+        raise ValueError(
+            format_invalid_provider_config_error(
+                source,
+                "must include string raw_model, provider, and model fields",
+            )
+        )
+
+    resolved = resolve_provider_model(raw_model, registry=registry)
+    if resolved.selection.provider != provider or resolved.selection.model != model:
+        raise ValueError(
+            format_invalid_provider_config_error(
+                source,
+                "must match the parsed provider/model reference",
+            )
+        )
+    return resolved
+
+
+def _require_raw_model(*, target: ResolvedProviderModel, source: str) -> str:
+    raw_model = target.selection.raw_model
+    if raw_model is None:
+        raise ValueError(format_invalid_provider_config_error(source, "must include a raw_model"))
+    return raw_model

--- a/src/voidcode/runtime/provider_errors.py
+++ b/src/voidcode/runtime/provider_errors.py
@@ -9,6 +9,17 @@ class SingleAgentContextLimitError(SingleAgentProviderError):
     """Provider failure caused by context window exhaustion."""
 
 
+def format_invalid_provider_config_error(field_path: str, reason: str) -> str:
+    return f"invalid provider config: {field_path} {reason}"
+
+
+def format_fallback_exhausted_error(*, provider_name: str, model_name: str, attempt: int) -> str:
+    return (
+        "provider fallback exhausted after "
+        f"{provider_name}/{model_name} failed at attempt {attempt}"
+    )
+
+
 def classify_provider_error(exc: Exception) -> SingleAgentProviderError | None:
     message = str(exc).lower()
     context_limit_markers = (

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -18,6 +18,8 @@ from .config import (
     RuntimeConfig,
     RuntimeProviderFallbackConfig,
     load_runtime_config,
+    parse_provider_fallback_payload,
+    serialize_provider_fallback_config,
 )
 from .context_window import ContextWindowPolicy, RuntimeContextWindow, prepare_single_agent_context
 from .contracts import RuntimeRequest, RuntimeResponse, RuntimeStreamChunk, validate_session_id
@@ -37,9 +39,11 @@ from .lsp import LspManager, LspManagerState, LspRequest, LspRequestResult, buil
 from .model_provider import (
     ModelProviderRegistry,
     ResolvedProviderChain,
+    ResolvedProviderConfig,
     ResolvedProviderModel,
-    resolve_provider_chain,
-    resolve_provider_model,
+    parse_resolved_provider_snapshot,
+    resolve_provider_config,
+    resolved_provider_snapshot,
 )
 from .permission import (
     PendingApproval,
@@ -48,7 +52,12 @@ from .permission import (
     PermissionResolution,
     resolve_permission,
 )
-from .provider_errors import SingleAgentContextLimitError, classify_provider_error
+from .provider_errors import (
+    SingleAgentContextLimitError,
+    classify_provider_error,
+    format_fallback_exhausted_error,
+    format_invalid_provider_config_error,
+)
 from .session import SessionRef, SessionState, SessionStatus, StoredSessionSummary
 from .single_agent_provider import ProviderExecutionError
 from .skills import SkillRegistry, SkillRuntimeContext
@@ -145,14 +154,13 @@ class VoidCodeRuntime:
         self._model_provider_registry = (
             model_provider_registry or ModelProviderRegistry.with_defaults()
         )
-        self._provider_model = resolve_provider_model(
+        self._resolved_provider_config = resolve_provider_config(
             self._config.model,
-            registry=self._model_provider_registry,
-        )
-        self._provider_chain = resolve_provider_chain(
             self._config.provider_fallback,
             registry=self._model_provider_registry,
         )
+        self._provider_model = self._resolved_provider_config.active_target
+        self._provider_chain = self._resolved_provider_config.target_chain
         self._lsp_manager = lsp_manager or build_lsp_manager(self._config.lsp)
         self._tool_registry = tool_registry or ToolRegistry.with_defaults(
             lsp_tool=self._build_lsp_tool()
@@ -166,6 +174,7 @@ class VoidCodeRuntime:
                 execution_engine=self._config.execution_engine,
                 max_steps=self._config.max_steps,
                 provider_fallback=self._config.provider_fallback,
+                resolved_provider=self._resolved_provider_config,
             )
         )
         self._permission_policy = permission_policy or PermissionPolicy(
@@ -224,23 +233,7 @@ class VoidCodeRuntime:
             return self._graph_cache[cache_key]
 
         # Build new graph and cache it
-        if config.provider_fallback is not None:
-            provider_chain = resolve_provider_chain(
-                config.provider_fallback,
-                registry=self._model_provider_registry,
-            )
-            provider_model = provider_chain.preferred
-            self._provider_chain = provider_chain
-        else:
-            provider_model = resolve_provider_model(
-                config.model,
-                registry=self._model_provider_registry,
-            )
-            self._provider_chain = ResolvedProviderChain(
-                preferred=provider_model,
-                all_targets=((provider_model,) if provider_model.provider is not None else ()),
-            )
-        self._provider_model = provider_model
+        provider_model = config.resolved_provider.active_target
         graph = self._build_graph_for_engine(
             config.execution_engine,
             provider_model,
@@ -265,6 +258,7 @@ class VoidCodeRuntime:
                 execution_engine=resolved.execution_engine,
                 max_steps=request_max_steps,
                 provider_fallback=resolved.provider_fallback,
+                resolved_provider=resolved.resolved_provider,
             )
         return resolved
 
@@ -598,6 +592,23 @@ class VoidCodeRuntime:
                             },
                         )
                         continue
+                    if exc.kind in {"rate_limit", "invalid_model", "transient_failure"}:
+                        yield self._failed_chunk(
+                            session=session,
+                            sequence=sequence + 1,
+                            error=format_fallback_exhausted_error(
+                                provider_name=exc.provider_name,
+                                model_name=exc.model_name,
+                                attempt=next_attempt,
+                            ),
+                            payload={
+                                "provider_error_kind": exc.kind,
+                                "provider": exc.provider_name,
+                                "model": exc.model_name,
+                                "fallback_exhausted": True,
+                            },
+                        )
+                        return
                 if isinstance(exc, ProviderExecutionError):
                     yield self._failed_chunk(
                         session=session,
@@ -1567,14 +1578,13 @@ class VoidCodeRuntime:
             "approval_mode": effective_config.approval_mode,
             "execution_engine": effective_config.execution_engine,
             "max_steps": effective_config.max_steps,
+            "provider_fallback": serialize_provider_fallback_config(
+                effective_config.provider_fallback
+            ),
+            "resolved_provider": resolved_provider_snapshot(effective_config.resolved_provider),
         }
         if effective_config.model is not None:
             runtime_config_metadata["model"] = effective_config.model
-        if effective_config.provider_fallback is not None:
-            runtime_config_metadata["provider_fallback"] = {
-                "preferred_model": effective_config.provider_fallback.preferred_model,
-                "fallback_models": list(effective_config.provider_fallback.fallback_models),
-            }
         lsp_state = self._lsp_manager.current_state()
         runtime_config_metadata["lsp"] = {
             "mode": lsp_state.mode,
@@ -1684,6 +1694,7 @@ class VoidCodeRuntime:
         execution_engine = self._config.execution_engine
         max_steps = self._config.max_steps
         provider_fallback = self._config.provider_fallback
+        resolved_provider = self._resolved_provider_config
         if metadata is None:
             return EffectiveRuntimeConfig(
                 approval_mode=approval_mode,
@@ -1691,6 +1702,7 @@ class VoidCodeRuntime:
                 execution_engine=execution_engine,
                 max_steps=max_steps,
                 provider_fallback=provider_fallback,
+                resolved_provider=resolved_provider,
             )
 
         persisted_runtime_config = metadata.get("runtime_config")
@@ -1701,6 +1713,7 @@ class VoidCodeRuntime:
                 execution_engine=execution_engine,
                 max_steps=max_steps,
                 provider_fallback=provider_fallback,
+                resolved_provider=resolved_provider,
             )
 
         runtime_config = cast(dict[str, object], persisted_runtime_config)
@@ -1716,42 +1729,51 @@ class VoidCodeRuntime:
                 raise ValueError("persisted runtime_config max_steps must be at least 1")
             max_steps = persisted_max_steps
         provider_fallback = None
-        persisted_provider_fallback = runtime_config.get("provider_fallback")
-        if isinstance(persisted_provider_fallback, dict):
-            payload = cast(dict[str, object], persisted_provider_fallback)
-            preferred_model = payload.get("preferred_model")
-            fallback_models = payload.get("fallback_models")
-            if isinstance(preferred_model, str) and isinstance(fallback_models, list):
-                raw_fallback_models = cast(list[object], fallback_models)
-                parsed_fallback_models = [
-                    item for item in raw_fallback_models if isinstance(item, str)
-                ]
-                if len(parsed_fallback_models) == len(raw_fallback_models):
-                    provider_fallback = RuntimeProviderFallbackConfig(
-                        preferred_model=preferred_model,
-                        fallback_models=tuple(parsed_fallback_models),
+        if "provider_fallback" in runtime_config:
+            try:
+                provider_fallback = parse_provider_fallback_payload(
+                    runtime_config.get("provider_fallback"),
+                    source="persisted runtime_config.provider_fallback",
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    format_invalid_provider_config_error(
+                        "persisted runtime_config.provider_fallback",
+                        str(exc),
                     )
+                ) from exc
         persisted_execution_engine = runtime_config.get("execution_engine")
         if persisted_execution_engine in ("deterministic", "single_agent"):
             execution_engine = persisted_execution_engine
+        raw_resolved_provider = runtime_config.get("resolved_provider")
+        if raw_resolved_provider is not None:
+            resolved_provider = parse_resolved_provider_snapshot(
+                raw_resolved_provider,
+                source="persisted runtime_config.resolved_provider",
+                registry=self._model_provider_registry,
+            )
+            model = resolved_provider.model
+            provider_fallback = resolved_provider.provider_fallback
+        else:
+            resolved_provider = resolve_provider_config(
+                model,
+                provider_fallback,
+                registry=self._model_provider_registry,
+            )
         return EffectiveRuntimeConfig(
             approval_mode=approval_mode,
             model=model,
             execution_engine=execution_engine,
             max_steps=max_steps,
             provider_fallback=provider_fallback,
+            resolved_provider=resolved_provider,
         )
 
     def _provider_chain_for_session_metadata(
         self, metadata: dict[str, object] | None
     ) -> ResolvedProviderChain:
         effective_config = self._effective_runtime_config_from_metadata(metadata)
-        if effective_config.provider_fallback is None:
-            return ResolvedProviderChain()
-        return resolve_provider_chain(
-            effective_config.provider_fallback,
-            registry=self._model_provider_registry,
-        )
+        return effective_config.resolved_provider.target_chain
 
     def _graph_for_session_metadata(self, metadata: dict[str, object] | None) -> RuntimeGraph:
         if self._graph_override is not None:
@@ -1786,6 +1808,7 @@ class EffectiveRuntimeConfig:
     execution_engine: ExecutionEngineName
     max_steps: int
     provider_fallback: RuntimeProviderFallbackConfig | None = None
+    resolved_provider: ResolvedProviderConfig = field(default_factory=ResolvedProviderConfig)
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -1039,6 +1039,21 @@ def test_single_agent_runtime_executes_read_path_and_persists_config(tmp_path: P
         "max_steps": 4,
         "lsp": {"configured_enabled": False, "mode": "disabled", "servers": []},
         "model": "opencode/gpt-5.4",
+        "provider_fallback": None,
+        "resolved_provider": {
+            "active_target": {
+                "raw_model": "opencode/gpt-5.4",
+                "provider": "opencode",
+                "model": "gpt-5.4",
+            },
+            "targets": [
+                {
+                    "raw_model": "opencode/gpt-5.4",
+                    "provider": "opencode",
+                    "model": "gpt-5.4",
+                }
+            ],
+        },
     }
     assert result.events[3].payload["mode"] == "single_agent"
     assert replay.output == result.output
@@ -1554,6 +1569,21 @@ def test_runtime_resume_uses_persisted_runtime_config_over_fresh_resume_override
         "max_steps": 4,
         "lsp": {"configured_enabled": False, "mode": "disabled", "servers": []},
         "model": "session/model",
+        "provider_fallback": None,
+        "resolved_provider": {
+            "active_target": {
+                "raw_model": "session/model",
+                "provider": "session",
+                "model": "model",
+            },
+            "targets": [
+                {
+                    "raw_model": "session/model",
+                    "provider": "session",
+                    "model": "model",
+                }
+            ],
+        },
     }
 
 

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -820,6 +820,21 @@ def test_config_show_outputs_workspace_effective_config() -> None:
         "model": "repo/model",
         "execution_engine": "deterministic",
         "max_steps": 4,
+        "provider_fallback": None,
+        "resolved_provider": {
+            "active_target": {
+                "raw_model": "repo/model",
+                "provider": "repo",
+                "model": "model",
+            },
+            "targets": [
+                {
+                    "raw_model": "repo/model",
+                    "provider": "repo",
+                    "model": "model",
+                }
+            ],
+        },
     }
     assert "Traceback" not in result.stderr
 
@@ -864,6 +879,21 @@ def test_config_show_outputs_resumed_session_effective_config() -> None:
         "model": "repo/model",
         "execution_engine": "deterministic",
         "max_steps": 4,
+        "provider_fallback": None,
+        "resolved_provider": {
+            "active_target": {
+                "raw_model": "repo/model",
+                "provider": "repo",
+                "model": "model",
+            },
+            "targets": [
+                {
+                    "raw_model": "repo/model",
+                    "provider": "repo",
+                    "model": "model",
+                }
+            ],
+        },
     }
     assert "Traceback" not in result.stderr
 
@@ -875,6 +905,21 @@ def test_config_show_delegates_to_runtime_effective_config(capsys: Any) -> None:
         model="runtime/model",
         execution_engine="deterministic",
         max_steps=9,
+        provider_fallback=None,
+        resolved_provider={
+            "active_target": {
+                "raw_model": "runtime/model",
+                "provider": "runtime",
+                "model": "model",
+            },
+            "targets": [
+                {
+                    "raw_model": "runtime/model",
+                    "provider": "runtime",
+                    "model": "model",
+                }
+            ],
+        },
     )
 
     with tempfile.TemporaryDirectory() as tmp:
@@ -908,6 +953,21 @@ def test_config_show_delegates_to_runtime_effective_config(capsys: Any) -> None:
                 "model": "runtime/model",
                 "execution_engine": "deterministic",
                 "max_steps": 9,
+                "provider_fallback": None,
+                "resolved_provider": {
+                    "active_target": {
+                        "raw_model": "runtime/model",
+                        "provider": "runtime",
+                        "model": "model",
+                    },
+                    "targets": [
+                        {
+                            "raw_model": "runtime/model",
+                            "provider": "runtime",
+                            "model": "model",
+                        }
+                    ],
+                },
             }
         )
         + "\n"

--- a/tests/unit/runtime/test_model_provider.py
+++ b/tests/unit/runtime/test_model_provider.py
@@ -5,7 +5,9 @@ import pytest
 from voidcode.runtime.config import RuntimeProviderFallbackConfig
 from voidcode.runtime.model_provider import (
     ModelProviderRegistry,
+    ResolvedProviderConfig,
     resolve_provider_chain,
+    resolve_provider_config,
     resolve_provider_model,
 )
 
@@ -71,6 +73,55 @@ def test_resolve_provider_chain_preserves_ordered_fallback_targets() -> None:
         "opencode/gpt-5.3",
         "custom/demo",
     ]
+
+
+def test_resolve_provider_config_builds_single_target_chain_from_model() -> None:
+    resolved = resolve_provider_config(
+        model="opencode/gpt-5.4",
+        provider_fallback=None,
+        registry=ModelProviderRegistry.with_defaults(),
+    )
+
+    assert resolved == ResolvedProviderConfig(
+        model="opencode/gpt-5.4",
+        provider_fallback=None,
+        active_target=resolved.active_target,
+        target_chain=resolved.target_chain,
+    )
+    assert resolved.active_target.selection.raw_model == "opencode/gpt-5.4"
+    assert [target.selection.raw_model for target in resolved.target_chain.all_targets] == [
+        "opencode/gpt-5.4"
+    ]
+
+
+def test_resolve_provider_config_normalizes_preferred_fallback_model_as_active_target() -> None:
+    resolved = resolve_provider_config(
+        model="opencode/gpt-5.4",
+        provider_fallback=RuntimeProviderFallbackConfig(
+            preferred_model="opencode/gpt-5.4",
+            fallback_models=("custom/demo",),
+        ),
+        registry=ModelProviderRegistry.with_defaults(),
+    )
+
+    assert resolved.model == "opencode/gpt-5.4"
+    assert resolved.active_target.selection.raw_model == "opencode/gpt-5.4"
+    assert [target.selection.raw_model for target in resolved.target_chain.all_targets] == [
+        "opencode/gpt-5.4",
+        "custom/demo",
+    ]
+
+
+def test_resolve_provider_config_rejects_mismatched_model_and_preferred_fallback() -> None:
+    with pytest.raises(ValueError, match="preferred_model"):
+        _ = resolve_provider_config(
+            model="opencode/gpt-5.4",
+            provider_fallback=RuntimeProviderFallbackConfig(
+                preferred_model="custom/demo",
+                fallback_models=("backup/model",),
+            ),
+            registry=ModelProviderRegistry.with_defaults(),
+        )
 
 
 @pytest.mark.parametrize("raw_model", ["", "provider", "/model", "provider/", "a/b/c"])

--- a/tests/unit/runtime/test_provider_errors.py
+++ b/tests/unit/runtime/test_provider_errors.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from voidcode.runtime.provider_errors import SingleAgentContextLimitError, classify_provider_error
+from voidcode.runtime.provider_errors import (
+    SingleAgentContextLimitError,
+    classify_provider_error,
+    format_fallback_exhausted_error,
+    format_invalid_provider_config_error,
+)
 
 
 def test_classify_provider_error_returns_context_limit_error_for_limit_messages() -> None:
@@ -12,3 +17,24 @@ def test_classify_provider_error_returns_context_limit_error_for_limit_messages(
 
 def test_classify_provider_error_returns_none_for_unrelated_errors() -> None:
     assert classify_provider_error(ValueError("network timeout")) is None
+
+
+def test_format_invalid_provider_config_error_includes_field_and_reason() -> None:
+    assert format_invalid_provider_config_error(
+        "provider_fallback.preferred_model",
+        "must match model when both are configured",
+    ) == (
+        "invalid provider config: provider_fallback.preferred_model "
+        "must match model when both are configured"
+    )
+
+
+def test_format_fallback_exhausted_error_includes_provider_model_and_attempt() -> None:
+    assert (
+        format_fallback_exhausted_error(
+            provider_name="opencode",
+            model_name="gpt-5.4",
+            attempt=2,
+        )
+        == "provider fallback exhausted after opencode/gpt-5.4 failed at attempt 2"
+    )

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1044,6 +1044,21 @@ def test_runtime_effective_runtime_config_recovers_persisted_max_steps(tmp_path:
         "execution_engine": "deterministic",
         "max_steps": 7,
         "model": "session/model",
+        "provider_fallback": None,
+        "resolved_provider": {
+            "active_target": {
+                "raw_model": "session/model",
+                "provider": "session",
+                "model": "model",
+            },
+            "targets": [
+                {
+                    "raw_model": "session/model",
+                    "provider": "session",
+                    "model": "model",
+                }
+            ],
+        },
         "lsp": {"mode": "disabled", "configured_enabled": False, "servers": []},
         "acp": {
             "mode": "disabled",
@@ -1163,6 +1178,8 @@ def test_runtime_effective_runtime_config_uses_request_metadata_max_steps_for_ne
         "approval_mode": "ask",
         "execution_engine": "deterministic",
         "max_steps": 2,
+        "provider_fallback": None,
+        "resolved_provider": None,
         "lsp": {"mode": "disabled", "configured_enabled": False, "servers": []},
         "acp": {
             "mode": "disabled",
@@ -1424,7 +1441,103 @@ def test_runtime_effective_runtime_config_treats_missing_persisted_provider_fall
     assert effective.approval_mode == "allow"
     assert effective.execution_engine == "single_agent"
     assert effective.model == "opencode/gpt-5.4"
-    assert effective.provider_fallback is None
+    assert effective.provider_fallback == RuntimeProviderFallbackConfig(
+        preferred_model="opencode/gpt-5.4",
+        fallback_models=("opencode/gpt-5.3", "custom/demo"),
+    )
+
+
+def test_runtime_persists_resolved_provider_snapshot_in_runtime_metadata(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("resolved provider config\n", encoding="utf-8")
+
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            approval_mode="allow",
+            execution_engine="single_agent",
+            model="opencode/gpt-5.4",
+            provider_fallback=RuntimeProviderFallbackConfig(
+                preferred_model="opencode/gpt-5.4",
+                fallback_models=("custom/demo",),
+            ),
+        ),
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="read sample.txt", session_id="resolved-provider"))
+
+    runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
+    assert runtime_config["resolved_provider"] == {
+        "active_target": {
+            "raw_model": "opencode/gpt-5.4",
+            "provider": "opencode",
+            "model": "gpt-5.4",
+        },
+        "targets": [
+            {
+                "raw_model": "opencode/gpt-5.4",
+                "provider": "opencode",
+                "model": "gpt-5.4",
+            },
+            {
+                "raw_model": "custom/demo",
+                "provider": "custom",
+                "model": "demo",
+            },
+        ],
+    }
+
+
+def test_runtime_effective_runtime_config_rejects_malformed_persisted_provider_fallback(
+    tmp_path: Path,
+) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("bad fallback\n", encoding="utf-8")
+
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            approval_mode="allow",
+            execution_engine="single_agent",
+            model="opencode/gpt-5.4",
+            provider_fallback=RuntimeProviderFallbackConfig(
+                preferred_model="opencode/gpt-5.4",
+                fallback_models=("custom/demo",),
+            ),
+        ),
+    )
+    _ = runtime.run(
+        RuntimeRequest(prompt="read sample.txt", session_id="malformed-provider-fallback")
+    )
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        row = connection.execute(
+            "SELECT metadata_json FROM sessions WHERE session_id = ?",
+            ("malformed-provider-fallback",),
+        ).fetchone()
+        assert row is not None
+        metadata = json.loads(str(row[0]))
+        assert isinstance(metadata, dict)
+        metadata_dict = cast(dict[str, object], metadata)
+        runtime_config = cast(dict[str, object], metadata_dict["runtime_config"])
+        runtime_config["provider_fallback"] = {
+            "preferred_model": "opencode/gpt-5.4",
+            "fallback_models": ["custom/demo", 7],
+        }
+        _ = connection.execute(
+            "UPDATE sessions SET metadata_json = ? WHERE session_id = ?",
+            (json.dumps(metadata_dict, sort_keys=True), "malformed-provider-fallback"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    resumed_runtime = VoidCodeRuntime(workspace=tmp_path, config=RuntimeConfig())
+
+    with pytest.raises(ValueError, match="invalid provider config"):
+        _ = resumed_runtime.effective_runtime_config(session_id="malformed-provider-fallback")
 
 
 def test_runtime_resume_preserves_provider_attempt_and_target_across_pending_approval(


### PR DESCRIPTION
close #90 
## Summary
- centralize provider config resolution behind a canonical resolved-provider control-plane model and tighten provider fallback validation
- persist a resume-safe resolved provider snapshot in runtime metadata so fresh runs, resume, and fallback selection share the same provider semantics
- align `voidcode config show` and runtime/session tests with the normalized provider config surface and provider error formatting

## Verification
- mise run check