### PR TITLE
feat(runtime): add developer diagnostics for lsp and fallback paths

### DIFF
--- a/src/voidcode/runtime/lsp.py
+++ b/src/voidcode/runtime/lsp.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import select
 import subprocess
@@ -21,6 +22,8 @@ from ..lsp import (
     resolve_lsp_server_configs,
 )
 from .config import RuntimeLspConfig
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -227,6 +230,13 @@ class ManagedLspManager:
             )
         except (FileNotFoundError, OSError) as exc:
             message = f"failed to start LSP server {server_name}: {exc}"
+            logger.error(
+                "failed to start LSP server %s in %s with command %s: %s",
+                server_name,
+                workspace_root,
+                list(server_config.command),
+                exc,
+            )
             self._mark_failed(server_name=server_name, error=message)
             self._record_event(
                 self._failed_event(
@@ -242,6 +252,12 @@ class ManagedLspManager:
             process.kill()
             process.wait(timeout=1)
             message = f"failed to start LSP server {server_name}: missing stdio pipe"
+            logger.error(
+                "failed to start LSP server %s in %s with command %s: missing stdio pipe",
+                server_name,
+                workspace_root,
+                list(server_config.command),
+            )
             self._mark_failed(server_name=server_name, error=message)
             self._record_event(
                 self._failed_event(

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
@@ -63,6 +64,8 @@ from .single_agent_provider import ProviderExecutionError
 from .skills import SkillRegistry, SkillRuntimeContext
 from .storage import SessionStore, SqliteSessionStore
 from .tool_provider import BuiltinToolProvider
+
+logger = logging.getLogger(__name__)
 
 
 @runtime_checkable
@@ -544,6 +547,19 @@ class VoidCodeRuntime:
                         exc.kind in {"rate_limit", "invalid_model", "transient_failure"}
                         and next_target is not None
                     ):
+                        logger.info(
+                            (
+                                "provider fallback for session %s: %s/%s -> %s/%s "
+                                "(reason=%s, attempt=%s)"
+                            ),
+                            session.session.id,
+                            exc.provider_name,
+                            exc.model_name,
+                            next_target.selection.provider,
+                            next_target.selection.model,
+                            exc.kind,
+                            next_attempt,
+                        )
                         sequence += 1
                         yield RuntimeStreamChunk(
                             kind="event",

--- a/tests/integration/test_lsp_tool_integration.py
+++ b/tests/integration/test_lsp_tool_integration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -193,7 +194,9 @@ def test_runtime_managed_lsp_tool_rejects_disabled_manager(tmp_path: Path) -> No
         )
 
 
-def test_runtime_managed_lsp_tool_surfaces_failed_startup_state(tmp_path: Path) -> None:
+def test_runtime_managed_lsp_tool_surfaces_failed_startup_state(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     sample_file = tmp_path / "sample.py"
     sample_file.write_text("x = 1\n", encoding="utf-8")
     runtime = _build_runtime_with_lsp(
@@ -202,7 +205,10 @@ def test_runtime_managed_lsp_tool_surfaces_failed_startup_state(tmp_path: Path) 
     )
     tool = LspTool(requester=runtime.request_lsp)
 
-    with pytest.raises(ValueError, match="failed to start LSP server pyright"):
+    with (
+        caplog.at_level(logging.ERROR),
+        pytest.raises(ValueError, match="failed to start LSP server pyright"),
+    ):
         _ = tool.invoke(
             ToolCall(
                 tool_name="lsp",
@@ -217,6 +223,7 @@ def test_runtime_managed_lsp_tool_surfaces_failed_startup_state(tmp_path: Path) 
         )
 
     assert runtime.current_lsp_state().servers["pyright"].status == "failed"
+    assert "failed to start LSP server pyright" in caplog.text
 
 
 def test_runtime_managed_lsp_tool_uses_builtin_root_markers_for_workspace_selection(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
@@ -1542,6 +1543,7 @@ def test_runtime_effective_runtime_config_rejects_malformed_persisted_provider_f
 
 def test_runtime_resume_preserves_provider_attempt_and_target_across_pending_approval(
     tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     custom_attempts: list[int] = []
     registry = ModelProviderRegistry(
@@ -1569,9 +1571,10 @@ def test_runtime_resume_preserves_provider_attempt_and_target_across_pending_app
         model_provider_registry=registry,
     )
 
-    waiting = initial_runtime.run(
-        RuntimeRequest(prompt="write alpha.txt 1", session_id="resume-provider-attempt")
-    )
+    with caplog.at_level(logging.INFO):
+        waiting = initial_runtime.run(
+            RuntimeRequest(prompt="write alpha.txt 1", session_id="resume-provider-attempt")
+        )
 
     assert waiting.session.status == "waiting"
     assert custom_attempts == [1]
@@ -1582,6 +1585,7 @@ def test_runtime_resume_preserves_provider_attempt_and_target_across_pending_app
         event for event in waiting.events if event.event_type == "runtime.provider_fallback"
     ]
     assert len(fallback_events) == 1
+    assert "provider fallback" in caplog.text
 
     resumed_runtime = VoidCodeRuntime(
         workspace=tmp_path,


### PR DESCRIPTION
## Summary
- add a first stdlib logging slice for runtime developer diagnostics without changing runtime event semantics
- log LSP server startup failures in the runtime-managed LSP layer and provider fallback transitions in the runtime service layer
- add caplog coverage to lock the new diagnostics behavior alongside the existing runtime events