### PR TITLE
feat(edit): align formatter-aware edit results

### DIFF
--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -133,12 +133,14 @@ class ToolRegistry:
         lsp_tool: Tool | None = None,
         format_tool: Tool | None = None,
         mcp_tools: tuple[Tool, ...] = (),
+        hooks_config: RuntimeHooksConfig | None = None,
     ) -> ToolRegistry:
         return cls.from_tools(
             BuiltinToolProvider(
                 lsp_tool=lsp_tool,
                 format_tool=format_tool,
                 mcp_tools=mcp_tools,
+                hooks_config=hooks_config,
             ).provide_tools()
         )
 
@@ -214,6 +216,7 @@ class VoidCodeRuntime:
         self._base_tool_registry = tool_registry or ToolRegistry.with_defaults(
             lsp_tool=self._build_lsp_tool(),
             format_tool=self._build_format_tool(),
+            hooks_config=self._config.hooks or RuntimeHooksConfig(),
         )
         self._tool_registry = self._base_tool_registry
         self._graph_override = graph

--- a/src/voidcode/runtime/tool_provider.py
+++ b/src/voidcode/runtime/tool_provider.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from ..hook.config import RuntimeHooksConfig
 from ..tools.contracts import Tool
 from ..tools.edit import EditTool
 from ..tools.glob import GlobTool
@@ -52,6 +53,7 @@ class BuiltinToolProvider:
     _lsp_tool: Tool | None
     _format_tool: Tool | None
     _mcp_tools: tuple[Tool, ...]
+    _hooks_config: RuntimeHooksConfig | None
 
     def __init__(
         self,
@@ -59,14 +61,17 @@ class BuiltinToolProvider:
         lsp_tool: Tool | None = None,
         format_tool: Tool | None = None,
         mcp_tools: tuple[Tool, ...] = (),
+        hooks_config: RuntimeHooksConfig | None = None,
     ) -> None:
         self._lsp_tool = lsp_tool
         self._format_tool = format_tool
         self._mcp_tools = mcp_tools
+        self._hooks_config = hooks_config
 
     def provide_tools(self) -> tuple[Tool, ...]:
+        edit_tool = EditTool(hooks_config=self._hooks_config)
         tools: list[Tool] = [
-            EditTool(),
+            edit_tool,
             GlobTool(),
             GrepTool(),
             ListTool(),
@@ -96,7 +101,7 @@ class BuiltinToolProvider:
         if _CodeSearchTool is not None:
             tools.append(_CodeSearchTool())
         if _MultiEditTool is not None:
-            tools.append(_MultiEditTool())
+            tools.append(_MultiEditTool(hooks_config=self._hooks_config))
         if _TodoWriteTool is not None:
             tools.append(_TodoWriteTool())
 

--- a/src/voidcode/tools/_formatter.py
+++ b/src/voidcode/tools/_formatter.py
@@ -8,6 +8,8 @@ from typing import Literal
 
 from ..hook.config import RuntimeFormatterPresetConfig, RuntimeHooksConfig
 
+FORMATTER_TIMEOUT_SECONDS = 10.0
+
 type FormatterExecutionStatus = Literal[
     "not_configured",
     "formatted",
@@ -54,7 +56,24 @@ class FormatterExecutor:
                     cwd=cwd,
                     capture_output=True,
                     text=True,
+                    timeout=FORMATTER_TIMEOUT_SECONDS,
                 )
+            except subprocess.TimeoutExpired as exc:
+                timeout_message = f"formatter timed out after {FORMATTER_TIMEOUT_SECONDS:.1f}s"
+                stdout = self._coerce_timeout_stream(exc.stdout or exc.output)
+                stderr = self._coerce_timeout_stream(exc.stderr) or timeout_message
+                failed_attempts.append(
+                    (
+                        cmd,
+                        subprocess.CompletedProcess(
+                            args=list(cmd),
+                            returncode=124,
+                            stdout=stdout,
+                            stderr=stderr,
+                        ),
+                    )
+                )
+                continue
             except OSError as exc:
                 if exc.errno == errno.ENOENT:
                     missing_tools.append(command_parts[0])
@@ -140,3 +159,9 @@ class FormatterExecutor:
                 break
             current = current.parent
         return None
+
+    @staticmethod
+    def _coerce_timeout_stream(stream: bytes | str | None) -> str:
+        if isinstance(stream, bytes):
+            return stream.decode("utf-8", errors="replace")
+        return stream or ""

--- a/src/voidcode/tools/_formatter.py
+++ b/src/voidcode/tools/_formatter.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import errno
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from ..hook.config import RuntimeFormatterPresetConfig, RuntimeHooksConfig
+
+type FormatterExecutionStatus = Literal[
+    "not_configured",
+    "formatted",
+    "failed",
+    "missing_executable",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class FormatterExecutionResult:
+    status: FormatterExecutionStatus
+    path: Path
+    language: str | None = None
+    cwd: Path | None = None
+    command: tuple[str, ...] | None = None
+    attempted_commands: tuple[tuple[str, ...], ...] = ()
+    stdout: str | None = None
+    stderr: str | None = None
+    error: str | None = None
+
+
+class FormatterExecutor:
+    def __init__(self, hooks_config: RuntimeHooksConfig, workspace: Path) -> None:
+        self._hooks = hooks_config
+        self._workspace = workspace.resolve()
+
+    def run(self, file_path: Path) -> FormatterExecutionResult:
+        resolved = self._hooks.resolve_formatter(file_path)
+        if not resolved:
+            return FormatterExecutionResult(status="not_configured", path=file_path)
+
+        lang, preset = resolved
+        cwd = self._resolve_formatter_cwd(file_path=file_path, preset=preset)
+        attempted_commands: list[tuple[str, ...]] = []
+        missing_tools: list[str] = []
+        failed_attempts: list[tuple[tuple[str, ...], subprocess.CompletedProcess[str]]] = []
+
+        for command_parts in (preset.command, *preset.fallback_commands):
+            cmd = (*command_parts, str(file_path))
+            attempted_commands.append(cmd)
+            try:
+                proc = subprocess.run(
+                    list(cmd),
+                    cwd=cwd,
+                    capture_output=True,
+                    text=True,
+                )
+            except OSError as exc:
+                if exc.errno == errno.ENOENT:
+                    missing_tools.append(command_parts[0])
+                    continue
+
+                failed_attempts.append(
+                    (
+                        cmd,
+                        subprocess.CompletedProcess(
+                            args=list(cmd),
+                            returncode=1,
+                            stdout="",
+                            stderr=str(exc),
+                        ),
+                    )
+                )
+                continue
+
+            if proc.returncode == 0:
+                return FormatterExecutionResult(
+                    status="formatted",
+                    path=file_path,
+                    language=lang,
+                    cwd=cwd,
+                    command=cmd,
+                    attempted_commands=tuple(attempted_commands),
+                )
+
+            failed_attempts.append((cmd, proc))
+
+        if failed_attempts:
+            last_cmd, last_proc = failed_attempts[-1]
+            stderr = (last_proc.stderr or last_proc.stdout)[:300].strip()
+            return FormatterExecutionResult(
+                status="failed",
+                path=file_path,
+                language=lang,
+                cwd=cwd,
+                command=last_cmd,
+                attempted_commands=tuple(attempted_commands),
+                stdout=last_proc.stdout,
+                stderr=last_proc.stderr,
+                error=(
+                    f"Format failed for {file_path.name} using preset '{lang}' from {cwd}: "
+                    f"{stderr or 'formatter exited with a non-zero status'}"
+                ),
+            )
+
+        attempted_tool_names = ", ".join(dict.fromkeys(missing_tools))
+        return FormatterExecutionResult(
+            status="missing_executable",
+            path=file_path,
+            language=lang,
+            cwd=cwd,
+            attempted_commands=tuple(attempted_commands),
+            error=(
+                f"No formatter executable was available for preset '{lang}'. "
+                f"Tried: {attempted_tool_names}. Install one of them or override "
+                f"hooks.formatter_presets.{lang}.command in .voidcode.json."
+            ),
+        )
+
+    def _resolve_formatter_cwd(
+        self, *, file_path: Path, preset: RuntimeFormatterPresetConfig
+    ) -> Path:
+        if preset.cwd_policy == "workspace":
+            return self._workspace
+        if preset.cwd_policy == "file_directory":
+            return file_path.parent
+        return self._find_nearest_root(file_path=file_path, preset=preset) or self._workspace
+
+    def _find_nearest_root(
+        self, *, file_path: Path, preset: RuntimeFormatterPresetConfig
+    ) -> Path | None:
+        if not preset.root_markers:
+            return None
+
+        current = file_path.parent
+        while current.is_relative_to(self._workspace):
+            if any((current / marker).exists() for marker in preset.root_markers):
+                return current
+            if current == self._workspace:
+                break
+            current = current.parent
+        return None

--- a/src/voidcode/tools/_formatter.py
+++ b/src/voidcode/tools/_formatter.py
@@ -37,6 +37,9 @@ class FormatterExecutor:
         self._workspace = workspace.resolve()
 
     def run(self, file_path: Path) -> FormatterExecutionResult:
+        if self._hooks.enabled is False:
+            return FormatterExecutionResult(status="not_configured", path=file_path)
+
         resolved = self._hooks.resolve_formatter(file_path)
         if not resolved:
             return FormatterExecutionResult(status="not_configured", path=file_path)

--- a/src/voidcode/tools/edit.py
+++ b/src/voidcode/tools/edit.py
@@ -7,6 +7,8 @@ from typing import ClassVar
 
 from rapidfuzz.distance import Levenshtein
 
+from ..hook.config import RuntimeHooksConfig
+from ._formatter import FormatterExecutionResult, FormatterExecutor
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 
@@ -66,6 +68,79 @@ def _trim_diff(diff: str) -> str:
             trimmed_lines.append(line)
 
     return "\n".join(trimmed_lines)
+
+
+def read_utf8_text(path: Path) -> str:
+    try:
+        with path.open("r", encoding="utf-8", newline="") as handle:
+            return handle.read()
+    except UnicodeDecodeError as exc:
+        raise ValueError("edit only supports UTF-8 text files") from exc
+
+
+def summarize_diff(*, path: Path, before: str, after: str) -> tuple[str, int, int]:
+    def _ensure_newlines(lines: list[str]) -> list[str]:
+        return [line + "\n" for line in lines]
+
+    diff = _trim_diff(
+        "".join(
+            difflib.unified_diff(
+                _ensure_newlines(before.splitlines()) if before else [],
+                _ensure_newlines(after.splitlines()) if after else [],
+                fromfile=str(path),
+                tofile=str(path),
+            )
+        )
+    )
+
+    additions = sum(
+        1 for line in diff.splitlines() if line.startswith("+") and not line.startswith("+++")
+    )
+    deletions = sum(
+        1 for line in diff.splitlines() if line.startswith("-") and not line.startswith("---")
+    )
+    return diff, additions, deletions
+
+
+def formatter_payload(result: FormatterExecutionResult) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "status": result.status,
+    }
+    if result.language is not None:
+        payload["language"] = result.language
+    if result.cwd is not None:
+        payload["cwd"] = str(result.cwd)
+    if result.command is not None:
+        payload["command"] = list(result.command)
+    if result.attempted_commands:
+        payload["attempted_commands"] = [list(cmd) for cmd in result.attempted_commands]
+    if result.stdout is not None:
+        payload["stdout"] = result.stdout
+    if result.stderr is not None:
+        payload["stderr"] = result.stderr
+    if result.error is not None:
+        payload["error"] = result.error
+    return payload
+
+
+def formatter_diagnostics(result: FormatterExecutionResult | None) -> list[dict[str, object]]:
+    if result is None or result.status in {"not_configured", "formatted"} or result.error is None:
+        return []
+
+    diagnostic: dict[str, object] = {
+        "source": "formatter",
+        "severity": "warning",
+        "message": result.error,
+    }
+    if result.language is not None:
+        diagnostic["language"] = result.language
+    if result.cwd is not None:
+        diagnostic["cwd"] = str(result.cwd)
+    if result.command is not None:
+        diagnostic["command"] = list(result.command)
+    if result.attempted_commands:
+        diagnostic["attempted_commands"] = [list(cmd) for cmd in result.attempted_commands]
+    return [diagnostic]
 
 
 class SimpleReplacer:
@@ -405,6 +480,9 @@ class EditTool:
         read_only=False,
     )
 
+    def __init__(self, *, hooks_config: RuntimeHooksConfig | None = None) -> None:
+        self._hooks_config = hooks_config
+
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
         path_value = call.arguments.get("path")
         if not isinstance(path_value, str):
@@ -435,11 +513,7 @@ class EditTool:
         if not candidate.is_file():
             raise ValueError(f"edit target is not a file: {path_value}")
 
-        try:
-            with candidate.open("r", encoding="utf-8", newline="") as handle:
-                content_old = handle.read()
-        except UnicodeDecodeError as exc:
-            raise ValueError("edit only supports UTF-8 text files") from exc
+        content_old = read_utf8_text(candidate)
 
         ending = _detect_line_ending(content_old)
         normalized_old = _normalize_line_endings(old_string)
@@ -458,45 +532,39 @@ class EditTool:
 
         new_content = _convert_line_endings(new_content, ending)
 
-        def _ensure_newlines(lines: list[str]) -> list[str]:
-            return [line + "\n" for line in lines]
-
-        old_lines = content_old.splitlines()
-        new_lines = new_content.splitlines()
-
-        diff = _trim_diff(
-            "".join(
-                difflib.unified_diff(
-                    _ensure_newlines(old_lines) if old_lines else [],
-                    _ensure_newlines(new_lines) if new_lines else [],
-                    fromfile=str(candidate),
-                    tofile=str(candidate),
-                )
-            )
-        )
-
-        additions = sum(
-            1 for line in diff.splitlines() if line.startswith("+") and not line.startswith("+++")
-        )
-        deletions = sum(
-            1 for line in diff.splitlines() if line.startswith("-") and not line.startswith("---")
-        )
-
         candidate.write_bytes(new_content.encode("utf-8"))
+        formatter_result: FormatterExecutionResult | None = None
+        if self._hooks_config is not None:
+            formatter_result = FormatterExecutor(self._hooks_config, workspace_root).run(candidate)
+        final_content = read_utf8_text(candidate)
+        diff, additions, deletions = summarize_diff(
+            path=candidate,
+            before=content_old,
+            after=final_content,
+        )
+        diagnostics = formatter_diagnostics(formatter_result)
 
         output = "Edit applied successfully."
         if match_count > 1:
             output += f" ({match_count} occurrences replaced)"
+        if diagnostics:
+            output += f" Formatter warning: {diagnostics[0]['message']}"
+
+        data: dict[str, object] = {
+            "path": candidate.relative_to(workspace_root).as_posix(),
+            "additions": additions,
+            "deletions": deletions,
+            "match_count": match_count,
+            "diff": diff,
+        }
+        if formatter_result is not None and formatter_result.status != "not_configured":
+            data["formatter"] = formatter_payload(formatter_result)
+        if diagnostics:
+            data["diagnostics"] = diagnostics
 
         return ToolResult(
             tool_name=self.definition.name,
             status="ok",
             content=output,
-            data={
-                "path": candidate.relative_to(workspace_root).as_posix(),
-                "additions": additions,
-                "deletions": deletions,
-                "match_count": match_count,
-                "diff": diff,
-            },
+            data=data,
         )

--- a/src/voidcode/tools/lsp.py
+++ b/src/voidcode/tools/lsp.py
@@ -3,15 +3,14 @@
 from __future__ import annotations
 
 import enum
-import errno
-import subprocess
 from pathlib import Path
 from typing import Any, ClassVar, Protocol, cast
 
 from lsprotocol import converters as lsp_converters
 from lsprotocol import types as lsp_types
 
-from ..hook.config import RuntimeFormatterPresetConfig, RuntimeHooksConfig
+from ..hook.config import RuntimeHooksConfig
+from ._formatter import FormatterExecutor
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 
@@ -203,7 +202,7 @@ FORMAT_DEFINITION = ToolDefinition(
 
 class FormatTool:
     def __init__(self, hooks_config: RuntimeHooksConfig, workspace: Path) -> None:
-        self._hooks = hooks_config
+        self._executor = FormatterExecutor(hooks_config, workspace)
         self._workspace = workspace.resolve()
 
     @property
@@ -212,9 +211,9 @@ class FormatTool:
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
         file_path = self._resolve_target_path(call)
-        resolved = self._hooks.resolve_formatter(file_path)
+        result = self._executor.run(file_path)
 
-        if not resolved:
+        if result.status == "not_configured":
             return ToolResult(
                 tool_name=FORMAT_DEFINITION.name,
                 status="error",
@@ -222,93 +221,33 @@ class FormatTool:
                 data={"path": str(file_path)},
             )
 
-        lang, preset = resolved
-        cwd = self._resolve_formatter_cwd(file_path=file_path, preset=preset)
-        attempted_commands = [
-            list(preset.command),
-            *[list(cmd) for cmd in preset.fallback_commands],
-        ]
-        missing_tools: list[str] = []
-        failed_attempts: list[tuple[list[str], subprocess.CompletedProcess[str]]] = []
+        data: dict[str, object] = {"path": str(file_path)}
+        if result.language is not None:
+            data["language"] = result.language
+        if result.cwd is not None:
+            data["cwd"] = str(result.cwd)
+        if result.command is not None:
+            data["command"] = list(result.command)
+        if result.attempted_commands:
+            data["attempted_commands"] = [list(cmd) for cmd in result.attempted_commands]
+        if result.stdout is not None:
+            data["stdout"] = result.stdout
+        if result.stderr is not None:
+            data["stderr"] = result.stderr
 
-        for command_parts in attempted_commands:
-            cmd = [*command_parts, str(file_path)]
-            try:
-                proc = subprocess.run(
-                    cmd,
-                    cwd=cwd,
-                    capture_output=True,
-                    text=True,
-                )
-            except OSError as exc:
-                if exc.errno == errno.ENOENT:
-                    missing_tools.append(command_parts[0])
-                    continue
-
-                failed_attempts.append(
-                    (
-                        cmd,
-                        subprocess.CompletedProcess(
-                            args=cmd,
-                            returncode=1,
-                            stdout="",
-                            stderr=str(exc),
-                        ),
-                    )
-                )
-                continue
-
-            if proc.returncode == 0:
-                return ToolResult(
-                    tool_name=FORMAT_DEFINITION.name,
-                    status="ok",
-                    content=f"Successfully formatted {file_path.name} ({lang})",
-                    data={
-                        "path": str(file_path),
-                        "language": lang,
-                        "command": cmd,
-                        "cwd": str(cwd),
-                    },
-                )
-
-            failed_attempts.append((cmd, proc))
-
-        if failed_attempts:
-            last_cmd, last_proc = failed_attempts[-1]
-            stderr = (last_proc.stderr or last_proc.stdout)[:300].strip()
+        if result.status == "formatted":
             return ToolResult(
                 tool_name=FORMAT_DEFINITION.name,
-                status="error",
-                error=(
-                    f"Format failed for {file_path.name} using preset '{lang}' from {cwd}: "
-                    f"{stderr or 'formatter exited with a non-zero status'}"
-                ),
-                data={
-                    "path": str(file_path),
-                    "language": lang,
-                    "cwd": str(cwd),
-                    "command": last_cmd,
-                    "attempted_commands": [cmd + [str(file_path)] for cmd in attempted_commands],
-                    "stdout": last_proc.stdout,
-                    "stderr": last_proc.stderr,
-                },
+                status="ok",
+                content=f"Successfully formatted {file_path.name} ({result.language})",
+                data=data,
             )
 
-        attempted_tool_names = ", ".join(dict.fromkeys(missing_tools))
         return ToolResult(
             tool_name=FORMAT_DEFINITION.name,
             status="error",
-            error=(
-                f"No formatter executable was available for preset '{lang}'. "
-                f"Tried: {attempted_tool_names}. Install one of them or override "
-                f"hooks.formatter_presets.{lang}.command in .voidcode.json."
-            ),
-            data={
-                "path": str(file_path),
-                "language": lang,
-                "cwd": str(cwd),
-                "attempted_commands": [cmd + [str(file_path)] for cmd in attempted_commands],
-            },
+            error=result.error,
+            data=data,
         )
 
     def _resolve_target_path(self, call: ToolCall) -> Path:
@@ -322,28 +261,3 @@ class FormatTool:
         if not file_path.is_file():
             raise ValueError(f"format_file target does not exist: {raw_path}")
         return file_path
-
-    def _resolve_formatter_cwd(
-        self, *, file_path: Path, preset: RuntimeFormatterPresetConfig
-    ) -> Path:
-        if preset.cwd_policy == "workspace":
-            return self._workspace
-        if preset.cwd_policy == "file_directory":
-            return file_path.parent
-
-        return self._find_nearest_root(file_path=file_path, preset=preset) or self._workspace
-
-    def _find_nearest_root(
-        self, *, file_path: Path, preset: RuntimeFormatterPresetConfig
-    ) -> Path | None:
-        if not preset.root_markers:
-            return None
-
-        current = file_path.parent
-        while current.is_relative_to(self._workspace):
-            if any((current / marker).exists() for marker in preset.root_markers):
-                return current
-            if current == self._workspace:
-                break
-            current = current.parent
-        return None

--- a/src/voidcode/tools/multi_edit.py
+++ b/src/voidcode/tools/multi_edit.py
@@ -5,9 +5,17 @@ from typing import ClassVar
 
 from pydantic import ValidationError
 
+from ..hook.config import RuntimeHooksConfig
+from ._formatter import FormatterExecutionResult, FormatterExecutor
 from ._pydantic_args import MultiEditArgs
 from .contracts import ToolCall, ToolDefinition, ToolResult
-from .edit import EditTool
+from .edit import (
+    EditTool,
+    formatter_diagnostics,
+    formatter_payload,
+    read_utf8_text,
+    summarize_diff,
+)
 
 
 class MultiEditTool:
@@ -23,6 +31,15 @@ class MultiEditTool:
         },
         read_only=False,
     )
+
+    def __init__(
+        self,
+        *,
+        hooks_config: RuntimeHooksConfig | None = None,
+        edit_tool: EditTool | None = None,
+    ) -> None:
+        self._hooks_config = hooks_config
+        self._edit_tool = edit_tool or EditTool()
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
         raw_path_value = call.arguments.get("path")
@@ -69,12 +86,12 @@ class MultiEditTool:
             raise ValueError(f"multi_edit target does not exist: {args.path}")
 
         relative_target = target.relative_to(workspace_root).as_posix()
+        content_before = read_utf8_text(target)
 
-        edit_tool = EditTool()
         applied = 0
         details: list[dict[str, object]] = []
         for idx, item in enumerate(args.edits, start=1):
-            result = edit_tool.invoke(
+            result = self._edit_tool.invoke(
                 ToolCall(
                     tool_name="edit",
                     arguments={
@@ -89,9 +106,37 @@ class MultiEditTool:
             applied += 1
             details.append({"index": idx, "result": result.data})
 
+        formatter_result: FormatterExecutionResult | None = None
+        if self._hooks_config is not None:
+            formatter_result = FormatterExecutor(self._hooks_config, workspace_root).run(target)
+        final_content = read_utf8_text(target)
+        diff, additions, deletions = summarize_diff(
+            path=target,
+            before=content_before,
+            after=final_content,
+        )
+        diagnostics = formatter_diagnostics(formatter_result)
+
+        content = f"Applied {applied} edits to {relative_target}"
+        if diagnostics:
+            content += f" Formatter warning: {diagnostics[0]['message']}"
+
+        data: dict[str, object] = {
+            "path": relative_target,
+            "applied": applied,
+            "edits": details,
+            "additions": additions,
+            "deletions": deletions,
+            "diff": diff,
+        }
+        if formatter_result is not None and formatter_result.status != "not_configured":
+            data["formatter"] = formatter_payload(formatter_result)
+        if diagnostics:
+            data["diagnostics"] = diagnostics
+
         return ToolResult(
             tool_name=self.definition.name,
             status="ok",
-            content=f"Applied {applied} edits to {relative_target}",
-            data={"path": relative_target, "applied": applied, "edits": details},
+            content=content,
+            data=data,
         )

--- a/tests/unit/runtime/test_tool_provider.py
+++ b/tests/unit/runtime/test_tool_provider.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import sys
+import textwrap
 from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import patch
 
+from voidcode.hook.config import RuntimeFormatterPresetConfig, RuntimeHooksConfig
 from voidcode.runtime.events import EventEnvelope
 from voidcode.runtime.mcp import (
     McpConfigState,
@@ -196,6 +199,47 @@ def test_builtin_tool_provider_can_include_runtime_managed_format_tool() -> None
     tools = BuiltinToolProvider(format_tool=format_tool).provide_tools()
 
     assert any(tool.definition.name == "format_file" for tool in tools)
+
+
+def test_builtin_tool_provider_injects_formatter_aware_edit_tools(tmp_path: Path) -> None:
+    formatter_script = tmp_path / "formatter.py"
+    formatter_script.write_text(
+        textwrap.dedent(
+            """
+            import pathlib
+            import sys
+
+            pathlib.Path(sys.argv[-1]).write_text("VALUE='BETA'\\n", encoding="utf-8")
+            """
+        ),
+        encoding="utf-8",
+    )
+    target = tmp_path / "sample.py"
+    target.write_text("value='alpha'\n", encoding="utf-8")
+
+    tools = BuiltinToolProvider(
+        hooks_config=RuntimeHooksConfig(
+            formatter_presets={
+                "python": RuntimeFormatterPresetConfig(
+                    command=(sys.executable, str(formatter_script)),
+                    extensions=(".py",),
+                )
+            }
+        )
+    ).provide_tools()
+
+    edit_tool = next(tool for tool in tools if tool.definition.name == "edit")
+    result = edit_tool.invoke(
+        ToolCall(
+            tool_name="edit",
+            arguments={"path": "sample.py", "oldString": "'alpha'", "newString": "'beta'"},
+        ),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert target.read_text(encoding="utf-8") == "VALUE='BETA'\n"
+    assert result.data["formatter"]["status"] == "formatted"
 
 
 def test_tool_registry_accepts_tools_from_provider_output() -> None:

--- a/tests/unit/tools/test_edit_tool.py
+++ b/tests/unit/tools/test_edit_tool.py
@@ -243,6 +243,37 @@ def test_edit_tool_skips_formatter_when_no_matching_preset(tmp_path: Path) -> No
     assert file_path.read_text(encoding="utf-8") == "hello voidcode\n"
 
 
+def test_edit_tool_skips_formatter_when_hooks_are_disabled(tmp_path: Path) -> None:
+    file_path = tmp_path / "main.py"
+    file_path.write_text("print('hi')\n", encoding="utf-8")
+
+    tool = EditTool(
+        hooks_config=RuntimeHooksConfig(
+            enabled=False,
+            formatter_presets={
+                "python": RuntimeFormatterPresetConfig(
+                    command=("missing-formatter-binary",),
+                    extensions=(".py",),
+                )
+            },
+        )
+    )
+
+    result = tool.invoke(
+        ToolCall(
+            tool_name="edit",
+            arguments={"path": "main.py", "oldString": "'hi'", "newString": "'bye'"},
+        ),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert result.content == "Edit applied successfully."
+    assert "diagnostics" not in result.data
+    assert "formatter" not in result.data
+    assert file_path.read_text(encoding="utf-8") == "print('bye')\n"
+
+
 def test_edit_tool_surfaces_warning_when_formatter_executable_is_missing(tmp_path: Path) -> None:
     file_path = tmp_path / "main.py"
     file_path.write_text("print('hi')\n", encoding="utf-8")

--- a/tests/unit/tools/test_edit_tool.py
+++ b/tests/unit/tools/test_edit_tool.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import sys
+import textwrap
 from pathlib import Path
 
 import pytest
 
+from voidcode.hook.config import RuntimeFormatterPresetConfig, RuntimeHooksConfig
 from voidcode.runtime.service import ToolRegistry
 from voidcode.tools import EditTool, ToolCall
 
@@ -205,6 +208,177 @@ def test_edit_tool_matches_block_anchors_with_small_typos(tmp_path: Path) -> Non
     assert file_path.read_text(encoding="utf-8") == (
         "alpha\nstart block\nupdated middle\nend block\nomega\n"
     )
+
+
+def test_edit_tool_skips_formatter_when_no_matching_preset(tmp_path: Path) -> None:
+    file_path = tmp_path / "note.txt"
+    file_path.write_text("hello world\n", encoding="utf-8")
+
+    tool = EditTool(
+        hooks_config=RuntimeHooksConfig(
+            formatter_presets={
+                "python": RuntimeFormatterPresetConfig(
+                    command=("missing-formatter",),
+                    extensions=(".py",),
+                )
+            }
+        )
+    )
+
+    result = tool.invoke(
+        ToolCall(
+            tool_name="edit",
+            arguments={"path": "note.txt", "oldString": "world", "newString": "voidcode"},
+        ),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert result.content == "Edit applied successfully."
+    assert "diagnostics" not in result.data
+    assert "formatter" not in result.data
+    assert file_path.read_text(encoding="utf-8") == "hello voidcode\n"
+
+
+def test_edit_tool_surfaces_warning_when_formatter_executable_is_missing(tmp_path: Path) -> None:
+    file_path = tmp_path / "main.py"
+    file_path.write_text("print('hi')\n", encoding="utf-8")
+
+    tool = EditTool(
+        hooks_config=RuntimeHooksConfig(
+            formatter_presets={
+                "python": RuntimeFormatterPresetConfig(
+                    command=("missing-formatter-binary",),
+                    extensions=(".py",),
+                    fallback_commands=(("also-missing",),),
+                )
+            }
+        )
+    )
+
+    result = tool.invoke(
+        ToolCall(
+            tool_name="edit",
+            arguments={"path": "main.py", "oldString": "'hi'", "newString": "'bye'"},
+        ),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert "Formatter warning:" in (result.content or "")
+    assert file_path.read_text(encoding="utf-8") == "print('bye')\n"
+    diagnostics = result.data["diagnostics"]
+    assert diagnostics == [
+        {
+            "source": "formatter",
+            "severity": "warning",
+            "message": (
+                "No formatter executable was available for preset 'python'. "
+                "Tried: missing-formatter-binary, also-missing. Install one of them or override "
+                "hooks.formatter_presets.python.command in .voidcode.json."
+            ),
+            "language": "python",
+            "cwd": str(tmp_path),
+            "attempted_commands": [
+                ["missing-formatter-binary", str(file_path)],
+                ["also-missing", str(file_path)],
+            ],
+        }
+    ]
+
+
+def test_edit_tool_re_reads_after_successful_formatter_rewrite(tmp_path: Path) -> None:
+    file_path = tmp_path / "main.py"
+    file_path.write_text("print('hi')\n", encoding="utf-8")
+    formatter_script = tmp_path / "formatter.py"
+    formatter_script.write_text(
+        textwrap.dedent(
+            """
+            import pathlib
+            import sys
+
+            pathlib.Path(sys.argv[-1]).write_text("print( 'bye' )\\n", encoding="utf-8")
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    tool = EditTool(
+        hooks_config=RuntimeHooksConfig(
+            formatter_presets={
+                "python": RuntimeFormatterPresetConfig(
+                    command=(sys.executable, str(formatter_script)),
+                    extensions=(".py",),
+                )
+            }
+        )
+    )
+
+    result = tool.invoke(
+        ToolCall(
+            tool_name="edit",
+            arguments={"path": "main.py", "oldString": "'hi'", "newString": "'bye'"},
+        ),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert file_path.read_text(encoding="utf-8") == "print( 'bye' )\n"
+    assert result.data["formatter"] == {
+        "status": "formatted",
+        "language": "python",
+        "cwd": str(tmp_path),
+        "command": [sys.executable, str(formatter_script), str(file_path)],
+        "attempted_commands": [[sys.executable, str(formatter_script), str(file_path)]],
+    }
+    assert "print( 'bye' )" in str(result.data["diff"])
+    assert "diagnostics" not in result.data
+
+
+def test_edit_tool_keeps_edit_successful_when_formatter_returns_non_zero(tmp_path: Path) -> None:
+    file_path = tmp_path / "main.py"
+    file_path.write_text("print('hi')\n", encoding="utf-8")
+    formatter_script = tmp_path / "broken_formatter.py"
+    formatter_script.write_text(
+        textwrap.dedent(
+            """
+            import pathlib
+            import sys
+
+            pathlib.Path(sys.argv[-1]).write_text("print('partial')\\n", encoding="utf-8")
+            raise SystemExit(1)
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    tool = EditTool(
+        hooks_config=RuntimeHooksConfig(
+            formatter_presets={
+                "python": RuntimeFormatterPresetConfig(
+                    command=(sys.executable, str(formatter_script)),
+                    extensions=(".py",),
+                )
+            }
+        )
+    )
+
+    result = tool.invoke(
+        ToolCall(
+            tool_name="edit",
+            arguments={"path": "main.py", "oldString": "'hi'", "newString": "'bye'"},
+        ),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert "Formatter warning:" in (result.content or "")
+    assert file_path.read_text(encoding="utf-8") == "print('partial')\n"
+    diagnostics = result.data["diagnostics"]
+    assert isinstance(diagnostics, list)
+    assert diagnostics[0]["source"] == "formatter"
+    assert "Format failed for main.py" in str(diagnostics[0]["message"])
+    assert "print('partial')" in str(result.data["diff"])
 
 
 def test_tools_package_and_default_registry_export_edit_tool() -> None:

--- a/tests/unit/tools/test_edit_tool.py
+++ b/tests/unit/tools/test_edit_tool.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import subprocess
 import sys
 import textwrap
 from pathlib import Path
+from typing import cast
+from unittest.mock import patch
 
 import pytest
 
@@ -376,9 +379,46 @@ def test_edit_tool_keeps_edit_successful_when_formatter_returns_non_zero(tmp_pat
     assert file_path.read_text(encoding="utf-8") == "print('partial')\n"
     diagnostics = result.data["diagnostics"]
     assert isinstance(diagnostics, list)
-    assert diagnostics[0]["source"] == "formatter"
-    assert "Format failed for main.py" in str(diagnostics[0]["message"])
+    first_diagnostic = cast(dict[str, object], diagnostics[0])
+    assert first_diagnostic["source"] == "formatter"
+    assert "Format failed for main.py" in str(first_diagnostic["message"])
     assert "print('partial')" in str(result.data["diff"])
+
+
+def test_edit_tool_keeps_edit_successful_when_formatter_times_out(tmp_path: Path) -> None:
+    file_path = tmp_path / "main.py"
+    file_path.write_text("print('hi')\n", encoding="utf-8")
+
+    tool = EditTool(
+        hooks_config=RuntimeHooksConfig(
+            formatter_presets={
+                "python": RuntimeFormatterPresetConfig(
+                    command=("slow-formatter",),
+                    extensions=(".py",),
+                )
+            }
+        )
+    )
+
+    with patch(
+        "voidcode.tools._formatter.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd=["slow-formatter"], timeout=10.0),
+    ):
+        result = tool.invoke(
+            ToolCall(
+                tool_name="edit",
+                arguments={"path": "main.py", "oldString": "'hi'", "newString": "'bye'"},
+            ),
+            workspace=tmp_path,
+        )
+
+    assert result.status == "ok"
+    assert "Formatter warning:" in (result.content or "")
+    diagnostics = result.data["diagnostics"]
+    assert isinstance(diagnostics, list)
+    first_diagnostic = cast(dict[str, object], diagnostics[0])
+    assert "timed out after 10.0s" in str(first_diagnostic["message"])
+    assert file_path.read_text(encoding="utf-8") == "print('bye')\n"
 
 
 def test_tools_package_and_default_registry_export_edit_tool() -> None:

--- a/tests/unit/tools/test_format_tool.py
+++ b/tests/unit/tools/test_format_tool.py
@@ -196,7 +196,7 @@ def test_format_tool_treats_non_enoent_launch_failure_as_formatter_attempt_failu
     )
 
     with patch(
-        "voidcode.tools.lsp.subprocess.run", side_effect=PermissionError("permission denied")
+        "voidcode.tools._formatter.subprocess.run", side_effect=PermissionError("permission denied")
     ):
         result = tool.invoke(
             ToolCall(tool_name="format_file", arguments={"path": "example.py"}),

--- a/tests/unit/tools/test_format_tool.py
+++ b/tests/unit/tools/test_format_tool.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 import sys
 import textwrap
 from pathlib import Path
@@ -210,3 +211,35 @@ def test_format_tool_treats_non_enoent_launch_failure_as_formatter_attempt_failu
         ["custom-formatter", str(target)],
         [sys.executable, "-c", "print('fallback')", str(target)],
     ]
+
+
+def test_format_tool_bounds_formatter_timeout(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "example.py"
+    target.write_text("print('hi')\n", encoding="utf-8")
+
+    tool = FormatTool(
+        RuntimeHooksConfig(
+            formatter_presets={
+                "python": RuntimeFormatterPresetConfig(
+                    command=("custom-formatter",),
+                    extensions=(".py",),
+                )
+            }
+        ),
+        workspace,
+    )
+
+    with patch(
+        "voidcode.tools._formatter.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd=["custom-formatter"], timeout=10.0),
+    ):
+        result = tool.invoke(
+            ToolCall(tool_name="format_file", arguments={"path": "example.py"}),
+            workspace=workspace,
+        )
+
+    assert result.status == "error"
+    assert "timed out after 10.0s" in (result.error or "")
+    assert result.data["attempted_commands"] == [["custom-formatter", str(target)]]

--- a/tests/unit/tools/test_format_tool.py
+++ b/tests/unit/tools/test_format_tool.py
@@ -175,6 +175,34 @@ def test_format_tool_supports_custom_user_defined_formatter_presets(tmp_path: Pa
     assert target.read_text(encoding="utf-8") == "<?php echo 'formatted';\n"
 
 
+def test_format_tool_honors_disabled_hooks_config(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "example.py"
+    target.write_text("print('hi')\n", encoding="utf-8")
+
+    tool = FormatTool(
+        RuntimeHooksConfig(
+            enabled=False,
+            formatter_presets={
+                "python": RuntimeFormatterPresetConfig(
+                    command=("missing-formatter-binary",),
+                    extensions=(".py",),
+                )
+            },
+        ),
+        workspace,
+    )
+
+    result = tool.invoke(
+        ToolCall(tool_name="format_file", arguments={"path": "example.py"}),
+        workspace=workspace,
+    )
+
+    assert result.status == "error"
+    assert result.error == f"No formatter available for {target}"
+
+
 def test_format_tool_treats_non_enoent_launch_failure_as_formatter_attempt_failure(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/tools/test_multi_edit_tool.py
+++ b/tests/unit/tools/test_multi_edit_tool.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import subprocess
 import sys
 import textwrap
 from pathlib import Path
+from typing import cast
+from unittest.mock import patch
 
 import pytest
 
@@ -127,3 +130,44 @@ def test_multi_edit_formats_once_after_all_edits(tmp_path: Path) -> None:
         "attempted_commands": [[sys.executable, str(formatter_script), str(target)]],
     }
     assert "VALUE='A'" in str(result.data["diff"])
+
+
+def test_multi_edit_keeps_edits_successful_when_formatter_times_out(tmp_path: Path) -> None:
+    target = tmp_path / "sample.py"
+    target.write_text("value = 'a'\nother = 'b'\n", encoding="utf-8")
+
+    tool = MultiEditTool(
+        hooks_config=RuntimeHooksConfig(
+            formatter_presets={
+                "python": RuntimeFormatterPresetConfig(
+                    command=("slow-formatter",),
+                    extensions=(".py",),
+                )
+            }
+        )
+    )
+
+    with patch(
+        "voidcode.tools._formatter.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd=["slow-formatter"], timeout=10.0),
+    ):
+        result = tool.invoke(
+            ToolCall(
+                tool_name="multi_edit",
+                arguments={
+                    "path": "sample.py",
+                    "edits": [
+                        {"oldString": "'a'", "newString": "'A'"},
+                        {"oldString": "'b'", "newString": "'B'"},
+                    ],
+                },
+            ),
+            workspace=tmp_path,
+        )
+
+    assert result.status == "ok"
+    assert target.read_text(encoding="utf-8") == "value = 'A'\nother = 'B'\n"
+    diagnostics = result.data["diagnostics"]
+    assert isinstance(diagnostics, list)
+    first_diagnostic = cast(dict[str, object], diagnostics[0])
+    assert "timed out after 10.0s" in str(first_diagnostic["message"])

--- a/tests/unit/tools/test_multi_edit_tool.py
+++ b/tests/unit/tools/test_multi_edit_tool.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import sys
+import textwrap
 from pathlib import Path
 
 import pytest
 
+from voidcode.hook.config import RuntimeFormatterPresetConfig, RuntimeHooksConfig
 from voidcode.tools import MultiEditTool, ToolCall
 
 
@@ -71,3 +74,56 @@ def test_multi_edit_rejects_empty_edits(tmp_path: Path) -> None:
             ),
             workspace=tmp_path,
         )
+
+
+def test_multi_edit_formats_once_after_all_edits(tmp_path: Path) -> None:
+    target = tmp_path / "sample.py"
+    target.write_text("value = 'a'\nother = 'b'\n", encoding="utf-8")
+    formatter_script = tmp_path / "formatter.py"
+    formatter_script.write_text(
+        textwrap.dedent(
+            """
+            import pathlib
+            import sys
+
+            pathlib.Path(sys.argv[-1]).write_text("VALUE='A'\\nOTHER='B'\\n", encoding="utf-8")
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    tool = MultiEditTool(
+        hooks_config=RuntimeHooksConfig(
+            formatter_presets={
+                "python": RuntimeFormatterPresetConfig(
+                    command=(sys.executable, str(formatter_script)),
+                    extensions=(".py",),
+                )
+            }
+        )
+    )
+    result = tool.invoke(
+        ToolCall(
+            tool_name="multi_edit",
+            arguments={
+                "path": "sample.py",
+                "edits": [
+                    {"oldString": "'a'", "newString": "'A'"},
+                    {"oldString": "'b'", "newString": "'B'"},
+                ],
+            },
+        ),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert target.read_text(encoding="utf-8") == "VALUE='A'\nOTHER='B'\n"
+    assert result.data["applied"] == 2
+    assert result.data["formatter"] == {
+        "status": "formatted",
+        "language": "python",
+        "cwd": str(tmp_path),
+        "command": [sys.executable, str(formatter_script), str(target)],
+        "attempted_commands": [[sys.executable, str(formatter_script), str(target)]],
+    }
+    assert "VALUE='A'" in str(result.data["diff"])

--- a/tests/unit/tools/test_multi_edit_tool.py
+++ b/tests/unit/tools/test_multi_edit_tool.py
@@ -132,6 +132,42 @@ def test_multi_edit_formats_once_after_all_edits(tmp_path: Path) -> None:
     assert "VALUE='A'" in str(result.data["diff"])
 
 
+def test_multi_edit_skips_formatter_when_hooks_are_disabled(tmp_path: Path) -> None:
+    target = tmp_path / "sample.py"
+    target.write_text("value = 'a'\nother = 'b'\n", encoding="utf-8")
+
+    tool = MultiEditTool(
+        hooks_config=RuntimeHooksConfig(
+            enabled=False,
+            formatter_presets={
+                "python": RuntimeFormatterPresetConfig(
+                    command=("missing-formatter-binary",),
+                    extensions=(".py",),
+                )
+            },
+        )
+    )
+    result = tool.invoke(
+        ToolCall(
+            tool_name="multi_edit",
+            arguments={
+                "path": "sample.py",
+                "edits": [
+                    {"oldString": "'a'", "newString": "'A'"},
+                    {"oldString": "'b'", "newString": "'B'"},
+                ],
+            },
+        ),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert result.data["applied"] == 2
+    assert "formatter" not in result.data
+    assert "diagnostics" not in result.data
+    assert target.read_text(encoding="utf-8") == "value = 'A'\nother = 'B'\n"
+
+
 def test_multi_edit_keeps_edits_successful_when_formatter_times_out(tmp_path: Path) -> None:
     target = tmp_path / "sample.py"
     target.write_text("value = 'a'\nother = 'b'\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

- make `edit` formatter-aware by running configured formatter presets after writes, then re-reading the file before building the final diff/result payload
- make `multi_edit` apply its internal edits first, then run formatter-aware final alignment once so the top-level result reflects post-format disk state
- reuse the runtime-managed formatter preset execution path for both `format_file` and edit flows, and inject hooks config through the builtin tool provider/runtime defaults
- add regression coverage for missing formatter, successful formatter rewrite, formatter failure degradation, and provider-level formatter-aware edit wiring

## Verification

- `uv run ruff check src/voidcode/tools/_formatter.py src/voidcode/tools/lsp.py src/voidcode/tools/edit.py src/voidcode/tools/multi_edit.py src/voidcode/runtime/tool_provider.py src/voidcode/runtime/service.py tests/unit/tools/test_format_tool.py tests/unit/tools/test_edit_tool.py tests/unit/tools/test_multi_edit_tool.py tests/unit/runtime/test_tool_provider.py tests/integration/test_tool_workflows_integration.py`
- `uv run basedpyright --warnings src`
- `uv run pytest -q -o addopts='' tests/unit/tools/test_format_tool.py tests/unit/tools/test_edit_tool.py tests/unit/tools/test_multi_edit_tool.py tests/unit/runtime/test_tool_provider.py tests/integration/test_tool_workflows_integration.py`

Closes #120
