### PR TITLE
refactor(skills): extract capability layer from runtime

### DIFF
--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -30,6 +30,7 @@ from ..provider.snapshot import (
     parse_resolved_provider_snapshot,
     resolved_provider_snapshot,
 )
+from ..skills import SkillRegistry
 from ..tools.contracts import Tool, ToolCall, ToolDefinition, ToolResult, ToolResultStatus
 from .acp import AcpAdapter, AcpRequestEnvelope, AcpResponseEnvelope, build_acp_adapter
 from .config import (
@@ -71,7 +72,7 @@ from .permission import (
 from .plan import PlanContributor, apply_plan_patch, build_plan_contributor
 from .session import SessionRef, SessionState, SessionStatus, StoredSessionSummary
 from .single_agent_provider import ProviderExecutionError
-from .skills import SkillRegistry, SkillRuntimeContext
+from .skills import SkillRuntimeContext, build_runtime_contexts
 from .storage import SessionStore, SqliteSessionStore
 from .tool_provider import BuiltinToolProvider
 
@@ -1697,7 +1698,7 @@ class VoidCodeRuntime:
         self, metadata: dict[str, object] | None = None
     ) -> tuple[SkillRuntimeContext, ...]:
         _ = metadata
-        return self._skill_registry.runtime_contexts()
+        return build_runtime_contexts(self._skill_registry)
 
     @staticmethod
     def _frozen_applied_skill_payloads(

--- a/src/voidcode/runtime/skills.py
+++ b/src/voidcode/runtime/skills.py
@@ -1,22 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
-from dataclasses import dataclass, field
-from pathlib import Path
+from dataclasses import dataclass
 
-SKILL_ENTRY_FILE_NAME = "SKILL.md"
-DEFAULT_SKILL_SEARCH_PATHS = (".voidcode/skills",)
-_FRONTMATTER_DELIMITER = "---"
-_SUPPORTED_FRONTMATTER_KEYS = frozenset({"name", "description"})
-
-
-@dataclass(frozen=True, slots=True)
-class SkillMetadata:
-    name: str
-    description: str
-    directory: Path
-    entry_path: Path
-    content: str
+from ..skills.registry import SkillRegistry
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,136 +12,18 @@ class SkillRuntimeContext:
     content: str
 
 
-@dataclass(slots=True)
-class SkillRegistry:
-    skills: dict[str, SkillMetadata] = field(default_factory=dict)
-
-    @classmethod
-    def from_skills(cls, skills: Iterable[SkillMetadata]) -> SkillRegistry:
-        return cls(skills={skill.name: skill for skill in skills})
-
-    @classmethod
-    def discover(
-        cls,
-        *,
-        workspace: Path,
-        search_paths: Iterable[str] = DEFAULT_SKILL_SEARCH_PATHS,
-        loader: LocalSkillMetadataLoader | None = None,
-    ) -> SkillRegistry:
-        metadata_loader = loader or LocalSkillMetadataLoader()
-        return cls.from_skills(
-            metadata_loader.discover(workspace=workspace, search_paths=search_paths)
+def build_runtime_contexts(registry: SkillRegistry) -> tuple[SkillRuntimeContext, ...]:
+    return tuple(
+        SkillRuntimeContext(
+            name=skill.name,
+            description=skill.description,
+            content=skill.content,
         )
-
-    def all(self) -> tuple[SkillMetadata, ...]:
-        return tuple(self.skills.values())
-
-    def runtime_contexts(self) -> tuple[SkillRuntimeContext, ...]:
-        return tuple(
-            SkillRuntimeContext(
-                name=skill.name,
-                description=skill.description,
-                content=skill.content,
-            )
-            for skill in self.all()
-        )
-
-    def resolve(self, skill_name: str) -> SkillMetadata:
-        try:
-            return self.skills[skill_name]
-        except KeyError as exc:
-            raise ValueError(f"unknown skill: {skill_name}") from exc
+        for skill in registry.all()
+    )
 
 
-class LocalSkillMetadataLoader:
-    def discover(
-        self,
-        *,
-        workspace: Path,
-        search_paths: Iterable[str] = DEFAULT_SKILL_SEARCH_PATHS,
-    ) -> tuple[SkillMetadata, ...]:
-        resolved_workspace = workspace.resolve()
-        discovered: list[SkillMetadata] = []
-
-        for search_path in search_paths:
-            skill_root = _resolve_workspace_relative_path(
-                workspace=resolved_workspace, configured_path=search_path
-            )
-            if not skill_root.exists() or not skill_root.is_dir():
-                continue
-            for skill_dir in sorted(path for path in skill_root.iterdir() if path.is_dir()):
-                entry_path = skill_dir / SKILL_ENTRY_FILE_NAME
-                if not entry_path.exists() or not entry_path.is_file():
-                    continue
-                discovered.append(self.load(entry_path))
-
-        return tuple(discovered)
-
-    def load(self, entry_path: Path) -> SkillMetadata:
-        resolved_entry_path = entry_path.resolve()
-        contents = resolved_entry_path.read_text(encoding="utf-8")
-        metadata = parse_skill_frontmatter(contents)
-        return SkillMetadata(
-            name=metadata["name"],
-            description=metadata["description"],
-            directory=resolved_entry_path.parent,
-            entry_path=resolved_entry_path,
-            content=_skill_body(contents),
-        )
-
-
-def parse_skill_frontmatter(contents: str) -> dict[str, str]:
-    lines = contents.splitlines()
-    if not lines or lines[0].strip() != _FRONTMATTER_DELIMITER:
-        raise ValueError("skill file must begin with a simplified frontmatter block")
-
-    parsed: dict[str, str] = {}
-    for index, raw_line in enumerate(lines[1:], start=2):
-        line = raw_line.strip()
-        if line == _FRONTMATTER_DELIMITER:
-            break
-        if not line:
-            continue
-        key, separator, value = raw_line.partition(":")
-        if separator != ":":
-            raise ValueError(f"skill frontmatter line {index} must use 'key: value' syntax")
-        normalized_key = key.strip()
-        if normalized_key not in _SUPPORTED_FRONTMATTER_KEYS:
-            raise ValueError(f"unsupported skill frontmatter key: {normalized_key}")
-        normalized_value = value.strip()
-        if not normalized_value:
-            raise ValueError(f"skill frontmatter field '{normalized_key}' must not be empty")
-        parsed[normalized_key] = normalized_value
-    else:
-        raise ValueError("skill frontmatter must terminate with a closing '---' line")
-
-    missing_keys = _SUPPORTED_FRONTMATTER_KEYS.difference(parsed)
-    if missing_keys:
-        missing = ", ".join(sorted(missing_keys))
-        raise ValueError(f"skill frontmatter missing required fields: {missing}")
-    return parsed
-
-
-def _skill_body(contents: str) -> str:
-    lines = contents.splitlines()
-    if not lines or lines[0].strip() != _FRONTMATTER_DELIMITER:
-        raise ValueError("skill file must begin with a simplified frontmatter block")
-
-    for index, raw_line in enumerate(lines[1:], start=2):
-        if raw_line.strip() == _FRONTMATTER_DELIMITER:
-            return "\n".join(lines[index:]).strip()
-
-    raise ValueError("skill frontmatter must terminate with a closing '---' line")
-
-
-def _resolve_workspace_relative_path(*, workspace: Path, configured_path: str) -> Path:
-    candidate_path = Path(configured_path)
-    if candidate_path.is_absolute():
-        return candidate_path.resolve()
-
-    resolved_path = (workspace / candidate_path).resolve()
-    try:
-        resolved_path.relative_to(workspace)
-    except ValueError as exc:
-        raise ValueError(f"skill search path escapes workspace: {configured_path}") from exc
-    return resolved_path
+__all__ = [
+    "SkillRuntimeContext",
+    "build_runtime_contexts",
+]

--- a/src/voidcode/skills/README.md
+++ b/src/voidcode/skills/README.md
@@ -1,13 +1,14 @@
 # `voidcode.skills`
 
-这里是 skills 能力层的预期目录，用来承载 skill manifest、发现规则、元数据解析以及可复用的 skill 注册定义。
+这里是 `skills` 的纯能力层目录。当前它已经承载 skill manifest、发现规则、元数据解析以及可复用的 skill registry primitive，不再只是预期中的规划目录。
 
 ## 负责什么
 
 - skill manifest 格式和解析规则
 - skill 搜索路径约定
 - 可复用的 skill 元数据模型
-- 不依赖 runtime session 状态的纯 registry 辅助逻辑
+- 不依赖 runtime session 状态的纯 registry 逻辑
+- 面向 workspace 的本地 discovery helper
 
 ## 不负责什么
 
@@ -18,8 +19,90 @@
 
 ## 与 runtime 的边界
 
-`src/voidcode/runtime/skills.py` 目前仍是 runtime 集成层，至少要等 manifest 解析和 discovery helper 被抽离后，才适合把更多实现放入这个包。runtime 仍应持有生效配置和面向 session 的行为。
+`src/voidcode/runtime/skills.py` 现在是一个很薄的 runtime 集成层，而不是 skill 主实现层。
+
+当前边界如下：
+
+- `src/voidcode/skills/`
+  负责 skill 的纯能力实现：
+  - metadata model
+  - manifest / frontmatter 解析
+  - 本地 discovery
+  - registry primitive
+
+- `src/voidcode/runtime/skills.py`
+  负责 runtime 专属表达：
+  - `SkillRuntimeContext`
+  - `build_runtime_contexts()`
+
+- `src/voidcode/runtime/service.py`
+  负责 runtime 主流程中的 skill 接入：
+  - skills enabled / paths 的生效配置
+  - `runtime.skills_loaded` / `runtime.skills_applied`
+  - applied skill payload persistence / replay
+  - run / stream / resume 路径中的 skill 传递
+
+换句话说，runtime 不再通过 `runtime/skills.py` 持有 skill 主实现，而是直接消费 `voidcode.skills` 的纯能力结果，并在需要 runtime-facing context 时调用 `runtime/skills.py` 做转换。
 
 ## 当前状态
 
-这个目录目前是规划中的能力层。现有实现仍然位于 `src/voidcode/runtime/skills.py`。
+当前这个目录已经包含以下实现：
+
+- [models.py](./models.py)
+  - `SkillMetadata`
+
+- [manifest.py](./manifest.py)
+  - `parse_skill_frontmatter()`
+  - `parse_skill_body()`
+
+- [discovery.py](./discovery.py)
+  - `LocalSkillMetadataLoader`
+  - `resolve_workspace_relative_path()`
+  - `DEFAULT_SKILL_SEARCH_PATHS`
+
+- [registry.py](./registry.py)
+  - `SkillRegistry`
+
+- [__init__.py](./__init__.py)
+  - 能力层稳定导出入口
+
+因此，`#96` 的核心目标已经实现：纯 discovery / parsing / registry 实现已经从 `runtime/skills.py` 中抽离出来。
+
+## runtime 集成层现状
+
+当前的 [runtime/skills.py](../runtime/skills.py) 只保留 runtime 专属内容：
+
+- `SkillRuntimeContext`
+- `build_runtime_contexts()`
+
+它的作用是把 `voidcode.skills.SkillRegistry` 中的纯 skill 元数据，转换成 runtime 主流程可消费的 `SkillRuntimeContext`。
+
+## 测试策略
+
+当前测试分层如下：
+
+- [tests/unit/skills/test_skills.py](../../../tests/unit/skills/test_skills.py)
+  - 更偏向 `voidcode.skills` 能力层测试
+  - 关注 manifest、discovery、registry 这类纯 skill 功能
+
+- [tests/unit/runtime/test_skills.py](../../../tests/unit/runtime/test_skills.py)
+  - 更偏向 runtime 侧检测
+  - 虽然仍覆盖了一部分 skill 相关内容，但语义上更接近 runtime 集成验证
+
+- [tests/unit/runtime/test_runtime_service_extensions.py](../../../tests/unit/runtime/test_runtime_service_extensions.py)
+  - 关注 runtime 主流程中的 skill 接入
+  - 包括 `runtime.skills_loaded`
+  - `runtime.skills_applied`
+  - applied skill payload persistence
+  - resume 使用 frozen skill payload
+
+## 当前结论
+
+从当前代码状态看，`#96` 的主目标已经达成：
+
+- `voidcode.skills` 已经成为 skill 纯能力层主实现
+- `runtime/skills.py` 已经降级为 runtime 集成层
+- runtime 主流程继续保持既有行为
+- 测试分层已经初步形成
+
+后续如果继续整理，重点应放在文档同步和测试归属细化，而不是再做大的结构迁移。

--- a/src/voidcode/skills/__init__.py
+++ b/src/voidcode/skills/__init__.py
@@ -1,0 +1,27 @@
+from .discovery import (
+    DEFAULT_SKILL_SEARCH_PATHS,
+    SKILL_ENTRY_FILE_NAME,
+    LocalSkillMetadataLoader,
+    resolve_workspace_relative_path,
+)
+from .manifest import (
+    FRONTMATTER_DELIMITER,
+    SUPPORTED_FRONTMATTER_KEYS,
+    parse_skill_body,
+    parse_skill_frontmatter,
+)
+from .models import SkillMetadata
+from .registry import SkillRegistry
+
+__all__ = [
+    "DEFAULT_SKILL_SEARCH_PATHS",
+    "FRONTMATTER_DELIMITER",
+    "LocalSkillMetadataLoader",
+    "SKILL_ENTRY_FILE_NAME",
+    "SUPPORTED_FRONTMATTER_KEYS",
+    "SkillMetadata",
+    "SkillRegistry",
+    "parse_skill_body",
+    "parse_skill_frontmatter",
+    "resolve_workspace_relative_path",
+]

--- a/src/voidcode/skills/discovery.py
+++ b/src/voidcode/skills/discovery.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+from .manifest import parse_skill_body, parse_skill_frontmatter
+from .models import SkillMetadata
+
+SKILL_ENTRY_FILE_NAME = "SKILL.md"
+DEFAULT_SKILL_SEARCH_PATHS = (".voidcode/skills",)
+
+
+class LocalSkillMetadataLoader:
+    def discover(
+        self,
+        *,
+        workspace: Path,
+        search_paths: Iterable[str] = DEFAULT_SKILL_SEARCH_PATHS,
+    ) -> tuple[SkillMetadata, ...]:
+        resolved_workspace = workspace.resolve()
+        discovered: list[SkillMetadata] = []
+
+        for search_path in search_paths:
+            skill_root = resolve_workspace_relative_path(
+                workspace=resolved_workspace, configured_path=search_path
+            )
+            if not skill_root.exists() or not skill_root.is_dir():
+                continue
+            for skill_dir in sorted(path for path in skill_root.iterdir() if path.is_dir()):
+                entry_path = skill_dir / SKILL_ENTRY_FILE_NAME
+                if not entry_path.exists() or not entry_path.is_file():
+                    continue
+                discovered.append(self.load(entry_path))
+
+        return tuple(discovered)
+
+    def load(self, entry_path: Path) -> SkillMetadata:
+        resolved_entry_path = entry_path.resolve()
+        contents = resolved_entry_path.read_text(encoding="utf-8")
+        metadata = parse_skill_frontmatter(contents)
+        return SkillMetadata(
+            name=metadata["name"],
+            description=metadata["description"],
+            directory=resolved_entry_path.parent,
+            entry_path=resolved_entry_path,
+            content=parse_skill_body(contents),
+        )
+
+
+def resolve_workspace_relative_path(*, workspace: Path, configured_path: str) -> Path:
+    candidate_path = Path(configured_path)
+    if candidate_path.is_absolute():
+        return candidate_path.resolve()
+
+    resolved_path = (workspace / candidate_path).resolve()
+    try:
+        resolved_path.relative_to(workspace)
+    except ValueError as exc:
+        raise ValueError(f"skill search path escapes workspace: {configured_path}") from exc
+    return resolved_path

--- a/src/voidcode/skills/manifest.py
+++ b/src/voidcode/skills/manifest.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+FRONTMATTER_DELIMITER = "---"
+SUPPORTED_FRONTMATTER_KEYS = frozenset({"name", "description"})
+
+
+def parse_skill_frontmatter(contents: str) -> dict[str, str]:
+    lines = contents.splitlines()
+    if not lines or lines[0].strip() != FRONTMATTER_DELIMITER:
+        raise ValueError("skill file must begin with a simplified frontmatter block")
+
+    parsed: dict[str, str] = {}
+    for index, raw_line in enumerate(lines[1:], start=2):
+        line = raw_line.strip()
+        if line == FRONTMATTER_DELIMITER:
+            break
+        if not line:
+            continue
+        key, separator, value = raw_line.partition(":")
+        if separator != ":":
+            raise ValueError(f"skill frontmatter line {index} must use 'key: value' syntax")
+        normalized_key = key.strip()
+        if normalized_key not in SUPPORTED_FRONTMATTER_KEYS:
+            raise ValueError(f"unsupported skill frontmatter key: {normalized_key}")
+        normalized_value = value.strip()
+        if not normalized_value:
+            raise ValueError(f"skill frontmatter field '{normalized_key}' must not be empty")
+        parsed[normalized_key] = normalized_value
+    else:
+        raise ValueError("skill frontmatter must terminate with a closing '---' line")
+
+    missing_keys = SUPPORTED_FRONTMATTER_KEYS.difference(parsed)
+    if missing_keys:
+        missing = ", ".join(sorted(missing_keys))
+        raise ValueError(f"skill frontmatter missing required fields: {missing}")
+    return parsed
+
+
+def parse_skill_body(contents: str) -> str:
+    lines = contents.splitlines()
+    if not lines or lines[0].strip() != FRONTMATTER_DELIMITER:
+        raise ValueError("skill file must begin with a simplified frontmatter block")
+
+    for index, raw_line in enumerate(lines[1:], start=2):
+        if raw_line.strip() == FRONTMATTER_DELIMITER:
+            return "\n".join(lines[index:]).strip()
+
+    raise ValueError("skill frontmatter must terminate with a closing '---' line")

--- a/src/voidcode/skills/models.py
+++ b/src/voidcode/skills/models.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class SkillMetadata:
+    name: str
+    description: str
+    directory: Path
+    entry_path: Path
+    content: str

--- a/src/voidcode/skills/registry.py
+++ b/src/voidcode/skills/registry.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .discovery import DEFAULT_SKILL_SEARCH_PATHS, LocalSkillMetadataLoader
+from .models import SkillMetadata
+
+
+@dataclass(slots=True)
+class SkillRegistry:
+    skills: dict[str, SkillMetadata] = field(default_factory=dict)
+
+    @classmethod
+    def from_skills(cls, skills: Iterable[SkillMetadata]) -> SkillRegistry:
+        return cls(skills={skill.name: skill for skill in skills})
+
+    @classmethod
+    def discover(
+        cls,
+        *,
+        workspace: Path,
+        search_paths: Iterable[str] = DEFAULT_SKILL_SEARCH_PATHS,
+        loader: LocalSkillMetadataLoader | None = None,
+    ) -> SkillRegistry:
+        metadata_loader = loader or LocalSkillMetadataLoader()
+        return cls.from_skills(
+            metadata_loader.discover(workspace=workspace, search_paths=search_paths)
+        )
+
+    def all(self) -> tuple[SkillMetadata, ...]:
+        return tuple(self.skills.values())
+
+    def resolve(self, skill_name: str) -> SkillMetadata:
+        try:
+            return self.skills[skill_name]
+        except KeyError as exc:
+            raise ValueError(f"unknown skill: {skill_name}") from exc

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -49,7 +49,7 @@ from voidcode.runtime.single_agent_provider import (
     SingleAgentTurnRequest,
     SingleAgentTurnResult,
 )
-from voidcode.runtime.skills import SkillRegistry
+from voidcode.skills import SkillRegistry
 from voidcode.tools import ToolCall
 
 

--- a/tests/unit/skills/test_skills.py
+++ b/tests/unit/skills/test_skills.py
@@ -72,7 +72,7 @@ def test_skill_registry_discovers_and_resolves_skills(tmp_path: Path) -> None:
     assert registry.resolve("summarize").description == "Summarize selected files."
 
 
-def test_skill_registry_builds_runtime_contexts_from_skill_bodies(tmp_path: Path) -> None:
+def test_runtime_build_runtime_contexts_from_skill_bodies(tmp_path: Path) -> None:
     skill_dir = tmp_path / ".voidcode" / "skills" / "summarize"
     skill_dir.mkdir(parents=True)
     skill_contents = (


### PR DESCRIPTION

## Summary
- extract skill manifest, discovery, metadata, and registry primitives into \\src/voidcode/skills/\\
- downgrade \\src/voidcode/runtime/skills.py\\ into a thin runtime integration layer
- update runtime usage and tests to consume the new capability-layer entry points

## Details
- add \\models.py\\, \\manifest.py\\, \\discovery.py\\, \\
egistry.py\\, and capability exports under \\src/voidcode/skills/\\
- keep runtime-specific skill context construction in \\
untime/skills.py\\
- switch \\
untime/service.py\\ to depend directly on \\oidcode.skills.SkillRegistry\\
- add \\	ests/unit/skills/test_skills.py\\ and update runtime tests to reflect the new boundary
- rewrite \\src/voidcode/skills/README.md\\ as a current-state boundary document

## Validation
- pre-commit hooks passed during commit
- \\uv run pytest tests/unit/runtime/test_skills.py tests/unit/skills/test_skills.py tests/unit/runtime/test_runtime_service_extensions.py\\
- \\uv run basedpyright --warnings src/voidcode/skills src/voidcode/runtime/skills.py src/voidcode/runtime/service.py\\

Closes #96 #98