### PR TITLE
feat(lsp): add preset and workspace-root capability layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ htmlcov/
 .opencode/
 .sisyphus/
 .test_venv/
+agent/

--- a/src/voidcode/lsp/__init__.py
+++ b/src/voidcode/lsp/__init__.py
@@ -1,0 +1,25 @@
+from .contracts import LspServerConfigOverride, LspServerPreset, ResolvedLspServerConfig
+from .presets import (
+    builtin_lsp_server_presets,
+    get_builtin_lsp_server_preset,
+    has_builtin_lsp_server_preset,
+)
+from .registry import (
+    match_lsp_servers_for_path,
+    resolve_lsp_server_config,
+    resolve_lsp_server_configs,
+)
+from .roots import discover_workspace_root
+
+__all__ = [
+    "LspServerConfigOverride",
+    "LspServerPreset",
+    "ResolvedLspServerConfig",
+    "builtin_lsp_server_presets",
+    "get_builtin_lsp_server_preset",
+    "has_builtin_lsp_server_preset",
+    "match_lsp_servers_for_path",
+    "resolve_lsp_server_config",
+    "resolve_lsp_server_configs",
+    "discover_workspace_root",
+]

--- a/src/voidcode/lsp/contracts.py
+++ b/src/voidcode/lsp/contracts.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class LspServerPreset:
+    id: str
+    command: tuple[str, ...]
+    extensions: tuple[str, ...] = ()
+    languages: tuple[str, ...] = ()
+    root_markers: tuple[str, ...] = ()
+    settings: dict[str, object] = field(default_factory=dict)
+    init_options: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class LspServerConfigOverride:
+    preset: str | None = None
+    command: tuple[str, ...] = ()
+    extensions: tuple[str, ...] = ()
+    languages: tuple[str, ...] = ()
+    root_markers: tuple[str, ...] = ()
+    settings: dict[str, object] = field(default_factory=dict)
+    init_options: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedLspServerConfig:
+    id: str
+    command: tuple[str, ...]
+    extensions: tuple[str, ...] = ()
+    languages: tuple[str, ...] = ()
+    root_markers: tuple[str, ...] = ()
+    settings: dict[str, object] = field(default_factory=dict)
+    init_options: dict[str, object] = field(default_factory=dict)
+    preset: str | None = None
+
+    def matches_path(self, path: Path) -> bool:
+        if not self.extensions:
+            return False
+        return path.suffix.lower() in self.extensions

--- a/src/voidcode/lsp/presets.py
+++ b/src/voidcode/lsp/presets.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from .contracts import LspServerPreset
+
+_PYTHON_ROOT_MARKERS = ("pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", ".git")
+
+_BUILTIN_LSP_SERVER_PRESETS: tuple[LspServerPreset, ...] = (
+    LspServerPreset(
+        id="pyright",
+        command=("pyright-langserver", "--stdio"),
+        extensions=(".py", ".pyi"),
+        languages=("python",),
+        root_markers=_PYTHON_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="ruff",
+        command=("ruff", "server"),
+        extensions=(".py", ".pyi"),
+        languages=("python",),
+        root_markers=_PYTHON_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="gopls",
+        command=("gopls",),
+        extensions=(".go",),
+        languages=("go",),
+        root_markers=("go.work", "go.mod", ".git"),
+    ),
+    LspServerPreset(
+        id="rust-analyzer",
+        command=("rust-analyzer",),
+        extensions=(".rs",),
+        languages=("rust",),
+        root_markers=("Cargo.toml", "rust-project.json", ".git"),
+    ),
+    LspServerPreset(
+        id="tsserver",
+        command=("typescript-language-server", "--stdio"),
+        extensions=(".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs"),
+        languages=("typescript", "javascript"),
+        root_markers=("tsconfig.json", "jsconfig.json", "package.json", ".git"),
+    ),
+)
+
+_BUILTIN_LSP_SERVER_PRESET_MAP = {preset.id: preset for preset in _BUILTIN_LSP_SERVER_PRESETS}
+
+
+def builtin_lsp_server_presets() -> tuple[LspServerPreset, ...]:
+    return _BUILTIN_LSP_SERVER_PRESETS
+
+
+def get_builtin_lsp_server_preset(server_id: str) -> LspServerPreset | None:
+    return _BUILTIN_LSP_SERVER_PRESET_MAP.get(server_id)
+
+
+def has_builtin_lsp_server_preset(server_id: str) -> bool:
+    return server_id in _BUILTIN_LSP_SERVER_PRESET_MAP

--- a/src/voidcode/lsp/registry.py
+++ b/src/voidcode/lsp/registry.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import cast
+
+from .contracts import LspServerConfigOverride, LspServerPreset, ResolvedLspServerConfig
+from .presets import get_builtin_lsp_server_preset, has_builtin_lsp_server_preset
+
+
+def resolve_lsp_server_config(
+    server_name: str,
+    override: LspServerConfigOverride | None,
+) -> ResolvedLspServerConfig:
+    effective_override = override or LspServerConfigOverride()
+
+    if effective_override.preset is not None and not has_builtin_lsp_server_preset(
+        effective_override.preset
+    ):
+        raise ValueError(f"unknown LSP preset: {effective_override.preset}")
+
+    preset = _resolve_preset(server_name=server_name, override=effective_override)
+    command = effective_override.command or (preset.command if preset is not None else ())
+    if not command:
+        raise ValueError(
+            f"LSP server '{server_name}' must define a command or reference a known preset"
+        )
+
+    return ResolvedLspServerConfig(
+        id=server_name,
+        preset=preset.id if preset is not None else None,
+        command=command,
+        extensions=_merge_string_sequences(
+            _normalize_extensions(preset.extensions if preset is not None else ()),
+            _normalize_extensions(effective_override.extensions),
+        ),
+        languages=_merge_string_sequences(
+            _normalize_names(preset.languages if preset is not None else ()),
+            _normalize_names(effective_override.languages),
+        ),
+        root_markers=_merge_string_sequences(
+            preset.root_markers if preset is not None else (),
+            effective_override.root_markers,
+        ),
+        settings=_deep_merge_dicts(
+            preset.settings if preset is not None else {},
+            effective_override.settings,
+        ),
+        init_options=_deep_merge_dicts(
+            preset.init_options if preset is not None else {},
+            effective_override.init_options,
+        ),
+    )
+
+
+def resolve_lsp_server_configs(
+    servers: Mapping[str, LspServerConfigOverride] | None,
+) -> dict[str, ResolvedLspServerConfig]:
+    if not servers:
+        return {}
+    return {
+        server_name: resolve_lsp_server_config(server_name, override)
+        for server_name, override in servers.items()
+    }
+
+
+def match_lsp_servers_for_path(
+    servers: Mapping[str, ResolvedLspServerConfig],
+    file_path: Path,
+) -> tuple[str, ...]:
+    return tuple(
+        server_name for server_name, config in servers.items() if config.matches_path(file_path)
+    )
+
+
+def _resolve_preset(
+    *,
+    server_name: str,
+    override: LspServerConfigOverride,
+) -> LspServerPreset | None:
+    if override.preset is not None:
+        return get_builtin_lsp_server_preset(override.preset)
+    if has_builtin_lsp_server_preset(server_name):
+        return get_builtin_lsp_server_preset(server_name)
+    return None
+
+
+def _merge_string_sequences(base: Iterable[str], extra: Iterable[str]) -> tuple[str, ...]:
+    merged: list[str] = []
+    seen: set[str] = set()
+    for item in (*tuple(base), *tuple(extra)):
+        if item in seen:
+            continue
+        seen.add(item)
+        merged.append(item)
+    return tuple(merged)
+
+
+def _normalize_extensions(values: Iterable[str]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        normalized_value = value.lower()
+        if not normalized_value.startswith("."):
+            normalized_value = f".{normalized_value}"
+        if normalized_value in seen:
+            continue
+        seen.add(normalized_value)
+        normalized.append(normalized_value)
+    return tuple(normalized)
+
+
+def _normalize_names(values: Iterable[str]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        normalized_value = value.lower()
+        if normalized_value in seen:
+            continue
+        seen.add(normalized_value)
+        normalized.append(normalized_value)
+    return tuple(normalized)
+
+
+def _deep_merge_dicts(
+    base: Mapping[str, object],
+    override: Mapping[str, object],
+) -> dict[str, object]:
+    merged = {key: value for key, value in base.items()}
+    for key, value in override.items():
+        current = merged.get(key)
+        if isinstance(current, dict) and isinstance(value, dict):
+            merged[key] = _deep_merge_dicts(
+                cast(dict[str, object], current),
+                cast(dict[str, object], value),
+            )
+            continue
+        merged[key] = value
+    return merged

--- a/src/voidcode/lsp/roots.py
+++ b/src/voidcode/lsp/roots.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+
+def discover_workspace_root(
+    *,
+    file_path: Path,
+    workspace_root: Path,
+    root_markers: Iterable[str],
+) -> Path:
+    resolved_workspace_root = workspace_root.resolve()
+    resolved_file_path = file_path.resolve()
+    markers = tuple(marker for marker in root_markers if marker)
+    if not markers:
+        return resolved_workspace_root
+
+    try:
+        resolved_file_path.relative_to(resolved_workspace_root)
+    except ValueError:
+        return resolved_workspace_root
+
+    search_dir = resolved_file_path if resolved_file_path.is_dir() else resolved_file_path.parent
+    current = search_dir
+
+    while True:
+        if any((current / marker).exists() for marker in markers):
+            return current
+        if current == resolved_workspace_root:
+            return resolved_workspace_root
+        parent = current.parent
+        if parent == current:
+            return resolved_workspace_root
+        try:
+            parent.relative_to(resolved_workspace_root)
+        except ValueError:
+            return resolved_workspace_root
+        current = parent

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from typing import Literal, cast
 
 from ..hook.config import RuntimeFormatterPresetConfig, RuntimeHooksConfig
+from ..lsp import LspServerConfigOverride as RuntimeLspServerConfig
+from ..lsp import has_builtin_lsp_server_preset
 from .permission import PermissionDecision
 
 RUNTIME_CONFIG_FILE_NAME = ".voidcode.json"
@@ -36,12 +38,6 @@ class RuntimeToolsConfig:
 class RuntimeSkillsConfig:
     enabled: bool | None = None
     paths: tuple[str, ...] = ()
-
-
-@dataclass(frozen=True, slots=True)
-class RuntimeLspServerConfig:
-    command: tuple[str, ...]
-    languages: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -331,18 +327,32 @@ def _parse_lsp_servers_config(
     for server_name, raw_server in raw_servers.items():
         parsed_servers[server_name] = _parse_lsp_server_config(
             raw_server,
+            server_name=server_name,
             field_path=f"{field_path}.{server_name}",
         )
     return parsed_servers
 
 
-def _parse_lsp_server_config(raw_value: object, *, field_path: str) -> RuntimeLspServerConfig:
+def _parse_lsp_server_config(
+    raw_value: object,
+    *,
+    server_name: str,
+    field_path: str,
+) -> RuntimeLspServerConfig:
     if not isinstance(raw_value, dict):
         raise ValueError(f"runtime config field '{field_path}' must be an object")
 
     server_payload = cast(dict[str, object], raw_value)
+    preset = server_payload.get("preset")
+    if preset is not None:
+        if not isinstance(preset, str) or not preset:
+            raise ValueError(f"runtime config field '{field_path}.preset' must be a string")
+        if not has_builtin_lsp_server_preset(preset):
+            raise ValueError(
+                f"runtime config field '{field_path}.preset' references unknown preset"
+            )
     command = _parse_string_list(server_payload.get("command"), field_path=f"{field_path}.command")
-    if not command:
+    if not command and preset is None and not has_builtin_lsp_server_preset(server_name):
         raise ValueError(
             f"runtime config field '{field_path}.command' must contain at least one string"
         )
@@ -350,7 +360,31 @@ def _parse_lsp_server_config(raw_value: object, *, field_path: str) -> RuntimeLs
         server_payload.get("languages"),
         field_path=f"{field_path}.languages",
     )
-    return RuntimeLspServerConfig(command=command, languages=languages)
+    extensions = _parse_string_list(
+        server_payload.get("extensions"),
+        field_path=f"{field_path}.extensions",
+    )
+    root_markers = _parse_string_list(
+        server_payload.get("root_markers"),
+        field_path=f"{field_path}.root_markers",
+    )
+    settings = _parse_object_container(
+        server_payload.get("settings"),
+        field_path=f"{field_path}.settings",
+    )
+    init_options = _parse_object_container(
+        server_payload.get("init_options"),
+        field_path=f"{field_path}.init_options",
+    )
+    return RuntimeLspServerConfig(
+        preset=preset,
+        command=command,
+        languages=languages,
+        extensions=extensions,
+        root_markers=root_markers,
+        settings=settings or {},
+        init_options=init_options or {},
+    )
 
 
 def _parse_acp_config(raw_acp: object) -> RuntimeAcpConfig | None:
@@ -450,6 +484,14 @@ def _parse_optional_bool(raw_value: object, *, field_path: str) -> bool | None:
     if not isinstance(raw_value, bool):
         raise ValueError(f"runtime config field '{field_path}' must be a boolean when provided")
     return raw_value
+
+
+def _parse_object_container(raw_value: object, *, field_path: str) -> dict[str, object] | None:
+    if raw_value is None:
+        return None
+    if not isinstance(raw_value, dict):
+        raise ValueError(f"runtime config field '{field_path}' must be an object when provided")
+    return cast(dict[str, object], raw_value)
 
 
 def _nested_config_field(source: str, nested: str) -> str:

--- a/src/voidcode/runtime/lsp.py
+++ b/src/voidcode/runtime/lsp.py
@@ -11,10 +11,6 @@ from typing import Literal, Protocol, cast
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
-if os.name == "nt":
-    import ctypes
-    import msvcrt
-
 from ..lsp import (
     ResolvedLspServerConfig,
     discover_workspace_root,
@@ -461,7 +457,8 @@ class ManagedLspManager:
             raw_container = params.get(container_key)
             if not isinstance(raw_container, dict):
                 continue
-            uri = raw_container.get("uri")
+            container = cast(dict[str, object], raw_container)
+            uri = container.get("uri")
             if isinstance(uri, str):
                 uris.append(uri)
         return tuple(uris)
@@ -567,6 +564,9 @@ class ManagedLspManager:
 
     @staticmethod
     def _wait_for_windows_pipe(*, fd: int, timeout: float) -> bool:
+        import ctypes
+        import msvcrt
+
         handle = msvcrt.get_osfhandle(fd)
         bytes_available = ctypes.c_ulong()
         deadline = time.monotonic() + timeout

--- a/src/voidcode/runtime/lsp.py
+++ b/src/voidcode/runtime/lsp.py
@@ -8,14 +8,26 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal, Protocol, cast
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 
-from .config import RuntimeLspConfig, RuntimeLspServerConfig
+if os.name == "nt":
+    import ctypes
+    import msvcrt
+
+from ..lsp import (
+    ResolvedLspServerConfig,
+    discover_workspace_root,
+    match_lsp_servers_for_path,
+    resolve_lsp_server_configs,
+)
+from .config import RuntimeLspConfig
 
 
 @dataclass(frozen=True, slots=True)
 class LspConfigState:
     configured_enabled: bool = False
-    servers: dict[str, RuntimeLspServerConfig] = field(default_factory=dict)
+    servers: dict[str, ResolvedLspServerConfig] = field(default_factory=dict)
 
     @classmethod
     def from_runtime_config(cls, config: RuntimeLspConfig | None) -> LspConfigState:
@@ -23,13 +35,20 @@ class LspConfigState:
             return cls()
         return cls(
             configured_enabled=bool(config.enabled),
-            servers={name: definition for name, definition in (config.servers or {}).items()},
+            servers=resolve_lsp_server_configs(config.servers),
         )
 
-    def resolve(self, server_name: str) -> RuntimeLspServerConfig | None:
+    def resolve(self, server_name: str) -> ResolvedLspServerConfig | None:
         return self.servers.get(server_name)
 
-    def default_server_name(self) -> str | None:
+    def matching_servers(self, file_path: Path) -> tuple[str, ...]:
+        return match_lsp_servers_for_path(self.servers, file_path)
+
+    def default_server_name(self, file_path: Path | None = None) -> str | None:
+        if file_path is not None:
+            matching_servers = self.matching_servers(file_path)
+            if matching_servers:
+                return matching_servers[0]
         if not self.servers:
             return None
         return next(iter(self.servers))
@@ -91,7 +110,7 @@ class DisabledLspManager:
     def configuration(self) -> LspConfigState:
         return self._configuration
 
-    def resolve(self, server_name: str) -> RuntimeLspServerConfig | None:
+    def resolve(self, server_name: str) -> ResolvedLspServerConfig | None:
         return self._configuration.resolve(server_name)
 
     def current_state(self) -> LspManagerState:
@@ -113,8 +132,9 @@ class DisabledLspManager:
 
 @dataclass(slots=True)
 class _RunningLspServer:
-    config: RuntimeLspServerConfig
+    config: ResolvedLspServerConfig
     process: subprocess.Popen[bytes]
+    workspace_root: Path
     initialized: bool = False
 
 
@@ -139,7 +159,8 @@ class ManagedLspManager:
         )
 
     def request(self, request: LspRequest) -> LspRequestResult:
-        server_name = request.server_name or self._configuration.default_server_name()
+        request_path = self._request_file_path(request)
+        server_name = request.server_name or self._configuration.default_server_name(request_path)
         if server_name is None:
             raise ValueError("no LSP server is configured")
 
@@ -147,10 +168,15 @@ class ManagedLspManager:
         if server_config is None:
             raise ValueError(f"unknown LSP server: {server_name}")
 
+        workspace_root = self._workspace_root_for_request(
+            request=request,
+            server_config=server_config,
+            request_path=request_path,
+        )
         running_server = self._ensure_running(
             server_name=server_name,
             server_config=server_config,
-            workspace=request.workspace,
+            workspace_root=workspace_root,
         )
         response = self._send_request(
             running_server,
@@ -161,42 +187,8 @@ class ManagedLspManager:
         return LspRequestResult(response=response)
 
     def shutdown(self) -> tuple[LspRuntimeEvent, ...]:
-        for server_name, running_server in list(self._running_servers.items()):
-            process = running_server.process
-            if process.poll() is None:
-                self._send_request(
-                    running_server,
-                    method="shutdown",
-                    params={},
-                    server_name=server_name,
-                )
-                self._send_notification(process, method="exit", params={})
-                try:
-                    process.wait(timeout=1)
-                except subprocess.TimeoutExpired:
-                    process.terminate()
-                    try:
-                        process.wait(timeout=1)
-                    except subprocess.TimeoutExpired:
-                        process.kill()
-                        process.wait(timeout=1)
-
-            self._running_servers.pop(server_name, None)
-            self._server_states[server_name] = LspServerState(
-                name=server_name,
-                status="stopped",
-                available=False,
-            )
-            self._record_event(
-                LspRuntimeEvent(
-                    event_type="runtime.lsp_server_stopped",
-                    payload={
-                        "server": server_name,
-                        "command": list(running_server.config.command),
-                        "state": "stopped",
-                    },
-                )
-            )
+        for server_name in tuple(self._running_servers):
+            self._stop_running_server(server_name, record_event=True)
         return self.drain_events()
 
     def drain_events(self) -> tuple[LspRuntimeEvent, ...]:
@@ -208,18 +200,17 @@ class ManagedLspManager:
         self,
         *,
         server_name: str,
-        server_config: RuntimeLspServerConfig,
-        workspace: Path,
+        server_config: ResolvedLspServerConfig,
+        workspace_root: Path,
     ) -> _RunningLspServer:
         running_server = self._running_servers.get(server_name)
         if running_server is not None and running_server.process.poll() is None:
-            if not running_server.initialized:
-                self._initialize_server(
-                    running_server,
-                    server_name=server_name,
-                    workspace=workspace,
-                )
-            return running_server
+            if running_server.workspace_root != workspace_root:
+                self._stop_running_server(server_name, record_event=True)
+            else:
+                if not running_server.initialized:
+                    self._initialize_server(running_server, server_name=server_name)
+                return running_server
 
         self._server_states[server_name] = LspServerState(
             name=server_name,
@@ -229,7 +220,7 @@ class ManagedLspManager:
         try:
             process = subprocess.Popen(
                 list(server_config.command),
-                cwd=workspace,
+                cwd=workspace_root,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
@@ -239,7 +230,10 @@ class ManagedLspManager:
             self._mark_failed(server_name=server_name, error=message)
             self._record_event(
                 self._failed_event(
-                    server_name=server_name, server_config=server_config, error=message
+                    server_name=server_name,
+                    server_config=server_config,
+                    workspace_root=workspace_root,
+                    error=message,
                 )
             )
             raise ValueError(message) from exc
@@ -251,18 +245,21 @@ class ManagedLspManager:
             self._mark_failed(server_name=server_name, error=message)
             self._record_event(
                 self._failed_event(
-                    server_name=server_name, server_config=server_config, error=message
+                    server_name=server_name,
+                    server_config=server_config,
+                    workspace_root=workspace_root,
+                    error=message,
                 )
             )
             raise ValueError(message)
 
-        running_server = _RunningLspServer(config=server_config, process=process)
-        self._running_servers[server_name] = running_server
-        self._initialize_server(
-            running_server,
-            server_name=server_name,
-            workspace=workspace,
+        running_server = _RunningLspServer(
+            config=server_config,
+            process=process,
+            workspace_root=workspace_root,
         )
+        self._running_servers[server_name] = running_server
+        self._initialize_server(running_server, server_name=server_name)
         return running_server
 
     def _initialize_server(
@@ -270,21 +267,23 @@ class ManagedLspManager:
         running_server: _RunningLspServer,
         *,
         server_name: str,
-        workspace: Path,
     ) -> None:
         init_params: dict[str, object] = {
             "processId": os.getpid(),
             "clientInfo": {"name": "voidcode", "version": "0.1.0"},
             "locale": "zh-CN",
-            "rootUri": workspace.as_uri(),
+            "rootUri": running_server.workspace_root.as_uri(),
             "workspaceFolders": [
                 {
-                    "uri": workspace.as_uri(),
-                    "name": workspace.name or str(workspace),
+                    "uri": running_server.workspace_root.as_uri(),
+                    "name": running_server.workspace_root.name
+                    or str(running_server.workspace_root),
                 }
             ],
             "capabilities": {},
         }
+        if running_server.config.init_options:
+            init_params["initializationOptions"] = dict(running_server.config.init_options)
         try:
             response = self._send_request(
                 running_server,
@@ -294,14 +293,12 @@ class ManagedLspManager:
             )
         except ValueError as exc:
             message = str(exc)
-            self._mark_failed(
-                server_name=server_name,
-                error=message,
-            )
+            self._mark_failed(server_name=server_name, error=message)
             self._record_event(
                 self._failed_event(
                     server_name=server_name,
                     server_config=running_server.config,
+                    workspace_root=running_server.workspace_root,
                     error=message,
                 )
             )
@@ -310,20 +307,24 @@ class ManagedLspManager:
         init_error = response.get("error")
         if init_error is not None:
             message = f"LSP initialize failed for {server_name}: {init_error}"
-            self._mark_failed(
-                server_name=server_name,
-                error=message,
-            )
+            self._mark_failed(server_name=server_name, error=message)
             self._record_event(
                 self._failed_event(
                     server_name=server_name,
                     server_config=running_server.config,
+                    workspace_root=running_server.workspace_root,
                     error=message,
                 )
             )
             raise ValueError(message)
 
         self._send_notification(running_server.process, method="initialized", params={})
+        if running_server.config.settings:
+            self._send_notification(
+                running_server.process,
+                method="workspace/didChangeConfiguration",
+                params={"settings": dict(running_server.config.settings)},
+            )
         running_server.initialized = True
         self._server_states[server_name] = LspServerState(
             name=server_name,
@@ -336,6 +337,7 @@ class ManagedLspManager:
                 payload={
                     "server": server_name,
                     "command": list(running_server.config.command),
+                    "workspace_root": str(running_server.workspace_root),
                     "state": "running",
                 },
             )
@@ -344,12 +346,7 @@ class ManagedLspManager:
     def _record_event(self, event: LspRuntimeEvent) -> None:
         self._pending_events.append(event)
 
-    def _mark_failed(
-        self,
-        *,
-        server_name: str,
-        error: str,
-    ) -> None:
+    def _mark_failed(self, *, server_name: str, error: str) -> None:
         running_server = self._running_servers.pop(server_name, None)
         if running_server is not None and running_server.process.poll() is None:
             running_server.process.terminate()
@@ -369,7 +366,8 @@ class ManagedLspManager:
     def _failed_event(
         *,
         server_name: str,
-        server_config: RuntimeLspServerConfig,
+        server_config: ResolvedLspServerConfig,
+        workspace_root: Path,
         error: str,
     ) -> LspRuntimeEvent:
         return LspRuntimeEvent(
@@ -377,10 +375,103 @@ class ManagedLspManager:
             payload={
                 "server": server_name,
                 "command": list(server_config.command),
+                "workspace_root": str(workspace_root),
                 "state": "failed",
                 "error": error,
             },
         )
+
+    def _stop_running_server(self, server_name: str, *, record_event: bool) -> None:
+        running_server = self._running_servers.pop(server_name, None)
+        if running_server is None:
+            return
+
+        process = running_server.process
+        if process.poll() is None:
+            try:
+                if running_server.initialized:
+                    self._send_request(
+                        running_server,
+                        method="shutdown",
+                        params={},
+                        server_name=server_name,
+                    )
+                    self._send_notification(process, method="exit", params={})
+                else:
+                    process.terminate()
+            except ValueError:
+                process.terminate()
+
+            try:
+                process.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                process.terminate()
+                try:
+                    process.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=1)
+
+        self._server_states[server_name] = LspServerState(
+            name=server_name,
+            status="stopped",
+            available=False,
+        )
+        if record_event:
+            self._record_event(
+                LspRuntimeEvent(
+                    event_type="runtime.lsp_server_stopped",
+                    payload={
+                        "server": server_name,
+                        "command": list(running_server.config.command),
+                        "workspace_root": str(running_server.workspace_root),
+                        "state": "stopped",
+                    },
+                )
+            )
+
+    def _workspace_root_for_request(
+        self,
+        *,
+        request: LspRequest,
+        server_config: ResolvedLspServerConfig,
+        request_path: Path | None,
+    ) -> Path:
+        workspace_root = request.workspace.resolve()
+        if request_path is None:
+            return workspace_root
+        return discover_workspace_root(
+            file_path=request_path,
+            workspace_root=workspace_root,
+            root_markers=server_config.root_markers,
+        )
+
+    @classmethod
+    def _request_file_path(cls, request: LspRequest) -> Path | None:
+        for uri in cls._candidate_uris(request.params):
+            candidate = cls._path_from_file_uri(uri)
+            if candidate is not None:
+                return candidate.resolve()
+        return None
+
+    @staticmethod
+    def _candidate_uris(params: dict[str, object]) -> tuple[str, ...]:
+        uris: list[str] = []
+        for container_key in ("textDocument", "item"):
+            raw_container = params.get(container_key)
+            if not isinstance(raw_container, dict):
+                continue
+            uri = raw_container.get("uri")
+            if isinstance(uri, str):
+                uris.append(uri)
+        return tuple(uris)
+
+    @staticmethod
+    def _path_from_file_uri(uri: str) -> Path | None:
+        parsed = urlparse(uri)
+        if parsed.scheme != "file":
+            return None
+        return Path(url2pathname(parsed.path))
 
     def _send_request(
         self,
@@ -410,7 +501,8 @@ class ManagedLspManager:
         params: dict[str, object],
     ) -> None:
         self._write_message(
-            process=process, message={"jsonrpc": "2.0", "method": method, "params": params}
+            process=process,
+            message={"jsonrpc": "2.0", "method": method, "params": params},
         )
 
     @staticmethod
@@ -439,11 +531,14 @@ class ManagedLspManager:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise TimeoutError(error_message)
+            if os.name == "nt":
+                if not ManagedLspManager._wait_for_windows_pipe(fd=fd, timeout=remaining):
+                    raise TimeoutError(error_message)
+                return
             ready, _, _ = select.select([fd], [], [], remaining)
             if not ready:
                 raise TimeoutError(error_message)
 
-        # Read header with timeout
         header = b""
         while b"\r\n\r\n" not in header:
             _wait_for_ready(f"LSP server did not respond within {timeout}s")
@@ -461,7 +556,6 @@ class ManagedLspManager:
         if content_length is None:
             return None
 
-        # Read body with timeout
         body = b""
         while len(body) < content_length:
             _wait_for_ready(f"LSP server did not send body within {timeout}s")
@@ -470,6 +564,31 @@ class ManagedLspManager:
                 return None
             body += chunk
         return cast(dict[str, object], json.loads(body.decode("utf-8")))
+
+    @staticmethod
+    def _wait_for_windows_pipe(*, fd: int, timeout: float) -> bool:
+        handle = msvcrt.get_osfhandle(fd)
+        bytes_available = ctypes.c_ulong()
+        deadline = time.monotonic() + timeout
+        while True:
+            success = ctypes.windll.kernel32.PeekNamedPipe(
+                ctypes.c_void_p(handle),
+                None,
+                0,
+                None,
+                ctypes.byref(bytes_available),
+                None,
+            )
+            if success == 0:
+                last_error = ctypes.get_last_error()
+                if last_error == 109:
+                    return True
+                raise OSError(last_error, "PeekNamedPipe failed")
+            if bytes_available.value > 0:
+                return True
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(0.01)
 
 
 def build_lsp_manager(config: RuntimeLspConfig | None) -> LspManager:

--- a/tests/integration/test_lsp_tool_integration.py
+++ b/tests/integration/test_lsp_tool_integration.py
@@ -159,9 +159,12 @@ def test_runtime_managed_lsp_tool_starts_server_and_returns_response(tmp_path: P
     tool_completed = next(
         event for event in result.events if event.event_type == "runtime.tool_completed"
     )
+    started_event = next(
+        event for event in result.events if event.event_type == "runtime.lsp_server_started"
+    )
     response = cast(dict[str, object], tool_completed.payload["lsp_response"])
     assert response["result"] == {"ok": True, "method": "textDocument/definition"}
-    assert any(event.event_type == "runtime.lsp_server_started" for event in result.events)
+    assert started_event.payload["workspace_root"] == str(tmp_path)
     assert runtime.current_lsp_state().servers["pyright"].status == "running"
 
     shutdown_events = runtime.shutdown_lsp()
@@ -214,3 +217,63 @@ def test_runtime_managed_lsp_tool_surfaces_failed_startup_state(tmp_path: Path) 
         )
 
     assert runtime.current_lsp_state().servers["pyright"].status == "failed"
+
+
+def test_runtime_managed_lsp_tool_uses_builtin_root_markers_for_workspace_selection(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "apps" / "demo"
+    sample_file = project_root / "src" / "sample.py"
+    project_root.mkdir(parents=True)
+    sample_file.parent.mkdir(parents=True, exist_ok=True)
+    sample_file.write_text("x = 1\n", encoding="utf-8")
+    (project_root / "pyproject.toml").write_text("[project]\nname='demo'\n", encoding="utf-8")
+    server_script = tmp_path / "fake_lsp_server.py"
+    _write_fake_lsp_server(server_script)
+
+    @dataclass(slots=True)
+    class _NestedLspGraph:
+        def step(
+            self,
+            request: GraphRunRequest,
+            tool_results: tuple[object, ...],
+            *,
+            session: SessionState,
+        ) -> _StubLspStep:
+            _ = request, session
+            if not tool_results:
+                return _StubLspStep(
+                    tool_call=ToolCall(
+                        tool_name="lsp",
+                        arguments={
+                            "operation": "textDocument/definition",
+                            "filePath": "apps/demo/src/sample.py",
+                            "line": 1,
+                            "character": 1,
+                        },
+                    )
+                )
+            return _StubLspStep(output="done", is_finished=True)
+
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_NestedLspGraph(),
+        config=RuntimeConfig(
+            lsp=RuntimeLspConfig(
+                enabled=True,
+                servers={
+                    "pyright": RuntimeLspServerConfig(
+                        command=(sys.executable, "-u", str(server_script))
+                    )
+                },
+            )
+        ),
+    )
+
+    result = runtime.run(RuntimeRequest(prompt="lsp please"))
+
+    started_event = next(
+        event for event in result.events if event.event_type == "runtime.lsp_server_started"
+    )
+
+    assert started_event.payload["workspace_root"] == str(project_root)

--- a/tests/unit/lsp/__init__.py
+++ b/tests/unit/lsp/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the LSP capability layer."""

--- a/tests/unit/lsp/test_registry.py
+++ b/tests/unit/lsp/test_registry.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from voidcode.lsp import (
+    LspServerConfigOverride,
+    match_lsp_servers_for_path,
+    resolve_lsp_server_config,
+    resolve_lsp_server_configs,
+)
+
+
+def test_resolve_lsp_server_config_uses_builtin_preset_by_server_name() -> None:
+    config = resolve_lsp_server_config("pyright", LspServerConfigOverride())
+
+    assert config.id == "pyright"
+    assert config.preset == "pyright"
+    assert config.command == ("pyright-langserver", "--stdio")
+    assert config.extensions == (".py", ".pyi")
+    assert config.languages == ("python",)
+    assert config.matches_path(Path("sample.py")) is True
+
+
+def test_resolve_lsp_server_config_merges_builtin_preset_with_project_override() -> None:
+    config = resolve_lsp_server_config(
+        "python",
+        LspServerConfigOverride(
+            preset="pyright",
+            command=("custom-pyright", "--stdio"),
+            extensions=(".pyw",),
+            root_markers=("requirements-dev.txt",),
+            settings={"python": {"analysis": {"typeCheckingMode": "strict"}}},
+            init_options={"diagnostics": {"enable": True}},
+        ),
+    )
+
+    assert config.id == "python"
+    assert config.preset == "pyright"
+    assert config.command == ("custom-pyright", "--stdio")
+    assert config.extensions == (".py", ".pyi", ".pyw")
+    assert "requirements-dev.txt" in config.root_markers
+    assert config.settings == {"python": {"analysis": {"typeCheckingMode": "strict"}}}
+    assert config.init_options == {"diagnostics": {"enable": True}}
+
+
+def test_resolve_lsp_server_config_deep_merges_settings() -> None:
+    config = resolve_lsp_server_config(
+        "pyright",
+        LspServerConfigOverride(
+            settings={
+                "python": {
+                    "analysis": {
+                        "typeCheckingMode": "strict",
+                    }
+                }
+            }
+        ),
+    )
+
+    assert config.settings == {
+        "python": {"analysis": {"typeCheckingMode": "strict"}},
+    }
+
+
+def test_resolve_lsp_server_configs_matches_servers_by_extension() -> None:
+    servers = resolve_lsp_server_configs(
+        {
+            "pyright": LspServerConfigOverride(),
+            "gopls": LspServerConfigOverride(),
+        }
+    )
+
+    assert match_lsp_servers_for_path(servers, Path("main.py")) == ("pyright",)
+    assert match_lsp_servers_for_path(servers, Path("main.go")) == ("gopls",)
+
+
+def test_resolve_lsp_server_config_rejects_unknown_preset() -> None:
+    with pytest.raises(ValueError, match="unknown LSP preset"):
+        _ = resolve_lsp_server_config(
+            "python",
+            LspServerConfigOverride(preset="not-real"),
+        )
+
+
+def test_resolve_lsp_server_config_requires_command_for_unknown_server() -> None:
+    with pytest.raises(ValueError, match="must define a command"):
+        _ = resolve_lsp_server_config(
+            "custom-python",
+            LspServerConfigOverride(),
+        )

--- a/tests/unit/lsp/test_roots.py
+++ b/tests/unit/lsp/test_roots.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from voidcode.lsp import discover_workspace_root
+
+
+def test_discover_workspace_root_uses_nearest_marker_inside_workspace(tmp_path: Path) -> None:
+    project_root = tmp_path / "apps" / "demo"
+    source_file = project_root / "src" / "sample.py"
+    project_root.mkdir(parents=True)
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text("x = 1\n", encoding="utf-8")
+    (project_root / "pyproject.toml").write_text("[project]\nname='demo'\n", encoding="utf-8")
+
+    resolved = discover_workspace_root(
+        file_path=source_file,
+        workspace_root=tmp_path,
+        root_markers=("pyproject.toml", ".git"),
+    )
+
+    assert resolved == project_root
+
+
+def test_discover_workspace_root_falls_back_to_workspace_root_when_no_marker(
+    tmp_path: Path,
+) -> None:
+    source_file = tmp_path / "src" / "sample.py"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("x = 1\n", encoding="utf-8")
+
+    resolved = discover_workspace_root(
+        file_path=source_file,
+        workspace_root=tmp_path,
+        root_markers=("pyproject.toml", ".git"),
+    )
+
+    assert resolved == tmp_path
+
+
+def test_discover_workspace_root_ignores_paths_outside_workspace(tmp_path: Path) -> None:
+    external_root = tmp_path.parent / "external-lsp-root"
+    external_root.mkdir(exist_ok=True)
+    external_file = external_root / "sample.py"
+    external_file.write_text("x = 1\n", encoding="utf-8")
+
+    resolved = discover_workspace_root(
+        file_path=external_file,
+        workspace_root=tmp_path,
+        root_markers=("pyproject.toml", ".git"),
+    )
+
+    assert resolved == tmp_path

--- a/tests/unit/runtime/test_lsp.py
+++ b/tests/unit/runtime/test_lsp.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 
+from voidcode.lsp import ResolvedLspServerConfig
 from voidcode.runtime.config import RuntimeLspConfig, RuntimeLspServerConfig
 
 
@@ -58,8 +59,16 @@ def test_lsp_config_state_wraps_runtime_lsp_config_servers() -> None:
 
     assert state.configured_enabled is True
     assert tuple(state.servers) == ("pyright", "ruff")
-    assert pyright_server == RuntimeLspServerConfig(command=("pyright-langserver", "--stdio"))
+    assert pyright_server == ResolvedLspServerConfig(
+        id="pyright",
+        preset="pyright",
+        command=("pyright-langserver", "--stdio"),
+        extensions=(".py", ".pyi"),
+        languages=("python",),
+        root_markers=("pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", ".git"),
+    )
     assert state.default_server_name() == "pyright"
+    assert state.default_server_name(Path("main.py")) == "pyright"
     assert state.resolve("missing") is None
 
 
@@ -81,6 +90,22 @@ def test_disabled_lsp_manager_reports_configured_servers_without_runtime_availab
     assert state.servers["pyright"].configured is True
     assert state.servers["pyright"].status == "stopped"
     assert state.servers["pyright"].available is False
+
+
+def test_lsp_config_state_matches_server_by_file_extension() -> None:
+    state = LspConfigState.from_runtime_config(
+        RuntimeLspConfig(
+            enabled=True,
+            servers={
+                "pyright": RuntimeLspServerConfig(command=("pyright-langserver", "--stdio")),
+                "gopls": RuntimeLspServerConfig(command=("gopls",)),
+            },
+        )
+    )
+
+    assert state.matching_servers(Path("main.py")) == ("pyright",)
+    assert state.matching_servers(Path("main.go")) == ("gopls",)
+    assert state.default_server_name(Path("main.go")) == "gopls"
 
 
 def test_disabled_lsp_manager_rejects_requests() -> None:
@@ -110,6 +135,19 @@ def test_build_lsp_manager_returns_managed_manager_when_enabled_and_configured()
     assert isinstance(manager, ManagedLspManager)
     assert state.mode == "managed"
     assert state.servers["pyright"].status == "stopped"
+
+
+def test_build_lsp_manager_accepts_builtin_preset_without_explicit_command() -> None:
+    manager = build_lsp_manager(
+        RuntimeLspConfig(
+            enabled=True,
+            servers={"pyright": RuntimeLspServerConfig()},
+        )
+    )
+
+    assert isinstance(manager, ManagedLspManager)
+    assert manager.configuration.resolve("pyright") is not None
+    assert manager.configuration.resolve("pyright").command == ("pyright-langserver", "--stdio")
 
 
 def test_managed_lsp_manager_marks_failed_startup_when_command_is_missing(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -140,6 +140,57 @@ def test_runtime_config_parses_extension_domains(tmp_path: Path) -> None:
     )
 
 
+def test_runtime_config_accepts_builtin_lsp_preset_without_explicit_command(tmp_path: Path) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps({"lsp": {"enabled": True, "servers": {"pyright": {}}}}),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.lsp == RuntimeLspConfig(
+        enabled=True,
+        servers={"pyright": RuntimeLspServerConfig()},
+    )
+
+
+def test_runtime_config_accepts_explicit_lsp_preset_override(tmp_path: Path) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps(
+            {
+                "lsp": {
+                    "enabled": True,
+                    "servers": {
+                        "python": {
+                            "preset": "pyright",
+                            "extensions": [".pyw"],
+                            "root_markers": ["requirements-dev.txt"],
+                            "settings": {"python": {"analysis": {"typeCheckingMode": "strict"}}},
+                            "init_options": {"diagnostics": {"enable": True}},
+                        }
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.lsp == RuntimeLspConfig(
+        enabled=True,
+        servers={
+            "python": RuntimeLspServerConfig(
+                preset="pyright",
+                extensions=(".pyw",),
+                root_markers=("requirements-dev.txt",),
+                settings={"python": {"analysis": {"typeCheckingMode": "strict"}}},
+                init_options={"diagnostics": {"enable": True}},
+            )
+        },
+    )
+
+
 def test_runtime_config_accepts_single_agent_execution_engine(tmp_path: Path) -> None:
     runtime_config_path(tmp_path).write_text(
         json.dumps({"execution_engine": "single_agent", "model": "opencode/gpt-5.4"}),
@@ -435,8 +486,8 @@ def test_runtime_config_rejects_invalid_max_steps(
             id="lsp-server-shape",
         ),
         pytest.param(
-            {"lsp": {"servers": {"pyright": {"command": []}}}},
-            "runtime config field 'lsp.servers.pyright.command'.*at least one string",
+            {"lsp": {"servers": {"custom": {"command": []}}}},
+            "runtime config field 'lsp.servers.custom.command'.*at least one string",
             id="lsp-server-command-empty",
         ),
         pytest.param(
@@ -448,6 +499,36 @@ def test_runtime_config_rejects_invalid_max_steps(
             {"lsp": {"servers": {"pyright": {"command": ["pyright"], "languages": [1]}}}},
             "runtime config field 'lsp.servers.pyright.languages\\[0\\]'",
             id="lsp-server-language-item-type",
+        ),
+        pytest.param(
+            {"lsp": {"servers": {"python": {"preset": 1}}}},
+            "runtime config field 'lsp.servers.python.preset'",
+            id="lsp-server-preset-type",
+        ),
+        pytest.param(
+            {"lsp": {"servers": {"python": {"preset": "not-real"}}}},
+            "runtime config field 'lsp.servers.python.preset' references unknown preset",
+            id="lsp-server-preset-unknown",
+        ),
+        pytest.param(
+            {"lsp": {"servers": {"pyright": {"extensions": [1]}}}},
+            "runtime config field 'lsp.servers.pyright.extensions\\[0\\]'",
+            id="lsp-server-extension-item-type",
+        ),
+        pytest.param(
+            {"lsp": {"servers": {"pyright": {"root_markers": [1]}}}},
+            "runtime config field 'lsp.servers.pyright.root_markers\\[0\\]'",
+            id="lsp-server-root-marker-item-type",
+        ),
+        pytest.param(
+            {"lsp": {"servers": {"pyright": {"settings": []}}}},
+            "runtime config field 'lsp.servers.pyright.settings'",
+            id="lsp-server-settings-shape",
+        ),
+        pytest.param(
+            {"lsp": {"servers": {"pyright": {"init_options": []}}}},
+            "runtime config field 'lsp.servers.pyright.init_options'",
+            id="lsp-server-init-options-shape",
         ),
         pytest.param(
             {"provider_fallback": []},


### PR DESCRIPTION
## Summary

- add a real `voidcode.lsp` capability layer with builtin server presets, registry resolution, and workspace-root discovery
- extend runtime LSP config parsing to support preset-aware overrides while preserving the existing minimal `command`/`languages` path
- update the runtime-managed LSP manager to consume resolved configs, auto-match servers by file extension, honor root markers, and forward `init_options` / `settings`
- fix Windows pipe waiting for managed LSP integration tests

## Details

- add builtin presets for `pyright`, `ruff`, `gopls`, `rust-analyzer`, and `tsserver`
- support `preset`, `extensions`, `root_markers`, `settings`, and `init_options` in `lsp.servers.<name>`
- merge project-local overrides on top of builtin preset defaults instead of forcing every repo to duplicate full server definitions
- derive workspace roots from file paths and preset root markers before starting managed LSP servers
- extend unit and integration coverage for preset resolution, root discovery, runtime config parsing, and runtime-managed LSP behavior

## Verification

- `uv run ruff check src/voidcode/lsp src/voidcode/runtime/config.py src/voidcode/runtime/lsp.py tests/unit/lsp tests/unit/runtime/test_lsp.py tests/unit/runtime/test_runtime_config.py tests/integration/test_lsp_tool_integration.py`
- `uv run pytest -q -o addopts='' tests/unit/lsp tests/unit/runtime/test_lsp.py tests/unit/runtime/test_runtime_config.py tests/integration/test_lsp_tool_integration.py tests/unit/runtime/test_runtime_service_extensions.py::test_runtime_initializes_empty_extension_state_by_default tests/unit/runtime/test_runtime_service_extensions.py::test_runtime_initializes_extension_state_from_config_when_enabled tests/unit/runtime/test_runtime_service_extensions.py::test_runtime_retains_explicit_injected_extension_instances`

Closes #87
