### PR TITLE
docs: define capability-layer ownership boundaries

### DIFF
--- a/src/voidcode/acp/README.md
+++ b/src/voidcode/acp/README.md
@@ -1,24 +1,24 @@
 # `voidcode.acp`
 
-Capability-layer home for ACP request/response contracts, config schemas, and reusable adapter-facing models when ACP semantics become stable enough to stand on their own.
+这里是 ACP 能力层的预期目录。当 ACP 的语义足够稳定、能够独立站住时，这里可以承载 ACP 请求/响应契约、配置 schema 和可复用的 adapter-facing 模型。
 
-## Owns
+## 负责什么
 
-- ACP envelope and state model definitions that are not runtime-coupled
-- reusable ACP configuration schema helpers
-- stable protocol contracts for ACP integrations
+- 不与 runtime 强绑定的 ACP envelope 和状态模型定义
+- 可复用的 ACP 配置 schema 辅助逻辑
+- 稳定的 ACP 集成协议契约
 
-## Does not own
+## 不负责什么
 
-- connection lifecycle management
-- runtime-managed availability state
-- session persistence and resume behavior
-- runtime event emission and recovery flow
+- 连接生命周期管理
+- runtime 管理的可用性状态
+- session 持久化与 resume 行为
+- runtime 事件发射与恢复流程
 
-## Runtime boundary
+## 与 runtime 的边界
 
-`src/voidcode/runtime/acp.py` remains the runtime-managed control plane. ACP should only move into this package when its pure contracts and schemas can be separated cleanly from runtime lifecycle ownership.
+`src/voidcode/runtime/acp.py` 仍然是 runtime 管理的控制面。只有当 ACP 的纯契约与 schema 能够干净地从 runtime 生命周期 ownership 中分离出来时，才适合把更多实现迁入这个包。
 
-## Current status
+## 当前状态
 
-This directory is a placeholder for a future capability layer. The current implementation still lives in `src/voidcode/runtime/acp.py`.
+这个目录目前只是未来能力层的占位。现有实现仍然位于 `src/voidcode/runtime/acp.py`。

--- a/src/voidcode/acp/README.md
+++ b/src/voidcode/acp/README.md
@@ -1,0 +1,24 @@
+# `voidcode.acp`
+
+Capability-layer home for ACP request/response contracts, config schemas, and reusable adapter-facing models when ACP semantics become stable enough to stand on their own.
+
+## Owns
+
+- ACP envelope and state model definitions that are not runtime-coupled
+- reusable ACP configuration schema helpers
+- stable protocol contracts for ACP integrations
+
+## Does not own
+
+- connection lifecycle management
+- runtime-managed availability state
+- session persistence and resume behavior
+- runtime event emission and recovery flow
+
+## Runtime boundary
+
+`src/voidcode/runtime/acp.py` remains the runtime-managed control plane. ACP should only move into this package when its pure contracts and schemas can be separated cleanly from runtime lifecycle ownership.
+
+## Current status
+
+This directory is a placeholder for a future capability layer. The current implementation still lives in `src/voidcode/runtime/acp.py`.

--- a/src/voidcode/lsp/README.md
+++ b/src/voidcode/lsp/README.md
@@ -1,25 +1,25 @@
 # `voidcode.lsp`
 
-Capability-layer home for LSP presets, language support definitions, config schemas, and registry logic.
+这里是 LSP 能力层的预期目录，用来承载 LSP 的预配置、语言支持定义、配置 schema 和注册中心逻辑。
 
-## Owns
+## 负责什么
 
-- language-to-server mappings
-- default LSP presets and reusable server definitions
-- pure config normalization and validation helpers
-- LSP-specific capability contracts that do not depend on runtime session state
+- 语言到 LSP server 的映射关系
+- 默认 LSP preset 和可复用的 server 定义
+- 纯粹的配置归一化与校验辅助逻辑
+- 不依赖 runtime session 状态的 LSP 能力契约
 
-## Does not own
+## 不负责什么
 
-- process lifecycle and stdio management
-- request routing from runtime entrypoints
-- runtime event emission
-- session persistence or resume state
+- 进程生命周期与 stdio 管理
+- 从 runtime 入口发起的请求路由
+- runtime 事件发射
+- session 持久化或 resume 状态
 
-## Runtime boundary
+## 与 runtime 的边界
 
-`src/voidcode/runtime/lsp.py` remains the runtime integration layer. It should depend on `voidcode.lsp` for reusable definitions and schemas, while continuing to own runtime-managed lifecycle, events, and effective session truth.
+`src/voidcode/runtime/lsp.py` 仍然是 runtime 集成层。它应当依赖 `voidcode.lsp` 中可复用的定义与 schema，同时继续持有 runtime 管理的生命周期、事件和 session 生效真相。
 
-## Current status
+## 当前状态
 
-This directory is a planned capability layer. The current implementation still lives in `src/voidcode/runtime/lsp.py` and `src/voidcode/tools/lsp.py`.
+这个目录目前是规划中的能力层。现有实现仍然位于 `src/voidcode/runtime/lsp.py` 与 `src/voidcode/tools/lsp.py`。

--- a/src/voidcode/lsp/README.md
+++ b/src/voidcode/lsp/README.md
@@ -1,0 +1,25 @@
+# `voidcode.lsp`
+
+Capability-layer home for LSP presets, language support definitions, config schemas, and registry logic.
+
+## Owns
+
+- language-to-server mappings
+- default LSP presets and reusable server definitions
+- pure config normalization and validation helpers
+- LSP-specific capability contracts that do not depend on runtime session state
+
+## Does not own
+
+- process lifecycle and stdio management
+- request routing from runtime entrypoints
+- runtime event emission
+- session persistence or resume state
+
+## Runtime boundary
+
+`src/voidcode/runtime/lsp.py` remains the runtime integration layer. It should depend on `voidcode.lsp` for reusable definitions and schemas, while continuing to own runtime-managed lifecycle, events, and effective session truth.
+
+## Current status
+
+This directory is a planned capability layer. The current implementation still lives in `src/voidcode/runtime/lsp.py` and `src/voidcode/tools/lsp.py`.

--- a/src/voidcode/provider/README.md
+++ b/src/voidcode/provider/README.md
@@ -1,0 +1,25 @@
+# `voidcode.provider`
+
+Capability-layer home for provider/model resolution contracts, provider registries, fallback semantics, and reusable provider configuration helpers.
+
+## Owns
+
+- provider and model reference schemas
+- resolved provider config models
+- provider registry and fallback resolution helpers
+- provider-specific config validation that is independent of runtime session state
+
+## Does not own
+
+- graph execution orchestration
+- runtime retry loops and provider attempt state
+- session metadata persistence
+- runtime error/event routing
+
+## Runtime boundary
+
+Runtime continues to own effective provider config resolution in-session, provider attempt tracking, and fallback execution flow. This package is the intended home for the pure provider-control-plane primitives that runtime consumes.
+
+## Current status
+
+The active implementation is still split across `src/voidcode/runtime/model_provider.py`, `src/voidcode/runtime/provider_errors.py`, and `src/voidcode/runtime/service.py`.

--- a/src/voidcode/provider/README.md
+++ b/src/voidcode/provider/README.md
@@ -1,25 +1,25 @@
 # `voidcode.provider`
 
-Capability-layer home for provider/model resolution contracts, provider registries, fallback semantics, and reusable provider configuration helpers.
+这里是 provider 能力层的预期目录，用来承载 provider/model 解析契约、provider 注册中心、fallback 语义以及可复用的 provider 配置辅助逻辑。
 
-## Owns
+## 负责什么
 
-- provider and model reference schemas
-- resolved provider config models
-- provider registry and fallback resolution helpers
-- provider-specific config validation that is independent of runtime session state
+- provider 和 model 引用 schema
+- resolved provider config 模型
+- provider registry 与 fallback 解析辅助逻辑
+- 不依赖 runtime session 状态的 provider 配置校验
 
-## Does not own
+## 不负责什么
 
-- graph execution orchestration
-- runtime retry loops and provider attempt state
-- session metadata persistence
-- runtime error/event routing
+- graph 执行编排
+- runtime 重试循环和 provider attempt 状态
+- session metadata 持久化
+- runtime 错误与事件路由
 
-## Runtime boundary
+## 与 runtime 的边界
 
-Runtime continues to own effective provider config resolution in-session, provider attempt tracking, and fallback execution flow. This package is the intended home for the pure provider-control-plane primitives that runtime consumes.
+runtime 继续持有 session 内的生效 provider config 解析、provider attempt 跟踪以及 fallback 执行流程。这个包的目标是承载那些可被 runtime 消费的纯 provider control-plane 原语。
 
-## Current status
+## 当前状态
 
-The active implementation is still split across `src/voidcode/runtime/model_provider.py`, `src/voidcode/runtime/provider_errors.py`, and `src/voidcode/runtime/service.py`.
+现有实现仍然分散在 `src/voidcode/runtime/model_provider.py`、`src/voidcode/runtime/provider_errors.py` 和 `src/voidcode/runtime/service.py` 中。

--- a/src/voidcode/skills/README.md
+++ b/src/voidcode/skills/README.md
@@ -1,0 +1,25 @@
+# `voidcode.skills`
+
+Capability-layer home for skill manifests, discovery rules, metadata parsing, and reusable skill registry definitions.
+
+## Owns
+
+- skill manifest format and parsing rules
+- discovery path conventions
+- reusable skill metadata models
+- pure registry helpers that do not require runtime session state
+
+## Does not own
+
+- runtime prompt assembly
+- session-bound applied skill state
+- runtime event emission
+- request execution semantics
+
+## Runtime boundary
+
+`src/voidcode/runtime/skills.py` remains the runtime integration layer until manifest parsing and discovery helpers are extracted into this package. Runtime should keep ownership of effective configuration and session-facing behavior.
+
+## Current status
+
+This directory is a planned capability layer. The current implementation still lives in `src/voidcode/runtime/skills.py`.

--- a/src/voidcode/skills/README.md
+++ b/src/voidcode/skills/README.md
@@ -1,25 +1,25 @@
 # `voidcode.skills`
 
-Capability-layer home for skill manifests, discovery rules, metadata parsing, and reusable skill registry definitions.
+这里是 skills 能力层的预期目录，用来承载 skill manifest、发现规则、元数据解析以及可复用的 skill 注册定义。
 
-## Owns
+## 负责什么
 
-- skill manifest format and parsing rules
-- discovery path conventions
-- reusable skill metadata models
-- pure registry helpers that do not require runtime session state
+- skill manifest 格式和解析规则
+- skill 搜索路径约定
+- 可复用的 skill 元数据模型
+- 不依赖 runtime session 状态的纯 registry 辅助逻辑
 
-## Does not own
+## 不负责什么
 
-- runtime prompt assembly
-- session-bound applied skill state
-- runtime event emission
-- request execution semantics
+- runtime prompt 组装
+- 与 session 绑定的 applied skill 状态
+- runtime 事件发射
+- 请求执行语义
 
-## Runtime boundary
+## 与 runtime 的边界
 
-`src/voidcode/runtime/skills.py` remains the runtime integration layer until manifest parsing and discovery helpers are extracted into this package. Runtime should keep ownership of effective configuration and session-facing behavior.
+`src/voidcode/runtime/skills.py` 目前仍是 runtime 集成层，至少要等 manifest 解析和 discovery helper 被抽离后，才适合把更多实现放入这个包。runtime 仍应持有生效配置和面向 session 的行为。
 
-## Current status
+## 当前状态
 
-This directory is a planned capability layer. The current implementation still lives in `src/voidcode/runtime/skills.py`.
+这个目录目前是规划中的能力层。现有实现仍然位于 `src/voidcode/runtime/skills.py`。


### PR DESCRIPTION
## Summary
- add a new `src/voidcode/lsp/README.md` that defines the intended capability-layer boundary for LSP presets, schemas, and reusable definitions
- add parallel capability-layer ownership READMEs for `src/voidcode/skills/`, `src/voidcode/provider/`, and `src/voidcode/acp/`
- document what each module should own, what should remain runtime-managed, and which current runtime files are still the implementation source of truth

## Verification
- mise run check
- verified the new README paths exist under `src/voidcode/`