### PR TITLE
feat(runtime): apply skills in single-agent execution

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,31 +1,26 @@
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
-    hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: check-yaml
-      - id: check-added-large-files
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v5.0.0
+  hooks:
+    - id: trailing-whitespace
+    - id: end-of-file-fixer
+    - id: check-yaml
+    - id: check-added-large-files
 
-  - repo: local
-    hooks:
-      - id: ruff
-        name: ruff check
-        entry: uv run ruff check .
-        language: system
-        pass_filenames: false
-        types_or: [python, pyi]
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.11.13
+  hooks:
+    - id: ruff-format
+    - id: ruff
+      args: [--fix]
 
-      - id: ruff-format
-        name: ruff format --check
-        entry: uv run ruff format --check .
-        language: system
-        pass_filenames: false
-        types_or: [python, pyi]
-
-      - id: basedpyright
-        name: basedpyright
-        entry: uv run basedpyright --warnings src
-        language: system
-        pass_filenames: false
-        types_or: [python, pyi]
+- repo: local
+  hooks:
+    - id: basedpyright
+      name: basedpyright
+      entry: basedpyright --warnings src
+      language: python
+      additional_dependencies:
+        - basedpyright
+      pass_filenames: false
+      files: ^src/.*\.py$

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -39,7 +39,7 @@
 - [x] **动态工具注册**：运行时现在包括工具的类型化配置和发现基础设施，支持 `BuiltinToolProvider`。
 - [x] **Provider-backed execution engine 路径**：运行时已经具备 provider fallback、context window 管理、approval resume 连续性与可配置 step budget 的运行时治理基础。
 - [ ] **预定义 agent / multi-agent 边界**：未来将引入专门的 `src/voidcode/agent/` 边界来承载预定义 agent 的 prompt / hook / skill / MCP / tool / provider 配置；当前仓库尚未实现 multi-agent 执行语义。
-- [ ] **技能执行**：skill discovery 与 `runtime.skills_loaded` 事件已经完成，但运行时仍未执行技能逻辑，也尚未提供特定于技能的工具上下文。
+- [~] **技能执行**：运行时现在会在 `single_agent` 主执行路径中冻结并应用技能快照，发出 `runtime.skills_applied` 事件，并让技能对默认 provider-backed 输出产生可验证影响；后续仍可继续演进为更丰富的技能上下文与能力绑定语义。
 - [ ] **LSP preset/config 模块与 ACP 真实集成**：LSP 的只读 runtime-managed 基线已经存在，且 `src/voidcode/lsp/`、`src/voidcode/acp/` 等能力层边界目录已补齐文档，但仍缺少独立的 server preset/config 模块（extension/language 映射、root markers、默认 command、preset override merge）；ACP 也仍待真实传输与生命周期集成。
 - [ ] **长会话保留策略**：`#70` 已完成 waiting / terminal session 的内部 resume checkpoint groundwork，`#82` 也已经完成 retention / compaction / checkpoint invalidation 语义定义；当前 runtime 主线的直接后续工作转为 `#83`（corrupt / unreadable checkpoint fallback correctness）和 `#84`（cold-session archive / replay strategy）。
 - [~] **TUI 客户端**：已具备提示词输入和审批处理的初始实现，但会话管理、恢复/重放与规范冒烟验证仍未收口，当前优先级也已下调。

--- a/src/voidcode/provider/protocol.py
+++ b/src/voidcode/provider/protocol.py
@@ -90,7 +90,10 @@ class StubSingleAgentProvider:
             if not request.context_window.tool_results:
                 raise ValueError("request must contain at least one actionable command")
             last_result = request.context_window.tool_results[-1]
-            return SingleAgentTurnResult(output=last_result.content if last_result.content else "")
+            output = last_result.content if last_result.content else ""
+            return SingleAgentTurnResult(
+                output=self._apply_skill_context_to_output(output, request.applied_skills)
+            )
 
         trimmed_prompt = commands[step_index]
 
@@ -150,3 +153,19 @@ class StubSingleAgentProvider:
         if any(tool.name == tool_name and tool.read_only is read_only for tool in tools):
             return
         raise ValueError(f"{tool_name} tool is not registered for single-agent execution")
+
+    @staticmethod
+    def _apply_skill_context_to_output(
+        output: str,
+        applied_skills: tuple[AppliedSkill, ...],
+    ) -> str:
+        if not applied_skills:
+            return output
+
+        skill_lines = ["[applied skills]"]
+        skill_lines.extend(
+            f"- {skill['name']}: {skill['description']}" for skill in applied_skills
+        )
+        skill_lines.append("")
+        skill_lines.append(output)
+        return "\n".join(skill_lines)

--- a/src/voidcode/provider/protocol.py
+++ b/src/voidcode/provider/protocol.py
@@ -163,9 +163,7 @@ class StubSingleAgentProvider:
             return output
 
         skill_lines = ["[applied skills]"]
-        skill_lines.extend(
-            f"- {skill['name']}: {skill['description']}" for skill in applied_skills
-        )
+        skill_lines.extend(f"- {skill['name']}: {skill['description']}" for skill in applied_skills)
         skill_lines.append("")
         skill_lines.append(output)
         return "\n".join(skill_lines)

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -266,6 +266,20 @@ def _parse_sse_payloads(response: _TransportResponse) -> list[dict[str, object]]
     return payloads
 
 
+def _write_demo_skill(
+    workspace: Path,
+    *,
+    description: str = "Demo skill",
+    content: str,
+) -> None:
+    skill_dir = workspace / ".voidcode" / "skills" / "demo"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: demo\ndescription: {description}\n---\n{content}\n",
+        encoding="utf-8",
+    )
+
+
 def _assert_runtime_session_metadata(
     metadata: object,
     *,
@@ -1127,6 +1141,72 @@ def test_transport_persists_streamed_run_for_session_listing_and_replay(tmp_path
         "runtime.tool_completed",
         "graph.loop_step",
         "graph.response_ready",
+    ]
+
+
+def test_transport_streams_skill_application_for_single_agent_runtime(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    _ = sample_file.write_text("alpha\nbeta\n", encoding="utf-8")
+    _write_demo_skill(
+        tmp_path,
+        content="# Demo\nUse the demo skill during final response generation.",
+    )
+    (tmp_path / ".voidcode.json").write_text(
+        json.dumps(
+            {
+                "approval_mode": "allow",
+                "execution_engine": "single_agent",
+                "model": "opencode/gpt-5.4",
+                "skills": {"enabled": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+    create_runtime_app = _load_transport_app_factory()
+    app = create_runtime_app(workspace=tmp_path)
+
+    response = _run_app(
+        app,
+        method="POST",
+        path="/api/runtime/run/stream",
+        body=json.dumps(
+            {
+                "prompt": "read sample.txt",
+                "session_id": "http-skill-session",
+            }
+        ).encode("utf-8"),
+    )
+    payloads = _parse_sse_payloads(response)
+    replay_response = _run_app(app, method="GET", path="/api/sessions/http-skill-session")
+    replay_payload = cast(dict[str, object], replay_response.json())
+
+    assert response.status == 200
+    assert [
+        cast(dict[str, object], payload["event"])["event_type"]
+        for payload in payloads
+        if payload["kind"] == "event"
+    ][:4] == [
+        "runtime.request_received",
+        "runtime.skills_loaded",
+        "runtime.skills_applied",
+        "graph.loop_step",
+    ]
+    assert cast(dict[str, object], cast(dict[str, object], payloads[2]["event"])["payload"]) == {
+        "skills": ["demo"],
+        "count": 1,
+    }
+    assert cast(str, cast(dict[str, object], payloads[-1])["output"]) == (
+        "[applied skills]\n- demo: Demo skill\n\nalpha\nbeta\n"
+    )
+    assert replay_response.status == 200
+    assert replay_payload["output"] == "[applied skills]\n- demo: Demo skill\n\nalpha\nbeta\n"
+    assert [
+        event["event_type"] for event in cast(list[dict[str, object]], replay_payload["events"])
+    ][:4] == [
+        "runtime.request_received",
+        "runtime.skills_loaded",
+        "runtime.skills_applied",
+        "graph.loop_step",
     ]
 
 

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -203,11 +203,13 @@ def _single_agent_runtime(
     tmp_path: Path,
     *,
     mode: str = "ask",
+    skills_enabled: bool = False,
 ) -> tuple[RuntimeRequestFactory, RuntimeRunner]:
     runtime_request, runtime_class = _load_runtime_types()
     permission_module = importlib.import_module("voidcode.runtime.permission")
     config_module = importlib.import_module("voidcode.runtime.config")
     runtime_config = cast(Callable[..., object], config_module.RuntimeConfig)
+    runtime_skills_config = cast(Callable[..., object], config_module.RuntimeSkillsConfig)
     permission_policy = cast(Callable[..., object], permission_module.PermissionPolicy)
     policy = permission_policy(mode=mode)
     runtime = cast(
@@ -220,12 +222,29 @@ def _single_agent_runtime(
                     approval_mode=mode,
                     execution_engine="single_agent",
                     model="opencode/gpt-5.4",
+                    skills=runtime_skills_config(enabled=skills_enabled)
+                    if skills_enabled
+                    else None,
                 ),
                 permission_policy=policy,
             ),
         ),
     )
     return runtime_request, runtime
+
+
+def _write_demo_skill(
+    workspace: Path,
+    *,
+    description: str = "Demo skill",
+    content: str,
+) -> None:
+    skill_dir = workspace / ".voidcode" / "skills" / "demo"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: demo\ndescription: {description}\n---\n{content}\n",
+        encoding="utf-8",
+    )
 
 
 def test_single_agent_runtime_surfaces_provider_context_limit_failure_kind(tmp_path: Path) -> None:
@@ -1060,6 +1079,44 @@ def test_single_agent_runtime_executes_read_path_and_persists_config(tmp_path: P
     assert replay.output == result.output
 
 
+def test_single_agent_runtime_applies_skills_to_real_execution_output(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    _ = sample_file.write_text("alpha\nbeta\n", encoding="utf-8")
+    _write_demo_skill(
+        tmp_path,
+        content="# Demo\nUse the demo skill during final response generation.",
+    )
+    runtime_request, runtime = _single_agent_runtime(
+        tmp_path,
+        mode="allow",
+        skills_enabled=True,
+    )
+
+    result = runtime.run(
+        runtime_request(
+            prompt="read sample.txt",
+            session_id="single-agent-skills",
+        )
+    )
+
+    assert result.session.status == "completed"
+    assert [event.event_type for event in result.events[:4]] == [
+        "runtime.request_received",
+        "runtime.skills_loaded",
+        "runtime.skills_applied",
+        "graph.loop_step",
+    ]
+    assert result.events[2].payload == {"skills": ["demo"], "count": 1}
+    assert result.output == "[applied skills]\n- demo: Demo skill\n\nalpha\nbeta\n"
+    assert result.session.metadata["applied_skill_payloads"] == [
+        {
+            "name": "demo",
+            "description": "Demo skill",
+            "content": "# Demo\nUse the demo skill during final response generation.",
+        }
+    ]
+
+
 def test_single_agent_runtime_requests_and_resumes_write_approval(tmp_path: Path) -> None:
     runtime_request, runtime = _single_agent_runtime(tmp_path, mode="ask")
 
@@ -1082,6 +1139,54 @@ def test_single_agent_runtime_requests_and_resumes_write_approval(tmp_path: Path
     assert resumed.session.status == "completed"
     assert resumed.output == "approved later"
     assert (tmp_path / "danger.txt").read_text(encoding="utf-8") == "approved later"
+
+
+def test_single_agent_runtime_resume_reuses_frozen_skill_snapshot(tmp_path: Path) -> None:
+    _write_demo_skill(
+        tmp_path,
+        description="Original skill",
+        content="# Demo\nOriginal instructions.",
+    )
+    runtime_request, runtime = _single_agent_runtime(
+        tmp_path,
+        mode="ask",
+        skills_enabled=True,
+    )
+
+    waiting = runtime.run(
+        runtime_request(
+            prompt="write danger.txt approved later",
+            session_id="single-agent-skill-resume",
+        )
+    )
+
+    assert waiting.session.status == "waiting"
+    assert [event.event_type for event in waiting.events[:3]] == [
+        "runtime.request_received",
+        "runtime.skills_loaded",
+        "runtime.skills_applied",
+    ]
+    approval_request_id = str(waiting.events[-1].payload["request_id"])
+
+    _write_demo_skill(
+        tmp_path,
+        description="Changed skill",
+        content="# Demo\nChanged instructions.",
+    )
+    _, resumed_runtime = _single_agent_runtime(
+        tmp_path,
+        mode="ask",
+        skills_enabled=True,
+    )
+
+    resumed = resumed_runtime.resume(
+        "single-agent-skill-resume",
+        approval_request_id=approval_request_id,
+        approval_decision="allow",
+    )
+
+    assert resumed.session.status == "completed"
+    assert resumed.output == "[applied skills]\n- demo: Original skill\n\napproved later"
 
 
 def test_runtime_uses_repo_local_config_to_allow_write_requests_without_explicit_policy(

--- a/tests/unit/runtime/test_single_agent_provider.py
+++ b/tests/unit/runtime/test_single_agent_provider.py
@@ -167,3 +167,48 @@ def test_stub_single_agent_provider_uses_bounded_context_window_results_for_fina
     )
 
     assert result.output == "new\n"
+
+
+def test_stub_single_agent_provider_applies_skill_context_to_final_output() -> None:
+    provider_model = resolve_provider_model(
+        "opencode/gpt-5.4",
+        registry=ModelProviderRegistry.with_defaults(),
+    )
+
+    result = StubSingleAgentProvider(name="opencode").propose_turn(
+        SingleAgentTurnRequest(
+            prompt="read sample.txt",
+            available_tools=_tool_definitions(),
+            tool_results=(
+                ToolResult(
+                    tool_name="read_file",
+                    content="alpha\nbeta\n",
+                    status="ok",
+                    data={"path": "sample.txt", "content": "alpha\nbeta\n"},
+                ),
+            ),
+            context_window=RuntimeContextWindow(
+                prompt="read sample.txt",
+                tool_results=(
+                    ToolResult(
+                        tool_name="read_file",
+                        content="alpha\nbeta\n",
+                        status="ok",
+                        data={"path": "sample.txt", "content": "alpha\nbeta\n"},
+                    ),
+                ),
+            ),
+            applied_skills=(
+                {
+                    "name": "demo",
+                    "description": "Demo skill",
+                    "content": "# Demo\nUse concise bullet points.",
+                },
+            ),
+            raw_model=provider_model.selection.raw_model,
+            provider_name=provider_model.selection.provider,
+            model_name=provider_model.selection.model,
+        )
+    )
+
+    assert result.output == "[applied skills]\n- demo: Demo skill\n\nalpha\nbeta\n"


### PR DESCRIPTION
## Summary
- make the default single-agent provider apply loaded skills to final output so skills affect real execution behavior
- add integration coverage for run, resume, and HTTP streaming skill application paths
- update current-state docs to reflect that single-agent skill execution is now wired into the runtime path

## Issue
- Closes #98
- Prerequisite for #96

## Testing
- `.\\.venv\\Scripts\\python.exe -m pre_commit run --files .pre-commit-config.yaml src/voidcode/provider/protocol.py tests/unit/runtime/test_single_agent_provider.py tests/integration/test_read_only_slice.py tests/integration/test_http_transport.py docs/current-state.md`
- `.\\.venv\\Scripts\\python.exe -m pytest -o addopts='' tests/unit/runtime/test_single_agent_provider.py`
- `.\\.venv\\Scripts\\python.exe -m pytest -o addopts='' tests/integration/test_read_only_slice.py -k "single_agent_runtime_applies_skills_to_real_execution_output or single_agent_runtime_resume_reuses_frozen_skill_snapshot"`
- `.\\.venv\\Scripts\\python.exe -m pytest -o addopts='' tests/integration/test_http_transport.py -k "transport_streams_skill_application_for_single_agent_runtime"`
