### PR TITLE
refactor: adopt rapidfuzz and unidiff for tool tooling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
   "textual",
   "httpx",
   "uvicorn",
+  "rapidfuzz>=3.14.5",
+  "unidiff>=0.7.5",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "langgraph",
   "lsprotocol",
   "pydantic",
+  "pydantic-settings",
   "typing-extensions",
   "textual",
   "httpx",

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -3,9 +3,14 @@ from __future__ import annotations
 import json
 import os
 from collections.abc import Mapping
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, cast
+from threading import Lock
+from typing import Literal, Protocol, cast
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, ValidationInfo, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from ..hook.config import RuntimeFormatterPresetConfig, RuntimeHooksConfig
 from ..lsp import LspServerConfigOverride as RuntimeLspServerConfig
@@ -20,12 +25,68 @@ serialize_provider_fallback_config = provider_config.serialize_provider_fallback
 RUNTIME_CONFIG_FILE_NAME = ".voidcode.json"
 APPROVAL_MODE_ENV_VAR = "VOIDCODE_APPROVAL_MODE"
 MODEL_ENV_VAR = "VOIDCODE_MODEL"
+EXECUTION_ENGINE_ENV_VAR = "VOIDCODE_EXECUTION_ENGINE"
+MAX_STEPS_ENV_VAR = "VOIDCODE_MAX_STEPS"
 _VALID_APPROVAL_MODES = ("allow", "deny", "ask")
 _VALID_TUI_COMMANDS = ("command_palette", "session_new", "session_resume")
 
 type ExecutionEngineName = Literal["deterministic", "single_agent"]
 
 _VALID_EXECUTION_ENGINES: tuple[ExecutionEngineName, ...] = ("deterministic", "single_agent")
+_TOP_LEVEL_ENV_VARS = (
+    APPROVAL_MODE_ENV_VAR,
+    MODEL_ENV_VAR,
+    EXECUTION_ENGINE_ENV_VAR,
+    MAX_STEPS_ENV_VAR,
+)
+_ENV_SETTINGS_LOCK = Lock()
+
+
+class _EnvironmentRuntimeSettings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="", extra="ignore")
+
+    approval_mode: PermissionDecision | None = Field(
+        default=None,
+        validation_alias=APPROVAL_MODE_ENV_VAR,
+    )
+    model: str | None = Field(default=None, validation_alias=MODEL_ENV_VAR)
+    execution_engine: ExecutionEngineName | None = Field(
+        default=None,
+        validation_alias=EXECUTION_ENGINE_ENV_VAR,
+    )
+    max_steps: int | None = Field(default=None, validation_alias=MAX_STEPS_ENV_VAR)
+
+    @field_validator("approval_mode", mode="before")
+    @classmethod
+    def _validate_approval_mode(cls, value: object) -> PermissionDecision | None:
+        return _parse_approval_mode(
+            value,
+            source=f"environment variable {APPROVAL_MODE_ENV_VAR}",
+            allow_none=True,
+        )
+
+    @field_validator("model", mode="before")
+    @classmethod
+    def _validate_model(cls, value: object) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"environment variable {MODEL_ENV_VAR} must be a non-empty string")
+        return value
+
+    @field_validator("execution_engine", mode="before")
+    @classmethod
+    def _validate_execution_engine(cls, value: object) -> ExecutionEngineName | None:
+        return _parse_execution_engine(
+            value,
+            source=f"environment variable {EXECUTION_ENGINE_ENV_VAR}",
+            allow_none=True,
+        )
+
+    @field_validator("max_steps", mode="before")
+    @classmethod
+    def _validate_max_steps(cls, value: object) -> int | None:
+        return _parse_environment_max_steps(value)
 
 
 @dataclass(frozen=True, slots=True)
@@ -119,25 +180,35 @@ def load_runtime_config(
     *,
     approval_mode: PermissionDecision | None = None,
     model: str | None = None,
+    execution_engine: ExecutionEngineName | None = None,
+    max_steps: int | None = None,
     env: Mapping[str, str] | None = None,
 ) -> RuntimeConfig:
     resolved_workspace = workspace.resolve()
     repo_local = _load_repo_local_config(resolved_workspace)
-    environment = os.environ if env is None else env
+    environment = _load_environment_runtime_config(env)
 
     return RuntimeConfig(
         approval_mode=_resolve_approval_mode(
             explicit=approval_mode,
             repo_local=repo_local.approval_mode,
-            environment=environment.get(APPROVAL_MODE_ENV_VAR),
+            environment=environment.approval_mode,
         ),
         model=_resolve_model(
             explicit=model,
             repo_local=repo_local.model,
-            environment=environment.get(MODEL_ENV_VAR),
+            environment=environment.model,
         ),
-        execution_engine=_resolve_execution_engine(repo_local=repo_local.execution_engine),
-        max_steps=_resolve_max_steps(repo_local=repo_local.max_steps),
+        execution_engine=_resolve_execution_engine(
+            explicit=execution_engine,
+            repo_local=repo_local.execution_engine,
+            environment=environment.execution_engine,
+        ),
+        max_steps=_resolve_max_steps(
+            explicit=max_steps,
+            repo_local=repo_local.max_steps,
+            environment=environment.max_steps,
+        ),
         hooks=repo_local.hooks,
         tools=repo_local.tools,
         skills=repo_local.skills,
@@ -287,6 +358,239 @@ def _parse_formatter_preset_config(
     return RuntimeFormatterPresetConfig(command=command)
 
 
+class _RuntimeToolsBuiltinValidationModel(BaseModel):
+    enabled: bool | None = None
+
+    @field_validator("enabled", mode="before")
+    @classmethod
+    def _validate_enabled(cls, value: object) -> bool | None:
+        return _parse_optional_bool(value, field_path="tools.builtin.enabled")
+
+    def to_runtime_config(self) -> RuntimeToolsBuiltinConfig:
+        return RuntimeToolsBuiltinConfig(enabled=self.enabled)
+
+
+class _RuntimeToolsValidationModel(BaseModel):
+    builtin: _RuntimeToolsBuiltinValidationModel | None = None
+    paths: tuple[str, ...] = ()
+
+    @field_validator("builtin", mode="before")
+    @classmethod
+    def _validate_builtin_shape(
+        cls, value: object
+    ) -> dict[str, object] | _RuntimeToolsBuiltinValidationModel | None:
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            raise ValueError("runtime config field 'tools.builtin' must be an object when provided")
+        return cast(dict[str, object], value)
+
+    @field_validator("paths", mode="before")
+    @classmethod
+    def _validate_paths(cls, value: object) -> tuple[str, ...]:
+        return _parse_string_list(value, field_path="tools.paths")
+
+    def to_runtime_config(self) -> RuntimeToolsConfig:
+        return RuntimeToolsConfig(
+            builtin=self.builtin.to_runtime_config() if self.builtin is not None else None,
+            paths=self.paths,
+        )
+
+
+class _RuntimeSkillsValidationModel(BaseModel):
+    enabled: bool | None = None
+    paths: tuple[str, ...] = ()
+
+    @field_validator("enabled", mode="before")
+    @classmethod
+    def _validate_enabled(cls, value: object) -> bool | None:
+        return _parse_optional_bool(value, field_path="skills.enabled")
+
+    @field_validator("paths", mode="before")
+    @classmethod
+    def _validate_paths(cls, value: object) -> tuple[str, ...]:
+        return _parse_string_list(value, field_path="skills.paths")
+
+    def to_runtime_config(self) -> RuntimeSkillsConfig:
+        return RuntimeSkillsConfig(enabled=self.enabled, paths=self.paths)
+
+
+class _RuntimeAcpValidationModel(BaseModel):
+    enabled: bool | None = None
+
+    @field_validator("enabled", mode="before")
+    @classmethod
+    def _validate_enabled(cls, value: object) -> bool | None:
+        return _parse_optional_bool(value, field_path="acp.enabled")
+
+    def to_runtime_config(self) -> RuntimeAcpConfig:
+        return RuntimeAcpConfig(enabled=self.enabled)
+
+
+def _validation_context_field_path(info: ValidationInfo, *, default: str) -> str:
+    context = info.context
+    if isinstance(context, dict):
+        typed_context = cast(dict[str, object], context)
+        field_path = typed_context.get("field_path")
+        if isinstance(field_path, str):
+            return field_path
+    return default
+
+
+class _RuntimeMcpServerValidationModel(BaseModel):
+    model_config = ConfigDict(validate_default=True)
+
+    transport: McpTransport = "stdio"
+    command: tuple[str, ...] = ()
+    env: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("transport", mode="before")
+    @classmethod
+    def _validate_transport(cls, value: object, info: ValidationInfo) -> McpTransport:
+        if value is None:
+            return "stdio"
+        field_path = _validation_context_field_path(info, default="mcp.servers")
+        if value != "stdio":
+            raise ValueError(f"runtime config field '{field_path}.transport' must be one of: stdio")
+        return "stdio"
+
+    @field_validator("command", mode="before")
+    @classmethod
+    def _validate_command(cls, value: object, info: ValidationInfo) -> tuple[str, ...]:
+        field_path = _validation_context_field_path(info, default="mcp.servers")
+        command = _parse_string_list(value, field_path=f"{field_path}.command")
+        if not command:
+            raise ValueError(
+                f"runtime config field '{field_path}.command' must contain at least one string"
+            )
+        return command
+
+    @field_validator("env", mode="before")
+    @classmethod
+    def _validate_env(cls, value: object, info: ValidationInfo) -> dict[str, str]:
+        field_path = _validation_context_field_path(info, default="mcp.servers")
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            raise ValueError(f"runtime config field '{field_path}.env' must be an object")
+
+        parsed_env: dict[str, str] = {}
+        raw_env = cast(dict[object, object], value)
+        for key, item in raw_env.items():
+            if not isinstance(key, str):
+                raise ValueError(f"runtime config field '{field_path}.env' keys must be strings")
+            if not isinstance(item, str):
+                raise ValueError(f"runtime config field '{field_path}.env.{key}' must be a string")
+            parsed_env[key] = item
+        return parsed_env
+
+    def to_runtime_config(self) -> RuntimeMcpServerConfig:
+        return RuntimeMcpServerConfig(
+            transport=self.transport,
+            command=self.command,
+            env=self.env,
+        )
+
+
+class _RuntimeMcpValidationModel(BaseModel):
+    enabled: bool | None = None
+    servers: dict[str, _RuntimeMcpServerValidationModel] | None = None
+
+    @field_validator("enabled", mode="before")
+    @classmethod
+    def _validate_enabled(cls, value: object) -> bool | None:
+        return _parse_optional_bool(value, field_path="mcp.enabled")
+
+    @field_validator("servers", mode="before")
+    @classmethod
+    def _validate_servers(cls, value: object) -> dict[str, _RuntimeMcpServerValidationModel] | None:
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            raise ValueError("runtime config field 'mcp.servers' must be an object when provided")
+
+        parsed_servers: dict[str, _RuntimeMcpServerValidationModel] = {}
+        raw_servers = cast(dict[object, object], value)
+        for server_name, raw_server in raw_servers.items():
+            if not isinstance(server_name, str):
+                raise ValueError("runtime config field 'mcp.servers' keys must be strings")
+            if not isinstance(raw_server, dict):
+                raise ValueError(
+                    f"runtime config field 'mcp.servers.{server_name}' must be an object"
+                )
+            parsed_servers[server_name] = _validate_runtime_config_model(
+                _RuntimeMcpServerValidationModel,
+                cast(dict[str, object], raw_server),
+                context={"field_path": f"mcp.servers.{server_name}"},
+            )
+        return parsed_servers
+
+    def to_runtime_config(self) -> RuntimeMcpConfig:
+        return RuntimeMcpConfig(
+            enabled=self.enabled,
+            servers={
+                server_name: server.to_runtime_config()
+                for server_name, server in self.servers.items()
+            }
+            if self.servers is not None
+            else None,
+        )
+
+
+class _RuntimeTuiValidationModel(BaseModel):
+    leader_key: str = "alt+x"
+    keymap: dict[str, str] | None = None
+
+    @field_validator("leader_key", mode="before")
+    @classmethod
+    def _validate_leader_key(cls, value: object) -> str:
+        if value is None:
+            return "alt+x"
+        if not isinstance(value, str):
+            raise ValueError("runtime config field 'tui.leader_key' must be a string when provided")
+        return value
+
+    @field_validator("keymap", mode="before")
+    @classmethod
+    def _validate_keymap(cls, value: object) -> dict[str, str] | None:
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            raise ValueError("runtime config field 'tui.keymap' must be an object when provided")
+
+        parsed_keymap: dict[str, str] = {}
+        raw_keymap = cast(dict[object, object], value)
+        for key, item in raw_keymap.items():
+            if not isinstance(key, str):
+                raise ValueError("runtime config field 'tui.keymap' keys must be strings")
+            if not isinstance(item, str):
+                raise ValueError("runtime config field 'tui.keymap' values must be strings")
+            if item not in _VALID_TUI_COMMANDS:
+                allowed = ", ".join(_VALID_TUI_COMMANDS)
+                raise ValueError(
+                    f"runtime config field 'tui.keymap' values must be one of: {allowed}"
+                )
+            parsed_keymap[key] = item
+
+        return parsed_keymap
+
+    def to_runtime_config(self) -> RuntimeTuiConfig:
+        return RuntimeTuiConfig(leader_key=self.leader_key, keymap=self.keymap)
+
+
+class _RuntimeConfigOutput(Protocol):
+    def to_runtime_config(self) -> object: ...
+
+
+def _validate_runtime_config_model[T: BaseModel](
+    model_type: type[T], raw_value: dict[str, object], *, context: dict[str, object] | None = None
+) -> T:
+    try:
+        return model_type.model_validate(raw_value, context=context)
+    except ValidationError as exc:
+        raise ValueError(_format_settings_validation_error(exc)) from exc
+
+
 def _parse_tools_config(raw_tools: object) -> RuntimeToolsConfig | None:
     if raw_tools is None:
         return None
@@ -294,22 +598,11 @@ def _parse_tools_config(raw_tools: object) -> RuntimeToolsConfig | None:
         raise ValueError("runtime config field 'tools' must be an object when provided")
 
     tools_payload = cast(dict[str, object], raw_tools)
-    builtin = _parse_tools_builtin_config(tools_payload.get("builtin"))
-    paths = _parse_string_list(tools_payload.get("paths"), field_path="tools.paths")
-    return RuntimeToolsConfig(builtin=builtin, paths=paths)
-
-
-def _parse_tools_builtin_config(raw_builtin: object) -> RuntimeToolsBuiltinConfig | None:
-    if raw_builtin is None:
-        return None
-    if not isinstance(raw_builtin, dict):
-        raise ValueError("runtime config field 'tools.builtin' must be an object when provided")
-
-    builtin_payload = cast(dict[str, object], raw_builtin)
-    enabled = _parse_optional_bool(
-        builtin_payload.get("enabled"), field_path="tools.builtin.enabled"
+    return _parse_runtime_config_section(
+        tools_payload,
+        field_path="tools",
+        model_type=_RuntimeToolsValidationModel,
     )
-    return RuntimeToolsBuiltinConfig(enabled=enabled)
 
 
 def _parse_skills_config(raw_skills: object) -> RuntimeSkillsConfig | None:
@@ -319,9 +612,11 @@ def _parse_skills_config(raw_skills: object) -> RuntimeSkillsConfig | None:
         raise ValueError("runtime config field 'skills' must be an object when provided")
 
     skills_payload = cast(dict[str, object], raw_skills)
-    enabled = _parse_optional_bool(skills_payload.get("enabled"), field_path="skills.enabled")
-    paths = _parse_string_list(skills_payload.get("paths"), field_path="skills.paths")
-    return RuntimeSkillsConfig(enabled=enabled, paths=paths)
+    return _parse_runtime_config_section(
+        skills_payload,
+        field_path="skills",
+        model_type=_RuntimeSkillsValidationModel,
+    )
 
 
 def _parse_lsp_config(raw_lsp: object) -> RuntimeLspConfig | None:
@@ -416,8 +711,11 @@ def _parse_acp_config(raw_acp: object) -> RuntimeAcpConfig | None:
         raise ValueError("runtime config field 'acp' must be an object when provided")
 
     acp_payload = cast(dict[str, object], raw_acp)
-    enabled = _parse_optional_bool(acp_payload.get("enabled"), field_path="acp.enabled")
-    return RuntimeAcpConfig(enabled=enabled)
+    return _parse_runtime_config_section(
+        acp_payload,
+        field_path="acp",
+        model_type=_RuntimeAcpValidationModel,
+    )
 
 
 def _parse_mcp_config(raw_mcp: object) -> RuntimeMcpConfig | None:
@@ -427,55 +725,11 @@ def _parse_mcp_config(raw_mcp: object) -> RuntimeMcpConfig | None:
         raise ValueError("runtime config field 'mcp' must be an object when provided")
 
     mcp_payload = cast(dict[str, object], raw_mcp)
-    enabled = _parse_optional_bool(mcp_payload.get("enabled"), field_path="mcp.enabled")
-    servers = _parse_mcp_servers_config(mcp_payload.get("servers"), field_path="mcp.servers")
-    return RuntimeMcpConfig(enabled=enabled, servers=servers)
-
-
-def _parse_mcp_servers_config(
-    raw_value: object, *, field_path: str
-) -> dict[str, RuntimeMcpServerConfig] | None:
-    if raw_value is None:
-        return None
-    if not isinstance(raw_value, dict):
-        raise ValueError(f"runtime config field '{field_path}' must be an object when provided")
-
-    raw_servers = cast(dict[str, object], raw_value)
-    parsed_servers: dict[str, RuntimeMcpServerConfig] = {}
-    for server_name, raw_server in raw_servers.items():
-        parsed_servers[server_name] = _parse_mcp_server_config(
-            raw_server,
-            field_path=f"{field_path}.{server_name}",
-        )
-    return parsed_servers
-
-
-def _parse_mcp_server_config(raw_value: object, *, field_path: str) -> RuntimeMcpServerConfig:
-    if not isinstance(raw_value, dict):
-        raise ValueError(f"runtime config field '{field_path}' must be an object")
-
-    server_payload = cast(dict[str, object], raw_value)
-    transport = server_payload.get("transport", "stdio")
-    if transport != "stdio":
-        raise ValueError(f"runtime config field '{field_path}.transport' must be one of: stdio")
-    command = _parse_string_list(server_payload.get("command"), field_path=f"{field_path}.command")
-    if not command:
-        raise ValueError(
-            f"runtime config field '{field_path}.command' must contain at least one string"
-        )
-
-    raw_env = server_payload.get("env")
-    env: dict[str, str] = {}
-    if raw_env is not None:
-        if not isinstance(raw_env, dict):
-            raise ValueError(f"runtime config field '{field_path}.env' must be an object")
-        env_payload = cast(dict[str, object], raw_env)
-        for key, value in env_payload.items():
-            if not isinstance(value, str):
-                raise ValueError(f"runtime config field '{field_path}.env.{key}' must be a string")
-            env[key] = value
-
-    return RuntimeMcpServerConfig(transport="stdio", command=command, env=env)
+    return _parse_runtime_config_section(
+        mcp_payload,
+        field_path="mcp",
+        model_type=_RuntimeMcpValidationModel,
+    )
 
 
 def _parse_tui_config(raw_tui: object) -> RuntimeTuiConfig | None:
@@ -485,29 +739,28 @@ def _parse_tui_config(raw_tui: object) -> RuntimeTuiConfig | None:
         raise ValueError("runtime config field 'tui' must be an object when provided")
 
     tui_payload = cast(dict[str, object], raw_tui)
-    leader_key = tui_payload.get("leader_key")
-    if leader_key is not None and not isinstance(leader_key, str):
-        raise ValueError("runtime config field 'tui.leader_key' must be a string when provided")
+    return _parse_runtime_config_section(
+        tui_payload,
+        field_path="tui",
+        model_type=_RuntimeTuiValidationModel,
+    )
 
-    keymap: Mapping[str, str] | None = None
-    raw_keymap = tui_payload.get("keymap")
-    if raw_keymap is not None:
-        if not isinstance(raw_keymap, dict):
-            raise ValueError("runtime config field 'tui.keymap' must be an object when provided")
-        dict_keymap = cast(dict[str, object], raw_keymap)
-        for value in dict_keymap.values():
-            if not isinstance(value, str):
-                raise ValueError("runtime config field 'tui.keymap' values must be strings")
-            if value not in _VALID_TUI_COMMANDS:
-                allowed = ", ".join(_VALID_TUI_COMMANDS)
-                raise ValueError(
-                    f"runtime config field 'tui.keymap' values must be one of: {allowed}"
-                )
-        keymap = cast(dict[str, str], raw_keymap)
 
-    return RuntimeTuiConfig(
-        leader_key=leader_key if leader_key is not None else "alt+x",
-        keymap=keymap,
+def _parse_runtime_config_section[TConfig, TModel: BaseModel](
+    raw_value: object,
+    *,
+    field_path: str,
+    model_type: type[TModel],
+) -> TConfig | None:
+    if raw_value is None:
+        return None
+    if not isinstance(raw_value, dict):
+        raise ValueError(f"runtime config field '{field_path}' must be an object when provided")
+
+    validated_model = _validate_runtime_config_model(model_type, cast(dict[str, object], raw_value))
+    return cast(
+        TConfig,
+        cast(_RuntimeConfigOutput, validated_model).to_runtime_config(),
     )
 
 
@@ -592,6 +845,57 @@ def _parse_command_list(raw_value: object, *, field_path: str) -> tuple[tuple[st
     return tuple(parsed_commands)
 
 
+def _load_environment_runtime_config(env: Mapping[str, str] | None) -> RuntimeConfigOverrides:
+    try:
+        with _temporary_runtime_environment(env):
+            settings = _EnvironmentRuntimeSettings()
+    except ValidationError as exc:
+        raise ValueError(_format_settings_validation_error(exc)) from exc
+
+    return RuntimeConfigOverrides(
+        approval_mode=settings.approval_mode,
+        model=settings.model,
+        execution_engine=settings.execution_engine,
+        max_steps=settings.max_steps,
+    )
+
+
+@contextmanager
+def _temporary_runtime_environment(env: Mapping[str, str] | None):
+    if env is None:
+        yield
+        return
+
+    with _ENV_SETTINGS_LOCK:
+        previous_values = {name: os.environ.get(name) for name in _TOP_LEVEL_ENV_VARS}
+        try:
+            for name in _TOP_LEVEL_ENV_VARS:
+                if name in env:
+                    os.environ[name] = env[name]
+                else:
+                    os.environ.pop(name, None)
+            yield
+        finally:
+            for name, previous_value in previous_values.items():
+                if previous_value is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = previous_value
+
+
+def _format_settings_validation_error(exc: ValidationError) -> str:
+    messages: list[str] = []
+    for error in exc.errors():
+        context = error.get("ctx")
+        if isinstance(context, dict):
+            original_error = context.get("error")
+            if isinstance(original_error, ValueError):
+                messages.append(str(original_error))
+                continue
+        messages.append(error["msg"])
+    return "; ".join(messages)
+
+
 def _resolve_approval_mode(
     *,
     explicit: PermissionDecision | None,
@@ -626,15 +930,30 @@ def _resolve_model(
     return None
 
 
-def _resolve_execution_engine(*, repo_local: ExecutionEngineName | None) -> ExecutionEngineName:
+def _resolve_execution_engine(
+    *,
+    explicit: ExecutionEngineName | None,
+    repo_local: ExecutionEngineName | None,
+    environment: ExecutionEngineName | None,
+) -> ExecutionEngineName:
+    if explicit is not None:
+        return explicit
     if repo_local is not None:
         return repo_local
+    if environment is not None:
+        return environment
     return "deterministic"
 
 
-def _resolve_max_steps(*, repo_local: int | None) -> int:
+def _resolve_max_steps(
+    *, explicit: int | None, repo_local: int | None, environment: int | None
+) -> int:
+    if explicit is not None:
+        return explicit
     if repo_local is not None:
         return repo_local
+    if environment is not None:
+        return environment
     return RuntimeConfig().max_steps
 
 
@@ -672,3 +991,22 @@ def _parse_max_steps(raw_value: object, *, source: str, allow_none: bool) -> int
     if not isinstance(raw_value, int) or isinstance(raw_value, bool) or raw_value < 1:
         raise ValueError(f"{source} must be an integer greater than or equal to 1")
     return raw_value
+
+
+def _parse_environment_max_steps(raw_value: object) -> int | None:
+    if raw_value is None:
+        return None
+    parsed_value = raw_value
+    if isinstance(raw_value, str):
+        try:
+            parsed_value = int(raw_value)
+        except ValueError as exc:
+            raise ValueError(
+                "environment variable "
+                f"{MAX_STEPS_ENV_VAR} must be an integer greater than or equal to 1"
+            ) from exc
+    return _parse_max_steps(
+        parsed_value,
+        source=f"environment variable {MAX_STEPS_ENV_VAR}",
+        allow_none=True,
+    )

--- a/src/voidcode/tools/_pydantic_args.py
+++ b/src/voidcode/tools/_pydantic_args.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, field_validator
+
+
+class ReadFileArgs(BaseModel):
+    path: str
+
+
+class WriteFileArgs(BaseModel):
+    path: str
+    content: str
+
+
+class GrepArgs(BaseModel):
+    pattern: str
+    path: str
+
+    @field_validator("pattern", mode="after")
+    @classmethod
+    def _validate_pattern(cls, value: str) -> str:
+        if value == "":
+            raise ValueError("pattern must not be empty")
+        return value
+
+
+class WebSearchArgs(BaseModel):
+    query: str
+
+    @field_validator("query", mode="after")
+    @classmethod
+    def _validate_query(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("query must not be empty")
+        return value
+
+
+class ShellExecArgs(BaseModel):
+    command: str
+
+    @field_validator("command", mode="after")
+    @classmethod
+    def _validate_command(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("command must not be empty")
+        return value
+
+
+class MultiEditItemArgs(BaseModel):
+    oldString: str
+    newString: str
+    replaceAll: bool = False
+
+
+class MultiEditArgs(BaseModel):
+    path: str
+    edits: list[MultiEditItemArgs]
+
+    @field_validator("path", mode="after")
+    @classmethod
+    def _validate_path(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("path must be a non-empty string")
+        return value
+
+    @field_validator("edits", mode="after")
+    @classmethod
+    def _validate_edits(cls, value: list[MultiEditItemArgs]) -> list[MultiEditItemArgs]:
+        if not value:
+            raise ValueError("edits must not be empty")
+        return value

--- a/src/voidcode/tools/apply_patch.py
+++ b/src/voidcode/tools/apply_patch.py
@@ -4,6 +4,9 @@ import subprocess
 from pathlib import Path
 from typing import ClassVar
 
+from unidiff import PatchSet
+from unidiff.errors import UnidiffParseError
+
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 
@@ -172,7 +175,55 @@ def _looks_like_mode_only_patch(patch_text: str) -> bool:
     return bool(blocks) and all(blocks)
 
 
-def _changes_from_patch(patch_text: str) -> list[dict[str, object]]:
+def _dedupe_changes(changes: list[dict[str, object]]) -> list[dict[str, object]]:
+    deduped: list[dict[str, object]] = []
+    seen: set[tuple[object, ...]] = set()
+    for change in changes:
+        key = (change.get("status"), change.get("old_path"), change.get("path"))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(change)
+    return deduped
+
+
+def _changes_from_unified_diff(patch_text: str) -> list[dict[str, object]]:
+    try:
+        patch_set = PatchSet(patch_text)
+    except (UnidiffParseError, ValueError):
+        return []
+
+    changes: list[dict[str, object]] = []
+    for patched_file in patch_set:
+        old_path = (
+            None
+            if patched_file.source_file == "/dev/null"
+            else _strip_diff_prefix(patched_file.source_file)
+        )
+        new_path = (
+            None
+            if patched_file.target_file == "/dev/null"
+            else _strip_diff_prefix(patched_file.target_file)
+        )
+
+        if old_path is not None and '"' in old_path:
+            old_path = None
+        if new_path is not None and '"' in new_path:
+            new_path = None
+
+        if old_path is None and new_path is not None:
+            changes.append({"path": new_path, "status": "A"})
+        elif old_path is not None and new_path is None:
+            changes.append({"path": old_path, "status": "D"})
+        elif old_path is not None and new_path is not None and old_path != new_path:
+            changes.append({"path": new_path, "old_path": old_path, "status": "R"})
+        elif new_path is not None:
+            changes.append({"path": new_path, "status": "M"})
+
+    return changes
+
+
+def _changes_from_patch_metadata(patch_text: str) -> list[dict[str, object]]:
     changes: list[dict[str, object]] = []
     block_old_path: str | None = None
     block_new_path: str | None = None
@@ -226,15 +277,13 @@ def _changes_from_patch(patch_text: str) -> list[dict[str, object]]:
 
     flush_block()
 
-    deduped: list[dict[str, object]] = []
-    seen: set[tuple[object, ...]] = set()
-    for change in changes:
-        key = (change.get("status"), change.get("old_path"), change.get("path"))
-        if key in seen:
-            continue
-        seen.add(key)
-        deduped.append(change)
-    return deduped
+    return changes
+
+
+def _changes_from_patch(patch_text: str) -> list[dict[str, object]]:
+    changes = _changes_from_unified_diff(_normalize_patch_text(patch_text))
+    changes.extend(_changes_from_patch_metadata(patch_text))
+    return _dedupe_changes(changes)
 
 
 class ApplyPatchTool:

--- a/src/voidcode/tools/edit.py
+++ b/src/voidcode/tools/edit.py
@@ -5,6 +5,8 @@ import re
 from pathlib import Path
 from typing import ClassVar
 
+from rapidfuzz.distance import Levenshtein
+
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 
@@ -116,8 +118,21 @@ class BlockAnchorReplacer:
     _MAX_LINES_SCAN = 2000
 
     @staticmethod
+    def _similar(a: str, b: str) -> bool:
+        if abs(len(a) - len(b)) > max(1, max(len(a), len(b)) // 4):
+            return False
+
+        if len(a) > BlockAnchorReplacer._MAX_ANCHOR_LENGTH:
+            a = a[: BlockAnchorReplacer._MAX_ANCHOR_LENGTH]
+        if len(b) > BlockAnchorReplacer._MAX_ANCHOR_LENGTH:
+            b = b[: BlockAnchorReplacer._MAX_ANCHOR_LENGTH]
+
+        max_distance = max(1, max(len(a), len(b)) // 4)
+        distance = Levenshtein.distance(a, b, score_cutoff=max_distance)
+        return distance <= max_distance
+
+    @staticmethod
     def find(content: str, old: str) -> list[str]:
-        # Enhanced: use anchors with simple Levenshtein similarity
         results: list[str] = []
         original_lines = content.split("\n")
         search_lines = old.split("\n")
@@ -130,49 +145,15 @@ class BlockAnchorReplacer:
         first_anchor = search_lines[0].strip()
         last_anchor = search_lines[-1].strip()
 
-        # simple Levenshtein distance implementation (bounded)
-        def _lev(a: str, b: str) -> int:
-            if abs(len(a) - len(b)) > max(1, max(len(a), len(b)) // 4):
-                return max(len(a), len(b))
-
-            if len(a) > BlockAnchorReplacer._MAX_ANCHOR_LENGTH:
-                a = a[: BlockAnchorReplacer._MAX_ANCHOR_LENGTH]
-            if len(b) > BlockAnchorReplacer._MAX_ANCHOR_LENGTH:
-                b = b[: BlockAnchorReplacer._MAX_ANCHOR_LENGTH]
-
-            m, n = len(a), len(b)
-            dp = [[0] * (n + 1) for _ in range(m + 1)]
-            for x in range(m + 1):
-                dp[x][0] = x
-            for y in range(n + 1):
-                dp[0][y] = y
-            for i in range(1, m + 1):
-                for j in range(1, n + 1):
-                    cost = 0 if a[i - 1] == b[j - 1] else 1
-                    dp[i][j] = min(
-                        dp[i - 1][j] + 1,  # delete
-                        dp[i][j - 1] + 1,  # insert
-                        dp[i - 1][j - 1] + cost,  # substitute
-                    )
-            return dp[m][n]
-
-        # Thresholds: allow small differences based on length
-        def similar(x: str, y: str) -> bool:
-            d = _lev(x, y)
-            max_len = max(len(x), len(y))
-            if max_len == 0:
-                return True
-            return d <= max(1, max_len // 4)
-
         # Try to locate blocks bounded by anchors with similarity tolerance
         max_scan = min(len(original_lines), BlockAnchorReplacer._MAX_LINES_SCAN)
         for i in range(max_scan):
-            if not similar(original_lines[i].strip(), first_anchor):
+            if not BlockAnchorReplacer._similar(original_lines[i].strip(), first_anchor):
                 continue
             # search a corresponding end line with similarity to last_anchor
             upper = min(len(original_lines), i + BlockAnchorReplacer._MAX_LINES_SCAN)
             for j in range(i + 2, upper):
-                if similar(original_lines[j].strip(), last_anchor):
+                if BlockAnchorReplacer._similar(original_lines[j].strip(), last_anchor):
                     # extract the block from i to j inclusive
                     block = "\n".join(original_lines[i : j + 1])
                     results.append(block)

--- a/src/voidcode/tools/grep.py
+++ b/src/voidcode/tools/grep.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import ClassVar, final
 
+from pydantic import ValidationError
+
+from ._pydantic_args import GrepArgs
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 
@@ -18,18 +21,23 @@ class GrepTool:
     )
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
-        pattern_value = call.arguments.get("pattern")
-        if not isinstance(pattern_value, str):
-            raise ValueError("grep requires a string pattern argument")
+        try:
+            args = GrepArgs.model_validate(
+                {
+                    "pattern": call.arguments.get("pattern"),
+                    "path": call.arguments.get("path"),
+                }
+            )
+        except ValidationError as exc:
+            first_error = exc.errors()[0]
+            field_name = first_error.get("loc", (None,))[0]
+            if field_name == "path":
+                raise ValueError("grep requires a string path argument") from exc
+            if first_error.get("type") == "value_error":
+                raise ValueError("grep pattern must not be empty") from exc
+            raise ValueError("grep requires a string pattern argument") from exc
 
-        path_value = call.arguments.get("path")
-        if not isinstance(path_value, str):
-            raise ValueError("grep requires a string path argument")
-
-        if pattern_value == "":
-            raise ValueError("grep pattern must not be empty")
-
-        relative_path = Path(path_value)
+        relative_path = Path(args.path)
         workspace_root = workspace.resolve()
         candidate = (workspace_root / relative_path).resolve()
 
@@ -37,7 +45,7 @@ class GrepTool:
             raise ValueError("grep only allows paths inside the workspace")
 
         if not candidate.is_file():
-            raise ValueError(f"grep target does not exist: {path_value}")
+            raise ValueError(f"grep target does not exist: {args.path}")
 
         try:
             content = candidate.read_text(encoding="utf-8")
@@ -55,12 +63,12 @@ class GrepTool:
             start_index = 0
 
             while True:
-                found_index = line_text.find(pattern_value, start_index)
+                found_index = line_text.find(args.pattern, start_index)
                 if found_index < 0:
                     break
                 columns.append(found_index + 1)
                 total_occurrences += 1
-                start_index = found_index + len(pattern_value)
+                start_index = found_index + len(args.pattern)
 
             if columns:
                 matches.append(
@@ -75,11 +83,11 @@ class GrepTool:
         if matches:
             preview_lines = [f"{match['line']}: {match['text']}" for match in matches[:10]]
             summary = (
-                f"Found {total_occurrences} match(es) for {pattern_value!r} in "
+                f"Found {total_occurrences} match(es) for {args.pattern!r} in "
                 f"{relative_result_path}\n" + "\n".join(preview_lines)
             )
         else:
-            summary = f"Found 0 match(es) for {pattern_value!r} in {relative_result_path}"
+            summary = f"Found 0 match(es) for {args.pattern!r} in {relative_result_path}"
 
         return ToolResult(
             tool_name=self.definition.name,
@@ -87,7 +95,7 @@ class GrepTool:
             content=summary,
             data={
                 "path": relative_result_path,
-                "pattern": pattern_value,
+                "pattern": args.pattern,
                 "match_count": total_occurrences,
                 "matches": matches,
             },

--- a/src/voidcode/tools/multi_edit.py
+++ b/src/voidcode/tools/multi_edit.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, ClassVar, cast
+from typing import ClassVar
 
+from pydantic import ValidationError
+
+from ._pydantic_args import MultiEditArgs
 from .contracts import ToolCall, ToolDefinition, ToolResult
 from .edit import EditTool
 
@@ -22,57 +25,63 @@ class MultiEditTool:
     )
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
-        path_value = call.arguments.get("path")
-        if path_value is None:
-            path_value = call.arguments.get("filePath")
-        if not isinstance(path_value, str) or not path_value.strip():
-            raise ValueError("multi_edit requires a string path argument")
+        raw_path_value = call.arguments.get("path")
+        if raw_path_value is None:
+            raw_path_value = call.arguments.get("filePath")
+
+        try:
+            args = MultiEditArgs.model_validate(
+                {
+                    "path": raw_path_value,
+                    "edits": call.arguments.get("edits", []),
+                }
+            )
+        except ValidationError as exc:
+            first_error = exc.errors()[0]
+            location = first_error.get("loc", ())
+            field_name = location[0] if location else None
+
+            if field_name == "path":
+                raise ValueError("multi_edit requires a string path argument") from exc
+            if field_name == "edits" and first_error.get("type") == "value_error":
+                raise ValueError("multi_edit requires at least one edit entry") from exc
+            if field_name == "edits" and len(location) == 1:
+                raise ValueError("multi_edit requires an array edits argument") from exc
+            if len(location) >= 2 and location[0] == "edits" and len(location) == 2:
+                idx = int(location[1]) + 1
+                raise ValueError(f"multi_edit edit #{idx} must be an object") from exc
+            if len(location) >= 3 and location[0] == "edits":
+                idx = int(location[1]) + 1
+                item_field = location[2]
+                if item_field == "oldString":
+                    raise ValueError(f"multi_edit edit #{idx} requires string oldString") from exc
+                if item_field == "newString":
+                    raise ValueError(f"multi_edit edit #{idx} requires string newString") from exc
+                if item_field == "replaceAll":
+                    raise ValueError(f"multi_edit edit #{idx} replaceAll must be boolean") from exc
+            raise ValueError("multi_edit requires an array edits argument") from exc
 
         workspace_root = workspace.resolve()
-        target = (workspace_root / Path(path_value)).resolve()
+        target = (workspace_root / Path(args.path)).resolve()
         if not target.is_relative_to(workspace_root):
             raise ValueError("multi_edit only allows paths inside the workspace")
         if not target.exists() or not target.is_file():
-            raise ValueError(f"multi_edit target does not exist: {path_value}")
+            raise ValueError(f"multi_edit target does not exist: {args.path}")
 
         relative_target = target.relative_to(workspace_root).as_posix()
-        edits_value = call.arguments.get("edits", [])
-        edits: list[object] = []
-        if isinstance(edits_value, list):
-            edits = cast(list[object], edits_value)
-        else:
-            raise ValueError("multi_edit requires an array edits argument")
-
-        if not edits:
-            raise ValueError("multi_edit requires at least one edit entry")
 
         edit_tool = EditTool()
         applied = 0
         details: list[dict[str, object]] = []
-        for idx, item in enumerate(edits, start=1):
-            if not isinstance(item, dict):
-                raise ValueError(f"multi_edit edit #{idx} must be an object")
-            item_dict = cast(dict[str, Any], item)
-
-            old_string = item_dict.get("oldString")
-            new_string = item_dict.get("newString")
-            replace_all = item_dict.get("replaceAll", False)
-
-            if not isinstance(old_string, str):
-                raise ValueError(f"multi_edit edit #{idx} requires string oldString")
-            if not isinstance(new_string, str):
-                raise ValueError(f"multi_edit edit #{idx} requires string newString")
-            if not isinstance(replace_all, bool):
-                raise ValueError(f"multi_edit edit #{idx} replaceAll must be boolean")
-
+        for idx, item in enumerate(args.edits, start=1):
             result = edit_tool.invoke(
                 ToolCall(
                     tool_name="edit",
                     arguments={
                         "path": relative_target,
-                        "oldString": old_string,
-                        "newString": new_string,
-                        "replaceAll": replace_all,
+                        "oldString": item.oldString,
+                        "newString": item.newString,
+                        "replaceAll": item.replaceAll,
                     },
                 ),
                 workspace=workspace,

--- a/src/voidcode/tools/read_file.py
+++ b/src/voidcode/tools/read_file.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import ClassVar, final
 
+from pydantic import ValidationError
+
+from ._pydantic_args import ReadFileArgs
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 
@@ -20,11 +23,12 @@ class ReadFileTool:
     )
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
-        path_value = call.arguments.get("path")
-        if not isinstance(path_value, str):
-            raise ValueError("read_file requires a string path argument")
+        try:
+            args = ReadFileArgs.model_validate({"path": call.arguments.get("path")})
+        except ValidationError as exc:
+            raise ValueError("read_file requires a string path argument") from exc
 
-        relative_path = Path(path_value)
+        relative_path = Path(args.path)
         workspace_root = workspace.resolve()
         candidate = (workspace_root / relative_path).resolve()
 
@@ -32,7 +36,7 @@ class ReadFileTool:
             raise ValueError("read_file only allows paths inside the workspace")
 
         if not candidate.is_file():
-            raise ValueError(f"read_file target does not exist: {path_value}")
+            raise ValueError(f"read_file target does not exist: {args.path}")
 
         content = candidate.read_text(encoding="utf-8")
         return ToolResult(

--- a/src/voidcode/tools/shell_exec.py
+++ b/src/voidcode/tools/shell_exec.py
@@ -5,6 +5,9 @@ import subprocess
 from pathlib import Path
 from typing import ClassVar, final
 
+from pydantic import ValidationError
+
+from ._pydantic_args import ShellExecArgs
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 DEFAULT_TIMEOUT_SECONDS = 30
@@ -34,13 +37,15 @@ class ShellExecTool:
     )
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
-        command_value = call.arguments.get("command")
-        if not isinstance(command_value, str):
-            raise ValueError("shell_exec requires a string command argument")
+        try:
+            args = ShellExecArgs.model_validate({"command": call.arguments.get("command")})
+        except ValidationError as exc:
+            first_error = exc.errors()[0]
+            if first_error.get("type") == "value_error":
+                raise ValueError("shell_exec command must not be empty") from exc
+            raise ValueError("shell_exec requires a string command argument") from exc
 
-        command_text = command_value.strip()
-        if not command_text:
-            raise ValueError("shell_exec command must not be empty")
+        command_text = args.command.strip()
 
         command_parts = shlex.split(command_text, posix=True)
         if not command_parts:

--- a/src/voidcode/tools/todo_write.py
+++ b/src/voidcode/tools/todo_write.py
@@ -2,9 +2,62 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, ClassVar, cast
+from typing import ClassVar, Literal, cast
+
+from pydantic import BaseModel, ValidationError, field_validator
 
 from .contracts import ToolCall, ToolDefinition, ToolResult
+
+
+class _TodoItemModel(BaseModel):
+    content: str
+    status: Literal["pending", "in_progress", "completed", "cancelled"]
+    priority: Literal["high", "medium", "low"]
+
+    @field_validator("content", mode="after")
+    @classmethod
+    def _validate_content(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("content must be non-empty string")
+        return stripped
+
+
+def _parse_todo_item(item: object, *, idx: int) -> dict[str, str]:
+    try:
+        parsed = _TodoItemModel.model_validate(item)
+    except ValidationError as exc:
+        first_error = exc.errors()[0]
+        location = first_error.get("loc", ())
+        field_name = location[0] if location else None
+
+        if field_name is None:
+            raise ValueError(f"todo_write item #{idx} must be an object") from exc
+
+        item_payload: dict[str, object]
+        if isinstance(item, dict):
+            item_payload = cast(dict[str, object], item)
+        else:
+            item_payload = {}
+
+        if field_name == "content":
+            raise ValueError(f"todo_write item #{idx} content must be non-empty string") from exc
+        if field_name == "status":
+            raise ValueError(
+                f"todo_write item #{idx} invalid status: {item_payload.get('status')}"
+            ) from exc
+        if field_name == "priority":
+            raise ValueError(
+                f"todo_write item #{idx} invalid priority: {item_payload.get('priority')}"
+            ) from exc
+
+        raise ValueError(f"todo_write item #{idx} must be an object") from exc
+
+    return {
+        "content": parsed.content,
+        "status": parsed.status,
+        "priority": parsed.priority,
+    }
 
 
 class TodoWriteTool:
@@ -19,33 +72,13 @@ class TodoWriteTool:
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
         todos_value = call.arguments.get("todos", [])
-        todos: list[object] = []
-        if isinstance(todos_value, list):
-            todos = cast(list[object], todos_value)
-        else:
+        if not isinstance(todos_value, list):
             raise ValueError("todo_write requires todos array")
-
-        allowed_status = {"pending", "in_progress", "completed", "cancelled"}
-        allowed_priority = {"high", "medium", "low"}
+        todos = cast(list[object], todos_value)
 
         normalized: list[dict[str, str]] = []
         for idx, item in enumerate(todos, start=1):
-            if not isinstance(item, dict):
-                raise ValueError(f"todo_write item #{idx} must be an object")
-            item_dict = cast(dict[str, Any], item)
-
-            content = item_dict.get("content")
-            status = item_dict.get("status")
-            priority = item_dict.get("priority")
-
-            if not isinstance(content, str) or not content.strip():
-                raise ValueError(f"todo_write item #{idx} content must be non-empty string")
-            if not isinstance(status, str) or status not in allowed_status:
-                raise ValueError(f"todo_write item #{idx} invalid status: {status}")
-            if not isinstance(priority, str) or priority not in allowed_priority:
-                raise ValueError(f"todo_write item #{idx} invalid priority: {priority}")
-
-            normalized.append({"content": content.strip(), "status": status, "priority": priority})
+            normalized.append(_parse_todo_item(item, idx=idx))
 
         store_dir = workspace / ".voidcode"
         store_dir.mkdir(parents=True, exist_ok=True)

--- a/src/voidcode/tools/web_search.py
+++ b/src/voidcode/tools/web_search.py
@@ -6,7 +6,9 @@ from pathlib import Path
 from typing import ClassVar
 
 import httpx
+from pydantic import ValidationError
 
+from ._pydantic_args import WebSearchArgs
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 DEFAULT_NUM_RESULTS = 8
@@ -125,12 +127,13 @@ class WebSearchTool:
     )
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
-        query_value = call.arguments.get("query")
-        if not isinstance(query_value, str):
-            raise ValueError("web_search requires a string query argument")
-
-        if not query_value.strip():
-            raise ValueError("web_search query must not be empty")
+        try:
+            args = WebSearchArgs.model_validate({"query": call.arguments.get("query")})
+        except ValidationError as exc:
+            first_error = exc.errors()[0]
+            if first_error.get("type") == "value_error":
+                raise ValueError("web_search query must not be empty") from exc
+            raise ValueError("web_search requires a string query argument") from exc
 
         num_results = call.arguments.get("numResults", DEFAULT_NUM_RESULTS)
         if isinstance(num_results, (int, float)) and num_results > 0:
@@ -138,13 +141,13 @@ class WebSearchTool:
         else:
             num_results = DEFAULT_NUM_RESULTS
 
-        exa_results = _search_exa(query_value, num_results)
+        exa_results = _search_exa(args.query, num_results)
 
         if exa_results:
             output = exa_results
             source = "exa"
         else:
-            output = _search_fallback(query_value, num_results)
+            output = _search_fallback(args.query, num_results)
             source = "duckduckgo"
 
         return ToolResult(
@@ -152,7 +155,7 @@ class WebSearchTool:
             status="ok",
             content=output,
             data={
-                "query": query_value,
+                "query": args.query,
                 "num_results": num_results,
                 "source": source,
             },

--- a/src/voidcode/tools/write_file.py
+++ b/src/voidcode/tools/write_file.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import ClassVar, final
 
+from pydantic import ValidationError
+
+from ._pydantic_args import WriteFileArgs
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 
@@ -16,15 +19,21 @@ class WriteFileTool:
     )
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
-        path_value = call.arguments.get("path")
-        if not isinstance(path_value, str):
-            raise ValueError("write_file requires a string path argument")
+        try:
+            args = WriteFileArgs.model_validate(
+                {
+                    "path": call.arguments.get("path"),
+                    "content": call.arguments.get("content"),
+                }
+            )
+        except ValidationError as exc:
+            first_error = exc.errors()[0]
+            field_name = first_error.get("loc", (None,))[0]
+            if field_name == "content":
+                raise ValueError("write_file requires a string content argument") from exc
+            raise ValueError("write_file requires a string path argument") from exc
 
-        content_value = call.arguments.get("content")
-        if not isinstance(content_value, str):
-            raise ValueError("write_file requires a string content argument")
-
-        relative_path = Path(path_value)
+        relative_path = Path(args.path)
         workspace_root = workspace.resolve()
         candidate = (workspace_root / relative_path).resolve()
 
@@ -32,14 +41,14 @@ class WriteFileTool:
             raise ValueError("write_file only allows paths inside the workspace")
 
         candidate.parent.mkdir(parents=True, exist_ok=True)
-        candidate.write_text(content_value, encoding="utf-8")
+        candidate.write_text(args.content, encoding="utf-8")
 
         return ToolResult(
             tool_name=self.definition.name,
             status="ok",
-            content=content_value,
+            content=args.content,
             data={
                 "path": candidate.relative_to(workspace_root).as_posix(),
-                "byte_count": len(content_value.encode("utf-8")),
+                "byte_count": len(args.content.encode("utf-8")),
             },
         )

--- a/tests/unit/runtime/test_mcp_config.py
+++ b/tests/unit/runtime/test_mcp_config.py
@@ -5,7 +5,10 @@ from pathlib import Path
 
 import pytest
 
+from voidcode.runtime import config as runtime_config
 from voidcode.runtime.config import RuntimeMcpConfig, RuntimeMcpServerConfig, load_runtime_config
+
+_parse_mcp_config = runtime_config.__dict__["_parse_mcp_config"]
 
 
 def test_runtime_config_parses_mcp_stdio_servers(tmp_path: Path) -> None:
@@ -82,3 +85,62 @@ def test_runtime_config_rejects_missing_mcp_command(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="mcp.servers.echo.command"):
         load_runtime_config(tmp_path, env={})
+
+
+def test_parse_mcp_config_defaults_transport_and_preserves_public_dataclasses() -> None:
+    assert _parse_mcp_config(
+        {
+            "enabled": False,
+            "servers": {
+                "echo": {
+                    "command": ["python", "tests/fixtures/echo_mcp.py"],
+                    "env": {"ECHO_MODE": "1"},
+                }
+            },
+        }
+    ) == RuntimeMcpConfig(
+        enabled=False,
+        servers={
+            "echo": RuntimeMcpServerConfig(
+                transport="stdio",
+                command=("python", "tests/fixtures/echo_mcp.py"),
+                env={"ECHO_MODE": "1"},
+            )
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "match"),
+    [
+        pytest.param([], "runtime config field 'mcp'", id="mcp-shape"),
+        pytest.param({"enabled": "yes"}, "runtime config field 'mcp.enabled'", id="enabled-type"),
+        pytest.param({"servers": []}, "runtime config field 'mcp.servers'", id="servers-shape"),
+        pytest.param(
+            {"servers": {"echo": []}}, "runtime config field 'mcp.servers.echo'", id="server-shape"
+        ),
+        pytest.param(
+            {"servers": {"echo": {"command": [False]}}},
+            "runtime config field 'mcp.servers.echo.command\\[0\\]'",
+            id="command-item-type",
+        ),
+        pytest.param(
+            {"servers": {"echo": {"command": ["python"], "env": []}}},
+            "runtime config field 'mcp.servers.echo.env'",
+            id="env-shape",
+        ),
+        pytest.param(
+            {"servers": {"echo": {"command": ["python"], "env": {"ECHO_MODE": False}}}},
+            "runtime config field 'mcp.servers.echo.env.ECHO_MODE'",
+            id="env-item-type",
+        ),
+        pytest.param(
+            {"servers": {"echo": {"command": ["python"], "env": {1: "enabled"}}}},
+            "runtime config field 'mcp.servers.echo.env' keys must be strings",
+            id="env-key-type",
+        ),
+    ],
+)
+def test_parse_mcp_config_rejects_invalid_shapes_and_values(raw_value: object, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        _ = _parse_mcp_config(raw_value)

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -6,8 +6,11 @@ from typing import cast
 
 import pytest
 
+from voidcode.runtime import config as runtime_config
 from voidcode.runtime.config import (
     APPROVAL_MODE_ENV_VAR,
+    EXECUTION_ENGINE_ENV_VAR,
+    MAX_STEPS_ENV_VAR,
     MODEL_ENV_VAR,
     RUNTIME_CONFIG_FILE_NAME,
     RuntimeAcpConfig,
@@ -19,9 +22,15 @@ from voidcode.runtime.config import (
     RuntimeSkillsConfig,
     RuntimeToolsBuiltinConfig,
     RuntimeToolsConfig,
+    RuntimeTuiConfig,
     load_runtime_config,
     runtime_config_path,
 )
+
+_parse_tui_config = runtime_config.__dict__["_parse_tui_config"]
+_parse_tools_config = runtime_config.__dict__["_parse_tools_config"]
+_parse_skills_config = runtime_config.__dict__["_parse_skills_config"]
+_parse_acp_config = runtime_config.__dict__["_parse_acp_config"]
 
 
 def test_runtime_config_defaults_to_ask_without_file_or_env(tmp_path: Path) -> None:
@@ -44,6 +53,20 @@ def test_runtime_config_uses_model_environment_when_repo_file_missing(tmp_path: 
     config = load_runtime_config(tmp_path, env={MODEL_ENV_VAR: "opencode/gpt-5.4"})
 
     assert config.model == "opencode/gpt-5.4"
+
+
+def test_runtime_config_uses_execution_engine_environment_when_repo_file_missing(
+    tmp_path: Path,
+) -> None:
+    config = load_runtime_config(tmp_path, env={EXECUTION_ENGINE_ENV_VAR: "single_agent"})
+
+    assert config.execution_engine == "single_agent"
+
+
+def test_runtime_config_uses_max_steps_environment_when_repo_file_missing(tmp_path: Path) -> None:
+    config = load_runtime_config(tmp_path, env={MAX_STEPS_ENV_VAR: "7"})
+
+    assert config.max_steps == 7
 
 
 def test_runtime_config_prefers_repo_file_over_environment(tmp_path: Path) -> None:
@@ -87,6 +110,62 @@ def test_runtime_config_prefers_repo_file_model_over_environment(tmp_path: Path)
     config = load_runtime_config(tmp_path, env={MODEL_ENV_VAR: "env/model"})
 
     assert config.model == "repo/model"
+
+
+def test_runtime_config_prefers_repo_file_execution_engine_over_environment(tmp_path: Path) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps({"execution_engine": "deterministic"}),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={EXECUTION_ENGINE_ENV_VAR: "single_agent"})
+
+    assert config.execution_engine == "deterministic"
+
+
+def test_runtime_config_prefers_repo_file_max_steps_over_environment(tmp_path: Path) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps({"max_steps": 4}),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={MAX_STEPS_ENV_VAR: "7"})
+
+    assert config.max_steps == 4
+
+
+def test_runtime_config_prefers_explicit_execution_engine_over_repo_file_and_environment(
+    tmp_path: Path,
+) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps({"execution_engine": "deterministic"}),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(
+        tmp_path,
+        execution_engine="single_agent",
+        env={EXECUTION_ENGINE_ENV_VAR: "deterministic"},
+    )
+
+    assert config.execution_engine == "single_agent"
+
+
+def test_runtime_config_prefers_explicit_max_steps_over_repo_file_and_environment(
+    tmp_path: Path,
+) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps({"max_steps": 4}),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(
+        tmp_path,
+        max_steps=9,
+        env={MAX_STEPS_ENV_VAR: "7"},
+    )
+
+    assert config.max_steps == 9
 
 
 def test_runtime_config_parses_extension_domains(tmp_path: Path) -> None:
@@ -386,9 +465,35 @@ def test_runtime_config_prefers_explicit_override_over_repo_file_and_environment
     assert config.approval_mode == "allow"
 
 
+def test_runtime_config_explicit_approval_mode_does_not_affect_environment_execution_engine(
+    tmp_path: Path,
+) -> None:
+    config = load_runtime_config(
+        tmp_path,
+        approval_mode="allow",
+        env={EXECUTION_ENGINE_ENV_VAR: "single_agent"},
+    )
+
+    assert config.approval_mode == "allow"
+    assert config.execution_engine == "single_agent"
+
+
 def test_runtime_config_rejects_invalid_environment_approval_mode(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match=APPROVAL_MODE_ENV_VAR):
         _ = load_runtime_config(tmp_path, env={APPROVAL_MODE_ENV_VAR: "maybe"})
+
+
+def test_runtime_config_rejects_invalid_environment_execution_engine(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match=EXECUTION_ENGINE_ENV_VAR):
+        _ = load_runtime_config(tmp_path, env={EXECUTION_ENGINE_ENV_VAR: "agent"})
+
+
+@pytest.mark.parametrize("raw_value", ["0", "-1", "four"])
+def test_runtime_config_rejects_invalid_environment_max_steps(
+    tmp_path: Path, raw_value: str
+) -> None:
+    with pytest.raises(ValueError, match=MAX_STEPS_ENV_VAR):
+        _ = load_runtime_config(tmp_path, env={MAX_STEPS_ENV_VAR: raw_value})
 
 
 def test_runtime_config_rejects_empty_model_environment(tmp_path: Path) -> None:
@@ -612,6 +717,80 @@ def test_runtime_config_rejects_invalid_extension_domain_shapes(
 
     with pytest.raises(ValueError, match=match):
         _ = load_runtime_config(tmp_path, env={})
+
+
+def test_parse_tui_config_returns_defaults_when_fields_missing() -> None:
+    assert _parse_tui_config({}) == RuntimeTuiConfig(leader_key="alt+x", keymap=None)
+
+
+def test_parse_tui_config_preserves_valid_leader_key_and_keymap() -> None:
+    assert _parse_tui_config(
+        {
+            "leader_key": "ctrl+space",
+            "keymap": {
+                "n": "session_new",
+                "r": "session_resume",
+                "p": "command_palette",
+            },
+        }
+    ) == RuntimeTuiConfig(
+        leader_key="ctrl+space",
+        keymap={
+            "n": "session_new",
+            "r": "session_resume",
+            "p": "command_palette",
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "match"),
+    [
+        pytest.param([], "runtime config field 'tui'", id="shape"),
+        pytest.param(
+            {"leader_key": 3},
+            "runtime config field 'tui.leader_key'",
+            id="leader-key-type",
+        ),
+        pytest.param(
+            {"keymap": []},
+            "runtime config field 'tui.keymap'",
+            id="keymap-shape",
+        ),
+        pytest.param(
+            {"keymap": {"n": False}},
+            "runtime config field 'tui.keymap' values must be strings",
+            id="keymap-value-type",
+        ),
+        pytest.param(
+            {"keymap": {1: "session_new"}},
+            "runtime config field 'tui.keymap' keys must be strings",
+            id="keymap-key-type",
+        ),
+        pytest.param(
+            {"keymap": {"n": "quit"}},
+            "runtime config field 'tui.keymap' values must be one of: "
+            "command_palette, session_new, session_resume",
+            id="keymap-value-enum",
+        ),
+    ],
+)
+def test_parse_tui_config_rejects_invalid_shapes_and_values(raw_value: object, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        _ = _parse_tui_config(raw_value)
+
+
+def test_parse_simple_extension_configs_preserve_public_dataclasses() -> None:
+    assert _parse_tools_config({"builtin": {"enabled": True}, "paths": [".voidcode/tools"]}) == (
+        RuntimeToolsConfig(
+            builtin=RuntimeToolsBuiltinConfig(enabled=True),
+            paths=(".voidcode/tools",),
+        )
+    )
+    assert _parse_skills_config({"enabled": False, "paths": [".voidcode/skills"]}) == (
+        RuntimeSkillsConfig(enabled=False, paths=(".voidcode/skills",))
+    )
+    assert _parse_acp_config({"enabled": True}) == RuntimeAcpConfig(enabled=True)
 
 
 def test_runtime_config_uses_repo_local_filename_inside_workspace(tmp_path: Path) -> None:

--- a/tests/unit/test_apply_patch_tool.py
+++ b/tests/unit/test_apply_patch_tool.py
@@ -54,6 +54,32 @@ def test_apply_patch_updates_file_with_valid_patch(tmp_path: Path) -> None:
     assert result.content == "M sample.txt"
 
 
+def test_apply_patch_reports_file_addition_from_unified_diff(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+
+    patch_text = "\n".join(
+        [
+            "diff --git a/new.txt b/new.txt",
+            "new file mode 100644",
+            "--- /dev/null",
+            "+++ b/new.txt",
+            "@@ -0,0 +1 @@",
+            "+hello",
+            "",
+        ]
+    )
+
+    result = ApplyPatchTool().invoke(
+        ToolCall(tool_name="apply_patch", arguments={"patch": patch_text}),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert (tmp_path / "new.txt").read_text(encoding="utf-8") == "hello\n"
+    assert result.data["changes"] == [{"path": "new.txt", "status": "A"}]
+    assert result.content == "A new.txt"
+
+
 def test_apply_patch_raises_on_invalid_patch(tmp_path: Path) -> None:
     _init_git_repo(tmp_path)
     (tmp_path / "sample.txt").write_text("line-1\n", encoding="utf-8")
@@ -211,9 +237,13 @@ def test_apply_patch_does_not_treat_mixed_mode_and_content_patch_as_mode_only(
 def test_apply_patch_raises_helpful_error_when_git_is_missing(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    def _raise_file_not_found(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise FileNotFoundError()
+
     monkeypatch.setattr(
         "voidcode.tools.apply_patch.subprocess.run",
-        lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError()),
+        _raise_file_not_found,
     )
 
     patch_text = "\n".join(

--- a/tests/unit/test_edit_tool.py
+++ b/tests/unit/test_edit_tool.py
@@ -180,6 +180,33 @@ def test_edit_tool_preserves_line_endings(tmp_path: Path) -> None:
     assert content == b"line1\r\nmodified\r\nline3"
 
 
+def test_edit_tool_matches_block_anchors_with_small_typos(tmp_path: Path) -> None:
+    file_path = tmp_path / "test.txt"
+    file_path.write_text(
+        "alpha\nstart block\nkeep middle\nend block\nomega\n",
+        encoding="utf-8",
+    )
+
+    tool = EditTool()
+
+    result = tool.invoke(
+        ToolCall(
+            tool_name="edit",
+            arguments={
+                "path": "test.txt",
+                "oldString": "start blok\nkeep middle\nend block",
+                "newString": "start block\nupdated middle\nend block",
+            },
+        ),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert file_path.read_text(encoding="utf-8") == (
+        "alpha\nstart block\nupdated middle\nend block\nomega\n"
+    )
+
+
 def test_tools_package_and_default_registry_export_edit_tool() -> None:
     registry = ToolRegistry.with_defaults()
 

--- a/tests/unit/test_todo_write_tool.py
+++ b/tests/unit/test_todo_write_tool.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -29,7 +30,10 @@ def test_todo_write_persists_todos_json(tmp_path: Path) -> None:
     assert payload[0]["content"] == "task-a"
     assert payload[1]["status"] == "completed"
     assert result.status == "ok"
-    assert result.data["summary"]["total"] == 2
+    summary_raw = result.data["summary"]
+    assert isinstance(summary_raw, dict)
+    summary = cast(dict[str, object], summary_raw)
+    assert summary["total"] == 2
 
 
 def test_todo_write_rejects_invalid_status(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -653,6 +653,36 @@ wheels = [
 ]
 
 [[package]]
+name = "rapidfuzz"
+version = "3.14.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/21/ef6157213316e85790041254259907eb722e00b03480256c0545d98acd33/rapidfuzz-3.14.5.tar.gz", hash = "sha256:ba10ac57884ce82112f7ed910b67e7fb6072d8ef2c06e30dc63c0f604a112e0e", size = 57901753, upload-time = "2026-04-07T11:16:31.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/66/252803f2010ba699618cdc048b6e1f7cc1f433c08b4a9a17579b92ab0142/rapidfuzz-3.14.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ebd8fd343bf8492a1e60bcb6dc99f90f74f65d98d8241a6b3e1fed225b76ecd6", size = 1940205, upload-time = "2026-04-07T11:14:40.319Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/59/b2afd98e41af9cd54554a4c1c423d84cdd60e6b1c0a09496f033b55f60ec/rapidfuzz-3.14.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6737b35d5af7479c5bf9710f7b17edd9d2c43128d974d25fb4ea653e42c64609", size = 1159639, upload-time = "2026-04-07T11:14:42.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/7aa7e62c4c516a7af322ed0c4f0774208b72d457d0cfec808bad0df12f4a/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b002c7994cc9f2bc9d9856f0fbaee6e8072c983873846c92f25cefba5b2a925f", size = 1367194, upload-time = "2026-04-07T11:14:44.25Z" },
+    { url = "https://files.pythonhosted.org/packages/90/79/2fc252a63bc91d3c3b234d0a3a6ad4ebc460037a23cdcdaf9285f986e6c9/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17a34330cd2a538c1ce5d400b61ba358c5b72c654b928ff87b362e88f8b864c7", size = 3151805, upload-time = "2026-04-07T11:14:46.21Z" },
+    { url = "https://files.pythonhosted.org/packages/17/54/0c83508f2683ea70e2d05f8527eb07328acf7bb1e9d97a3bece5702378e7/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:95d937e74c1a7a1287dfb03b62a827be08ede10a155cf1af73bbf47f2b73ee6e", size = 1455667, upload-time = "2026-04-07T11:14:47.991Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1b/070175e873177814d58850a01ebe80e20ae11e93eb4da894d563988660fa/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:46b92a9970dcc34f0096901c792644094cab49554ac3547f35e3aebbdf0a3610", size = 2388246, upload-time = "2026-04-07T11:14:50.098Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/dd/77caf7aaf9c2be050ad1f128d7c24ff0f59079aa62c5f62f9df41c0af45e/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e012177c8e8a8a0754ae0d6027d63042aa5ff036d9f40f07cb3466a6082e21b8", size = 2494333, upload-time = "2026-04-07T11:14:52.303Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/dd7e1f2aa31a8fbbfc16b0610af1d770ffaf1287490f3c8c5b1c52da264f/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a2ae6f53f99c9a0eca7a0afc5b4e45fc73bc1dd4ac74c00509031d76df80ed98", size = 4258579, upload-time = "2026-04-07T11:14:54.538Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0a/ac99e1ba347ba0e85e0bb60b74231d55fb93c0eff43f2920ccb413d0be08/rapidfuzz-3.14.5-cp313-cp313-win32.whl", hash = "sha256:4a60f0057231188e3bd30216f7b4e0f279b11fa4ec818bb6c1d9f014d1562fbc", size = 1709231, upload-time = "2026-04-07T11:14:56.524Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/cb/0e251d731b3166378644238e8f0cf9e89858c024e19f75ca9f7e3ae83fd5/rapidfuzz-3.14.5-cp313-cp313-win_amd64.whl", hash = "sha256:11bfc2ed8fbe4ab86bd516fadefab126f90e6dcadffa761739fcb304707dfd35", size = 1538519, upload-time = "2026-04-07T11:14:58.635Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/4548132acc947db6d5346a248e44a8b3a22d608ef30e770fb578caaf2d00/rapidfuzz-3.14.5-cp313-cp313-win_arm64.whl", hash = "sha256:b486b5218808f6f4dc471b114b1054e63553db69705c97da0271f47bd706aedd", size = 812628, upload-time = "2026-04-07T11:15:00.552Z" },
+    { url = "https://files.pythonhosted.org/packages/00/60/69b177577290c5eab892c6f75fe89c3aff3f9ae80298a78d9372b1cecb9a/rapidfuzz-3.14.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:39ef8658aaf67d51667e7bdaf7096f432333377d8302ac43c70b5df8a4cf89b8", size = 1970231, upload-time = "2026-04-07T11:15:02.603Z" },
+    { url = "https://files.pythonhosted.org/packages/48/38/2fd790052659cc4e2907b63c25433f0987864b445c1aeec1a302ef5ad948/rapidfuzz-3.14.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9ad37a0be705b544af6296da8edddc260d10a8ae5462530fc9991f66498bb1f9", size = 1194394, upload-time = "2026-04-07T11:15:04.572Z" },
+    { url = "https://files.pythonhosted.org/packages/80/f4/28430ad8472fc3536e8ebd51a864a226e979cfe924c6e3f83d111373aa74/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d45e06f60729e07d9b20c205f7e5cff90b6ef2584e852eecf46e045aea69627d", size = 1377051, upload-time = "2026-04-07T11:15:06.728Z" },
+    { url = "https://files.pythonhosted.org/packages/77/7e/9aeacabcfd1e77397968362e5b98fe14248b8307011136b17daf99752a8e/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e52da10236aa6212de71b9e170bace65b64b129c0dea7fc243d6c9ce976f5074", size = 3160565, upload-time = "2026-04-07T11:15:08.667Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f4/db4dd7be0cd2f2022117ac5407d905f435d60e48baaea313a567ad27e865/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:440d30faaf682ca496170a7f0cc5453ec942e3e079f0fd802c9a7f938dfb50a3", size = 1442113, upload-time = "2026-04-07T11:15:11.138Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/99/0e9f6aa57f3e32a767216f797e56dc96b720fcecfb9d8ee907ecc82f8d66/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:56227a61fd3d17b0cd9793132431f3a3d07c8654be96794ba9f89fe0fc8b2d09", size = 2396618, upload-time = "2026-04-07T11:15:13.154Z" },
+    { url = "https://files.pythonhosted.org/packages/60/94/44a78e39ffce17cbdd3e2b53b696acc751d5d153be0f499d052b07a4d904/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:2e83cd2e25bb4edd97b689d9979d9c3acccdaaf26ceac08212ceece202febcfa", size = 2478220, upload-time = "2026-04-07T11:15:15.193Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/df/454311469a09a507e9d784a35796742bec22e4cebe75551e2da4e0e290fd/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:af3b859726cd3374287e405e14b9634563c078c5531a4f62375508addebddad1", size = 4265027, upload-time = "2026-04-07T11:15:17.28Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/01/175465a9ab3e3b70ba669058372f009d1d49c1746e2dcd56b69df188d3a5/rapidfuzz-3.14.5-cp313-cp313t-win32.whl", hash = "sha256:8ce1d850b3c0178440efde9e884d98421b5e87ff925f364d6d79e23910d7593f", size = 1766814, upload-time = "2026-04-07T11:15:19.687Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a0/a9b84a47af06ebed94a1439eb2f02adebfb8628bcd30af1fe3e02f5ef56c/rapidfuzz-3.14.5-cp313-cp313t-win_amd64.whl", hash = "sha256:c84af70bcf34e99aee894e46a0f1ac77f17d0ef828179c387407642e2466d28a", size = 1582448, upload-time = "2026-04-07T11:15:21.98Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f1/5937800238b3f8248e70860d79f69ba8f73e764fff47e36bc9e2f26dbcc6/rapidfuzz-3.14.5-cp313-cp313t-win_arm64.whl", hash = "sha256:aac0ad28c686a5e72b81668b906c030ee28050b244544b8af68e12fb32543895", size = 832932, upload-time = "2026-04-07T11:15:24.358Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -783,6 +813,15 @@ wheels = [
 ]
 
 [[package]]
+name = "unidiff"
+version = "0.7.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/48/81be0ac96e423a877754153699731ef439fd7b80b4c8b5425c94ed079ebd/unidiff-0.7.5.tar.gz", hash = "sha256:2e5f0162052248946b9f0970a40e9e124236bf86c82b70821143a6fc1dea2574", size = 20931, upload-time = "2023-03-10T01:05:39.185Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/54/57c411a6e8f7bd7848c8b66e4dcaffa586bf4c02e63f2280db0327a4e6eb/unidiff-0.7.5-py2.py3-none-any.whl", hash = "sha256:c93bf2265cc1ba2a520e415ab05da587370bc2a3ae9e0414329f54f0c2fc09e8", size = 14386, upload-time = "2023-03-10T01:05:36.594Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -852,8 +891,10 @@ dependencies = [
     { name = "langgraph" },
     { name = "lsprotocol" },
     { name = "pydantic" },
+    { name = "rapidfuzz" },
     { name = "textual" },
     { name = "typing-extensions" },
+    { name = "unidiff" },
     { name = "uvicorn" },
 ]
 
@@ -878,9 +919,11 @@ requires-dist = [
     { name = "pydantic" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
+    { name = "rapidfuzz", specifier = ">=3.14.5" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "textual" },
     { name = "typing-extensions" },
+    { name = "unidiff", specifier = ">=0.7.5" },
     { name = "uvicorn" },
 ]
 provides-extras = ["dev"]

--- a/uv.lock
+++ b/uv.lock
@@ -583,6 +583,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -632,6 +646,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b9/88/815e53084c5079a59df912825a279f41dd2e0df82281770eadc732f5352c/python_discovery-1.2.1.tar.gz", hash = "sha256:180c4d114bff1c32462537eac5d6a332b768242b76b69c0259c7d14b1b680c9e", size = 58457, upload-time = "2026-03-26T22:30:44.496Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/67/0f/019d3949a40280f6193b62bc010177d4ce702d0fce424322286488569cd3/python_discovery-1.2.1-py3-none-any.whl", hash = "sha256:b6a957b24c1cd79252484d3566d1b49527581d46e789aaf43181005e56201502", size = 31674, upload-time = "2026-03-26T22:30:43.396Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -891,6 +914,7 @@ dependencies = [
     { name = "langgraph" },
     { name = "lsprotocol" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "rapidfuzz" },
     { name = "textual" },
     { name = "typing-extensions" },
@@ -917,6 +941,7 @@ requires-dist = [
     { name = "lsprotocol" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "rapidfuzz", specifier = ">=3.14.5" },


### PR DESCRIPTION
## Summary
- add rapidfuzz and unidiff as project dependencies for the first round of tool-library adoptions
- replace the handwritten anchor-distance logic in \
  \
  `tools/edit.py` with RapidFuzz-backed matching and add a regression test for typo-tolerant block anchors
- let `tools/apply_patch.py` use unidiff for standard unified-diff metadata extraction while keeping git apply as the execution authority and preserving metadata fallbacks for rename/mode-only cases

## Verification
- `uv run pytest tests/unit/test_edit_tool.py tests/unit/test_multi_edit_tool.py tests/unit/test_apply_patch_tool.py tests/integration/test_tool_workflows_integration.py -q`
- `uv run basedpyright src/voidcode/tools/edit.py tests/unit/test_edit_tool.py`
- `uv run basedpyright src/voidcode/tools/apply_patch.py tests/unit/test_apply_patch_tool.py`
- `uv run ruff check src/voidcode/tools/edit.py tests/unit/test_edit_tool.py`
- `uv run ruff check src/voidcode/tools/apply_patch.py tests/unit/test_apply_patch_tool.py`
- manual QA: executed `EditTool` typo-tolerant block replacement and `ApplyPatchTool` unified-diff application via `uv run python`