### PR TITLE
feat(runtime): add runtime-managed MCP tool plumbing

### DIFF
--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import os
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal, cast
 
@@ -51,6 +51,22 @@ class RuntimeAcpConfig:
     enabled: bool | None = None
 
 
+type McpTransport = Literal["stdio"]
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeMcpServerConfig:
+    transport: McpTransport = "stdio"
+    command: tuple[str, ...] = ()
+    env: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeMcpConfig:
+    enabled: bool | None = None
+    servers: Mapping[str, RuntimeMcpServerConfig] | None = None
+
+
 @dataclass(frozen=True, slots=True)
 class RuntimeTuiConfig:
     leader_key: str = "alt+x"
@@ -74,6 +90,7 @@ class RuntimeConfig:
     skills: RuntimeSkillsConfig | None = None
     lsp: RuntimeLspConfig | None = None
     acp: RuntimeAcpConfig | None = None
+    mcp: RuntimeMcpConfig | None = None
     tui: RuntimeTuiConfig | None = None
     provider_fallback: RuntimeProviderFallbackConfig | None = None
 
@@ -89,6 +106,7 @@ class RuntimeConfigOverrides:
     skills: RuntimeSkillsConfig | None = None
     lsp: RuntimeLspConfig | None = None
     acp: RuntimeAcpConfig | None = None
+    mcp: RuntimeMcpConfig | None = None
     tui: RuntimeTuiConfig | None = None
     provider_fallback: RuntimeProviderFallbackConfig | None = None
 
@@ -126,6 +144,7 @@ def load_runtime_config(
         skills=repo_local.skills,
         lsp=repo_local.lsp,
         acp=repo_local.acp,
+        mcp=repo_local.mcp,
         tui=repo_local.tui,
         provider_fallback=repo_local.provider_fallback,
     )
@@ -178,6 +197,9 @@ def _load_repo_local_config(workspace: Path) -> RuntimeConfigOverrides:
     raw_acp = payload.get("acp")
     acp = _parse_acp_config(raw_acp)
 
+    raw_mcp = payload.get("mcp")
+    mcp = _parse_mcp_config(raw_mcp)
+
     raw_tui = payload.get("tui")
     tui = _parse_tui_config(raw_tui)
 
@@ -201,6 +223,7 @@ def _load_repo_local_config(workspace: Path) -> RuntimeConfigOverrides:
         skills=skills,
         lsp=lsp,
         acp=acp,
+        mcp=mcp,
         tui=tui,
         provider_fallback=provider_fallback,
     )
@@ -396,6 +419,64 @@ def _parse_acp_config(raw_acp: object) -> RuntimeAcpConfig | None:
     acp_payload = cast(dict[str, object], raw_acp)
     enabled = _parse_optional_bool(acp_payload.get("enabled"), field_path="acp.enabled")
     return RuntimeAcpConfig(enabled=enabled)
+
+
+def _parse_mcp_config(raw_mcp: object) -> RuntimeMcpConfig | None:
+    if raw_mcp is None:
+        return None
+    if not isinstance(raw_mcp, dict):
+        raise ValueError("runtime config field 'mcp' must be an object when provided")
+
+    mcp_payload = cast(dict[str, object], raw_mcp)
+    enabled = _parse_optional_bool(mcp_payload.get("enabled"), field_path="mcp.enabled")
+    servers = _parse_mcp_servers_config(mcp_payload.get("servers"), field_path="mcp.servers")
+    return RuntimeMcpConfig(enabled=enabled, servers=servers)
+
+
+def _parse_mcp_servers_config(
+    raw_value: object, *, field_path: str
+) -> dict[str, RuntimeMcpServerConfig] | None:
+    if raw_value is None:
+        return None
+    if not isinstance(raw_value, dict):
+        raise ValueError(f"runtime config field '{field_path}' must be an object when provided")
+
+    raw_servers = cast(dict[str, object], raw_value)
+    parsed_servers: dict[str, RuntimeMcpServerConfig] = {}
+    for server_name, raw_server in raw_servers.items():
+        parsed_servers[server_name] = _parse_mcp_server_config(
+            raw_server,
+            field_path=f"{field_path}.{server_name}",
+        )
+    return parsed_servers
+
+
+def _parse_mcp_server_config(raw_value: object, *, field_path: str) -> RuntimeMcpServerConfig:
+    if not isinstance(raw_value, dict):
+        raise ValueError(f"runtime config field '{field_path}' must be an object")
+
+    server_payload = cast(dict[str, object], raw_value)
+    transport = server_payload.get("transport", "stdio")
+    if transport != "stdio":
+        raise ValueError(f"runtime config field '{field_path}.transport' must be one of: stdio")
+    command = _parse_string_list(server_payload.get("command"), field_path=f"{field_path}.command")
+    if not command:
+        raise ValueError(
+            f"runtime config field '{field_path}.command' must contain at least one string"
+        )
+
+    raw_env = server_payload.get("env")
+    env: dict[str, str] = {}
+    if raw_env is not None:
+        if not isinstance(raw_env, dict):
+            raise ValueError(f"runtime config field '{field_path}.env' must be an object")
+        env_payload = cast(dict[str, object], raw_env)
+        for key, value in env_payload.items():
+            if not isinstance(value, str):
+                raise ValueError(f"runtime config field '{field_path}.env.{key}' must be a string")
+            env[key] = value
+
+    return RuntimeMcpServerConfig(transport="stdio", command=command, env=env)
 
 
 def _parse_tui_config(raw_tui: object) -> RuntimeTuiConfig | None:

--- a/src/voidcode/runtime/events.py
+++ b/src/voidcode/runtime/events.py
@@ -16,6 +16,8 @@ type ExistingEventType = Literal[
     "runtime.lsp_server_started",
     "runtime.lsp_server_stopped",
     "runtime.lsp_server_failed",
+    "runtime.mcp_server_started",
+    "runtime.mcp_server_stopped",
     "graph.loop_step",
     "graph.model_turn",
     "graph.tool_request_created",
@@ -42,6 +44,8 @@ RUNTIME_ACP_FAILED: Final[ExistingEventType] = "runtime.acp_failed"
 RUNTIME_LSP_SERVER_STARTED: Final[ExistingEventType] = "runtime.lsp_server_started"
 RUNTIME_LSP_SERVER_STOPPED: Final[ExistingEventType] = "runtime.lsp_server_stopped"
 RUNTIME_LSP_SERVER_FAILED: Final[ExistingEventType] = "runtime.lsp_server_failed"
+RUNTIME_MCP_SERVER_STARTED: Final[ExistingEventType] = "runtime.mcp_server_started"
+RUNTIME_MCP_SERVER_STOPPED: Final[ExistingEventType] = "runtime.mcp_server_stopped"
 GRAPH_LOOP_STEP: Final[ExistingEventType] = "graph.loop_step"
 GRAPH_MODEL_TURN: Final[ExistingEventType] = "graph.model_turn"
 GRAPH_TOOL_REQUEST_CREATED: Final[ExistingEventType] = "graph.tool_request_created"
@@ -68,6 +72,8 @@ EMITTED_EVENT_TYPES: Final[tuple[ExistingEventType, ...]] = (
     RUNTIME_LSP_SERVER_STARTED,
     RUNTIME_LSP_SERVER_STOPPED,
     RUNTIME_LSP_SERVER_FAILED,
+    RUNTIME_MCP_SERVER_STARTED,
+    RUNTIME_MCP_SERVER_STOPPED,
     GRAPH_LOOP_STEP,
     GRAPH_MODEL_TURN,
     GRAPH_TOOL_REQUEST_CREATED,

--- a/src/voidcode/runtime/mcp.py
+++ b/src/voidcode/runtime/mcp.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -200,10 +201,10 @@ class ManagedMcpManager:
             list(server_config.command),
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
             text=True,
             cwd=workspace.resolve(),
-            env={**server_config.env},
+            env={**os.environ, **server_config.env},
             bufsize=1,
         )
         if process.stdin is None or process.stdout is None:
@@ -262,28 +263,35 @@ class ManagedMcpManager:
             raise ValueError("MCP server stdio is unavailable")
 
         self._next_id += 1
-        payload: dict[str, object] = {"jsonrpc": "2.0", "id": self._next_id, "method": method}
+        request_id = self._next_id
+        payload: dict[str, object] = {"jsonrpc": "2.0", "id": request_id, "method": method}
         if params is not None:
             payload["params"] = params
         running.process.stdin.write(json.dumps(payload) + "\n")
         running.process.stdin.flush()
 
-        line = running.process.stdout.readline()
-        if not line:
-            raise ValueError("MCP server closed stdout before responding")
-        response = json.loads(line)
-        if not isinstance(response, dict):
-            raise ValueError("MCP server returned non-object response")
-        response_payload = cast(dict[str, object], response)
-        error_obj = response_payload.get("error")
-        if isinstance(error_obj, dict):
-            error_payload = cast(dict[str, object], error_obj)
-            message = error_payload.get("message")
-            raise ValueError(
-                str(message) if isinstance(message, str) else f"MCP error: {error_obj}"
-            )
-        result = response_payload.get("result")
-        return cast(dict[str, object], result if isinstance(result, dict) else {})
+        while True:
+            line = running.process.stdout.readline()
+            if not line:
+                raise ValueError("MCP server closed stdout before responding")
+            try:
+                response = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"MCP server returned invalid JSON: {exc}") from exc
+            if not isinstance(response, dict):
+                raise ValueError("MCP server returned non-object response")
+            response_payload = cast(dict[str, object], response)
+            if response_payload.get("id") != request_id:
+                continue
+            error_obj = response_payload.get("error")
+            if isinstance(error_obj, dict):
+                error_payload = cast(dict[str, object], error_obj)
+                message = error_payload.get("message")
+                raise ValueError(
+                    str(message) if isinstance(message, str) else f"MCP error: {error_obj}"
+                )
+            result = response_payload.get("result")
+            return cast(dict[str, object], result if isinstance(result, dict) else {})
 
     def _stop_running_server(self, server_name: str) -> None:
         running = self._running_servers.pop(server_name, None)

--- a/src/voidcode/runtime/mcp.py
+++ b/src/voidcode/runtime/mcp.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 import os
+import queue
 import subprocess
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal, Protocol, cast
@@ -114,6 +116,8 @@ class _RunningMcpServer:
 
 
 class ManagedMcpManager:
+    _request_timeout_seconds = 2.0
+
     def __init__(self, config: RuntimeMcpConfig) -> None:
         self._configuration = McpConfigState.from_runtime_config(config)
         self._running_servers: dict[str, _RunningMcpServer] = {}
@@ -271,7 +275,22 @@ class ManagedMcpManager:
         running.process.stdin.flush()
 
         while True:
-            line = running.process.stdout.readline()
+            response_queue: queue.Queue[str] = queue.Queue(maxsize=1)
+
+            def _readline(target_queue: queue.Queue[str]) -> None:
+                assert running.process.stdout is not None
+                target_queue.put(running.process.stdout.readline())
+
+            reader = threading.Thread(target=_readline, args=(response_queue,), daemon=True)
+            reader.start()
+
+            try:
+                line = response_queue.get(timeout=self._request_timeout_seconds)
+            except queue.Empty as exc:
+                raise ValueError(
+                    f"MCP server timed out waiting for response to {method} after "
+                    f"{self._request_timeout_seconds:.1f}s"
+                ) from exc
             if not line:
                 raise ValueError("MCP server closed stdout before responding")
             try:

--- a/src/voidcode/runtime/mcp.py
+++ b/src/voidcode/runtime/mcp.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal, Protocol, cast
+
+from .config import RuntimeMcpConfig, RuntimeMcpServerConfig
+
+
+@dataclass(frozen=True, slots=True)
+class McpConfigState:
+    configured_enabled: bool = False
+    servers: dict[str, RuntimeMcpServerConfig] = field(default_factory=dict)
+
+    @classmethod
+    def from_runtime_config(cls, config: RuntimeMcpConfig | None) -> McpConfigState:
+        if config is None:
+            return cls()
+        return cls(
+            configured_enabled=bool(config.enabled),
+            servers=dict(config.servers or {}),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class McpToolDescriptor:
+    server_name: str
+    tool_name: str
+    description: str
+    input_schema: dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class McpToolCallResult:
+    content: list[dict[str, object]]
+    is_error: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class McpRuntimeEvent:
+    event_type: str
+    payload: dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class McpManagerState:
+    mode: Literal["disabled", "managed"] = "disabled"
+    configuration: McpConfigState = field(default_factory=McpConfigState)
+
+
+class McpManager(Protocol):
+    @property
+    def configuration(self) -> McpConfigState: ...
+
+    def current_state(self) -> McpManagerState: ...
+
+    def list_tools(self, *, workspace: Path) -> tuple[McpToolDescriptor, ...]: ...
+
+    def call_tool(
+        self,
+        *,
+        server_name: str,
+        tool_name: str,
+        arguments: dict[str, object],
+        workspace: Path,
+    ) -> McpToolCallResult: ...
+
+    def shutdown(self) -> tuple[McpRuntimeEvent, ...]: ...
+
+    def drain_events(self) -> tuple[McpRuntimeEvent, ...]: ...
+
+
+class DisabledMcpManager:
+    def __init__(self, config: RuntimeMcpConfig | None = None) -> None:
+        self._configuration = McpConfigState.from_runtime_config(config)
+
+    @property
+    def configuration(self) -> McpConfigState:
+        return self._configuration
+
+    def current_state(self) -> McpManagerState:
+        return McpManagerState(configuration=self._configuration)
+
+    def list_tools(self, *, workspace: Path) -> tuple[McpToolDescriptor, ...]:
+        _ = workspace
+        raise ValueError("MCP runtime support is disabled")
+
+    def call_tool(
+        self,
+        *,
+        server_name: str,
+        tool_name: str,
+        arguments: dict[str, object],
+        workspace: Path,
+    ) -> McpToolCallResult:
+        _ = server_name, tool_name, arguments, workspace
+        raise ValueError("MCP runtime support is disabled")
+
+    def shutdown(self) -> tuple[McpRuntimeEvent, ...]:
+        return ()
+
+    def drain_events(self) -> tuple[McpRuntimeEvent, ...]:
+        return ()
+
+
+@dataclass(slots=True)
+class _RunningMcpServer:
+    process: subprocess.Popen[str]
+    workspace_root: Path
+    initialized: bool = False
+
+
+class ManagedMcpManager:
+    def __init__(self, config: RuntimeMcpConfig) -> None:
+        self._configuration = McpConfigState.from_runtime_config(config)
+        self._running_servers: dict[str, _RunningMcpServer] = {}
+        self._pending_events: list[McpRuntimeEvent] = []
+        self._next_id = 0
+
+    @property
+    def configuration(self) -> McpConfigState:
+        return self._configuration
+
+    def current_state(self) -> McpManagerState:
+        return McpManagerState(mode="managed", configuration=self._configuration)
+
+    def list_tools(self, *, workspace: Path) -> tuple[McpToolDescriptor, ...]:
+        tools: list[McpToolDescriptor] = []
+        for server_name in self._configuration.servers:
+            running = self._ensure_running(server_name=server_name, workspace=workspace)
+            result = self._send_request(running, method="tools/list")
+            for tool_obj in cast(list[object], result.get("tools", [])):
+                if not isinstance(tool_obj, dict):
+                    continue
+                tool_payload = cast(dict[str, object], tool_obj)
+                tool_name = tool_payload.get("name")
+                if not isinstance(tool_name, str):
+                    continue
+                description = tool_payload.get("description")
+                input_schema = tool_payload.get("inputSchema")
+                tools.append(
+                    McpToolDescriptor(
+                        server_name=server_name,
+                        tool_name=tool_name,
+                        description=description if isinstance(description, str) else "",
+                        input_schema=(
+                            cast(dict[str, object], input_schema)
+                            if isinstance(input_schema, dict)
+                            else {}
+                        ),
+                    )
+                )
+        return tuple(tools)
+
+    def call_tool(
+        self,
+        *,
+        server_name: str,
+        tool_name: str,
+        arguments: dict[str, object],
+        workspace: Path,
+    ) -> McpToolCallResult:
+        running = self._ensure_running(server_name=server_name, workspace=workspace)
+        result = self._send_request(
+            running,
+            method="tools/call",
+            params={"name": tool_name, "arguments": arguments},
+        )
+        content = result.get("content")
+        is_error = result.get("isError")
+        return McpToolCallResult(
+            content=cast(list[dict[str, object]], content if isinstance(content, list) else []),
+            is_error=bool(is_error),
+        )
+
+    def shutdown(self) -> tuple[McpRuntimeEvent, ...]:
+        for server_name in tuple(self._running_servers):
+            self._stop_running_server(server_name)
+        return self.drain_events()
+
+    def drain_events(self) -> tuple[McpRuntimeEvent, ...]:
+        events = tuple(self._pending_events)
+        self._pending_events.clear()
+        return events
+
+    def _ensure_running(self, *, server_name: str, workspace: Path) -> _RunningMcpServer:
+        running = self._running_servers.get(server_name)
+        if running is not None and running.process.poll() is None:
+            if not running.initialized:
+                self._initialize_server(running)
+            return running
+
+        server_config = self._configuration.servers.get(server_name)
+        if server_config is None:
+            raise ValueError(f"unknown MCP server: {server_name}")
+
+        process = subprocess.Popen(
+            list(server_config.command),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=workspace.resolve(),
+            env={**server_config.env},
+            bufsize=1,
+        )
+        if process.stdin is None or process.stdout is None:
+            process.kill()
+            process.wait(timeout=1)
+            raise ValueError(f"failed to start MCP server {server_name}: missing stdio pipe")
+
+        running = _RunningMcpServer(process=process, workspace_root=workspace.resolve())
+        self._running_servers[server_name] = running
+        self._record_event(
+            McpRuntimeEvent(
+                event_type="runtime.mcp_server_started",
+                payload={"server": server_name, "workspace_root": str(workspace.resolve())},
+            )
+        )
+        self._initialize_server(running)
+        return running
+
+    def _initialize_server(self, running: _RunningMcpServer) -> None:
+        initialize_payload = {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "voidcode-runtime", "version": "0.1.0"},
+        }
+        self._send_request(
+            running,
+            method="initialize",
+            params=cast(dict[str, object], initialize_payload),
+        )
+        self._send_notification(running, method="notifications/initialized")
+        running.initialized = True
+
+    def _send_notification(
+        self,
+        running: _RunningMcpServer,
+        *,
+        method: str,
+        params: dict[str, object] | None = None,
+    ) -> None:
+        if running.process.stdin is None:
+            raise ValueError("MCP server stdin is unavailable")
+        payload: dict[str, object] = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            payload["params"] = params
+        running.process.stdin.write(json.dumps(payload) + "\n")
+        running.process.stdin.flush()
+
+    def _send_request(
+        self,
+        running: _RunningMcpServer,
+        *,
+        method: str,
+        params: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        if running.process.stdin is None or running.process.stdout is None:
+            raise ValueError("MCP server stdio is unavailable")
+
+        self._next_id += 1
+        payload: dict[str, object] = {"jsonrpc": "2.0", "id": self._next_id, "method": method}
+        if params is not None:
+            payload["params"] = params
+        running.process.stdin.write(json.dumps(payload) + "\n")
+        running.process.stdin.flush()
+
+        line = running.process.stdout.readline()
+        if not line:
+            raise ValueError("MCP server closed stdout before responding")
+        response = json.loads(line)
+        if not isinstance(response, dict):
+            raise ValueError("MCP server returned non-object response")
+        response_payload = cast(dict[str, object], response)
+        error_obj = response_payload.get("error")
+        if isinstance(error_obj, dict):
+            error_payload = cast(dict[str, object], error_obj)
+            message = error_payload.get("message")
+            raise ValueError(
+                str(message) if isinstance(message, str) else f"MCP error: {error_obj}"
+            )
+        result = response_payload.get("result")
+        return cast(dict[str, object], result if isinstance(result, dict) else {})
+
+    def _stop_running_server(self, server_name: str) -> None:
+        running = self._running_servers.pop(server_name, None)
+        if running is None:
+            return
+        if running.process.stdin is not None:
+            running.process.stdin.close()
+        try:
+            running.process.terminate()
+            running.process.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            running.process.kill()
+            running.process.wait(timeout=1)
+        self._record_event(
+            McpRuntimeEvent(
+                event_type="runtime.mcp_server_stopped",
+                payload={"server": server_name, "workspace_root": str(running.workspace_root)},
+            )
+        )
+
+    def _record_event(self, event: McpRuntimeEvent) -> None:
+        self._pending_events.append(event)
+
+
+def build_mcp_manager(config: RuntimeMcpConfig | None) -> McpManager:
+    configuration = McpConfigState.from_runtime_config(config)
+    if configuration.configured_enabled is not True:
+        return DisabledMcpManager(config)
+    return ManagedMcpManager(config or RuntimeMcpConfig())

--- a/src/voidcode/runtime/mcp.py
+++ b/src/voidcode/runtime/mcp.py
@@ -287,6 +287,7 @@ class ManagedMcpManager:
             try:
                 line = response_queue.get(timeout=self._request_timeout_seconds)
             except queue.Empty as exc:
+                self._stop_running_server_by_process(running)
                 raise ValueError(
                     f"MCP server timed out waiting for response to {method} after "
                     f"{self._request_timeout_seconds:.1f}s"
@@ -316,6 +317,32 @@ class ManagedMcpManager:
         running = self._running_servers.pop(server_name, None)
         if running is None:
             return
+        self._terminate_running_server(running)
+        self._record_event(
+            McpRuntimeEvent(
+                event_type="runtime.mcp_server_stopped",
+                payload={"server": server_name, "workspace_root": str(running.workspace_root)},
+            )
+        )
+
+    def _stop_running_server_by_process(self, running: _RunningMcpServer) -> None:
+        server_name = next(
+            (name for name, active in self._running_servers.items() if active is running),
+            None,
+        )
+        if server_name is None:
+            return
+        self._running_servers.pop(server_name, None)
+        self._terminate_running_server(running)
+        self._record_event(
+            McpRuntimeEvent(
+                event_type="runtime.mcp_server_stopped",
+                payload={"server": server_name, "workspace_root": str(running.workspace_root)},
+            )
+        )
+
+    @staticmethod
+    def _terminate_running_server(running: _RunningMcpServer) -> None:
         if running.process.stdin is not None:
             running.process.stdin.close()
         try:
@@ -324,12 +351,6 @@ class ManagedMcpManager:
         except subprocess.TimeoutExpired:
             running.process.kill()
             running.process.wait(timeout=1)
-        self._record_event(
-            McpRuntimeEvent(
-                event_type="runtime.mcp_server_stopped",
-                payload={"server": server_name, "workspace_root": str(running.workspace_root)},
-            )
-        )
 
     def _record_event(self, event: McpRuntimeEvent) -> None:
         self._pending_events.append(event)

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -129,6 +129,7 @@ class VoidCodeRuntime:
     """Headless runtime entrypoint for one local deterministic request."""
 
     _workspace: Path
+    _base_tool_registry: ToolRegistry
     _tool_registry: ToolRegistry
     _graph: RuntimeGraph
     _graph_override: RuntimeGraph | None
@@ -175,9 +176,10 @@ class VoidCodeRuntime:
         self._provider_chain = self._resolved_provider_config.target_chain
         self._lsp_manager = lsp_manager or build_lsp_manager(self._config.lsp)
         self._mcp_manager = mcp_manager or build_mcp_manager(self._config.mcp)
-        self._tool_registry = tool_registry or ToolRegistry.with_defaults(
+        self._base_tool_registry = tool_registry or ToolRegistry.with_defaults(
             lsp_tool=self._build_lsp_tool()
         )
+        self._tool_registry = self._base_tool_registry
         self._graph_override = graph
         self._graph_cache = {}
         self._graph = graph or self._build_graph_for_engine_from_config(
@@ -313,10 +315,10 @@ class VoidCodeRuntime:
     def _refresh_mcp_tools(self) -> None:
         if self._mcp_manager.current_state().mode != "managed":
             return
-        self._tool_registry = ToolRegistry.with_defaults(
-            lsp_tool=self._build_lsp_tool(),
-            mcp_tools=self._build_mcp_tools(),
-        )
+        merged_tools = dict(self._base_tool_registry.tools)
+        for tool in self._build_mcp_tools():
+            merged_tools[tool.definition.name] = tool
+        self._tool_registry = ToolRegistry(tools=merged_tools)
 
     def current_lsp_state(self) -> LspManagerState:
         return self._lsp_manager.current_state()

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -37,6 +37,7 @@ from .events import (
     EventEnvelope,
 )
 from .lsp import LspManager, LspManagerState, LspRequest, LspRequestResult, build_lsp_manager
+from .mcp import McpManager, build_mcp_manager
 from .model_provider import (
     ModelProviderRegistry,
     ResolvedProviderChain,
@@ -104,8 +105,12 @@ class ToolRegistry:
         return cls(tools={tool.definition.name: tool for tool in tools})
 
     @classmethod
-    def with_defaults(cls, *, lsp_tool: Tool | None = None) -> ToolRegistry:
-        return cls.from_tools(BuiltinToolProvider(lsp_tool=lsp_tool).provide_tools())
+    def with_defaults(
+        cls, *, lsp_tool: Tool | None = None, mcp_tools: tuple[Tool, ...] = ()
+    ) -> ToolRegistry:
+        return cls.from_tools(
+            BuiltinToolProvider(lsp_tool=lsp_tool, mcp_tools=mcp_tools).provide_tools()
+        )
 
     def definitions(self) -> tuple[ToolDefinition, ...]:
         return tuple(tool.definition for tool in self.tools.values())
@@ -133,6 +138,7 @@ class VoidCodeRuntime:
     _provider_chain: ResolvedProviderChain
     _skill_registry: SkillRegistry
     _lsp_manager: LspManager
+    _mcp_manager: McpManager
     _acp_adapter: AcpAdapter
     _graph_cache: dict[tuple[ExecutionEngineName, str], RuntimeGraph]
     _hook_recursion_env_var = "VOIDCODE_RUNNING_TOOL_HOOK"
@@ -150,6 +156,7 @@ class VoidCodeRuntime:
         model_provider_registry: ModelProviderRegistry | None = None,
         skill_registry: SkillRegistry | None = None,
         lsp_manager: LspManager | None = None,
+        mcp_manager: McpManager | None = None,
         acp_adapter: AcpAdapter | None = None,
     ) -> None:
         self._workspace = workspace.resolve()
@@ -165,8 +172,10 @@ class VoidCodeRuntime:
         self._provider_model = self._resolved_provider_config.active_target
         self._provider_chain = self._resolved_provider_config.target_chain
         self._lsp_manager = lsp_manager or build_lsp_manager(self._config.lsp)
+        self._mcp_manager = mcp_manager or build_mcp_manager(self._config.mcp)
         self._tool_registry = tool_registry or ToolRegistry.with_defaults(
-            lsp_tool=self._build_lsp_tool()
+            lsp_tool=self._build_lsp_tool(),
+            mcp_tools=self._build_mcp_tools(),
         )
         self._graph_override = graph
         self._graph_cache = {}
@@ -283,6 +292,22 @@ class VoidCodeRuntime:
 
         return LspTool(requester=self.request_lsp)
 
+    def _build_mcp_tools(self) -> tuple[Tool, ...]:
+        if self._mcp_manager.current_state().mode != "managed":
+            return ()
+        from ..tools.mcp import McpTool
+
+        return tuple(
+            McpTool(
+                server_name=tool.server_name,
+                tool_name=tool.tool_name,
+                description=tool.description,
+                input_schema=tool.input_schema,
+                requester=self.request_mcp_tool,
+            )
+            for tool in self._mcp_manager.list_tools(workspace=self._workspace)
+        )
+
     def current_lsp_state(self) -> LspManagerState:
         return self._lsp_manager.current_state()
 
@@ -301,6 +326,21 @@ class VoidCodeRuntime:
                 params=params,
                 workspace=workspace,
             )
+        )
+
+    def request_mcp_tool(
+        self,
+        *,
+        server_name: str,
+        tool_name: str,
+        arguments: dict[str, object],
+        workspace: Path,
+    ):
+        return self._mcp_manager.call_tool(
+            server_name=server_name,
+            tool_name=tool_name,
+            arguments=arguments,
+            workspace=workspace,
         )
 
     def shutdown_lsp(self) -> tuple[EventEnvelope, ...]:

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -31,6 +31,8 @@ from .events import (
     RUNTIME_LSP_SERVER_FAILED,
     RUNTIME_LSP_SERVER_STARTED,
     RUNTIME_LSP_SERVER_STOPPED,
+    RUNTIME_MCP_SERVER_STARTED,
+    RUNTIME_MCP_SERVER_STOPPED,
     RUNTIME_MEMORY_REFRESHED,
     RUNTIME_SKILLS_APPLIED,
     RUNTIME_SKILLS_LOADED,
@@ -202,6 +204,7 @@ class VoidCodeRuntime:
     def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
         _ = exc_type, exc, tb
         _ = self.disconnect_acp()
+        _ = self.shutdown_mcp()
         _ = self.shutdown_lsp()
 
     @staticmethod
@@ -341,6 +344,13 @@ class VoidCodeRuntime:
             tool_name=tool_name,
             arguments=arguments,
             workspace=workspace,
+        )
+
+    def shutdown_mcp(self) -> tuple[EventEnvelope, ...]:
+        return self._envelopes_for_mcp_events(
+            session_id="runtime",
+            start_sequence=1,
+            mcp_events=self._mcp_manager.shutdown(),
         )
 
     def shutdown_lsp(self) -> tuple[EventEnvelope, ...]:
@@ -828,6 +838,13 @@ class VoidCodeRuntime:
             try:
                 tool_result = tool.invoke(plan_tool_call, workspace=self._workspace)
             except Exception as exc:
+                for mcp_event in self._envelopes_for_mcp_events(
+                    session_id=session.session.id,
+                    start_sequence=sequence + 1,
+                    mcp_events=self._mcp_manager.drain_events(),
+                ):
+                    sequence = mcp_event.sequence
+                    yield RuntimeStreamChunk(kind="event", session=session, event=mcp_event)
                 for lsp_event in self._envelopes_for_lsp_events(
                     session_id=session.session.id,
                     start_sequence=sequence + 1,
@@ -837,6 +854,14 @@ class VoidCodeRuntime:
                     yield RuntimeStreamChunk(kind="event", session=session, event=lsp_event)
                 yield self._failed_chunk(session=session, sequence=sequence + 1, error=str(exc))
                 raise
+
+            for mcp_event in self._envelopes_for_mcp_events(
+                session_id=session.session.id,
+                start_sequence=sequence + 1,
+                mcp_events=self._mcp_manager.drain_events(),
+            ):
+                sequence = mcp_event.sequence
+                yield RuntimeStreamChunk(kind="event", session=session, event=mcp_event)
 
             for lsp_event in self._envelopes_for_lsp_events(
                 session_id=session.session.id,
@@ -1655,6 +1680,12 @@ class VoidCodeRuntime:
             "available": acp_state.available,
             "last_error": acp_state.last_error,
         }
+        mcp_state = self._mcp_manager.current_state()
+        runtime_config_metadata["mcp"] = {
+            "mode": mcp_state.mode,
+            "configured_enabled": mcp_state.configuration.configured_enabled,
+            "servers": list(mcp_state.configuration.servers),
+        }
         return runtime_config_metadata
 
     @staticmethod
@@ -1708,6 +1739,41 @@ class VoidCodeRuntime:
         envelopes: list[EventEnvelope] = []
         sequence = start_sequence
         for raw_event in acp_events:
+            if isinstance(raw_event, dict):
+                raw_event_dict = cast(dict[str, object], raw_event)
+                event_type = raw_event_dict.get("event_type")
+                payload = raw_event_dict.get("payload")
+            else:
+                event_type = getattr(raw_event, "event_type", None)
+                payload = getattr(raw_event, "payload", None)
+            if event_type not in known_event_types or not isinstance(payload, dict):
+                continue
+            envelopes.append(
+                EventEnvelope(
+                    session_id=session_id,
+                    sequence=sequence,
+                    event_type=cast(str, event_type),
+                    source="runtime",
+                    payload=cast(dict[str, object], payload),
+                )
+            )
+            sequence += 1
+        return tuple(envelopes)
+
+    @staticmethod
+    def _envelopes_for_mcp_events(
+        *,
+        session_id: str,
+        start_sequence: int,
+        mcp_events: tuple[object, ...],
+    ) -> tuple[EventEnvelope, ...]:
+        known_event_types = {
+            RUNTIME_MCP_SERVER_STARTED,
+            RUNTIME_MCP_SERVER_STOPPED,
+        }
+        envelopes: list[EventEnvelope] = []
+        sequence = start_sequence
+        for raw_event in mcp_events:
             if isinstance(raw_event, dict):
                 raw_event_dict = cast(dict[str, object], raw_event)
                 event_type = raw_event_dict.get("event_type")

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -176,8 +176,7 @@ class VoidCodeRuntime:
         self._lsp_manager = lsp_manager or build_lsp_manager(self._config.lsp)
         self._mcp_manager = mcp_manager or build_mcp_manager(self._config.mcp)
         self._tool_registry = tool_registry or ToolRegistry.with_defaults(
-            lsp_tool=self._build_lsp_tool(),
-            mcp_tools=self._build_mcp_tools(),
+            lsp_tool=self._build_lsp_tool()
         )
         self._graph_override = graph
         self._graph_cache = {}
@@ -311,6 +310,14 @@ class VoidCodeRuntime:
             for tool in self._mcp_manager.list_tools(workspace=self._workspace)
         )
 
+    def _refresh_mcp_tools(self) -> None:
+        if self._mcp_manager.current_state().mode != "managed":
+            return
+        self._tool_registry = ToolRegistry.with_defaults(
+            lsp_tool=self._build_lsp_tool(),
+            mcp_tools=self._build_mcp_tools(),
+        )
+
     def current_lsp_state(self) -> LspManagerState:
         return self._lsp_manager.current_state()
 
@@ -442,6 +449,7 @@ class VoidCodeRuntime:
     def _stream_chunks(self, request: RuntimeRequest) -> Iterator[RuntimeStreamChunk]:
         session_id = self._resolve_session_id(request)
         effective_config = self._runtime_config_for_request(request)
+        self._refresh_mcp_tools()
         session = SessionState(
             session=SessionRef(id=session_id),
             status="running",

--- a/src/voidcode/runtime/tool_provider.py
+++ b/src/voidcode/runtime/tool_provider.py
@@ -40,8 +40,9 @@ class ToolProvider(Protocol):
 
 
 class BuiltinToolProvider:
-    def __init__(self, *, lsp_tool: Tool | None = None) -> None:
+    def __init__(self, *, lsp_tool: Tool | None = None, mcp_tools: tuple[Tool, ...] = ()) -> None:
         self._lsp_tool = lsp_tool
+        self._mcp_tools = mcp_tools
 
     def provide_tools(self) -> tuple[Tool, ...]:
         tools: list[Tool] = [
@@ -58,6 +59,8 @@ class BuiltinToolProvider:
 
         if self._lsp_tool is not None:
             tools.append(self._lsp_tool)
+
+        tools.extend(self._mcp_tools)
 
         # Add optional tools if available.
         if _ApplyPatchTool is not None:

--- a/src/voidcode/tools/__init__.py
+++ b/src/voidcode/tools/__init__.py
@@ -6,6 +6,7 @@ from .glob import GlobTool
 from .grep import GrepTool
 from .list_dir import ListTool
 from .lsp import LspTool
+from .mcp import McpTool
 from .multi_edit import MultiEditTool
 from .read_file import ReadFileTool
 from .shell_exec import ShellExecTool
@@ -25,6 +26,7 @@ __all__ = [
     "WebSearchTool",
     "WriteFileTool",
     "LspTool",
+    "McpTool",
     "MultiEditTool",
     "ApplyPatchTool",
     "CodeSearchTool",

--- a/src/voidcode/tools/contracts.py
+++ b/src/voidcode/tools/contracts.py
@@ -37,7 +37,18 @@ class ToolResult:
 
 
 @runtime_checkable
-class Tool(Protocol):
+class StaticTool(Protocol):
     definition: ClassVar[ToolDefinition]
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult: ...
+
+
+@runtime_checkable
+class DynamicTool(Protocol):
+    @property
+    def definition(self) -> ToolDefinition: ...
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult: ...
+
+
+type Tool = StaticTool | DynamicTool

--- a/src/voidcode/tools/mcp.py
+++ b/src/voidcode/tools/mcp.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+from .contracts import ToolCall, ToolDefinition, ToolResult
+
+
+class McpToolCallLike(Protocol):
+    @property
+    def content(self) -> list[dict[str, object]]: ...
+
+    @property
+    def is_error(self) -> bool: ...
+
+
+class McpRequester(Protocol):
+    def __call__(
+        self,
+        *,
+        server_name: str,
+        tool_name: str,
+        arguments: dict[str, object],
+        workspace: Path,
+    ) -> McpToolCallLike: ...
+
+
+class McpTool:
+    def __init__(
+        self,
+        *,
+        server_name: str,
+        tool_name: str,
+        description: str,
+        input_schema: dict[str, object],
+        requester: McpRequester,
+    ) -> None:
+        self._server_name = server_name
+        self._tool_name = tool_name
+        self._requester = requester
+        self.definition = ToolDefinition(
+            name=f"mcp/{server_name}/{tool_name}",
+            description=description,
+            input_schema=input_schema,
+            read_only=False,
+        )
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        result = self._requester(
+            server_name=self._server_name,
+            tool_name=self._tool_name,
+            arguments=dict(call.arguments),
+            workspace=workspace,
+        )
+        content_parts: list[str] = []
+        for item in result.content:
+            text = item.get("text")
+            if isinstance(text, str) and text.strip():
+                content_parts.append(text)
+        content = "\n\n".join(content_parts) if content_parts else None
+        payload: dict[str, object] = {
+            "server": self._server_name,
+            "tool": self._tool_name,
+            "content": result.content,
+        }
+        if result.is_error:
+            return ToolResult(
+                tool_name=self.definition.name,
+                status="error",
+                error=content or f"MCP tool {self.definition.name} reported an error",
+                data=payload,
+            )
+        return ToolResult(
+            tool_name=self.definition.name,
+            status="ok",
+            content=content,
+            data=payload,
+        )

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -1038,6 +1038,7 @@ def test_single_agent_runtime_executes_read_path_and_persists_config(tmp_path: P
         "execution_engine": "single_agent",
         "max_steps": 4,
         "lsp": {"configured_enabled": False, "mode": "disabled", "servers": []},
+        "mcp": {"configured_enabled": False, "mode": "disabled", "servers": []},
         "model": "opencode/gpt-5.4",
         "provider_fallback": None,
         "resolved_provider": {
@@ -1568,6 +1569,7 @@ def test_runtime_resume_uses_persisted_runtime_config_over_fresh_resume_override
         "execution_engine": "deterministic",
         "max_steps": 4,
         "lsp": {"configured_enabled": False, "mode": "disabled", "servers": []},
+        "mcp": {"configured_enabled": False, "mode": "disabled", "servers": []},
         "model": "session/model",
         "provider_fallback": None,
         "resolved_provider": {

--- a/tests/unit/runtime/test_mcp.py
+++ b/tests/unit/runtime/test_mcp.py
@@ -399,3 +399,95 @@ while True:
         assert elapsed < 5
     else:
         raise AssertionError("expected MCP manager to time out waiting for a silent server")
+
+
+def test_mcp_manager_restarts_server_after_timeout(tmp_path: Path) -> None:
+    server_script = tmp_path / "retryable_mcp_server.py"
+    marker_path = tmp_path / "first_run_marker"
+    server_script.write_text(
+        rf'''
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import time
+
+marker = pathlib.Path(r"{marker_path}")
+first_run = not marker.exists()
+if first_run:
+    marker.write_text("seen", encoding="utf-8")
+
+
+def send(message: dict[str, object]) -> None:
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+
+for raw_line in sys.stdin:
+    line = raw_line.strip()
+    if not line:
+        continue
+    message = json.loads(line)
+    method = message.get("method")
+    if first_run:
+        time.sleep(10)
+        continue
+    if method == "initialize":
+        send(
+            {{
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {{
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {{"tools": {{}}}},
+                    "serverInfo": {{"name": "retry-mcp", "version": "0.1.0"}},
+                }},
+            }}
+        )
+        continue
+    if method == "notifications/initialized":
+        continue
+    if method == "tools/list":
+        send(
+            {{
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {{
+                    "tools": [
+                        {{
+                            "name": "echo",
+                            "description": "Echo the text argument.",
+                            "inputSchema": {{"type": "object"}},
+                        }}
+                    ]
+                }},
+            }}
+        )
+        continue
+''',
+        encoding="utf-8",
+    )
+
+    config = RuntimeMcpConfig(
+        enabled=True,
+        servers={
+            "retry": RuntimeMcpServerConfig(
+                transport="stdio",
+                command=(sys.executable, str(server_script)),
+            )
+        },
+    )
+
+    manager = build_mcp_manager(config)
+
+    try:
+        manager.list_tools(workspace=tmp_path)
+    except ValueError as exc:
+        assert "timed out" in str(exc)
+    else:
+        raise AssertionError("expected first MCP attempt to time out")
+
+    discovered = manager.list_tools(workspace=tmp_path)
+
+    assert [tool.tool_name for tool in discovered] == ["echo"]

--- a/tests/unit/runtime/test_mcp.py
+++ b/tests/unit/runtime/test_mcp.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from voidcode.runtime.config import RuntimeMcpConfig, RuntimeMcpServerConfig
+from voidcode.runtime.mcp import McpConfigState, McpManagerState, build_mcp_manager
+
+_MCP_SERVER_SCRIPT = r"""
+from __future__ import annotations
+
+import json
+import sys
+
+
+def send(message: dict[str, object]) -> None:
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+
+for raw_line in sys.stdin:
+    line = raw_line.strip()
+    if not line:
+        continue
+    message = json.loads(line)
+    method = message.get("method")
+    if method == "initialize":
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "echo-mcp", "version": "0.1.0"},
+                },
+            }
+        )
+        continue
+    if method == "notifications/initialized":
+        continue
+    if method == "tools/list":
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {
+                    "tools": [
+                        {
+                            "name": "echo",
+                            "description": "Echo the text argument.",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {"text": {"type": "string"}},
+                                "required": ["text"],
+                            },
+                        }
+                    ]
+                },
+            }
+        )
+        continue
+    if method == "tools/call":
+        params = message.get("params", {})
+        arguments = params.get("arguments", {}) if isinstance(params, dict) else {}
+        text = arguments.get("text", "") if isinstance(arguments, dict) else ""
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {
+                    "content": [{"type": "text", "text": f"echo:{text}"}],
+                    "isError": False,
+                },
+            }
+        )
+        continue
+"""
+
+
+def test_mcp_manager_discovers_stdio_tools_and_invokes_calls(tmp_path: Path) -> None:
+    server_script = tmp_path / "echo_mcp_server.py"
+    server_script.write_text(_MCP_SERVER_SCRIPT, encoding="utf-8")
+
+    config = RuntimeMcpConfig(
+        enabled=True,
+        servers={
+            "echo": RuntimeMcpServerConfig(
+                transport="stdio",
+                command=(sys.executable, str(server_script)),
+            )
+        },
+    )
+
+    manager = build_mcp_manager(config)
+    assert manager.configuration == McpConfigState.from_runtime_config(config)
+    assert manager.current_state().mode == "managed"
+
+    discovered = manager.list_tools(workspace=tmp_path)
+
+    assert len(discovered) == 1
+    assert discovered[0].server_name == "echo"
+    assert discovered[0].tool_name == "echo"
+    assert discovered[0].input_schema == {
+        "type": "object",
+        "properties": {"text": {"type": "string"}},
+        "required": ["text"],
+    }
+
+    result = manager.call_tool(
+        server_name="echo",
+        tool_name="echo",
+        arguments={"text": "hello"},
+        workspace=tmp_path,
+    )
+
+    assert result.is_error is False
+    assert result.content == [{"type": "text", "text": "echo:hello"}]
+
+    shutdown_events = manager.shutdown()
+    assert shutdown_events
+    assert any(event.event_type == "runtime.mcp_server_stopped" for event in shutdown_events)
+
+
+def test_disabled_mcp_manager_rejects_tool_listing(tmp_path: Path) -> None:
+    manager = build_mcp_manager(RuntimeMcpConfig(enabled=False))
+
+    assert manager.current_state() == McpManagerState(
+        mode="disabled",
+        configuration=McpConfigState.from_runtime_config(RuntimeMcpConfig(enabled=False)),
+    )
+
+    try:
+        manager.list_tools(workspace=tmp_path)
+    except ValueError as exc:
+        assert str(exc) == "MCP runtime support is disabled"
+    else:
+        raise AssertionError("expected MCP manager to reject listing while disabled")

--- a/tests/unit/runtime/test_mcp.py
+++ b/tests/unit/runtime/test_mcp.py
@@ -136,3 +136,229 @@ def test_disabled_mcp_manager_rejects_tool_listing(tmp_path: Path) -> None:
         assert str(exc) == "MCP runtime support is disabled"
     else:
         raise AssertionError("expected MCP manager to reject listing while disabled")
+
+
+def test_mcp_manager_matches_jsonrpc_response_ids_when_notifications_interleave(
+    tmp_path: Path,
+) -> None:
+    server_script = tmp_path / "interleaved_mcp_server.py"
+    server_script.write_text(
+        r"""
+from __future__ import annotations
+
+import json
+import sys
+
+
+def send(message: dict[str, object]) -> None:
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+
+for raw_line in sys.stdin:
+    line = raw_line.strip()
+    if not line:
+        continue
+    message = json.loads(line)
+    method = message.get("method")
+    if method == "initialize":
+        send(
+            {
+                "jsonrpc": "2.0",
+                "method": "notifications/message",
+                "params": {"text": "warming up"},
+            }
+        )
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "echo-mcp", "version": "0.1.0"},
+                },
+            }
+        )
+        continue
+    if method == "notifications/initialized":
+        continue
+    if method == "tools/list":
+        send(
+            {
+                "jsonrpc": "2.0",
+                "method": "notifications/message",
+                "params": {"text": "listing"},
+            }
+        )
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {
+                    "tools": [
+                        {
+                            "name": "echo",
+                            "description": "Echo the text argument.",
+                            "inputSchema": {"type": "object"},
+                        }
+                    ]
+                },
+            }
+        )
+        continue
+    if method == "tools/call":
+        send(
+            {
+                "jsonrpc": "2.0",
+                "method": "notifications/message",
+                "params": {"text": "calling"},
+            }
+        )
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {
+                    "content": [{"type": "text", "text": "echo:ok"}],
+                    "isError": False,
+                },
+            }
+        )
+        continue
+""",
+        encoding="utf-8",
+    )
+
+    config = RuntimeMcpConfig(
+        enabled=True,
+        servers={
+            "echo": RuntimeMcpServerConfig(
+                transport="stdio",
+                command=(sys.executable, str(server_script)),
+            )
+        },
+    )
+
+    manager = build_mcp_manager(config)
+
+    discovered = manager.list_tools(workspace=tmp_path)
+
+    assert [tool.tool_name for tool in discovered] == ["echo"]
+
+    result = manager.call_tool(
+        server_name="echo",
+        tool_name="echo",
+        arguments={},
+        workspace=tmp_path,
+    )
+
+    assert result.content == [{"type": "text", "text": "echo:ok"}]
+
+
+def test_mcp_manager_inherits_parent_environment_for_server_process(tmp_path: Path) -> None:
+    server_script = tmp_path / "env_mcp_server.py"
+    server_script.write_text(
+        r"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def send(message: dict[str, object]) -> None:
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+
+for raw_line in sys.stdin:
+    line = raw_line.strip()
+    if not line:
+        continue
+    message = json.loads(line)
+    method = message.get("method")
+    if method == "initialize":
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "env-mcp", "version": "0.1.0"},
+                },
+            }
+        )
+        continue
+    if method == "notifications/initialized":
+        continue
+    if method == "tools/list":
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {
+                    "tools": [
+                        {
+                            "name": "inspect_env",
+                            "description": "Inspect inherited environment.",
+                            "inputSchema": {"type": "object"},
+                        }
+                    ]
+                },
+            }
+        )
+        continue
+    if method == "tools/call":
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": os.environ.get("VOIDCODE_TEST_PARENT_ENV", "missing"),
+                        }
+                    ],
+                    "isError": False,
+                },
+            }
+        )
+        continue
+""",
+        encoding="utf-8",
+    )
+
+    config = RuntimeMcpConfig(
+        enabled=True,
+        servers={
+            "env": RuntimeMcpServerConfig(
+                transport="stdio",
+                command=(sys.executable, str(server_script)),
+            )
+        },
+    )
+
+    manager = build_mcp_manager(config)
+
+    import os
+
+    previous = os.environ.get("VOIDCODE_TEST_PARENT_ENV")
+    os.environ["VOIDCODE_TEST_PARENT_ENV"] = "inherited"
+    try:
+        _ = manager.list_tools(workspace=tmp_path)
+        result = manager.call_tool(
+            server_name="env",
+            tool_name="inspect_env",
+            arguments={},
+            workspace=tmp_path,
+        )
+    finally:
+        if previous is None:
+            del os.environ["VOIDCODE_TEST_PARENT_ENV"]
+        else:
+            os.environ["VOIDCODE_TEST_PARENT_ENV"] = previous
+
+    assert result.content == [{"type": "text", "text": "inherited"}]

--- a/tests/unit/runtime/test_mcp.py
+++ b/tests/unit/runtime/test_mcp.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import time
 from pathlib import Path
 
 from voidcode.runtime.config import RuntimeMcpConfig, RuntimeMcpServerConfig
@@ -362,3 +363,39 @@ for raw_line in sys.stdin:
             os.environ["VOIDCODE_TEST_PARENT_ENV"] = previous
 
     assert result.content == [{"type": "text", "text": "inherited"}]
+
+
+def test_mcp_manager_times_out_when_server_never_responds(tmp_path: Path) -> None:
+    server_script = tmp_path / "silent_mcp_server.py"
+    server_script.write_text(
+        r"""
+from __future__ import annotations
+
+import time
+
+while True:
+    time.sleep(10)
+""",
+        encoding="utf-8",
+    )
+
+    config = RuntimeMcpConfig(
+        enabled=True,
+        servers={
+            "silent": RuntimeMcpServerConfig(
+                transport="stdio",
+                command=(sys.executable, str(server_script)),
+            )
+        },
+    )
+
+    manager = build_mcp_manager(config)
+    start = time.monotonic()
+    try:
+        manager.list_tools(workspace=tmp_path)
+    except ValueError as exc:
+        elapsed = time.monotonic() - start
+        assert "timed out" in str(exc)
+        assert elapsed < 5
+    else:
+        raise AssertionError("expected MCP manager to time out waiting for a silent server")

--- a/tests/unit/runtime/test_mcp_config.py
+++ b/tests/unit/runtime/test_mcp_config.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from voidcode.runtime.config import RuntimeMcpConfig, RuntimeMcpServerConfig, load_runtime_config
+
+
+def test_runtime_config_parses_mcp_stdio_servers(tmp_path: Path) -> None:
+    (tmp_path / ".voidcode.json").write_text(
+        json.dumps(
+            {
+                "mcp": {
+                    "enabled": True,
+                    "servers": {
+                        "echo": {
+                            "transport": "stdio",
+                            "command": ["python", "tests/fixtures/echo_mcp.py"],
+                            "env": {"ECHO_MODE": "1"},
+                        }
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.mcp == RuntimeMcpConfig(
+        enabled=True,
+        servers={
+            "echo": RuntimeMcpServerConfig(
+                transport="stdio",
+                command=("python", "tests/fixtures/echo_mcp.py"),
+                env={"ECHO_MODE": "1"},
+            )
+        },
+    )
+
+
+def test_runtime_config_rejects_unknown_mcp_transport(tmp_path: Path) -> None:
+    (tmp_path / ".voidcode.json").write_text(
+        json.dumps(
+            {
+                "mcp": {
+                    "enabled": True,
+                    "servers": {
+                        "echo": {
+                            "transport": "sse",
+                            "command": ["python", "tests/fixtures/echo_mcp.py"],
+                        }
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="mcp.servers.echo.transport"):
+        load_runtime_config(tmp_path, env={})
+
+
+def test_runtime_config_rejects_missing_mcp_command(tmp_path: Path) -> None:
+    (tmp_path / ".voidcode.json").write_text(
+        json.dumps(
+            {
+                "mcp": {
+                    "enabled": True,
+                    "servers": {
+                        "echo": {
+                            "transport": "stdio",
+                        }
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="mcp.servers.echo.command"):
+        load_runtime_config(tmp_path, env={})

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -15,11 +15,17 @@ from voidcode.runtime.config import (
     RuntimeConfig,
     RuntimeLspConfig,
     RuntimeLspServerConfig,
+    RuntimeMcpServerConfig,
     RuntimeProviderFallbackConfig,
     RuntimeSkillsConfig,
 )
-from voidcode.runtime.events import EventEnvelope
+from voidcode.runtime.events import (
+    RUNTIME_MCP_SERVER_STARTED,
+    RUNTIME_MCP_SERVER_STOPPED,
+    EventEnvelope,
+)
 from voidcode.runtime.lsp import DisabledLspManager
+from voidcode.runtime.mcp import McpConfigState, McpManagerState, McpRuntimeEvent
 from voidcode.runtime.model_provider import ModelProviderRegistry
 from voidcode.runtime.permission import PermissionPolicy
 from voidcode.runtime.service import (
@@ -415,6 +421,131 @@ def test_runtime_exit_disconnects_managed_acp(tmp_path: Path) -> None:
     runtime.__exit__(None, None, None)
 
     assert runtime.current_acp_state().status == "disconnected"
+
+
+def test_runtime_exit_shuts_down_managed_mcp(tmp_path: Path) -> None:
+    class _StubMcpManager:
+        def __init__(self) -> None:
+            self.shutdown_calls = 0
+
+        @property
+        def configuration(self) -> McpConfigState:
+            return McpConfigState(configured_enabled=True)
+
+        def current_state(self) -> McpManagerState:
+            return McpManagerState(mode="managed", configuration=self.configuration)
+
+        def list_tools(self, *, workspace: Path):
+            _ = workspace
+            return ()
+
+        def call_tool(
+            self, *, server_name: str, tool_name: str, arguments: dict[str, object], workspace: Path
+        ):
+            _ = server_name, tool_name, arguments, workspace
+            raise AssertionError("not used")
+
+        def shutdown(self) -> tuple[McpRuntimeEvent, ...]:
+            self.shutdown_calls += 1
+            return (
+                McpRuntimeEvent(
+                    event_type=RUNTIME_MCP_SERVER_STOPPED,
+                    payload={"server": "echo", "workspace_root": str(tmp_path)},
+                ),
+            )
+
+        def drain_events(self) -> tuple[McpRuntimeEvent, ...]:
+            return ()
+
+    mcp_manager = _StubMcpManager()
+    runtime = VoidCodeRuntime(workspace=tmp_path, mcp_manager=mcp_manager)
+
+    runtime.__exit__(None, None, None)
+
+    assert mcp_manager.shutdown_calls == 1
+
+
+def test_runtime_surfaces_mcp_lifecycle_events_in_run_responses(tmp_path: Path) -> None:
+    class _StubMcpManager:
+        @property
+        def configuration(self) -> McpConfigState:
+            return McpConfigState(configured_enabled=True)
+
+        def current_state(self) -> McpManagerState:
+            return McpManagerState(mode="managed", configuration=self.configuration)
+
+        def list_tools(self, *, workspace: Path):
+            _ = workspace
+            return ()
+
+        def call_tool(
+            self, *, server_name: str, tool_name: str, arguments: dict[str, object], workspace: Path
+        ):
+            _ = server_name, tool_name, arguments, workspace
+            raise AssertionError("not used")
+
+        def shutdown(self) -> tuple[McpRuntimeEvent, ...]:
+            return ()
+
+        def drain_events(self) -> tuple[McpRuntimeEvent, ...]:
+            return (
+                McpRuntimeEvent(
+                    event_type=RUNTIME_MCP_SERVER_STARTED,
+                    payload={"server": "echo", "workspace_root": str(tmp_path)},
+                ),
+            )
+
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("alpha beta\n", encoding="utf-8")
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_StubGraph(), mcp_manager=_StubMcpManager())
+
+    response = runtime.run(RuntimeRequest(prompt="hello"))
+
+    assert any(event.event_type == RUNTIME_MCP_SERVER_STARTED for event in response.events)
+
+
+def test_runtime_metadata_includes_mcp_state_when_configured(tmp_path: Path) -> None:
+    class _StubMcpManager:
+        @property
+        def configuration(self) -> McpConfigState:
+            return McpConfigState(
+                configured_enabled=True,
+                servers={
+                    "echo": RuntimeMcpServerConfig(
+                        transport="stdio",
+                        command=("python", "server.py"),
+                    )
+                },
+            )
+
+        def current_state(self) -> McpManagerState:
+            return McpManagerState(mode="managed", configuration=self.configuration)
+
+        def list_tools(self, *, workspace: Path):
+            _ = workspace
+            return ()
+
+        def call_tool(
+            self, *, server_name: str, tool_name: str, arguments: dict[str, object], workspace: Path
+        ):
+            _ = server_name, tool_name, arguments, workspace
+            raise AssertionError("not used")
+
+        def shutdown(self) -> tuple[McpRuntimeEvent, ...]:
+            return ()
+
+        def drain_events(self) -> tuple[McpRuntimeEvent, ...]:
+            return ()
+
+    runtime = VoidCodeRuntime(workspace=tmp_path, mcp_manager=_StubMcpManager())
+
+    runtime_config_metadata = runtime._runtime_config_metadata()  # pyright: ignore[reportPrivateUsage]
+
+    assert runtime_config_metadata["mcp"] == {
+        "mode": "managed",
+        "configured_enabled": True,
+        "servers": ["echo"],
+    }
 
 
 def test_runtime_default_extension_construction_preserves_public_run_path(
@@ -1068,6 +1199,7 @@ def test_runtime_effective_runtime_config_recovers_persisted_max_steps(tmp_path:
             "available": False,
             "last_error": None,
         },
+        "mcp": {"mode": "disabled", "configured_enabled": False, "servers": []},
     }
 
     resumed_runtime = VoidCodeRuntime(
@@ -1189,6 +1321,7 @@ def test_runtime_effective_runtime_config_uses_request_metadata_max_steps_for_ne
             "available": False,
             "last_error": None,
         },
+        "mcp": {"mode": "disabled", "configured_enabled": False, "servers": []},
     }
 
 

--- a/tests/unit/runtime/test_tool_provider.py
+++ b/tests/unit/runtime/test_tool_provider.py
@@ -5,6 +5,13 @@ from pathlib import Path
 from unittest.mock import patch
 
 from voidcode.runtime.events import EventEnvelope
+from voidcode.runtime.mcp import (
+    McpConfigState,
+    McpManagerState,
+    McpToolCallResult,
+    McpToolDescriptor,
+)
+from voidcode.runtime.permission import PermissionPolicy
 from voidcode.runtime.service import (
     GraphRunRequest,
     RuntimeRequest,
@@ -19,6 +26,7 @@ from voidcode.tools import (
     GlobTool,
     GrepTool,
     ListTool,
+    McpTool,
     MultiEditTool,
     ReadFileTool,
     ShellExecTool,
@@ -55,6 +63,25 @@ class _StubGraph:
         return _StubStep(output=request.prompt, is_finished=True)
 
 
+class _StubMcpGraph:
+    def step(
+        self,
+        request: GraphRunRequest,
+        tool_results: tuple[object, ...],
+        *,
+        session: SessionState,
+    ) -> _StubStep:
+        _ = session
+        if not tool_results:
+            return _StubStep(
+                tool_call=ToolCall(
+                    tool_name="mcp/echo/echo",
+                    arguments={"message": "hi"},
+                )
+            )
+        return _StubStep(output=request.prompt, is_finished=True)
+
+
 def test_builtin_tool_provider_returns_expected_builtin_tools() -> None:
     tools = BuiltinToolProvider().provide_tools()
 
@@ -77,6 +104,30 @@ def test_builtin_tool_provider_returns_expected_builtin_tools() -> None:
     tool_types = tuple(type(tool) for tool in tools)
     for expected in expected_tools:
         assert expected in tool_types, f"Missing tool: {expected.__name__}"
+
+
+def test_builtin_tool_provider_can_include_runtime_managed_mcp_tools() -> None:
+    def _requester(
+        *,
+        server_name: str,
+        tool_name: str,
+        arguments: dict[str, object],
+        workspace: Path,
+    ) -> McpToolCallResult:
+        _ = server_name, tool_name, arguments, workspace
+        return McpToolCallResult(content=[{"type": "text", "text": "ok"}], is_error=False)
+
+    mcp_tool = McpTool(
+        server_name="echo",
+        tool_name="echo",
+        description="Echo input",
+        input_schema={"type": "object"},
+        requester=_requester,
+    )
+
+    tools = BuiltinToolProvider(mcp_tools=(mcp_tool,)).provide_tools()
+
+    assert any(tool.definition.name == "mcp/echo/echo" for tool in tools)
 
 
 def test_tool_registry_accepts_tools_from_provider_output() -> None:
@@ -141,6 +192,65 @@ def test_tool_registry_with_defaults_delegates_through_builtin_provider() -> Non
             assert registry.resolve(tool_name) is not None
 
 
+def test_runtime_registry_includes_discovered_mcp_tools(tmp_path: Path) -> None:
+    class _StubMcpManager:
+        @property
+        def configuration(self) -> McpConfigState:
+            return McpConfigState(configured_enabled=True)
+
+        def current_state(self) -> McpManagerState:
+            return McpManagerState(mode="managed", configuration=self.configuration)
+
+        def list_tools(self, *, workspace: Path):
+            _ = workspace
+            return (
+                McpToolDescriptor(
+                    server_name="echo",
+                    tool_name="echo",
+                    description="Echo input",
+                    input_schema={"type": "object"},
+                ),
+            )
+
+        def call_tool(
+            self,
+            *,
+            server_name: str,
+            tool_name: str,
+            arguments: dict[str, object],
+            workspace: Path,
+        ) -> McpToolCallResult:
+            _ = server_name, tool_name, arguments, workspace
+            return McpToolCallResult(content=[{"type": "text", "text": "echo:hi"}])
+
+        def shutdown(self):
+            return ()
+
+        def drain_events(self):
+            return ()
+
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_StubMcpGraph(),
+        mcp_manager=_StubMcpManager(),
+        permission_policy=PermissionPolicy(mode="allow"),
+    )
+    response = runtime.run(RuntimeRequest(prompt="done"))
+
+    assert response.output == "done"
+    assert any(
+        event.event_type == "runtime.tool_lookup_succeeded"
+        and event.payload == {"tool": "mcp/echo/echo"}
+        for event in response.events
+    )
+    assert any(
+        event.event_type == "runtime.tool_completed"
+        and event.payload["server"] == "echo"
+        and event.payload["tool"] == "echo"
+        for event in response.events
+    )
+
+
 def test_runtime_default_registry_behavior_remains_unchanged(tmp_path: Path) -> None:
     sample_file = tmp_path / "sample.txt"
     _ = sample_file.write_text("alpha beta\n", encoding="utf-8")
@@ -159,3 +269,4 @@ def test_runtime_default_registry_behavior_remains_unchanged(tmp_path: Path) -> 
 def test_tools_package_exports_code_search_tool() -> None:
     tools_module = __import__("voidcode.tools", fromlist=["__all__"])
     assert "CodeSearchTool" in tools_module.__all__
+    assert "McpTool" in tools_module.__all__

--- a/tests/unit/runtime/test_tool_provider.py
+++ b/tests/unit/runtime/test_tool_provider.py
@@ -194,6 +194,9 @@ def test_tool_registry_with_defaults_delegates_through_builtin_provider() -> Non
 
 def test_runtime_registry_includes_discovered_mcp_tools(tmp_path: Path) -> None:
     class _StubMcpManager:
+        def __init__(self) -> None:
+            self.list_tools_calls = 0
+
         @property
         def configuration(self) -> McpConfigState:
             return McpConfigState(configured_enabled=True)
@@ -203,6 +206,7 @@ def test_runtime_registry_includes_discovered_mcp_tools(tmp_path: Path) -> None:
 
         def list_tools(self, *, workspace: Path):
             _ = workspace
+            self.list_tools_calls += 1
             return (
                 McpToolDescriptor(
                     server_name="echo",
@@ -229,15 +233,19 @@ def test_runtime_registry_includes_discovered_mcp_tools(tmp_path: Path) -> None:
         def drain_events(self):
             return ()
 
+    mcp_manager = _StubMcpManager()
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
         graph=_StubMcpGraph(),
-        mcp_manager=_StubMcpManager(),
+        mcp_manager=mcp_manager,
         permission_policy=PermissionPolicy(mode="allow"),
     )
+    assert mcp_manager.list_tools_calls == 0
+
     response = runtime.run(RuntimeRequest(prompt="done"))
 
     assert response.output == "done"
+    assert mcp_manager.list_tools_calls == 1
     assert any(
         event.event_type == "runtime.tool_lookup_succeeded"
         and event.payload == {"tool": "mcp/echo/echo"}

--- a/tests/unit/runtime/test_tool_provider.py
+++ b/tests/unit/runtime/test_tool_provider.py
@@ -36,6 +36,7 @@ from voidcode.tools import (
     WebSearchTool,
     WriteFileTool,
 )
+from voidcode.tools.contracts import ToolDefinition, ToolResult
 
 
 @dataclass(slots=True)
@@ -80,6 +81,44 @@ class _StubMcpGraph:
                 )
             )
         return _StubStep(output=request.prompt, is_finished=True)
+
+
+class _InjectedToolGraph:
+    def __init__(self) -> None:
+        self._step_count = 0
+
+    def step(
+        self,
+        request: GraphRunRequest,
+        tool_results: tuple[object, ...],
+        *,
+        session: SessionState,
+    ) -> _StubStep:
+        _ = request, tool_results, session
+        self._step_count += 1
+        if self._step_count == 1:
+            return _StubStep(
+                tool_call=ToolCall(tool_name="mcp/echo/echo", arguments={"message": "hi"})
+            )
+        if self._step_count == 2:
+            return _StubStep(tool_call=ToolCall(tool_name="injected_tool", arguments={}))
+        return _StubStep(output="done", is_finished=True)
+
+
+class _InjectedTool:
+    definition = ToolDefinition(
+        name="injected_tool",
+        description="Injected test tool",
+        input_schema={"type": "object"},
+    )
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        _ = call, workspace
+        return ToolResult(
+            tool_name="injected_tool",
+            status="ok",
+            content="injected ok",
+        )
 
 
 def test_builtin_tool_provider_returns_expected_builtin_tools() -> None:
@@ -255,6 +294,62 @@ def test_runtime_registry_includes_discovered_mcp_tools(tmp_path: Path) -> None:
         event.event_type == "runtime.tool_completed"
         and event.payload["server"] == "echo"
         and event.payload["tool"] == "echo"
+        for event in response.events
+    )
+
+
+def test_runtime_refresh_preserves_injected_tool_registry_entries(tmp_path: Path) -> None:
+    class _StubMcpManager:
+        @property
+        def configuration(self) -> McpConfigState:
+            return McpConfigState(configured_enabled=True)
+
+        def current_state(self) -> McpManagerState:
+            return McpManagerState(mode="managed", configuration=self.configuration)
+
+        def list_tools(self, *, workspace: Path):
+            _ = workspace
+            return (
+                McpToolDescriptor(
+                    server_name="echo",
+                    tool_name="echo",
+                    description="Echo input",
+                    input_schema={"type": "object"},
+                ),
+            )
+
+        def call_tool(
+            self,
+            *,
+            server_name: str,
+            tool_name: str,
+            arguments: dict[str, object],
+            workspace: Path,
+        ) -> McpToolCallResult:
+            _ = server_name, tool_name, arguments, workspace
+            return McpToolCallResult(content=[{"type": "text", "text": "echo:hi"}])
+
+        def shutdown(self):
+            return ()
+
+        def drain_events(self):
+            return ()
+
+    injected_tool = _InjectedTool()
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_InjectedToolGraph(),
+        tool_registry=ToolRegistry.from_tools((injected_tool,)),
+        mcp_manager=_StubMcpManager(),
+        permission_policy=PermissionPolicy(mode="allow"),
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="go"))
+
+    assert response.output == "done"
+    assert any(
+        event.event_type == "runtime.tool_lookup_succeeded"
+        and event.payload == {"tool": "injected_tool"}
         for event in response.events
     )
 


### PR DESCRIPTION
## Summary
- add runtime MCP config parsing and a stdio-only runtime-owned MCP manager with focused unit coverage
- add a runtime-managed MCP tool adapter plus dynamic tool contract support so discovered MCP tools can be exposed safely
- register MCP tools through the runtime registry and verify the MCP provider/runtime integration path with unit tests

## Verification
- mise run check