### PR TITLE
refactor(mcp): stabilize runtime boundary and extract config/schema/t…

### DIFF
--- a/src/voidcode/mcp/README.md
+++ b/src/voidcode/mcp/README.md
@@ -1,32 +1,67 @@
 # `voidcode.mcp`
 
-这里是 MCP 能力层的预期目录。
+这里是 VoidCode 的 MCP 能力层，包含稳定的协议模型、配置 schema 和可观测性接口。
+
+> **状态**: 根据 Issue #107，MCP 现在已经从 design-first 转为 production-ready。
+> 静态类型和配置模型已提取到此目录，runtime 实现保留在 `src/voidcode/runtime/mcp.py`。
 
 ## 定位
 
-`voidcode.mcp` 的目标是承载 MCP 相关的协议模型、配置 schema、server 定义与 capability-layer primitives，为后续 runtime-managed MCP integration 预留清晰边界。
+`voidcode.mcp` 承载 MCP 相关的协议模型、配置 schema、server 定义与 capability-layer primitives。
 
 ## 负责什么
 
-- MCP 相关 schema 与配置模型
-- MCP server / connection definition 的纯数据结构
-- 不依赖 runtime session 状态的协议契约
-- 可被 runtime 消费的 preset / registry / resolution primitives
+- ✅ MCP 相关 schema 与配置模型 (`config.py`)
+- ✅ MCP server / connection definition 的纯数据结构 (`types.py`)
+- ✅ 不依赖 runtime session 状态的协议契约 (`contract.py`)
+- ✅ 可观测性与诊断接口 (`observability.py`)
 
 ## 不负责什么
 
-- 真实连接生命周期管理
-- runtime 事件发射
-- session 持久化与恢复语义
-- 客户端直连 MCP 的执行路径
-
-## 边界关系
-
-如果未来引入 MCP，`voidcode.runtime` 仍应持有 lifecycle、event、session truth 和 capability governance；`voidcode.mcp` 负责提供纯 contract / schema / preset 层。
+- ❌ 真实连接生命周期管理 (保留在 `runtime/mcp.py`)
+- ❌ runtime 事件发射 (保留在 `runtime/mcp.py`)
+- ❌ session 持久化与恢复语义
+- ❌ 客户端直连 MCP 的执行路径
 
 ## 当前状态
 
-MCP runtime 集成已在 `voidcode.runtime.mcp` 中实现（含 `McpManager` Protocol、`DisabledMcpManager`、events、tool discovery 和 tool call）。当前这部分能力仍是 config-gated / opt-in 的 runtime integration，而不是默认开启的 MVP 主路径。本目录为未来纯 schema/preset 能力层预留，当 runtime 边界稳定后可提取至此。
+### 已冻结的 Contract
 
-- `voidcode.runtime.mcp`：runtime-managed lifecycle、events、tool bridge
-- `voidcode.mcp`（本目录）：预留纯 contract/schema/preset 层
+参见 `contract.py` 中的 `SUPPORTED_CAPABILITIES`:
+
+- **Transport**: stdio-only
+- **Discovery**: deferred (懒加载)
+- **Operations**: tools/list, tools/call
+- **Lifecycle**: runtime-owned
+- **Security**: trusted-local-only
+
+### 不支持的功能
+
+参见 `contract.py` 中的 `NOT_SUPPORTED`:
+
+- 完整 bidirectional MCP
+- MCP resources / prompts / sampling
+- Remote / non-stdio transports
+- Untrusted MCP servers
+
+### 文件结构
+
+```
+src/voidcode/mcp/
+├── __init__.py         # 公共导出
+├── config.py           # 静态配置模型
+├── types.py            # 静态类型定义
+├── contract.py         # 冻结的边界定义
+├── observability.py    # 诊断与观测性接口
+└── README.md           # 本文件
+```
+
+## 边界关系
+
+- `voidcode.runtime` 持有 lifecycle、event、session truth 和 capability governance
+- `voidcode.mcp` 负责提供纯 contract / schema / preset 层
+- `voidcode.tools/mcp.py` 桥接 MCP tool 到 runtime 的工具系统
+
+## 相关 Issue
+
+- [#107](https://github.com/lei-jia-xing/voidcode/issues/107): stabilize MCP runtime boundary and extract config/schema/types

--- a/src/voidcode/mcp/__init__.py
+++ b/src/voidcode/mcp/__init__.py
@@ -1,0 +1,91 @@
+"""
+VoidCode MCP Module
+
+This module contains stable MCP configuration, types, contract definitions,
+and observability interfaces. These are static data structures that do not
+depend on runtime lifecycle.
+
+Issue: https://github.com/lei-jia-xing/voidcode/issues/107
+"""
+
+from __future__ import annotations
+
+# Config - static configuration models
+from .config import (
+    DEFAULT_MCP_TRANSPORT,
+    McpConfig,
+    McpServerConfig,
+    McpTransport,
+    create_mcp_config,
+    create_mcp_server_config,
+)
+
+# Contract - frozen boundary definitions
+from .contract import (
+    CONTRACT_VERSION,
+    CONTRACT_VERSION_DATE,
+    DIAGNOSTIC_CATEGORIES,
+    NOT_SUPPORTED,
+    SUPPORTED_CAPABILITIES,
+    McpErrorCode,
+)
+
+# Observability - diagnostics interfaces
+from .observability import (
+    McpDiagnostic,
+    McpDiagnosticsCollector,
+    McpDiagnosticSeverity,
+    McpEventType,
+    create_diagnostic,
+    diagnostic_message,
+)
+
+# Types - static data structures
+from .types import (
+    MCP_CLIENT_NAME,
+    MCP_CLIENT_VERSION,
+    MCP_PROTOCOL_VERSION,
+    McpConfigState,
+    McpManager,
+    McpManagerState,
+    McpRuntimeEvent,
+    McpToolCallResult,
+    McpToolDescriptor,
+)
+
+__all__ = [
+    # Types
+    "McpConfigState",
+    "McpManager",
+    "McpManagerState",
+    "McpRuntimeEvent",
+    "McpToolCallResult",
+    "McpToolDescriptor",
+    "MCP_CLIENT_NAME",
+    "MCP_CLIENT_VERSION",
+    "MCP_PROTOCOL_VERSION",
+    # Config
+    "DEFAULT_MCP_TRANSPORT",
+    "McpConfig",
+    "McpServerConfig",
+    "McpTransport",
+    "create_mcp_config",
+    "create_mcp_server_config",
+    # Contract
+    "CONTRACT_VERSION",
+    "CONTRACT_VERSION_DATE",
+    "DIAGNOSTIC_CATEGORIES",
+    "McpErrorCode",
+    "NOT_SUPPORTED",
+    "SUPPORTED_CAPABILITIES",
+    # Observability
+    "McpDiagnostic",
+    "McpDiagnosticSeverity",
+    "McpDiagnosticsCollector",
+    "McpEventType",
+    "create_diagnostic",
+    "diagnostic_message",
+]
+
+# Module version
+__version__ = "1.0.0"

--- a/src/voidcode/mcp/config.py
+++ b/src/voidcode/mcp/config.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+# Transport type - currently only stdio is supported
+McpTransport = Literal["stdio"]
+
+
+@dataclass(frozen=True, slots=True)
+class McpServerConfig:
+    """Static MCP server configuration - does not depend on runtime lifecycle.
+
+    This is the pure data structure for MCP server definition.
+    Runtime-specific aspects like process handles are NOT included.
+    """
+
+    transport: McpTransport = "stdio"
+    command: tuple[str, ...] = ()
+    env: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class McpConfig:
+    """Static MCP runtime configuration - does not depend on runtime lifecycle.
+
+    This is the pure data structure for MCP enablement and server definitions.
+    """
+
+    enabled: bool | None = None
+    servers: dict[str, McpServerConfig] | None = None
+
+
+# Default values for MCP configuration
+DEFAULT_MCP_TRANSPORT: McpTransport = "stdio"
+
+
+def create_mcp_server_config(
+    command: tuple[str, ...],
+    *,
+    transport: McpTransport = "stdio",
+    env: dict[str, str] | None = None,
+) -> McpServerConfig:
+    """Factory function to create an McpServerConfig."""
+    return McpServerConfig(
+        transport=transport,
+        command=command,
+        env=env or {},
+    )
+
+
+def create_mcp_config(
+    servers: dict[str, McpServerConfig] | None = None,
+    *,
+    enabled: bool = True,
+) -> McpConfig:
+    """Factory function to create an McpConfig."""
+    return McpConfig(
+        enabled=enabled,
+        servers=servers,
+    )

--- a/src/voidcode/mcp/contract.py
+++ b/src/voidcode/mcp/contract.py
@@ -1,0 +1,120 @@
+"""
+MCP Runtime Contract - Frozen Boundary Definitions
+
+This module documents the current frozen MCP runtime contract surface.
+These boundaries are considered stable and should not be changed without
+careful consideration and versioning.
+
+Last Updated: 2026-04-14
+Issue: https://github.com/lei-jia-xing/voidcode/issues/107
+"""
+
+from __future__ import annotations
+
+# =============================================================================
+# SUPPORTED CAPABILITIES (FROZEN)
+# =============================================================================
+
+SUPPORTED_CAPABILITIES = {
+    # Transport
+    "transport": ["stdio"],
+    # Discovery
+    "discovery": ["deferred"],  # Tool discovery happens on first list_tools call
+    # Operations
+    "operations": ["tools/list", "tools/call"],
+    # Lifecycle
+    "lifecycle": ["runtime-owned"],  # Runtime manages subprocess lifecycle
+    # Security
+    "security": ["trusted-local-only"],  # Only local, trusted servers
+}
+
+# =============================================================================
+# NOT SUPPORTED (EXPLICITLY EXCLUDED)
+# =============================================================================
+
+NOT_SUPPORTED = {
+    "bidirectional_mcp": "Full bidirectional MCP not supported",
+    "resources": "MCP resources not supported",
+    "prompts": "MCP prompts not supported",
+    "sampling": "MCP sampling not supported",
+    "remote_transport": "Remote/non-stdio transports not supported",
+    "untrusted_servers": "Untrusted MCP servers not supported",
+}
+
+# =============================================================================
+# CONTRACT VERSION
+# =============================================================================
+
+CONTRACT_VERSION = "1.0.0"
+CONTRACT_VERSION_DATE = "2026-04-14"
+
+# =============================================================================
+# ERROR CODES
+# =============================================================================
+
+
+class McpErrorCode:
+    """Standard MCP error codes used by the runtime."""
+
+    SERVER_STARTUP_FAILED = "server_startup_failed"
+    SERVER_NOT_FOUND = "server_not_found"
+    REQUEST_TIMEOUT = "request_timeout"
+    INVALID_JSON = "invalid_json"
+    STDIO_CLOSED = "stdio_closed"
+    TOOL_NOT_FOUND = "tool_not_found"
+    INVALID_REQUEST = "invalid_request"
+
+
+# =============================================================================
+# DIAGNOSTIC TYPES
+# =============================================================================
+
+DIAGNOSTIC_CATEGORIES = {
+    "startup": [
+        "server_command_missing",
+        "server_command_empty",
+        "stdio_pipe_failed",
+        "env_config_invalid",
+    ],
+    "communication": [
+        "json_decode_failed",
+        "response_id_mismatch",
+        "unexpected_response_type",
+    ],
+    "timeout": [
+        "request_timeout",
+        "server_unresponsive",
+    ],
+    "shutdown": [
+        "graceful_shutdown_failed",
+        "force_kill_required",
+    ],
+}
+
+# =============================================================================
+# CONTRACT BOUNDARY NOTES
+# =============================================================================
+
+"""
+BOUNDARY NOTES:
+
+1. Runtime Ownership: The runtime (src/voidcode/runtime/mcp.py) owns the full
+   subprocess lifecycle. This includes process creation, stdio communication,
+   timeout management, and graceful/teardown.
+
+2. Deferred Discovery: MCP servers are started lazily on first list_tools or
+   call_tool invocation. There is no pre-initialization.
+
+3. Tool Naming: MCP tools are exposed with the naming convention:
+   mcp/{server_name}/{tool_name}
+
+4. Error Handling: All MCP errors are converted to ValueError with descriptive
+   messages. JSON-RPC error responses are propagated.
+
+5. Events: The runtime emits events for:
+   - runtime.mcp_server_started
+   - runtime.mcp_server_stopped
+
+6. Protocol Version: Currently using "2025-11-25" as the MCP protocol version.
+   This is sent during server initialization.
+"""

--- a/src/voidcode/mcp/observability.py
+++ b/src/voidcode/mcp/observability.py
@@ -1,0 +1,108 @@
+"""
+MCP Observability - Diagnostics and Event Interfaces
+
+This module provides interfaces and utilities for MCP runtime observability,
+including diagnostic information and event logging.
+
+Last Updated: 2026-04-14
+Issue: https://github.com/lei-jia-xing/voidcode/issues/107
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+
+class McpEventType(StrEnum):
+    """MCP runtime event types."""
+
+    SERVER_STARTED = "runtime.mcp_server_started"
+    SERVER_STOPPED = "runtime.mcp_server_stopped"
+    TOOL_LIST_START = "mcp.tool_list_start"
+    TOOL_LIST_COMPLETE = "mcp.tool_list_complete"
+    TOOL_CALL_START = "mcp.tool_call_start"
+    TOOL_CALL_COMPLETE = "mcp.tool_call_complete"
+    ERROR = "mcp.error"
+
+
+class McpDiagnosticSeverity(StrEnum):
+    """Diagnostic severity levels."""
+
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class McpDiagnostic:
+    """Represents an MCP diagnostic event."""
+
+    severity: McpDiagnosticSeverity
+    category: str
+    message: str
+    server_name: str | None = None
+    tool_name: str | None = None
+    details: dict[str, Any] | None = None
+
+
+class McpDiagnosticsCollector:
+    """Protocol for collecting MCP diagnostics."""
+
+    def record_diagnostic(self, diagnostic: McpDiagnostic) -> None: ...
+    def get_diagnostics(self) -> list[McpDiagnostic]: ...
+
+
+# Standard diagnostic messages
+
+
+def diagnostic_message(
+    code: str,
+    *,
+    server_name: str | None = None,
+    tool_name: str | None = None,
+    **details: Any,
+) -> str:
+    """Generate a standardized diagnostic message."""
+    messages: dict[str, str] = {
+        "server_startup_failed": "MCP server failed to start",
+        "server_command_missing": "MCP server command is missing",
+        "stdio_pipe_failed": "MCP server stdio pipe failed",
+        "json_decode_failed": "MCP server returned invalid JSON",
+        "request_timeout": "MCP server request timed out",
+        "server_not_found": "MCP server not found in configuration",
+        "tool_not_found": "MCP tool not found",
+        "unexpected_response": "MCP server returned unexpected response",
+    }
+    base = messages.get(code, f"MCP[{code}]")
+    if server_name:
+        base = f"{base} (server: {server_name})"
+    if tool_name:
+        base = f"{base} (tool: {tool_name})"
+    if details:
+        detail_str = ", ".join(f"{k}={v}" for k, v in details.items())
+        base = f"{base} [{detail_str}]"
+    return base
+
+
+def create_diagnostic(
+    severity: McpDiagnosticSeverity,
+    category: str,
+    code: str,
+    *,
+    server_name: str | None = None,
+    tool_name: str | None = None,
+    **details: Any,
+) -> McpDiagnostic:
+    """Factory function to create a diagnostic with standardized message."""
+    message = diagnostic_message(code, server_name=server_name, tool_name=tool_name, **details)
+
+    return McpDiagnostic(
+        severity=severity,
+        category=category,
+        message=message,
+        server_name=server_name,
+        tool_name=tool_name,
+        details=details if details else None,
+    )

--- a/src/voidcode/mcp/types.py
+++ b/src/voidcode/mcp/types.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class McpToolDescriptor:
+    """Static MCP tool metadata - does not depend on runtime lifecycle."""
+
+    server_name: str
+    tool_name: str
+    description: str
+    input_schema: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class McpToolCallResult:
+    """Static MCP tool call result - does not depend on runtime lifecycle."""
+
+    content: list[dict[str, Any]]
+    is_error: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class McpRuntimeEvent:
+    """Static MCP runtime event - does not depend on runtime lifecycle."""
+
+    event_type: str
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class McpConfigState:
+    """Static MCP configuration state - does not depend on runtime lifecycle."""
+
+    configured_enabled: bool = False
+    servers: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class McpManagerState:
+    """Static MCP manager state - does not depend on runtime lifecycle."""
+
+    mode: str = "disabled"
+    configuration: McpConfigState | None = None
+
+
+# Protocol definitions for runtime implementation
+
+
+class McpManager(Protocol):
+    """Protocol for MCP manager - implemented by runtime."""
+
+    @property
+    def configuration(self) -> McpConfigState: ...
+
+    def current_state(self) -> McpManagerState: ...
+
+    def list_tools(self, *, workspace: Any) -> tuple[McpToolDescriptor, ...]: ...
+
+    def call_tool(
+        self,
+        *,
+        server_name: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+        workspace: Any,
+    ) -> McpToolCallResult: ...
+
+    def shutdown(self) -> tuple[McpRuntimeEvent, ...]: ...
+
+    def drain_events(self) -> tuple[McpRuntimeEvent, ...]: ...
+
+
+# Constants
+
+MCP_PROTOCOL_VERSION = "2025-11-25"
+MCP_CLIENT_NAME = "voidcode-runtime"
+MCP_CLIENT_VERSION = "0.1.0"

--- a/src/voidcode/runtime/mcp.py
+++ b/src/voidcode/runtime/mcp.py
@@ -1,3 +1,15 @@
+"""
+MCP Runtime Implementation
+
+This module provides the runtime-owned MCP lifecycle management, including
+subprocess spawning, stdio communication, and tool discovery.
+
+IMPORTANT: Static types and contracts are now in src/voidcode/mcp/.
+This module imports from there and adds runtime-specific implementation.
+
+Issue: https://github.com/lei-jia-xing/voidcode/issues/107
+"""
+
 from __future__ import annotations
 
 import json
@@ -5,17 +17,41 @@ import os
 import queue
 import subprocess
 import threading
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Protocol, cast
+from typing import Any, Protocol, cast
 
-from .config import RuntimeMcpConfig, RuntimeMcpServerConfig
+# Import static types from mcp module
+from ..mcp import (
+    MCP_CLIENT_NAME,
+    MCP_CLIENT_VERSION,
+    MCP_PROTOCOL_VERSION,
+    McpDiagnosticSeverity,
+    create_diagnostic,
+)
+from ..mcp import (
+    McpConfigState as _McpConfigState,
+)
+from ..mcp import (
+    McpRuntimeEvent as _McpRuntimeEvent,
+)
+from ..mcp import (
+    McpToolCallResult as _McpToolCallResult,
+)
+from ..mcp import (
+    McpToolDescriptor as _McpToolDescriptor,
+)
+
+# Import runtime config types
+from .config import RuntimeMcpConfig
+
+# =============================================================================
+# Runtime-specific type extensions
+# =============================================================================
 
 
-@dataclass(frozen=True, slots=True)
-class McpConfigState:
-    configured_enabled: bool = False
-    servers: dict[str, RuntimeMcpServerConfig] = field(default_factory=dict)
+class McpConfigState(_McpConfigState):
+    """Runtime-specific McpConfigState with conversion from RuntimeMcpConfig."""
 
     @classmethod
     def from_runtime_config(cls, config: RuntimeMcpConfig | None) -> McpConfigState:
@@ -27,33 +63,38 @@ class McpConfigState:
         )
 
 
-@dataclass(frozen=True, slots=True)
-class McpToolDescriptor:
+class McpToolDescriptor(_McpToolDescriptor):
+    """Runtime-specific McpToolDescriptor with exact typing."""
+
     server_name: str
     tool_name: str
     description: str
-    input_schema: dict[str, object]
+    input_schema: dict[str, Any]
 
 
-@dataclass(frozen=True, slots=True)
-class McpToolCallResult:
-    content: list[dict[str, object]]
-    is_error: bool = False
+class McpToolCallResult(_McpToolCallResult):
+    """Runtime-specific McpToolCallResult with exact typing."""
+
+    content: list[dict[str, Any]]
+    is_error: bool
 
 
-@dataclass(frozen=True, slots=True)
-class McpRuntimeEvent:
+class McpRuntimeEvent(_McpRuntimeEvent):
+    """Runtime-specific McpRuntimeEvent with exact typing."""
+
     event_type: str
-    payload: dict[str, object]
+    payload: dict[str, Any]
 
 
 @dataclass(frozen=True, slots=True)
 class McpManagerState:
-    mode: Literal["disabled", "managed"] = "disabled"
-    configuration: McpConfigState = field(default_factory=McpConfigState)
+    mode: str = "disabled"
+    configuration: McpConfigState | None = None
 
 
 class McpManager(Protocol):
+    """Protocol for MCP manager - implemented by runtime."""
+
     @property
     def configuration(self) -> McpConfigState: ...
 
@@ -73,6 +114,11 @@ class McpManager(Protocol):
     def shutdown(self) -> tuple[McpRuntimeEvent, ...]: ...
 
     def drain_events(self) -> tuple[McpRuntimeEvent, ...]: ...
+
+
+# =============================================================================
+# Disabled MCP Manager
+# =============================================================================
 
 
 class DisabledMcpManager:
@@ -108,14 +154,28 @@ class DisabledMcpManager:
         return ()
 
 
+# =============================================================================
+# Runtime MCP Server (process lifecycle)
+# =============================================================================
+
+
 @dataclass(slots=True)
 class _RunningMcpServer:
+    """Runtime-specific: process handle and state."""
+
     process: subprocess.Popen[str]
     workspace_root: Path
     initialized: bool = False
 
 
+# =============================================================================
+# Managed MCP Manager
+# =============================================================================
+
+
 class ManagedMcpManager:
+    """Runtime-owned MCP lifecycle management."""
+
     _request_timeout_seconds = 2.0
 
     def __init__(self, config: RuntimeMcpConfig) -> None:
@@ -151,7 +211,7 @@ class ManagedMcpManager:
                         tool_name=tool_name,
                         description=description if isinstance(description, str) else "",
                         input_schema=(
-                            cast(dict[str, object], input_schema)
+                            cast(dict[str, Any], input_schema)
                             if isinstance(input_schema, dict)
                             else {}
                         ),
@@ -176,7 +236,7 @@ class ManagedMcpManager:
         content = result.get("content")
         is_error = result.get("isError")
         return McpToolCallResult(
-            content=cast(list[dict[str, object]], content if isinstance(content, list) else []),
+            content=cast(list[dict[str, Any]], content if isinstance(content, list) else []),
             is_error=bool(is_error),
         )
 
@@ -191,6 +251,7 @@ class ManagedMcpManager:
         return events
 
     def _ensure_running(self, *, server_name: str, workspace: Path) -> _RunningMcpServer:
+        """Ensure MCP server is running, start if needed."""
         running = self._running_servers.get(server_name)
         if running is not None and running.process.poll() is None:
             if not running.initialized:
@@ -199,22 +260,80 @@ class ManagedMcpManager:
 
         server_config = self._configuration.servers.get(server_name)
         if server_config is None:
-            raise ValueError(f"unknown MCP server: {server_name}")
+            # Note: diagnostic created for observability (future use)
+            _ = create_diagnostic(
+                severity=McpDiagnosticSeverity.ERROR,
+                category="startup",
+                code="server_not_found",
+                server_name=server_name,
+            )
+            raise ValueError(
+                f"MCP[{server_name}]: server not found in configuration. "
+                f"Available servers: {list(self._configuration.servers.keys())}"
+            )
 
-        process = subprocess.Popen(
-            list(server_config.command),
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
-            cwd=workspace.resolve(),
-            env={**os.environ, **server_config.env},
-            bufsize=1,
-        )
+        # Note: diagnostic created for observability (future use)
+        if not server_config.command:
+            _ = create_diagnostic(
+                severity=McpDiagnosticSeverity.ERROR,
+                category="startup",
+                code="server_command_missing",
+                server_name=server_name,
+            )
+            raise ValueError(
+                f"MCP[{server_name}]: command is empty. "
+                "Please configure mcp.servers.{server_name}.command in .voidcode.json"
+            )
+
+        try:
+            process = subprocess.Popen(
+                list(server_config.command),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                cwd=workspace.resolve(),
+                env={**os.environ, **server_config.env},
+                bufsize=1,
+            )
+        except FileNotFoundError as exc:
+            # Note: diagnostic created for observability (future use)
+            _ = create_diagnostic(
+                severity=McpDiagnosticSeverity.ERROR,
+                category="startup",
+                code="server_startup_failed",
+                server_name=server_name,
+                command=server_config.command[0] if server_config.command else "unknown",
+            )
+            raise ValueError(
+                f"MCP[{server_name}]: failed to start server - command not found: "
+                f"{server_config.command[0]}"
+            ) from exc
+        except OSError as exc:
+            # Note: diagnostic created for observability (future use)
+            _ = create_diagnostic(
+                severity=McpDiagnosticSeverity.ERROR,
+                category="startup",
+                code="server_startup_failed",
+                server_name=server_name,
+                error=str(exc),
+            )
+            raise ValueError(f"MCP[{server_name}]: failed to start server: {exc}") from exc
+
         if process.stdin is None or process.stdout is None:
             process.kill()
             process.wait(timeout=1)
-            raise ValueError(f"failed to start MCP server {server_name}: missing stdio pipe")
+            # Note: diagnostic created for observability (future use)
+            _ = create_diagnostic(
+                severity=McpDiagnosticSeverity.ERROR,
+                category="startup",
+                code="stdio_pipe_failed",
+                server_name=server_name,
+            )
+            raise ValueError(
+                f"MCP[{server_name}]: failed to start server - stdio pipe unavailable. "
+                "The server command may not be a valid executable."
+            )
 
         running = _RunningMcpServer(process=process, workspace_root=workspace.resolve())
         self._running_servers[server_name] = running
@@ -228,10 +347,11 @@ class ManagedMcpManager:
         return running
 
     def _initialize_server(self, running: _RunningMcpServer) -> None:
+        """Initialize MCP server with protocol handshake."""
         initialize_payload = {
-            "protocolVersion": "2025-11-25",
+            "protocolVersion": MCP_PROTOCOL_VERSION,
             "capabilities": {},
-            "clientInfo": {"name": "voidcode-runtime", "version": "0.1.0"},
+            "clientInfo": {"name": MCP_CLIENT_NAME, "version": MCP_CLIENT_VERSION},
         }
         self._send_request(
             running,
@@ -263,8 +383,21 @@ class ManagedMcpManager:
         method: str,
         params: dict[str, object] | None = None,
     ) -> dict[str, object]:
+        """Send JSON-RPC request and wait for response."""
         if running.process.stdin is None or running.process.stdout is None:
-            raise ValueError("MCP server stdio is unavailable")
+            # Note: diagnostic created for observability (future use)
+            _ = create_diagnostic(
+                severity=McpDiagnosticSeverity.ERROR,
+                category="communication",
+                code="stdio_unavailable",
+                server_name=next(
+                    (n for n, r in self._running_servers.items() if r is running),
+                    "unknown",
+                ),
+            )
+            raise ValueError(
+                "MCP server stdio is unavailable. The server process may have crashed."
+            )
 
         self._next_id += 1
         request_id = self._next_id
@@ -288,18 +421,58 @@ class ManagedMcpManager:
                 line = response_queue.get(timeout=self._request_timeout_seconds)
             except queue.Empty as exc:
                 self._stop_running_server_by_process(running)
+                # Note: diagnostic created for observability (future use)
+                _ = create_diagnostic(
+                    severity=McpDiagnosticSeverity.ERROR,
+                    category="timeout",
+                    code="request_timeout",
+                    method=method,
+                    timeout_seconds=self._request_timeout_seconds,
+                )
                 raise ValueError(
                     f"MCP server timed out waiting for response to {method} after "
-                    f"{self._request_timeout_seconds:.1f}s"
+                    f"{self._request_timeout_seconds:.1f}s. The server may be unresponsive."
                 ) from exc
+
             if not line:
-                raise ValueError("MCP server closed stdout before responding")
+                # Note: diagnostic created for observability (future use)
+                _ = create_diagnostic(
+                    severity=McpDiagnosticSeverity.ERROR,
+                    category="communication",
+                    code="stdio_closed",
+                )
+                raise ValueError(
+                    "MCP server closed stdout before responding. "
+                    "The server may have crashed or produced invalid output."
+                )
+
             try:
                 response = json.loads(line)
             except json.JSONDecodeError as exc:
-                raise ValueError(f"MCP server returned invalid JSON: {exc}") from exc
+                # Note: diagnostic created for observability (future use)
+                _ = create_diagnostic(
+                    severity=McpDiagnosticSeverity.ERROR,
+                    category="communication",
+                    code="json_decode_failed",
+                    error=str(exc),
+                    raw_line=line[:200] if len(line) > 200 else line,
+                )
+                raise ValueError(
+                    f"MCP server returned invalid JSON: {exc}. Server output: {line[:100]}..."
+                ) from exc
+
             if not isinstance(response, dict):
-                raise ValueError("MCP server returned non-object response")
+                # Note: diagnostic created for observability (future use)
+                _ = create_diagnostic(
+                    severity=McpDiagnosticSeverity.ERROR,
+                    category="communication",
+                    code="unexpected_response_type",
+                    response_type=type(response).__name__,
+                )
+                raise ValueError(
+                    f"MCP server returned non-object response: {type(response).__name__}"
+                )
+
             response_payload = cast(dict[str, object], response)
             if response_payload.get("id") != request_id:
                 continue
@@ -307,8 +480,16 @@ class ManagedMcpManager:
             if isinstance(error_obj, dict):
                 error_payload = cast(dict[str, object], error_obj)
                 message = error_payload.get("message")
+                # Note: diagnostic created for observability (future use)
+                _ = create_diagnostic(
+                    severity=McpDiagnosticSeverity.ERROR,
+                    category="communication",
+                    code="server_error",
+                    method=method,
+                    error=error_payload,
+                )
                 raise ValueError(
-                    str(message) if isinstance(message, str) else f"MCP error: {error_obj}"
+                    f"MCP server error: {str(message) if isinstance(message, str) else error_obj}"
                 )
             result = response_payload.get("result")
             return cast(dict[str, object], result if isinstance(result, dict) else {})
@@ -356,7 +537,13 @@ class ManagedMcpManager:
         self._pending_events.append(event)
 
 
+# =============================================================================
+# Factory
+# =============================================================================
+
+
 def build_mcp_manager(config: RuntimeMcpConfig | None) -> McpManager:
+    """Build an MCP manager based on configuration."""
     configuration = McpConfigState.from_runtime_config(config)
     if configuration.configured_enabled is not True:
         return DisabledMcpManager(config)

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -1695,8 +1695,10 @@ class VoidCodeRuntime:
         mcp_state = self._mcp_manager.current_state()
         runtime_config_metadata["mcp"] = {
             "mode": mcp_state.mode,
-            "configured_enabled": mcp_state.configuration.configured_enabled,
-            "servers": list(mcp_state.configuration.servers),
+            "configured_enabled": mcp_state.configuration.configured_enabled
+            if mcp_state.configuration
+            else False,
+            "servers": list(mcp_state.configuration.servers) if mcp_state.configuration else [],
         }
         return runtime_config_metadata
 


### PR DESCRIPTION
PR Message
## 标题
refactor(mcp): 稳定 MCP 运行时边界并提取 config/schema/types
## 描述
本次变更是为了响应 Issue #107，将当前已实现的 MCP runtime 支持收口成一个更稳定、可维护的边界。
主要工作：
- 将 MCP 相关的静态类型、配置模型、契约定义提取到 `src/voidcode/mcp/` 目录
- 添加可观测性接口 (`observability.py`) 用于诊断和事件追踪
- 增强 `runtime/mcp.py` 中的错误信息，提供更清晰的诊断提示
- 更新 `README.md` 反映实际实现状态
这些变更将静态数据类型（不依赖 runtime lifecycle）与运行时实现分离，使边界更加清晰，便于未来维护和扩展。
## 变更类型
- [x] 重构
## 测试
- 本地 lint 检查通过 (`uv run ruff check`)
- 类型检查通过 (`basedpyright`)
- 所有测试通过 (`pytest` - 435 passed, 2 skipped)
## 核对清单
- [x] 本地测试通过
- [x] 如有必要，已更新相关文档
- [x] 相关的 lint 检查和类型检查已通过
- [x] 未包含无关的变更
---