### PR TITLE
fix(lsp): address shutdown cleanup and UNC URI follow-ups

### DIFF
--- a/src/voidcode/runtime/lsp.py
+++ b/src/voidcode/runtime/lsp.py
@@ -409,6 +409,7 @@ class ManagedLspManager:
 
         process = running_server.process
         if process.poll() is None:
+            should_terminate = not running_server.initialized
             try:
                 if running_server.initialized:
                     self._send_request(
@@ -418,20 +419,12 @@ class ManagedLspManager:
                         server_name=server_name,
                     )
                     self._send_notification(process, method="exit", params={})
-                else:
-                    process.terminate()
-            except ValueError:
+            except Exception as exc:
+                should_terminate = True
+                logger.warning("failed to shut down LSP server %s cleanly: %s", server_name, exc)
+            if should_terminate and process.poll() is None:
                 process.terminate()
-
-            try:
-                process.wait(timeout=1)
-            except subprocess.TimeoutExpired:
-                process.terminate()
-                try:
-                    process.wait(timeout=1)
-                except subprocess.TimeoutExpired:
-                    process.kill()
-                    process.wait(timeout=1)
+            self._wait_for_process_exit(process)
 
         self._server_states[server_name] = LspServerState(
             name=server_name,
@@ -493,7 +486,24 @@ class ManagedLspManager:
         parsed = urlparse(uri)
         if parsed.scheme != "file":
             return None
-        return Path(url2pathname(parsed.path))
+        raw_path = parsed.path
+        if parsed.netloc and parsed.netloc != "localhost":
+            raw_path = f"//{parsed.netloc}{parsed.path}"
+        return Path(url2pathname(raw_path))
+
+    @staticmethod
+    def _wait_for_process_exit(process: subprocess.Popen[bytes], *, timeout: float = 1.0) -> None:
+        if process.poll() is not None:
+            return
+        try:
+            process.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            process.terminate()
+            try:
+                process.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=timeout)
 
     def _send_request(
         self,

--- a/tests/unit/runtime/test_lsp.py
+++ b/tests/unit/runtime/test_lsp.py
@@ -243,9 +243,7 @@ def test_stop_running_server_cleans_up_after_shutdown_timeout(tmp_path: Path) ->
 def test_path_from_file_uri_preserves_unc_host() -> None:
     expected = Path(url2pathname("//server/share/project/main.py"))
 
-    assert (
-        ManagedLspManager._path_from_file_uri("file://server/share/project/main.py") == expected
-    )
+    assert ManagedLspManager._path_from_file_uri("file://server/share/project/main.py") == expected
 
 
 def test_lsp_operation_strings_match_protocol_method_names() -> None:

--- a/tests/unit/runtime/test_lsp.py
+++ b/tests/unit/runtime/test_lsp.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import subprocess
 from importlib import import_module
 from pathlib import Path
 from typing import Any
+from urllib.request import url2pathname
 
 import pytest
 from lsprotocol import converters as lsp_converters
@@ -177,6 +179,73 @@ def test_managed_lsp_manager_marks_failed_startup_when_command_is_missing(tmp_pa
     assert state.servers["broken"].status == "failed"
     assert state.servers["broken"].available is False
     assert state.servers["broken"].last_error is not None
+
+
+def test_stop_running_server_cleans_up_after_shutdown_timeout(tmp_path: Path) -> None:
+    manager = ManagedLspManager(
+        RuntimeLspConfig(
+            enabled=True,
+            servers={"pyright": RuntimeLspServerConfig(command=("pyright-langserver", "--stdio"))},
+        )
+    )
+    module = import_module("voidcode.runtime.lsp")
+    running_server_cls = module._RunningLspServer
+
+    class _FakeProcess:
+        def __init__(self) -> None:
+            self.terminated = False
+            self.killed = False
+
+        def poll(self) -> int | None:
+            if self.terminated or self.killed:
+                return 0
+            return None
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+        def kill(self) -> None:
+            self.killed = True
+            self.terminated = True
+
+        def wait(self, timeout: float = 0.0) -> int:
+            if self.terminated or self.killed:
+                return 0
+            raise subprocess.TimeoutExpired(cmd="fake-lsp", timeout=timeout)
+
+    fake_process = _FakeProcess()
+    server_config = manager.configuration.resolve("pyright")
+    assert server_config is not None
+    manager._running_servers["pyright"] = running_server_cls(
+        config=server_config,
+        process=fake_process,
+        workspace_root=tmp_path,
+        initialized=True,
+    )
+
+    def _raise_timeout(*args: object, **kwargs: object) -> object:
+        raise TimeoutError("shutdown timed out")
+
+    manager._send_request = _raise_timeout
+
+    manager._stop_running_server("pyright", record_event=True)
+
+    assert "pyright" not in manager._running_servers
+    state = manager.current_state().servers["pyright"]
+    assert state.status == "stopped"
+    assert state.available is False
+    assert fake_process.terminated is True
+    stopped_event = manager.drain_events()[0]
+    assert stopped_event.event_type == "runtime.lsp_server_stopped"
+    assert stopped_event.payload["workspace_root"] == str(tmp_path)
+
+
+def test_path_from_file_uri_preserves_unc_host() -> None:
+    expected = Path(url2pathname("//server/share/project/main.py"))
+
+    assert (
+        ManagedLspManager._path_from_file_uri("file://server/share/project/main.py") == expected
+    )
 
 
 def test_lsp_operation_strings_match_protocol_method_names() -> None:


### PR DESCRIPTION
## Summary

- make runtime-managed LSP shutdown resilient to `TimeoutError` and other shutdown-time transport failures
- preserve the host component when converting UNC-style `file://server/share/...` URIs into local paths
- add regression coverage for both review findings from PR #102

## Verification

- `uv run basedpyright --warnings src tests/unit/runtime/test_lsp.py`
- `uv run ruff check src/voidcode/runtime/lsp.py tests/unit/runtime/test_lsp.py`
- `uv run pytest -q -o addopts='' tests/unit/runtime/test_lsp.py tests/integration/test_lsp_tool_integration.py`

Follow-up for #102
