### PR TITLE
feat: add ast-grep structural search and replace substrate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,14 +11,14 @@ repos:
     hooks:
       - id: ruff
         name: ruff check
-        entry: uv run ruff check .
+        entry: uv run ruff check --fix .
         language: system
         pass_filenames: false
         types_or: [python, pyi]
 
       - id: ruff-format
-        name: ruff format --check
-        entry: uv run ruff format --check .
+        name: ruff format
+        entry: uv run ruff format .
         language: system
         pass_filenames: false
         types_or: [python, pyi]

--- a/docs/development.md
+++ b/docs/development.md
@@ -58,6 +58,8 @@ uv run voidcode sessions resume <session-id> --workspace .
 - `mise run check` → 运行所有 Python 和前端检查
 - `mise run pre-commit` → `uv run pre-commit run --all-files`
 
+当前 pre-commit 会直接执行仓库约定的 Python 质量门禁：`ruff check --fix` 会自动修复可安全修复的问题，`ruff format` 会直接格式化文件，随后再运行 `basedpyright` 做类型检查。
+
 ## MVP 演示与验证
 
 关于规范的端到端演示流程和完整的验证阶梯（单元测试、集成测试、客户端冒烟测试），请参阅 [`docs/mvp-demo-guide.md`](./mvp-demo-guide.md)。使用该指南验证稳定的确定性运行时循环、内联审批和会话持久化。

--- a/src/voidcode/runtime/tool_provider.py
+++ b/src/voidcode/runtime/tool_provider.py
@@ -20,6 +20,13 @@ except ImportError:
     _ApplyPatchTool = None
 
 try:
+    from ..tools.ast_grep import AstGrepReplaceTool as _AstGrepReplaceTool
+    from ..tools.ast_grep import AstGrepSearchTool as _AstGrepSearchTool
+except ImportError:
+    _AstGrepReplaceTool = None
+    _AstGrepSearchTool = None
+
+try:
     from ..tools.code_search import CodeSearchTool as _CodeSearchTool
 except ImportError:
     _CodeSearchTool = None
@@ -65,6 +72,10 @@ class BuiltinToolProvider:
         # Add optional tools if available.
         if _ApplyPatchTool is not None:
             tools.append(_ApplyPatchTool())
+        if _AstGrepSearchTool is not None:
+            tools.append(_AstGrepSearchTool())
+        if _AstGrepReplaceTool is not None:
+            tools.append(_AstGrepReplaceTool())
         if _CodeSearchTool is not None:
             tools.append(_CodeSearchTool())
         if _MultiEditTool is not None:

--- a/src/voidcode/runtime/tool_provider.py
+++ b/src/voidcode/runtime/tool_provider.py
@@ -20,9 +20,11 @@ except ImportError:
     _ApplyPatchTool = None
 
 try:
+    from ..tools.ast_grep import AstGrepPreviewTool as _AstGrepPreviewTool
     from ..tools.ast_grep import AstGrepReplaceTool as _AstGrepReplaceTool
     from ..tools.ast_grep import AstGrepSearchTool as _AstGrepSearchTool
 except ImportError:
+    _AstGrepPreviewTool = None
     _AstGrepReplaceTool = None
     _AstGrepSearchTool = None
 
@@ -74,6 +76,8 @@ class BuiltinToolProvider:
             tools.append(_ApplyPatchTool())
         if _AstGrepSearchTool is not None:
             tools.append(_AstGrepSearchTool())
+        if _AstGrepPreviewTool is not None:
+            tools.append(_AstGrepPreviewTool())
         if _AstGrepReplaceTool is not None:
             tools.append(_AstGrepReplaceTool())
         if _CodeSearchTool is not None:

--- a/src/voidcode/tools/__init__.py
+++ b/src/voidcode/tools/__init__.py
@@ -1,4 +1,5 @@
 from .apply_patch import ApplyPatchTool
+from .ast_grep import AstGrepReplaceTool, AstGrepSearchTool
 from .code_search import CodeSearchTool
 from .contracts import ToolCall, ToolDefinition, ToolResult, ToolResultStatus
 from .edit import EditTool
@@ -29,6 +30,8 @@ __all__ = [
     "McpTool",
     "MultiEditTool",
     "ApplyPatchTool",
+    "AstGrepSearchTool",
+    "AstGrepReplaceTool",
     "CodeSearchTool",
     "TodoWriteTool",
     "ToolCall",

--- a/src/voidcode/tools/__init__.py
+++ b/src/voidcode/tools/__init__.py
@@ -1,5 +1,5 @@
 from .apply_patch import ApplyPatchTool
-from .ast_grep import AstGrepReplaceTool, AstGrepSearchTool
+from .ast_grep import AstGrepPreviewTool, AstGrepReplaceTool, AstGrepSearchTool
 from .code_search import CodeSearchTool
 from .contracts import ToolCall, ToolDefinition, ToolResult, ToolResultStatus
 from .edit import EditTool
@@ -31,6 +31,7 @@ __all__ = [
     "MultiEditTool",
     "ApplyPatchTool",
     "AstGrepSearchTool",
+    "AstGrepPreviewTool",
     "AstGrepReplaceTool",
     "CodeSearchTool",
     "TodoWriteTool",

--- a/src/voidcode/tools/_pydantic_args.py
+++ b/src/voidcode/tools/_pydantic_args.py
@@ -114,13 +114,6 @@ class AstGrepReplaceArgs(BaseModel):
             raise ValueError("pattern must not be empty")
         return value
 
-    @field_validator("rewrite", mode="after")
-    @classmethod
-    def _validate_rewrite(cls, value: str) -> str:
-        if not value.strip():
-            raise ValueError("rewrite must not be empty")
-        return value
-
     @field_validator("path", mode="after")
     @classmethod
     def _validate_path(cls, value: str) -> str:

--- a/src/voidcode/tools/_pydantic_args.py
+++ b/src/voidcode/tools/_pydantic_args.py
@@ -69,3 +69,70 @@ class MultiEditArgs(BaseModel):
         if not value:
             raise ValueError("edits must not be empty")
         return value
+
+
+class AstGrepSearchArgs(BaseModel):
+    pattern: str
+    path: str
+    lang: str | None = None
+
+    @field_validator("pattern", mode="after")
+    @classmethod
+    def _validate_pattern(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("pattern must not be empty")
+        return value
+
+    @field_validator("path", mode="after")
+    @classmethod
+    def _validate_path(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("path must be a non-empty string")
+        return value
+
+    @field_validator("lang", mode="after")
+    @classmethod
+    def _validate_lang(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if not value.strip():
+            raise ValueError("lang must not be empty")
+        return value
+
+
+class AstGrepReplaceArgs(BaseModel):
+    pattern: str
+    rewrite: str
+    path: str
+    lang: str | None = None
+    apply: bool = False
+
+    @field_validator("pattern", mode="after")
+    @classmethod
+    def _validate_pattern(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("pattern must not be empty")
+        return value
+
+    @field_validator("rewrite", mode="after")
+    @classmethod
+    def _validate_rewrite(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("rewrite must not be empty")
+        return value
+
+    @field_validator("path", mode="after")
+    @classmethod
+    def _validate_path(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("path must be a non-empty string")
+        return value
+
+    @field_validator("lang", mode="after")
+    @classmethod
+    def _validate_lang(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if not value.strip():
+            raise ValueError("lang must not be empty")
+        return value

--- a/src/voidcode/tools/ast_grep.py
+++ b/src/voidcode/tools/ast_grep.py
@@ -75,6 +75,77 @@ def _is_no_match_result(completed: subprocess.CompletedProcess[str]) -> bool:
     )
 
 
+def _validate_search_call(call: ToolCall) -> AstGrepSearchArgs:
+    try:
+        return AstGrepSearchArgs.model_validate(
+            {
+                "pattern": call.arguments.get("pattern"),
+                "path": call.arguments.get("path"),
+                "lang": call.arguments.get("lang"),
+            }
+        )
+    except ValidationError as exc:
+        first_error = exc.errors()[0]
+        field_name = first_error.get("loc", (None,))[0]
+        if field_name == "path":
+            raise ValueError("ast_grep_search requires a string path argument") from exc
+        if field_name == "lang":
+            raise ValueError("ast_grep_search requires a string lang argument") from exc
+        if first_error.get("type") == "value_error":
+            raise ValueError("ast_grep_search pattern must not be empty") from exc
+        raise ValueError("ast_grep_search requires a string pattern argument") from exc
+
+
+def _validate_replace_call(call: ToolCall) -> AstGrepReplaceArgs:
+    try:
+        return AstGrepReplaceArgs.model_validate(
+            {
+                "pattern": call.arguments.get("pattern"),
+                "rewrite": call.arguments.get("rewrite"),
+                "path": call.arguments.get("path"),
+                "lang": call.arguments.get("lang"),
+                "apply": call.arguments.get("apply", False),
+            }
+        )
+    except ValidationError as exc:
+        first_error = exc.errors()[0]
+        field_name = first_error.get("loc", (None,))[0]
+        if field_name == "path":
+            raise ValueError("ast_grep_replace requires a string path argument") from exc
+        if field_name == "rewrite":
+            raise ValueError("ast_grep_replace requires a string rewrite argument") from exc
+        if field_name == "lang":
+            raise ValueError("ast_grep_replace requires a string lang argument") from exc
+        if field_name == "apply":
+            raise ValueError("ast_grep_replace apply must be boolean") from exc
+        if first_error.get("type") == "value_error":
+            raise ValueError("ast_grep_replace pattern must not be empty") from exc
+        raise ValueError("ast_grep_replace requires a string pattern argument") from exc
+
+
+def _run_preview_replace(
+    *, args: AstGrepReplaceArgs, workspace: Path
+) -> ToolResult | tuple[str, list[dict[str, Any]], int]:
+    _, relative_path = _resolve_candidate(workspace=workspace, path_text=args.path)
+    preview_cmd = ["ast-grep", "run", "--json=stream", "-p", args.pattern, "-r", args.rewrite]
+    if args.lang:
+        preview_cmd.extend(["--lang", args.lang])
+    preview_cmd.append(relative_path)
+
+    completed = _run_ast_grep(cmd=preview_cmd, workspace=workspace)
+    if isinstance(completed, ToolResult):
+        return completed
+
+    if _is_no_match_result(completed):
+        matches: list[dict[str, Any]] = []
+    else:
+        _raise_on_process_failure(completed=completed, fallback_message="ast-grep replace failed")
+        matches = _parse_stream_output(completed.stdout)
+
+    replacement_count = len(matches)
+    return relative_path, matches, replacement_count
+
+
 class AstGrepSearchTool:
     definition: ClassVar[ToolDefinition] = ToolDefinition(
         name="ast_grep_search",
@@ -88,25 +159,7 @@ class AstGrepSearchTool:
     )
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
-        try:
-            args = AstGrepSearchArgs.model_validate(
-                {
-                    "pattern": call.arguments.get("pattern"),
-                    "path": call.arguments.get("path"),
-                    "lang": call.arguments.get("lang"),
-                }
-            )
-        except ValidationError as exc:
-            first_error = exc.errors()[0]
-            field_name = first_error.get("loc", (None,))[0]
-            if field_name == "path":
-                raise ValueError("ast_grep_search requires a string path argument") from exc
-            if field_name == "lang":
-                raise ValueError("ast_grep_search requires a string lang argument") from exc
-            if first_error.get("type") == "value_error":
-                raise ValueError("ast_grep_search pattern must not be empty") from exc
-            raise ValueError("ast_grep_search requires a string pattern argument") from exc
-
+        args = _validate_search_call(call)
         _, relative_path = _resolve_candidate(workspace=workspace, path_text=args.path)
         cmd = ["ast-grep", "run", "--json=stream", "-p", args.pattern]
         if args.lang:
@@ -145,10 +198,52 @@ class AstGrepSearchTool:
         )
 
 
+class AstGrepPreviewTool:
+    definition: ClassVar[ToolDefinition] = ToolDefinition(
+        name="ast_grep_preview",
+        description="Preview structural code rewrites with ast-grep without modifying files.",
+        input_schema={
+            "pattern": {"type": "string"},
+            "rewrite": {"type": "string"},
+            "path": {"type": "string"},
+            "lang": {"type": "string"},
+        },
+        read_only=True,
+    )
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        args = _validate_replace_call(call)
+        args = args.model_copy(update={"apply": False})
+
+        preview = _run_preview_replace(args=args, workspace=workspace)
+        if isinstance(preview, ToolResult):
+            return ToolResult(
+                tool_name=self.definition.name,
+                status=preview.status,
+                error=preview.error,
+            )
+        relative_path, matches, replacement_count = preview
+
+        return ToolResult(
+            tool_name=self.definition.name,
+            status="ok",
+            content=f"Previewed {replacement_count} AST replacement(s) in {relative_path}",
+            data={
+                "path": relative_path,
+                "pattern": args.pattern,
+                "rewrite": args.rewrite,
+                "lang": args.lang,
+                "replacement_count": replacement_count,
+                "matches": matches,
+                "applied": False,
+            },
+        )
+
+
 class AstGrepReplaceTool:
     definition: ClassVar[ToolDefinition] = ToolDefinition(
         name="ast_grep_replace",
-        description="Preview or apply structural code rewrites with ast-grep.",
+        description="Apply structural code rewrites with ast-grep.",
         input_schema={
             "pattern": {"type": "string"},
             "rewrite": {"type": "string"},
@@ -160,110 +255,39 @@ class AstGrepReplaceTool:
     )
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
-        try:
-            args = AstGrepReplaceArgs.model_validate(
-                {
-                    "pattern": call.arguments.get("pattern"),
-                    "rewrite": call.arguments.get("rewrite"),
-                    "path": call.arguments.get("path"),
-                    "lang": call.arguments.get("lang"),
-                    "apply": call.arguments.get("apply", False),
-                }
-            )
-        except ValidationError as exc:
-            first_error = exc.errors()[0]
-            field_name = first_error.get("loc", (None,))[0]
-            if field_name == "path":
-                raise ValueError("ast_grep_replace requires a string path argument") from exc
-            if field_name == "rewrite" and first_error.get("type") == "value_error":
-                raise ValueError("ast_grep_replace rewrite must not be empty") from exc
-            if field_name == "rewrite":
-                raise ValueError("ast_grep_replace requires a string rewrite argument") from exc
-            if field_name == "lang":
-                raise ValueError("ast_grep_replace requires a string lang argument") from exc
-            if field_name == "apply":
-                raise ValueError("ast_grep_replace apply must be boolean") from exc
-            if first_error.get("type") == "value_error":
-                raise ValueError("ast_grep_replace pattern must not be empty") from exc
-            raise ValueError("ast_grep_replace requires a string pattern argument") from exc
+        args = _validate_replace_call(call)
+        if not args.apply:
+            raise ValueError("ast_grep_replace requires apply=True")
 
-        _, relative_path = _resolve_candidate(workspace=workspace, path_text=args.path)
-        preview_cmd = ["ast-grep", "run", "--json=stream", "-p", args.pattern, "-r", args.rewrite]
-        if args.lang:
-            preview_cmd.extend(["--lang", args.lang])
-
-        if args.apply:
-            preview_cmd.append(relative_path)
-            preview_completed = _run_ast_grep(cmd=preview_cmd, workspace=workspace)
-            if isinstance(preview_completed, ToolResult):
-                return ToolResult(
-                    tool_name=self.definition.name,
-                    status=preview_completed.status,
-                    error=preview_completed.error,
-                )
-            if _is_no_match_result(preview_completed):
-                matches: list[dict[str, Any]] = []
-            else:
-                _raise_on_process_failure(
-                    completed=preview_completed, fallback_message="ast-grep replace failed"
-                )
-                matches = _parse_stream_output(preview_completed.stdout)
-
-            replacement_count = len(matches)
-            apply_cmd = ["ast-grep", "run", "-p", args.pattern, "-r", args.rewrite]
-            if args.lang:
-                apply_cmd.extend(["--lang", args.lang])
-            apply_cmd.extend(["-U", relative_path])
-            completed = _run_ast_grep(cmd=apply_cmd, workspace=workspace)
-            if isinstance(completed, ToolResult):
-                return ToolResult(
-                    tool_name=self.definition.name,
-                    status=completed.status,
-                    error=completed.error,
-                )
-            if not _is_no_match_result(completed):
-                _raise_on_process_failure(
-                    completed=completed, fallback_message="ast-grep replace failed"
-                )
+        preview = _run_preview_replace(args=args, workspace=workspace)
+        if isinstance(preview, ToolResult):
             return ToolResult(
                 tool_name=self.definition.name,
-                status="ok",
-                content=f"Applied {replacement_count} AST replacement(s) in {relative_path}",
-                data={
-                    "path": relative_path,
-                    "pattern": args.pattern,
-                    "rewrite": args.rewrite,
-                    "lang": args.lang,
-                    "replacement_count": replacement_count,
-                    "matches": matches,
-                    "applied": True,
-                },
+                status=preview.status,
+                error=preview.error,
             )
+        relative_path, matches, replacement_count = preview
 
-        preview_cmd.append(relative_path)
-
-        completed = _run_ast_grep(cmd=preview_cmd, workspace=workspace)
+        apply_cmd = ["ast-grep", "run", "-p", args.pattern, "-r", args.rewrite]
+        if args.lang:
+            apply_cmd.extend(["--lang", args.lang])
+        apply_cmd.extend(["-U", relative_path])
+        completed = _run_ast_grep(cmd=apply_cmd, workspace=workspace)
         if isinstance(completed, ToolResult):
             return ToolResult(
                 tool_name=self.definition.name,
                 status=completed.status,
                 error=completed.error,
             )
-
-        if _is_no_match_result(completed):
-            matches = []
-        else:
+        if not _is_no_match_result(completed):
             _raise_on_process_failure(
                 completed=completed, fallback_message="ast-grep replace failed"
             )
-            matches = _parse_stream_output(completed.stdout)
 
-        replacement_count = len(matches)
-        action = "Applied" if args.apply else "Previewed"
         return ToolResult(
             tool_name=self.definition.name,
             status="ok",
-            content=f"{action} {replacement_count} AST replacement(s) in {relative_path}",
+            content=f"Applied {replacement_count} AST replacement(s) in {relative_path}",
             data={
                 "path": relative_path,
                 "pattern": args.pattern,
@@ -271,6 +295,6 @@ class AstGrepReplaceTool:
                 "lang": args.lang,
                 "replacement_count": replacement_count,
                 "matches": matches,
-                "applied": args.apply,
+                "applied": True,
             },
         )

--- a/src/voidcode/tools/ast_grep.py
+++ b/src/voidcode/tools/ast_grep.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, ClassVar, cast
+
+from pydantic import ValidationError
+
+from ._pydantic_args import AstGrepReplaceArgs, AstGrepSearchArgs
+from .contracts import ToolCall, ToolDefinition, ToolResult
+
+
+def _resolve_candidate(*, workspace: Path, path_text: str) -> tuple[Path, str]:
+    workspace_root = workspace.resolve()
+    candidate = (workspace_root / Path(path_text)).resolve()
+    if not candidate.is_relative_to(workspace_root):
+        raise ValueError("ast_grep only allows paths inside the workspace")
+    if not candidate.exists():
+        raise ValueError(f"ast_grep target does not exist: {path_text}")
+    return candidate, candidate.relative_to(workspace_root).as_posix()
+
+
+def _parse_stream_output(stdout: str) -> list[dict[str, Any]]:
+    matches: list[dict[str, Any]] = []
+    for line in stdout.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"ast-grep returned invalid JSON stream output: {stripped}") from exc
+        if isinstance(parsed, dict):
+            matches.append(cast(dict[str, Any], parsed))
+    return matches
+
+
+def _run_ast_grep(
+    *, cmd: list[str], workspace: Path
+) -> ToolResult | subprocess.CompletedProcess[str]:
+    try:
+        completed = subprocess.run(
+            cmd,
+            cwd=workspace.resolve(),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        return ToolResult(
+            tool_name=cmd[0].replace("-", "_"),
+            status="error",
+            error="ast-grep timed out after 30s",
+        )
+    except OSError as exc:
+        return ToolResult(
+            tool_name=cmd[0].replace("-", "_"),
+            status="error",
+            error=f"ast-grep not found or failed: {exc}",
+        )
+    return completed
+
+
+def _raise_on_process_failure(
+    *, completed: subprocess.CompletedProcess[str], fallback_message: str
+) -> None:
+    if completed.returncode != 0:
+        raise ValueError(completed.stderr.strip() or fallback_message)
+
+
+def _is_no_match_result(completed: subprocess.CompletedProcess[str]) -> bool:
+    return (
+        completed.returncode == 1 and not completed.stdout.strip() and not completed.stderr.strip()
+    )
+
+
+class AstGrepSearchTool:
+    definition: ClassVar[ToolDefinition] = ToolDefinition(
+        name="ast_grep_search",
+        description="Search code structurally with ast-grep patterns.",
+        input_schema={
+            "pattern": {"type": "string"},
+            "path": {"type": "string"},
+            "lang": {"type": "string"},
+        },
+        read_only=True,
+    )
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        try:
+            args = AstGrepSearchArgs.model_validate(
+                {
+                    "pattern": call.arguments.get("pattern"),
+                    "path": call.arguments.get("path"),
+                    "lang": call.arguments.get("lang"),
+                }
+            )
+        except ValidationError as exc:
+            first_error = exc.errors()[0]
+            field_name = first_error.get("loc", (None,))[0]
+            if field_name == "path":
+                raise ValueError("ast_grep_search requires a string path argument") from exc
+            if field_name == "lang":
+                raise ValueError("ast_grep_search requires a string lang argument") from exc
+            if first_error.get("type") == "value_error":
+                raise ValueError("ast_grep_search pattern must not be empty") from exc
+            raise ValueError("ast_grep_search requires a string pattern argument") from exc
+
+        _, relative_path = _resolve_candidate(workspace=workspace, path_text=args.path)
+        cmd = ["ast-grep", "run", "--json=stream", "-p", args.pattern]
+        if args.lang:
+            cmd.extend(["--lang", args.lang])
+        cmd.append(relative_path)
+
+        completed = _run_ast_grep(cmd=cmd, workspace=workspace)
+        if isinstance(completed, ToolResult):
+            return ToolResult(
+                tool_name=self.definition.name,
+                status=completed.status,
+                error=completed.error,
+            )
+
+        if _is_no_match_result(completed):
+            matches: list[dict[str, Any]] = []
+        else:
+            _raise_on_process_failure(
+                completed=completed, fallback_message="ast-grep search failed"
+            )
+            matches = _parse_stream_output(completed.stdout)
+
+        match_count = len(matches)
+        summary = f"Found {match_count} AST match(es) in {relative_path}"
+        return ToolResult(
+            tool_name=self.definition.name,
+            status="ok",
+            content=summary,
+            data={
+                "path": relative_path,
+                "pattern": args.pattern,
+                "lang": args.lang,
+                "match_count": match_count,
+                "matches": matches,
+            },
+        )
+
+
+class AstGrepReplaceTool:
+    definition: ClassVar[ToolDefinition] = ToolDefinition(
+        name="ast_grep_replace",
+        description="Preview or apply structural code rewrites with ast-grep.",
+        input_schema={
+            "pattern": {"type": "string"},
+            "rewrite": {"type": "string"},
+            "path": {"type": "string"},
+            "lang": {"type": "string"},
+            "apply": {"type": "boolean"},
+        },
+        read_only=False,
+    )
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        try:
+            args = AstGrepReplaceArgs.model_validate(
+                {
+                    "pattern": call.arguments.get("pattern"),
+                    "rewrite": call.arguments.get("rewrite"),
+                    "path": call.arguments.get("path"),
+                    "lang": call.arguments.get("lang"),
+                    "apply": call.arguments.get("apply", False),
+                }
+            )
+        except ValidationError as exc:
+            first_error = exc.errors()[0]
+            field_name = first_error.get("loc", (None,))[0]
+            if field_name == "path":
+                raise ValueError("ast_grep_replace requires a string path argument") from exc
+            if field_name == "rewrite" and first_error.get("type") == "value_error":
+                raise ValueError("ast_grep_replace rewrite must not be empty") from exc
+            if field_name == "rewrite":
+                raise ValueError("ast_grep_replace requires a string rewrite argument") from exc
+            if field_name == "lang":
+                raise ValueError("ast_grep_replace requires a string lang argument") from exc
+            if field_name == "apply":
+                raise ValueError("ast_grep_replace apply must be boolean") from exc
+            if first_error.get("type") == "value_error":
+                raise ValueError("ast_grep_replace pattern must not be empty") from exc
+            raise ValueError("ast_grep_replace requires a string pattern argument") from exc
+
+        _, relative_path = _resolve_candidate(workspace=workspace, path_text=args.path)
+        preview_cmd = ["ast-grep", "run", "--json=stream", "-p", args.pattern, "-r", args.rewrite]
+        if args.lang:
+            preview_cmd.extend(["--lang", args.lang])
+
+        if args.apply:
+            preview_cmd.append(relative_path)
+            preview_completed = _run_ast_grep(cmd=preview_cmd, workspace=workspace)
+            if isinstance(preview_completed, ToolResult):
+                return ToolResult(
+                    tool_name=self.definition.name,
+                    status=preview_completed.status,
+                    error=preview_completed.error,
+                )
+            if _is_no_match_result(preview_completed):
+                matches: list[dict[str, Any]] = []
+            else:
+                _raise_on_process_failure(
+                    completed=preview_completed, fallback_message="ast-grep replace failed"
+                )
+                matches = _parse_stream_output(preview_completed.stdout)
+
+            replacement_count = len(matches)
+            apply_cmd = ["ast-grep", "run", "-p", args.pattern, "-r", args.rewrite]
+            if args.lang:
+                apply_cmd.extend(["--lang", args.lang])
+            apply_cmd.extend(["-U", relative_path])
+            completed = _run_ast_grep(cmd=apply_cmd, workspace=workspace)
+            if isinstance(completed, ToolResult):
+                return ToolResult(
+                    tool_name=self.definition.name,
+                    status=completed.status,
+                    error=completed.error,
+                )
+            if not _is_no_match_result(completed):
+                _raise_on_process_failure(
+                    completed=completed, fallback_message="ast-grep replace failed"
+                )
+            return ToolResult(
+                tool_name=self.definition.name,
+                status="ok",
+                content=f"Applied {replacement_count} AST replacement(s) in {relative_path}",
+                data={
+                    "path": relative_path,
+                    "pattern": args.pattern,
+                    "rewrite": args.rewrite,
+                    "lang": args.lang,
+                    "replacement_count": replacement_count,
+                    "matches": matches,
+                    "applied": True,
+                },
+            )
+
+        preview_cmd.append(relative_path)
+
+        completed = _run_ast_grep(cmd=preview_cmd, workspace=workspace)
+        if isinstance(completed, ToolResult):
+            return ToolResult(
+                tool_name=self.definition.name,
+                status=completed.status,
+                error=completed.error,
+            )
+
+        if _is_no_match_result(completed):
+            matches = []
+        else:
+            _raise_on_process_failure(
+                completed=completed, fallback_message="ast-grep replace failed"
+            )
+            matches = _parse_stream_output(completed.stdout)
+
+        replacement_count = len(matches)
+        action = "Applied" if args.apply else "Previewed"
+        return ToolResult(
+            tool_name=self.definition.name,
+            status="ok",
+            content=f"{action} {replacement_count} AST replacement(s) in {relative_path}",
+            data={
+                "path": relative_path,
+                "pattern": args.pattern,
+                "rewrite": args.rewrite,
+                "lang": args.lang,
+                "replacement_count": replacement_count,
+                "matches": matches,
+                "applied": args.apply,
+            },
+        )

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -179,6 +179,51 @@ class _GraphStep:
     is_finished: bool = False
 
 
+class _AstGrepPreviewGraph:
+    def step(self, request: object, tool_results: tuple[object, ...], *, session: object) -> object:
+        _ = request, session
+        if not tool_results:
+            return _GraphStep(
+                events=(),
+                tool_call=cast(
+                    ToolCallFactory,
+                    importlib.import_module("voidcode.tools.contracts").ToolCall,
+                )(
+                    tool_name="ast_grep_preview",
+                    arguments={
+                        "pattern": "print($X)",
+                        "rewrite": "logger.info($X)",
+                        "path": "sample.py",
+                        "lang": "python",
+                    },
+                ),
+            )
+        return _GraphStep(events=(), tool_call=None, output="previewed", is_finished=True)
+
+
+class _AstGrepReplaceGraph:
+    def step(self, request: object, tool_results: tuple[object, ...], *, session: object) -> object:
+        _ = request, session
+        if not tool_results:
+            return _GraphStep(
+                events=(),
+                tool_call=cast(
+                    ToolCallFactory,
+                    importlib.import_module("voidcode.tools.contracts").ToolCall,
+                )(
+                    tool_name="ast_grep_replace",
+                    arguments={
+                        "pattern": "print($X)",
+                        "rewrite": "logger.info($X)",
+                        "path": "sample.py",
+                        "lang": "python",
+                        "apply": True,
+                    },
+                ),
+            )
+        return _GraphStep(events=(), tool_call=None, output="applied", is_finished=True)
+
+
 def _approval_runtime(
     tmp_path: Path, *, mode: str = "ask"
 ) -> tuple[RuntimeRequestFactory, RuntimeRunner]:
@@ -989,6 +1034,78 @@ def test_runtime_denies_non_read_only_tool_when_policy_is_deny(tmp_path: Path) -
     assert denied.events[6].payload["decision"] == "deny"
     assert denied.output is None
     assert (tmp_path / "danger.txt").exists() is False
+
+
+def test_runtime_allows_ast_grep_preview_when_policy_is_deny(tmp_path: Path) -> None:
+    runtime_request, runtime_class = _load_runtime_types()
+    permission_module = importlib.import_module("voidcode.runtime.permission")
+    policy = cast(Callable[..., object], permission_module.PermissionPolicy)(mode="deny")
+    sample_file = tmp_path / "sample.py"
+    _ = sample_file.write_text("print('hello')\n", encoding="utf-8")
+
+    runtime = cast(
+        RuntimeRunner,
+        cast(
+            object,
+            runtime_class(
+                workspace=tmp_path,
+                graph=_AstGrepPreviewGraph(),
+                permission_policy=policy,
+            ),
+        ),
+    )
+    completed = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=(
+            '{"text":"print(\'hello\')","file":"sample.py","replacement":"logger.info(\'hello\')"}\n'
+        ),
+        stderr="",
+    )
+
+    with patch("subprocess.run", return_value=completed):
+        result = runtime.run(runtime_request(prompt="preview", session_id="ast-grep-preview-deny"))
+
+    assert result.session.status == "completed"
+    event_types = [event.event_type for event in result.events]
+    assert "runtime.permission_resolved" in event_types
+    assert "runtime.approval_requested" not in event_types
+    assert result.output == "previewed"
+
+
+def test_runtime_requests_approval_for_ast_grep_replace_when_policy_is_ask(tmp_path: Path) -> None:
+    runtime_request, runtime_class = _load_runtime_types()
+    permission_module = importlib.import_module("voidcode.runtime.permission")
+    policy = cast(Callable[..., object], permission_module.PermissionPolicy)(mode="ask")
+    sample_file = tmp_path / "sample.py"
+    _ = sample_file.write_text("print('hello')\n", encoding="utf-8")
+
+    runtime = cast(
+        RuntimeRunner,
+        cast(
+            object,
+            runtime_class(
+                workspace=tmp_path,
+                graph=_AstGrepReplaceGraph(),
+                permission_policy=policy,
+            ),
+        ),
+    )
+
+    waiting = runtime.run(runtime_request(prompt="replace", session_id="ast-grep-replace-ask"))
+
+    assert waiting.session.status == "waiting"
+    event_types = [event.event_type for event in waiting.events]
+    assert event_types[-1] == "runtime.approval_requested"
+    assert "runtime.tool_lookup_succeeded" in event_types
+    assert waiting.events[-1].payload["tool"] == "ast_grep_replace"
+    assert waiting.events[-1].payload["arguments"] == {
+        "pattern": "print($X)",
+        "rewrite": "logger.info($X)",
+        "path": "sample.py",
+        "lang": "python",
+        "apply": True,
+    }
 
 
 def test_runtime_executes_read_only_slice_and_emits_events(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_tool_provider.py
+++ b/tests/unit/runtime/test_tool_provider.py
@@ -21,6 +21,7 @@ from voidcode.runtime.service import (
 )
 from voidcode.runtime.tool_provider import BuiltinToolProvider
 from voidcode.tools import (
+    AstGrepPreviewTool,
     AstGrepReplaceTool,
     AstGrepSearchTool,
     CodeSearchTool,
@@ -134,6 +135,7 @@ def test_builtin_tool_provider_returns_expected_builtin_tools() -> None:
         ReadFileTool,
         ShellExecTool,
         AstGrepSearchTool,
+        AstGrepPreviewTool,
         AstGrepReplaceTool,
         WebFetchTool,
         WebSearchTool,
@@ -195,6 +197,7 @@ def test_tool_registry_accepts_tools_from_provider_output() -> None:
     optional_tools = {
         "apply_patch",
         "ast_grep_search",
+        "ast_grep_preview",
         "ast_grep_replace",
         "code_search",
         "multi_edit",
@@ -239,6 +242,7 @@ def test_tool_registry_with_defaults_delegates_through_builtin_provider() -> Non
     optional_tools = [
         "apply_patch",
         "ast_grep_search",
+        "ast_grep_preview",
         "ast_grep_replace",
         "code_search",
         "multi_edit",
@@ -390,6 +394,7 @@ def test_runtime_default_registry_behavior_remains_unchanged(tmp_path: Path) -> 
 def test_tools_package_exports_code_search_tool() -> None:
     tools_module = __import__("voidcode.tools", fromlist=["__all__"])
     assert "AstGrepSearchTool" in tools_module.__all__
+    assert "AstGrepPreviewTool" in tools_module.__all__
     assert "AstGrepReplaceTool" in tools_module.__all__
     assert "CodeSearchTool" in tools_module.__all__
     assert "McpTool" in tools_module.__all__

--- a/tests/unit/runtime/test_tool_provider.py
+++ b/tests/unit/runtime/test_tool_provider.py
@@ -21,6 +21,8 @@ from voidcode.runtime.service import (
 )
 from voidcode.runtime.tool_provider import BuiltinToolProvider
 from voidcode.tools import (
+    AstGrepReplaceTool,
+    AstGrepSearchTool,
     CodeSearchTool,
     EditTool,
     GlobTool,
@@ -131,6 +133,8 @@ def test_builtin_tool_provider_returns_expected_builtin_tools() -> None:
         ListTool,
         ReadFileTool,
         ShellExecTool,
+        AstGrepSearchTool,
+        AstGrepReplaceTool,
         WebFetchTool,
         WebSearchTool,
         WriteFileTool,
@@ -188,7 +192,14 @@ def test_tool_registry_accepts_tools_from_provider_output() -> None:
         assert registry.resolve(tool_name).definition.name == tool_name
 
     # Optional tools
-    optional_tools = {"apply_patch", "code_search", "multi_edit", "todo_write"}
+    optional_tools = {
+        "apply_patch",
+        "ast_grep_search",
+        "ast_grep_replace",
+        "code_search",
+        "multi_edit",
+        "todo_write",
+    }
     for tool_name in optional_tools:
         if tool_name in registry.tools:
             assert registry.resolve(tool_name).definition.name == tool_name
@@ -225,7 +236,14 @@ def test_tool_registry_with_defaults_delegates_through_builtin_provider() -> Non
         assert registry.resolve(tool_name) is provided_tools[i]
 
     # Verify optional tools if present
-    optional_tools = ["apply_patch", "code_search", "multi_edit", "todo_write"]
+    optional_tools = [
+        "apply_patch",
+        "ast_grep_search",
+        "ast_grep_replace",
+        "code_search",
+        "multi_edit",
+        "todo_write",
+    ]
     for tool_name in optional_tools:
         if tool_name in registry.tools:
             assert registry.resolve(tool_name) is not None
@@ -371,5 +389,7 @@ def test_runtime_default_registry_behavior_remains_unchanged(tmp_path: Path) -> 
 
 def test_tools_package_exports_code_search_tool() -> None:
     tools_module = __import__("voidcode.tools", fromlist=["__all__"])
+    assert "AstGrepSearchTool" in tools_module.__all__
+    assert "AstGrepReplaceTool" in tools_module.__all__
     assert "CodeSearchTool" in tools_module.__all__
     assert "McpTool" in tools_module.__all__

--- a/tests/unit/tools/test_ast_grep_tool.py
+++ b/tests/unit/tools/test_ast_grep_tool.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
-from voidcode.tools import AstGrepReplaceTool, AstGrepSearchTool, ToolCall
+from voidcode.tools import AstGrepPreviewTool, AstGrepReplaceTool, AstGrepSearchTool, ToolCall
 
 
 def test_ast_grep_search_parses_json_stream_results(tmp_path: Path) -> None:
@@ -153,10 +153,10 @@ def test_ast_grep_search_raises_on_invalid_json_stream_output(tmp_path: Path) ->
             )
 
 
-def test_ast_grep_replace_defaults_to_preview_mode(tmp_path: Path) -> None:
+def test_ast_grep_preview_defaults_to_read_only_preview_mode(tmp_path: Path) -> None:
     sample = tmp_path / "sample.py"
     _ = sample.write_text("print('hello')\n", encoding="utf-8")
-    tool = AstGrepReplaceTool()
+    tool = AstGrepPreviewTool()
     completed = subprocess.CompletedProcess(
         args=[],
         returncode=0,
@@ -169,7 +169,7 @@ def test_ast_grep_replace_defaults_to_preview_mode(tmp_path: Path) -> None:
     with patch("subprocess.run", return_value=completed) as run_mock:
         result = tool.invoke(
             ToolCall(
-                tool_name="ast_grep_replace",
+                tool_name="ast_grep_preview",
                 arguments={
                     "pattern": "print($X)",
                     "rewrite": "logger.info($X)",
@@ -187,6 +187,36 @@ def test_ast_grep_replace_defaults_to_preview_mode(tmp_path: Path) -> None:
     assert "-U" not in run_mock.call_args.args[0]
     assert "-r" in run_mock.call_args.args[0]
     assert "--json=stream" in run_mock.call_args.args[0]
+
+
+def test_ast_grep_preview_allows_empty_rewrite_strings(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.py"
+    _ = sample.write_text("print('hello')\n", encoding="utf-8")
+    tool = AstGrepPreviewTool()
+    completed = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout='{"text":"print(\'hello\')","file":"sample.py","replacement":""}\n',
+        stderr="",
+    )
+
+    with patch("subprocess.run", return_value=completed):
+        result = tool.invoke(
+            ToolCall(
+                tool_name="ast_grep_preview",
+                arguments={
+                    "pattern": "print($X)",
+                    "rewrite": "",
+                    "path": "sample.py",
+                    "lang": "python",
+                },
+            ),
+            workspace=tmp_path,
+        )
+
+    assert result.status == "ok"
+    assert result.data["rewrite"] == ""
+    assert result.data["replacement_count"] == 1
 
 
 def test_ast_grep_replace_can_apply_changes(tmp_path: Path) -> None:
@@ -231,13 +261,65 @@ def test_ast_grep_replace_can_apply_changes(tmp_path: Path) -> None:
     assert "--json=stream" not in run_mock.call_args_list[1].args[0]
 
 
+def test_ast_grep_replace_requires_apply_true(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.py"
+    _ = sample.write_text("print('hello')\n", encoding="utf-8")
+    tool = AstGrepReplaceTool()
+
+    with pytest.raises(ValueError, match="requires apply=True"):
+        tool.invoke(
+            ToolCall(
+                tool_name="ast_grep_replace",
+                arguments={
+                    "pattern": "print($X)",
+                    "rewrite": "logger.info($X)",
+                    "path": "sample.py",
+                },
+            ),
+            workspace=tmp_path,
+        )
+
+
+def test_ast_grep_replace_allows_empty_rewrite_strings(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.py"
+    _ = sample.write_text("print('hello')\n", encoding="utf-8")
+    tool = AstGrepReplaceTool()
+    preview_completed = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout='{"text":"print(\'hello\')","file":"sample.py","replacement":""}\n',
+        stderr="",
+    )
+    apply_completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+    with patch("subprocess.run", side_effect=[preview_completed, apply_completed]):
+        result = tool.invoke(
+            ToolCall(
+                tool_name="ast_grep_replace",
+                arguments={
+                    "pattern": "print($X)",
+                    "rewrite": "",
+                    "path": "sample.py",
+                    "apply": True,
+                },
+            ),
+            workspace=tmp_path,
+        )
+
+    assert result.status == "ok"
+    assert result.data["rewrite"] == ""
+    assert result.data["replacement_count"] == 1
+
+
 def test_ast_grep_replace_raises_on_cli_failure(tmp_path: Path) -> None:
     sample = tmp_path / "sample.py"
     _ = sample.write_text("print('hello')\n", encoding="utf-8")
     tool = AstGrepReplaceTool()
-    completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="bad rewrite")
+    preview_completed = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout="", stderr="bad rewrite"
+    )
 
-    with patch("subprocess.run", return_value=completed):
+    with patch("subprocess.run", return_value=preview_completed):
         with pytest.raises(ValueError, match="bad rewrite"):
             tool.invoke(
                 ToolCall(
@@ -247,23 +329,24 @@ def test_ast_grep_replace_raises_on_cli_failure(tmp_path: Path) -> None:
                         "rewrite": "logger.info($X)",
                         "path": "sample.py",
                         "lang": "python",
+                        "apply": True,
                     },
                 ),
                 workspace=tmp_path,
             )
 
 
-def test_ast_grep_replace_raises_on_invalid_json_stream_output(tmp_path: Path) -> None:
+def test_ast_grep_preview_raises_on_invalid_json_stream_output(tmp_path: Path) -> None:
     sample = tmp_path / "sample.py"
     _ = sample.write_text("print('hello')\n", encoding="utf-8")
-    tool = AstGrepReplaceTool()
+    tool = AstGrepPreviewTool()
     completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="not-json\n", stderr="")
 
     with patch("subprocess.run", return_value=completed):
         with pytest.raises(ValueError, match="invalid JSON stream output"):
             tool.invoke(
                 ToolCall(
-                    tool_name="ast_grep_replace",
+                    tool_name="ast_grep_preview",
                     arguments={
                         "pattern": "print($X)",
                         "rewrite": "logger.info($X)",
@@ -275,16 +358,16 @@ def test_ast_grep_replace_raises_on_invalid_json_stream_output(tmp_path: Path) -
             )
 
 
-def test_ast_grep_replace_preview_returns_zero_matches_for_empty_cli_result(tmp_path: Path) -> None:
+def test_ast_grep_preview_returns_zero_matches_for_empty_cli_result(tmp_path: Path) -> None:
     sample = tmp_path / "sample.py"
     _ = sample.write_text("print('hello')\n", encoding="utf-8")
-    tool = AstGrepReplaceTool()
+    tool = AstGrepPreviewTool()
     completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="")
 
     with patch("subprocess.run", return_value=completed):
         result = tool.invoke(
             ToolCall(
-                tool_name="ast_grep_replace",
+                tool_name="ast_grep_preview",
                 arguments={
                     "pattern": "missing($X)",
                     "rewrite": "logger.info($X)",

--- a/tests/unit/tools/test_ast_grep_tool.py
+++ b/tests/unit/tools/test_ast_grep_tool.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+
+from voidcode.tools import AstGrepReplaceTool, AstGrepSearchTool, ToolCall
+
+
+def test_ast_grep_search_parses_json_stream_results(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.py"
+    _ = sample.write_text("print('hello')\n", encoding="utf-8")
+    tool = AstGrepSearchTool()
+    completed = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=(
+            '{"text":"print(\'hello\')","file":"sample.py","range":{"start":{"line":0,"column":0},"end":{"line":0,"column":14}}}\n'
+        ),
+        stderr="",
+    )
+
+    with patch("subprocess.run", return_value=completed) as run_mock:
+        result = tool.invoke(
+            ToolCall(
+                tool_name="ast_grep_search",
+                arguments={"pattern": "print($X)", "path": "sample.py", "lang": "python"},
+            ),
+            workspace=tmp_path,
+        )
+
+    assert result.status == "ok"
+    assert result.data["match_count"] == 1
+    assert result.data["path"] == "sample.py"
+    first_match = cast(list[dict[str, object]], result.data["matches"])[0]
+    assert first_match["file"] == "sample.py"
+    assert "Found 1 AST match(es)" in (result.content or "")
+    assert "--json=stream" in run_mock.call_args.args[0]
+    assert "--lang" in run_mock.call_args.args[0]
+
+
+def test_ast_grep_search_rejects_invalid_arguments_and_workspace_escape(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.py"
+    _ = sample.write_text("print('hello')\n", encoding="utf-8")
+    tool = AstGrepSearchTool()
+
+    with pytest.raises(ValueError, match="string pattern"):
+        tool.invoke(
+            ToolCall(tool_name="ast_grep_search", arguments={"pattern": 123, "path": "sample.py"}),
+            workspace=tmp_path,
+        )
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        tool.invoke(
+            ToolCall(tool_name="ast_grep_search", arguments={"pattern": "", "path": "sample.py"}),
+            workspace=tmp_path,
+        )
+
+    with pytest.raises(ValueError, match="string path"):
+        tool.invoke(
+            ToolCall(tool_name="ast_grep_search", arguments={"pattern": "print($X)", "path": 123}),
+            workspace=tmp_path,
+        )
+
+    with pytest.raises(ValueError, match="inside the workspace"):
+        tool.invoke(
+            ToolCall(
+                tool_name="ast_grep_search",
+                arguments={"pattern": "print($X)", "path": "../escape.py"},
+            ),
+            workspace=tmp_path,
+        )
+
+
+def test_ast_grep_search_returns_error_when_cli_is_missing(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.py"
+    _ = sample.write_text("print('hello')\n", encoding="utf-8")
+    tool = AstGrepSearchTool()
+
+    with patch("subprocess.run", side_effect=OSError("not found")):
+        result = tool.invoke(
+            ToolCall(
+                tool_name="ast_grep_search",
+                arguments={"pattern": "print($X)", "path": "sample.py"},
+            ),
+            workspace=tmp_path,
+        )
+
+    assert result.status == "error"
+    assert "ast-grep" in (result.error or "")
+
+
+def test_ast_grep_search_raises_on_cli_failure(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.py"
+    _ = sample.write_text("print('hello')\n", encoding="utf-8")
+    tool = AstGrepSearchTool()
+    completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="bad pattern")
+
+    with patch("subprocess.run", return_value=completed):
+        with pytest.raises(ValueError, match="bad pattern"):
+            tool.invoke(
+                ToolCall(
+                    tool_name="ast_grep_search",
+                    arguments={"pattern": "print(", "path": "sample.py", "lang": "python"},
+                ),
+                workspace=tmp_path,
+            )
+
+
+def test_ast_grep_search_returns_zero_matches_for_empty_cli_result(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.py"
+    _ = sample.write_text("print('hello')\n", encoding="utf-8")
+    tool = AstGrepSearchTool()
+    completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="")
+
+    with patch("subprocess.run", return_value=completed):
+        result = tool.invoke(
+            ToolCall(
+                tool_name="ast_grep_search",
+                arguments={"pattern": "missing($X)", "path": "sample.py", "lang": "python"},
+            ),
+            workspace=tmp_path,
+        )
+
+    assert result.status == "ok"
+    assert result.content == "Found 0 AST match(es) in sample.py"
+    assert result.data == {
+        "path": "sample.py",
+        "pattern": "missing($X)",
+        "lang": "python",
+        "match_count": 0,
+        "matches": [],
+    }
+
+
+def test_ast_grep_search_raises_on_invalid_json_stream_output(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.py"
+    _ = sample.write_text("print('hello')\n", encoding="utf-8")
+    tool = AstGrepSearchTool()
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="not-json\n", stderr="")
+
+    with patch("subprocess.run", return_value=completed):
+        with pytest.raises(ValueError, match="invalid JSON stream output"):
+            tool.invoke(
+                ToolCall(
+                    tool_name="ast_grep_search",
+                    arguments={"pattern": "print($X)", "path": "sample.py", "lang": "python"},
+                ),
+                workspace=tmp_path,
+            )
+
+
+def test_ast_grep_replace_defaults_to_preview_mode(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.py"
+    _ = sample.write_text("print('hello')\n", encoding="utf-8")
+    tool = AstGrepReplaceTool()
+    completed = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=(
+            '{"text":"print(\'hello\')","file":"sample.py","replacement":"logger.info(\'hello\')"}\n'
+        ),
+        stderr="",
+    )
+
+    with patch("subprocess.run", return_value=completed) as run_mock:
+        result = tool.invoke(
+            ToolCall(
+                tool_name="ast_grep_replace",
+                arguments={
+                    "pattern": "print($X)",
+                    "rewrite": "logger.info($X)",
+                    "path": "sample.py",
+                    "lang": "python",
+                },
+            ),
+            workspace=tmp_path,
+        )
+
+    assert result.status == "ok"
+    assert result.data["replacement_count"] == 1
+    assert result.data["applied"] is False
+    assert "Previewed 1 AST replacement(s)" in (result.content or "")
+    assert "-U" not in run_mock.call_args.args[0]
+    assert "-r" in run_mock.call_args.args[0]
+    assert "--json=stream" in run_mock.call_args.args[0]
+
+
+def test_ast_grep_replace_can_apply_changes(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.py"
+    _ = sample.write_text("print('hello')\n", encoding="utf-8")
+    tool = AstGrepReplaceTool()
+    preview_completed = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=(
+            '{"text":"print(\'hello\')","file":"sample.py","replacement":"logger.info(\'hello\')"}\n'
+        ),
+        stderr="",
+    )
+    apply_completed = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="", stderr="Applied 1 changes\n"
+    )
+
+    with patch("subprocess.run", side_effect=[preview_completed, apply_completed]) as run_mock:
+        result = tool.invoke(
+            ToolCall(
+                tool_name="ast_grep_replace",
+                arguments={
+                    "pattern": "print($X)",
+                    "rewrite": "logger.info($X)",
+                    "path": "sample.py",
+                    "apply": True,
+                },
+            ),
+            workspace=tmp_path,
+        )
+
+    assert result.status == "ok"
+    assert result.data["applied"] is True
+    assert result.data["replacement_count"] == 1
+    first_match = cast(list[dict[str, object]], result.data["matches"])[0]
+    assert first_match["file"] == "sample.py"
+    assert result.content == "Applied 1 AST replacement(s) in sample.py"
+    assert "--json=stream" in run_mock.call_args_list[0].args[0]
+    assert "-U" not in run_mock.call_args_list[0].args[0]
+    assert "-U" in run_mock.call_args_list[1].args[0]
+    assert "--json=stream" not in run_mock.call_args_list[1].args[0]
+
+
+def test_ast_grep_replace_raises_on_cli_failure(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.py"
+    _ = sample.write_text("print('hello')\n", encoding="utf-8")
+    tool = AstGrepReplaceTool()
+    completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="bad rewrite")
+
+    with patch("subprocess.run", return_value=completed):
+        with pytest.raises(ValueError, match="bad rewrite"):
+            tool.invoke(
+                ToolCall(
+                    tool_name="ast_grep_replace",
+                    arguments={
+                        "pattern": "print($X)",
+                        "rewrite": "logger.info($X)",
+                        "path": "sample.py",
+                        "lang": "python",
+                    },
+                ),
+                workspace=tmp_path,
+            )
+
+
+def test_ast_grep_replace_raises_on_invalid_json_stream_output(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.py"
+    _ = sample.write_text("print('hello')\n", encoding="utf-8")
+    tool = AstGrepReplaceTool()
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="not-json\n", stderr="")
+
+    with patch("subprocess.run", return_value=completed):
+        with pytest.raises(ValueError, match="invalid JSON stream output"):
+            tool.invoke(
+                ToolCall(
+                    tool_name="ast_grep_replace",
+                    arguments={
+                        "pattern": "print($X)",
+                        "rewrite": "logger.info($X)",
+                        "path": "sample.py",
+                        "lang": "python",
+                    },
+                ),
+                workspace=tmp_path,
+            )
+
+
+def test_ast_grep_replace_preview_returns_zero_matches_for_empty_cli_result(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.py"
+    _ = sample.write_text("print('hello')\n", encoding="utf-8")
+    tool = AstGrepReplaceTool()
+    completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="")
+
+    with patch("subprocess.run", return_value=completed):
+        result = tool.invoke(
+            ToolCall(
+                tool_name="ast_grep_replace",
+                arguments={
+                    "pattern": "missing($X)",
+                    "rewrite": "logger.info($X)",
+                    "path": "sample.py",
+                    "lang": "python",
+                },
+            ),
+            workspace=tmp_path,
+        )
+
+    assert result.status == "ok"
+    assert result.content == "Previewed 0 AST replacement(s) in sample.py"
+    assert result.data == {
+        "path": "sample.py",
+        "pattern": "missing($X)",
+        "rewrite": "logger.info($X)",
+        "lang": "python",
+        "replacement_count": 0,
+        "matches": [],
+        "applied": False,
+    }
+
+
+def test_ast_grep_replace_apply_returns_zero_changes_for_empty_cli_result(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.py"
+    _ = sample.write_text("print('hello')\n", encoding="utf-8")
+    tool = AstGrepReplaceTool()
+    preview_completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="")
+    apply_completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="")
+
+    with patch("subprocess.run", side_effect=[preview_completed, apply_completed]):
+        result = tool.invoke(
+            ToolCall(
+                tool_name="ast_grep_replace",
+                arguments={
+                    "pattern": "missing($X)",
+                    "rewrite": "logger.info($X)",
+                    "path": "sample.py",
+                    "apply": True,
+                },
+            ),
+            workspace=tmp_path,
+        )
+
+    assert result.status == "ok"
+    assert result.content == "Applied 0 AST replacement(s) in sample.py"
+    assert result.data == {
+        "path": "sample.py",
+        "pattern": "missing($X)",
+        "rewrite": "logger.info($X)",
+        "lang": None,
+        "replacement_count": 0,
+        "matches": [],
+        "applied": True,
+    }
+
+
+def test_ast_grep_replace_apply_raises_when_apply_step_returns_stderr(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.py"
+    _ = sample.write_text("print('hello')\n", encoding="utf-8")
+    tool = AstGrepReplaceTool()
+    preview_completed = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=(
+            '{"text":"print(\'hello\')","file":"sample.py","replacement":"logger.info(\'hello\')"}\n'
+        ),
+        stderr="",
+    )
+    apply_completed = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout="", stderr="apply failed"
+    )
+
+    with patch("subprocess.run", side_effect=[preview_completed, apply_completed]):
+        with pytest.raises(ValueError, match="apply failed"):
+            tool.invoke(
+                ToolCall(
+                    tool_name="ast_grep_replace",
+                    arguments={
+                        "pattern": "print($X)",
+                        "rewrite": "logger.info($X)",
+                        "path": "sample.py",
+                        "lang": "python",
+                        "apply": True,
+                    },
+                ),
+                workspace=tmp_path,
+            )


### PR DESCRIPTION

close #121 
## Summary
- add `ast_grep_search` and `ast_grep_replace` tools with workspace-safe path validation and ast-grep CLI execution
- harden ast-grep result handling so no-match cases stay non-fatal while malformed JSON stream output and apply-step failures surface clearly
- register the new tools in the builtin provider and cover the substrate with targeted unit tests

## Verification
- `uv run pytest tests/unit/tools/test_ast_grep_tool.py tests/unit/tools/test_grep_tool.py tests/unit/runtime/test_tool_provider.py -q`
- `lsp_diagnostics` on changed files returned no diagnostics
- manual smoke test with real `ast-grep` verified search, preview, and apply behavior against a temporary Python file