### PR TITLE
feat(doctor): add runtime capability doctor for external tool readiness

### DIFF
--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -10,7 +10,9 @@ from typing import Protocol, cast
 from . import __version__
 from .doctor import (
     CapabilityCheckResult,
+    CapabilityCheckStatus,
     CapabilityDoctor,
+    DoctorCheckType,
     create_doctor_for_config,
     create_report,
     format_report,
@@ -340,6 +342,14 @@ def _handle_doctor_command(args: argparse.Namespace) -> int:
         doctor = CapabilityDoctor(workspace=workspace)
         doctor.add_executable_check("ast-grep", "ast-grep")
         results = doctor.results
+        results.append(
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.ERROR,
+                name="runtime.config",
+                check_type=DoctorCheckType.RUNTIME_CONFIG.value,
+                error_message=config_error,
+            )
+        )
     except Exception:
         # OSError (permissions, path not found) and other unexpected errors
         # should propagate so they are not silently swallowed.
@@ -361,8 +371,8 @@ def _handle_doctor_command(args: argparse.Namespace) -> int:
     else:
         print(format_report(report, verbose=verbose))
 
-    # Return 0 if healthy, 1 if there are issues
-    return 0 if report.is_healthy else 1
+    # Return 0 only when healthy and runtime config parsed successfully.
+    return 0 if (report.is_healthy and config_error is None) else 1
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -9,6 +9,7 @@ from typing import Protocol, cast
 
 from . import __version__
 from .doctor import (
+    CapabilityCheckResult,
     CapabilityDoctor,
     create_doctor_for_config,
     create_report,
@@ -16,7 +17,7 @@ from .doctor import (
     format_report_json,
 )
 from .provider.snapshot import resolved_provider_snapshot
-from .runtime.config import load_runtime_config, serialize_provider_fallback_config
+from .runtime.config import RuntimeConfig, load_runtime_config, serialize_provider_fallback_config
 from .runtime.contracts import RuntimeRequest, RuntimeStreamChunk
 from .runtime.events import EventEnvelope
 from .runtime.permission import PermissionDecision, PermissionResolution
@@ -327,15 +328,27 @@ def _handle_doctor_command(args: argparse.Namespace) -> int:
     json_output = cast(bool, args.json)
 
     # Load runtime config to get all capability settings
+    config_error: str | None = None
+    config: RuntimeConfig | None = None
+    results: list[CapabilityCheckResult] = []
     try:
         config = load_runtime_config(workspace)
-    except Exception:
-        # If config loading fails, run with minimal checks
+    except ValueError as exc:
+        # Config file has a parse/validation error - report it but continue
+        # with minimal checks so the user can still see what's wrong.
+        config_error = str(exc)
         doctor = CapabilityDoctor(workspace=workspace)
-        # Always check ast-grep
         doctor.add_executable_check("ast-grep", "ast-grep")
         results = doctor.results
-    else:
+    except Exception:
+        # OSError (permissions, path not found) and other unexpected errors
+        # should propagate so they are not silently swallowed.
+        raise
+
+    if config_error is not None:
+        print(f"WARN runtime config error: {config_error}", file=sys.stderr, flush=True)
+
+    if config is not None:
         # Create doctor with full config
         doctor = create_doctor_for_config(workspace, config)
         results = doctor.run_all_checks()

--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -8,6 +8,13 @@ from pathlib import Path
 from typing import Protocol, cast
 
 from . import __version__
+from .doctor import (
+    CapabilityDoctor,
+    create_doctor_for_config,
+    create_report,
+    format_report,
+    format_report_json,
+)
 from .provider.snapshot import resolved_provider_snapshot
 from .runtime.config import load_runtime_config, serialize_provider_fallback_config
 from .runtime.contracts import RuntimeRequest, RuntimeStreamChunk
@@ -313,6 +320,38 @@ def _handle_tui_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def _handle_doctor_command(args: argparse.Namespace) -> int:
+    """Run the capability doctor to check external tool readiness."""
+    workspace = cast(Path, args.workspace)
+    verbose = cast(bool, args.verbose)
+    json_output = cast(bool, args.json)
+
+    # Load runtime config to get all capability settings
+    try:
+        config = load_runtime_config(workspace)
+    except Exception:
+        # If config loading fails, run with minimal checks
+        doctor = CapabilityDoctor(workspace=workspace)
+        # Always check ast-grep
+        doctor.add_executable_check("ast-grep", "ast-grep")
+        results = doctor.results
+    else:
+        # Create doctor with full config
+        doctor = create_doctor_for_config(workspace, config)
+        results = doctor.run_all_checks()
+
+    # Create and format report
+    report = create_report(results, workspace=workspace)
+
+    if json_output:
+        print(format_report_json(report))
+    else:
+        print(format_report(report, verbose=verbose))
+
+    # Return 0 if healthy, 1 if there are issues
+    return 0 if report.is_healthy else 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="voidcode",
@@ -468,6 +507,31 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional approval decision applied to the pending request during resume.",
     )
     resume_parser.set_defaults(handler=_handle_sessions_resume_command)
+
+    # Capability doctor command
+    doctor_parser = subparsers.add_parser(
+        "doctor",
+        help="Check runtime capability readiness (external tools, formatters, LSP, MCP).",
+    )
+    _ = doctor_parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd(),
+        help="Workspace root used to resolve runtime config.",
+    )
+    _ = doctor_parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Show all capabilities including successful ones.",
+    )
+    _ = doctor_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output report in JSON format.",
+    )
+    doctor_parser.set_defaults(handler=_handle_doctor_command)
+
     return parser
 
 

--- a/src/voidcode/doctor/__init__.py
+++ b/src/voidcode/doctor/__init__.py
@@ -1,0 +1,49 @@
+"""VoidCode Capability Doctor - runtime capability readiness checker.
+
+This module provides a unified capability doctor surface for checking external
+tool readiness including:
+- ast-grep binary availability
+- formatter presets and their executables
+- LSP server commands
+- MCP server commands
+
+The doctor is non-blocking and provides structured output suitable for both
+CLI users and agents.
+"""
+
+from __future__ import annotations
+
+from .checker import (
+    CapabilityCheckResult,
+    CapabilityCheckStatus,
+    DoctorCheck,
+    DoctorCheckType,
+    ExecutableChecker,
+    FormatterPresetChecker,
+    LspServerChecker,
+    McpServerChecker,
+)
+from .doctor import CapabilityDoctor, create_doctor_for_config
+from .reporter import (
+    CapabilityReport,
+    create_report,
+    format_report,
+    format_report_json,
+)
+
+__all__ = [
+    "CapabilityCheckResult",
+    "CapabilityCheckStatus",
+    "CapabilityDoctor",
+    "CapabilityReport",
+    "DoctorCheck",
+    "DoctorCheckType",
+    "ExecutableChecker",
+    "FormatterPresetChecker",
+    "LspServerChecker",
+    "McpServerChecker",
+    "create_doctor_for_config",
+    "create_report",
+    "format_report",
+    "format_report_json",
+]

--- a/src/voidcode/doctor/checker.py
+++ b/src/voidcode/doctor/checker.py
@@ -1,0 +1,342 @@
+"""Capability doctor checker implementations."""
+
+from __future__ import annotations
+
+import enum
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..hook.config import RuntimeFormatterPresetConfig
+    from ..lsp.presets import LspServerPreset
+    from ..mcp.config import McpServerConfig
+
+# Timeout for executable checks
+_EXECUTABLE_CHECK_TIMEOUT = 5.0
+
+
+class CapabilityCheckStatus(enum.Enum):
+    """Status of a capability check."""
+
+    READY = "ready"
+    """Executable/command is available and working."""
+
+    NOT_FOUND = "not_found"
+    """Required executable was not found in PATH."""
+
+    ERROR = "error"
+    """Check failed with an error (e.g., wrong version, permission denied)."""
+
+    NOT_CONFIGURED = "not_configured"
+    """Capability is defined but not configured/enabled."""
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityCheckResult:
+    """Result of a single capability check."""
+
+    status: CapabilityCheckStatus
+    name: str
+    check_type: str
+    details: dict[str, Any] = field(default_factory=dict)
+    error_message: str | None = None
+
+    @property
+    def is_ok(self) -> bool:
+        """Return True if the capability is ready."""
+        return self.status == CapabilityCheckStatus.READY
+
+
+class DoctorCheckType(enum.Enum):
+    """Types of capability checks."""
+
+    EXECUTABLE = "executable"
+    FORMATTER_PRESET = "formatter_preset"
+    LSP_SERVER = "lsp_server"
+    MCP_SERVER = "mcp_server"
+
+
+@dataclass(frozen=True, slots=True)
+class DoctorCheck:
+    """A single check to be performed by the capability doctor."""
+
+    check_type: DoctorCheckType
+    name: str
+    description: str
+    data: Any = None
+
+
+class ExecutableChecker:
+    """Check if an executable is available in PATH."""
+
+    def __init__(self, name: str, *commands: str) -> None:
+        self._name = name
+        self._commands = commands
+
+    def check(self) -> CapabilityCheckResult:
+        """Check if any of the executable names are available."""
+        for cmd in self._commands:
+            if shutil.which(cmd) is not None:
+                # Found it, try to get version info
+                version_info = self._get_version_info(cmd)
+                return CapabilityCheckResult(
+                    status=CapabilityCheckStatus.READY,
+                    name=self._name,
+                    check_type=DoctorCheckType.EXECUTABLE.value,
+                    details={"command": cmd, "version_info": version_info},
+                )
+
+        # Not found - provide helpful suggestion
+        return CapabilityCheckResult(
+            status=CapabilityCheckStatus.NOT_FOUND,
+            name=self._name,
+            check_type=DoctorCheckType.EXECUTABLE.value,
+            details={"tried_commands": list(self._commands)},
+            error_message=f"'{self._name}' not found. Tried: {', '.join(self._commands)}",
+        )
+
+    def _get_version_info(self, command: str) -> str | None:
+        """Try to get version information from the executable."""
+        for version_arg in ("--version", "-v", "-V", "version"):
+            try:
+                result = subprocess.run(
+                    [command, version_arg],
+                    capture_output=True,
+                    text=True,
+                    timeout=_EXECUTABLE_CHECK_TIMEOUT,
+                )
+                if result.returncode == 0:
+                    version = result.stdout.strip() or result.stderr.strip()
+                    if version:
+                        # Truncate long version strings
+                        return version[:100] if len(version) > 100 else version
+            except (subprocess.TimeoutExpired, OSError, ValueError):
+                pass
+        return None
+
+
+class FormatterPresetChecker:
+    """Check formatter preset executables."""
+
+    def __init__(
+        self,
+        preset_name: str,
+        preset: RuntimeFormatterPresetConfig,
+        *,
+        check_all_commands: bool = False,
+    ) -> None:
+        self._preset_name = preset_name
+        self._preset = preset
+        self._check_all_commands = check_all_commands
+
+    def check(self) -> CapabilityCheckResult:
+        """Check if the formatter preset's executable(s) are available."""
+        all_commands = [self._preset.command, *self._preset.fallback_commands]
+        available: list[str] = []
+        missing: list[str] = []
+
+        for cmd in all_commands:
+            executable = cmd[0] if cmd else ""
+            if executable and shutil.which(executable) is not None:
+                version = self._get_version_info(executable)
+                available.append(f"{executable} (version: {version})" if version else executable)
+            else:
+                missing.append(executable)
+
+        if not available:
+            return CapabilityCheckResult(
+                status=CapabilityCheckStatus.NOT_FOUND,
+                name=f"formatter:{self._preset_name}",
+                check_type=DoctorCheckType.FORMATTER_PRESET.value,
+                details={
+                    "preset_name": self._preset_name,
+                    "extensions": list(self._preset.extensions),
+                    "primary_command": list(self._preset.command) if self._preset.command else [],
+                    "fallback_commands": [list(cmd) for cmd in self._preset.fallback_commands],
+                },
+                error_message=(
+                    f"Formatter preset '{self._preset_name}' has no available executable. "
+                    f"Tried: {', '.join(missing)}"
+                ),
+            )
+
+        # Some commands are available
+        if not missing:
+            return CapabilityCheckResult(
+                status=CapabilityCheckStatus.READY,
+                name=f"formatter:{self._preset_name}",
+                check_type=DoctorCheckType.FORMATTER_PRESET.value,
+                details={
+                    "preset_name": self._preset_name,
+                    "extensions": list(self._preset.extensions),
+                    "available_commands": available,
+                    "primary_command": list(self._preset.command) if self._preset.command else [],
+                },
+            )
+
+        # Partial availability (some fallbacks work)
+        return CapabilityCheckResult(
+            status=CapabilityCheckStatus.READY,
+            name=f"formatter:{self._preset_name}",
+            check_type=DoctorCheckType.FORMATTER_PRESET.value,
+            details={
+                "preset_name": self._preset_name,
+                "extensions": list(self._preset.extensions),
+                "available_commands": available,
+                "missing_fallbacks": missing,
+                "note": "Some fallback commands are missing, primary command works",
+            },
+        )
+
+    def _get_version_info(self, command: str) -> str | None:
+        """Try to get version information from the executable."""
+        for version_arg in ("--version", "-v", "-V"):
+            try:
+                result = subprocess.run(
+                    [command, version_arg],
+                    capture_output=True,
+                    text=True,
+                    timeout=_EXECUTABLE_CHECK_TIMEOUT,
+                )
+                if result.returncode == 0:
+                    version = result.stdout.strip() or result.stderr.strip()
+                    if version:
+                        return version[:100] if len(version) > 100 else version
+            except (subprocess.TimeoutExpired, OSError, ValueError):
+                pass
+        return None
+
+
+class LspServerChecker:
+    """Check LSP server command availability."""
+
+    def __init__(self, server_name: str, preset: LspServerPreset) -> None:
+        self._server_name = server_name
+        self._preset = preset
+
+    def check(self) -> CapabilityCheckResult:
+        """Check if the LSP server command is available."""
+        command = self._preset.command
+        if not command:
+            return CapabilityCheckResult(
+                status=CapabilityCheckStatus.NOT_CONFIGURED,
+                name=f"lsp:{self._server_name}",
+                check_type=DoctorCheckType.LSP_SERVER.value,
+                details={
+                    "server_name": self._server_name,
+                    "languages": list(self._preset.languages) if self._preset.languages else [],
+                    "extensions": list(self._preset.extensions) if self._preset.extensions else [],
+                },
+                error_message=f"LSP server '{self._server_name}' has no command configured",
+            )
+
+        executable = command[0] if command else ""
+        if not executable:
+            return CapabilityCheckResult(
+                status=CapabilityCheckStatus.NOT_CONFIGURED,
+                name=f"lsp:{self._server_name}",
+                check_type=DoctorCheckType.LSP_SERVER.value,
+                details={
+                    "server_name": self._server_name,
+                },
+                error_message=f"LSP server '{self._server_name}' has empty command",
+            )
+
+        if shutil.which(executable) is not None:
+            return CapabilityCheckResult(
+                status=CapabilityCheckStatus.READY,
+                name=f"lsp:{self._server_name}",
+                check_type=DoctorCheckType.LSP_SERVER.value,
+                details={
+                    "server_name": self._server_name,
+                    "preset_id": self._preset.id if hasattr(self._preset, "id") else None,
+                    "command": list(command),
+                    "languages": list(self._preset.languages) if self._preset.languages else [],
+                    "extensions": list(self._preset.extensions) if self._preset.extensions else [],
+                },
+            )
+
+        return CapabilityCheckResult(
+            status=CapabilityCheckStatus.NOT_FOUND,
+            name=f"lsp:{self._server_name}",
+            check_type=DoctorCheckType.LSP_SERVER.value,
+            details={
+                "server_name": self._server_name,
+                "command": list(command),
+                "languages": list(self._preset.languages) if self._preset.languages else [],
+                "extensions": list(self._preset.extensions) if self._preset.extensions else [],
+            },
+            error_message=(
+                f"LSP server '{self._server_name}' command '{executable}' not found in PATH. "
+                f"Full command: {' '.join(command)}"
+            ),
+        )
+
+
+class McpServerChecker:
+    """Check MCP server command availability."""
+
+    def __init__(
+        self,
+        server_name: str,
+        config: McpServerConfig,
+    ) -> None:
+        self._server_name = server_name
+        self._config = config
+
+    def check(self) -> CapabilityCheckResult:
+        """Check if the MCP server command is available."""
+        command = self._config.command
+        if not command:
+            return CapabilityCheckResult(
+                status=CapabilityCheckStatus.NOT_CONFIGURED,
+                name=f"mcp:{self._server_name}",
+                check_type=DoctorCheckType.MCP_SERVER.value,
+                details={
+                    "server_name": self._server_name,
+                    "transport": self._config.transport,
+                },
+                error_message=f"MCP server '{self._server_name}' has no command configured",
+            )
+
+        executable = command[0] if command else ""
+        if not executable:
+            return CapabilityCheckResult(
+                status=CapabilityCheckStatus.NOT_CONFIGURED,
+                name=f"mcp:{self._server_name}",
+                check_type=DoctorCheckType.MCP_SERVER.value,
+                details={
+                    "server_name": self._server_name,
+                },
+                error_message=f"MCP server '{self._server_name}' has empty command",
+            )
+
+        if shutil.which(executable) is not None:
+            return CapabilityCheckResult(
+                status=CapabilityCheckStatus.READY,
+                name=f"mcp:{self._server_name}",
+                check_type=DoctorCheckType.MCP_SERVER.value,
+                details={
+                    "server_name": self._server_name,
+                    "command": list(command),
+                    "transport": self._config.transport,
+                    "has_env": bool(self._config.env),
+                },
+            )
+
+        return CapabilityCheckResult(
+            status=CapabilityCheckStatus.NOT_FOUND,
+            name=f"mcp:{self._server_name}",
+            check_type=DoctorCheckType.MCP_SERVER.value,
+            details={
+                "server_name": self._server_name,
+                "command": list(command),
+                "transport": self._config.transport,
+            },
+            error_message=(
+                f"MCP server '{self._server_name}' command '{executable}' not found in PATH. "
+                f"Full command: {' '.join(command)}"
+            ),
+        )

--- a/src/voidcode/doctor/checker.py
+++ b/src/voidcode/doctor/checker.py
@@ -56,6 +56,7 @@ class DoctorCheckType(enum.Enum):
     FORMATTER_PRESET = "formatter_preset"
     LSP_SERVER = "lsp_server"
     MCP_SERVER = "mcp_server"
+    RUNTIME_CONFIG = "runtime_config"
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/voidcode/doctor/doctor.py
+++ b/src/voidcode/doctor/doctor.py
@@ -1,0 +1,239 @@
+"""Main CapabilityDoctor class that orchestrates all capability checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from .checker import (
+    CapabilityCheckResult,
+    CapabilityCheckStatus,
+    DoctorCheck,
+    DoctorCheckType,
+    ExecutableChecker,
+    FormatterPresetChecker,
+    LspServerChecker,
+    McpServerChecker,
+)
+
+if TYPE_CHECKING:
+    from ..runtime.config import RuntimeConfig
+
+
+@dataclass
+class CapabilityDoctor:
+    """Unified capability readiness checker for VoidCode.
+
+    This doctor checks the availability and readiness of external tools
+    and capabilities that VoidCode depends on, including:
+    - ast-grep binary
+    - Formatter presets and their executables
+    - LSP server commands
+    - MCP server commands
+
+    The doctor is non-blocking and provides structured output suitable
+    for both CLI users and agents.
+    """
+
+    workspace: Path | None = None
+    config: RuntimeConfig | None = None
+    _results: list[CapabilityCheckResult] = field(default_factory=list, init=False)
+    _checks: list[DoctorCheck] = field(default_factory=list, init=False)
+
+    def add_executable_check(
+        self,
+        name: str,
+        *commands: str,
+        description: str = "",
+    ) -> None:
+        """Add a check for an executable binary.
+
+        Args:
+            name: Display name for the capability (e.g., "ast-grep")
+            *commands: Possible command names to check in PATH
+            description: Human-readable description of what this executable does
+        """
+        self._checks.append(
+            DoctorCheck(
+                check_type=DoctorCheckType.EXECUTABLE,
+                name=name,
+                description=description or f"Check if {name} is available",
+            )
+        )
+        self._results.append(ExecutableChecker(name, *commands).check())
+
+    def add_formatter_preset_check(
+        self,
+        preset_name: str,
+        preset: Any,  # RuntimeFormatterPresetConfig
+        description: str = "",
+    ) -> None:
+        """Add a check for a formatter preset.
+
+        Args:
+            preset_name: Name of the formatter preset (e.g., "python", "typescript")
+            preset: The RuntimeFormatterPresetConfig object
+            description: Human-readable description
+        """
+        self._checks.append(
+            DoctorCheck(
+                check_type=DoctorCheckType.FORMATTER_PRESET,
+                name=f"formatter:{preset_name}",
+                description=description or f"Check formatter preset: {preset_name}",
+                data=preset,
+            )
+        )
+        self._results.append(FormatterPresetChecker(preset_name, preset).check())
+
+    def add_lsp_server_check(
+        self,
+        server_name: str,
+        preset: Any,  # LspServerPreset
+        description: str = "",
+    ) -> None:
+        """Add a check for an LSP server.
+
+        Args:
+            server_name: Name of the LSP server (e.g., "pyright", "ruff")
+            preset: The LspServerPreset object
+            description: Human-readable description
+        """
+        self._checks.append(
+            DoctorCheck(
+                check_type=DoctorCheckType.LSP_SERVER,
+                name=f"lsp:{server_name}",
+                description=description or f"Check LSP server: {server_name}",
+                data=preset,
+            )
+        )
+        self._results.append(LspServerChecker(server_name, preset).check())
+
+    def add_mcp_server_check(
+        self,
+        server_name: str,
+        config: Any,  # McpServerConfig
+        description: str = "",
+    ) -> None:
+        """Add a check for an MCP server.
+
+        Args:
+            server_name: Name of the MCP server
+            config: The McpServerConfig object
+            description: Human-readable description
+        """
+        self._checks.append(
+            DoctorCheck(
+                check_type=DoctorCheckType.MCP_SERVER,
+                name=f"mcp:{server_name}",
+                description=description or f"Check MCP server: {server_name}",
+                data=config,
+            )
+        )
+        self._results.append(McpServerChecker(server_name, config).check())
+
+    def run_all_checks(self) -> list[CapabilityCheckResult]:
+        """Run all registered checks and return results.
+
+        Returns:
+            List of CapabilityCheckResult objects, one per check.
+        """
+        return list(self._results)
+
+    @property
+    def results(self) -> list[CapabilityCheckResult]:
+        """Get all check results."""
+        return list(self._results)
+
+    @property
+    def ready_count(self) -> int:
+        """Count of checks that are ready."""
+        return sum(1 for r in self._results if r.status == CapabilityCheckStatus.READY)
+
+    @property
+    def missing_count(self) -> int:
+        """Count of checks that are not found."""
+        return sum(1 for r in self._results if r.status == CapabilityCheckStatus.NOT_FOUND)
+
+    @property
+    def error_count(self) -> int:
+        """Count of checks that had errors."""
+        return sum(1 for r in self._results if r.status == CapabilityCheckStatus.ERROR)
+
+    @property
+    def not_configured_count(self) -> int:
+        """Count of checks that are not configured."""
+        return sum(1 for r in self._results if r.status == CapabilityCheckStatus.NOT_CONFIGURED)
+
+    def summary(self) -> dict[str, Any]:
+        """Get a summary of all check results."""
+        return {
+            "total": len(self._results),
+            "ready": self.ready_count,
+            "missing": self.missing_count,
+            "errors": self.error_count,
+            "not_configured": self.not_configured_count,
+        }
+
+    def reset(self) -> None:
+        """Reset all checks and results."""
+        self._checks.clear()
+        self._results.clear()
+
+
+def create_doctor_for_config(
+    workspace: Path,
+    config: RuntimeConfig,
+) -> CapabilityDoctor:
+    """Create a CapabilityDoctor pre-populated with checks from runtime config.
+
+    Args:
+        workspace: The workspace path
+        config: The runtime configuration
+
+    Returns:
+        A CapabilityDoctor with all relevant checks registered
+    """
+    doctor = CapabilityDoctor(workspace=workspace, config=config)
+
+    # Check ast-grep
+    doctor.add_executable_check(
+        "ast-grep",
+        "ast-grep",
+        description="Structural code search and replace tool",
+    )
+
+    # Check formatter presets
+    hooks_config = config.hooks
+    if hooks_config is not None and hooks_config.formatter_presets:
+        for preset_name, preset in hooks_config.formatter_presets.items():
+            doctor.add_formatter_preset_check(preset_name, preset)
+
+    # Check LSP servers
+    lsp_config = config.lsp
+    if lsp_config is not None and lsp_config.servers:
+        from ..lsp.presets import get_builtin_lsp_server_preset
+        from ..lsp.registry import resolve_lsp_server_config
+
+        for server_name, server_override in lsp_config.servers.items():
+            # Resolve the effective config
+            try:
+                resolved = resolve_lsp_server_config(server_name, server_override)
+                doctor.add_lsp_server_check(
+                    server_name,
+                    resolved,
+                    description=f"LSP server for {server_name}",
+                )
+            except Exception:
+                # If we can't resolve, try the builtin preset
+                preset = get_builtin_lsp_server_preset(server_name)
+                if preset:
+                    doctor.add_lsp_server_check(server_name, preset)
+
+    # Check MCP servers
+    mcp_config = config.mcp
+    if mcp_config is not None and mcp_config.servers:
+        for server_name, server_config in mcp_config.servers.items():
+            doctor.add_mcp_server_check(server_name, server_config)
+
+    return doctor

--- a/src/voidcode/doctor/doctor.py
+++ b/src/voidcode/doctor/doctor.py
@@ -216,8 +216,11 @@ def create_doctor_for_config(
     # Check formatter presets.
     # When config.hooks is None, use the built-in defaults (same as runtime does).
     hooks_config = config.hooks if config.hooks is not None else _default_hooks_config()
-    for preset_name, preset in hooks_config.formatter_presets.items():
-        doctor.add_formatter_preset_check(preset_name, preset)
+    # Respect explicit disablement: runtime formatter execution short-circuits
+    # when hooks.enabled is False.
+    if hooks_config.enabled is not False:
+        for preset_name, preset in hooks_config.formatter_presets.items():
+            doctor.add_formatter_preset_check(preset_name, preset)
 
     # Check LSP servers (only when lsp.enabled is True).
     lsp_config = config.lsp

--- a/src/voidcode/doctor/doctor.py
+++ b/src/voidcode/doctor/doctor.py
@@ -18,6 +18,9 @@ from .checker import (
 )
 
 if TYPE_CHECKING:
+    from ..hook.config import RuntimeHooksConfig
+
+if TYPE_CHECKING:
     from ..runtime.config import RuntimeConfig
 
 
@@ -181,6 +184,13 @@ class CapabilityDoctor:
         self._results.clear()
 
 
+def _default_hooks_config() -> RuntimeHooksConfig:
+    """Return a RuntimeHooksConfig with built-in formatter presets."""
+    from ..hook.config import RuntimeHooksConfig
+
+    return RuntimeHooksConfig()
+
+
 def create_doctor_for_config(
     workspace: Path,
     config: RuntimeConfig,
@@ -203,20 +213,19 @@ def create_doctor_for_config(
         description="Structural code search and replace tool",
     )
 
-    # Check formatter presets
-    hooks_config = config.hooks
-    if hooks_config is not None and hooks_config.formatter_presets:
-        for preset_name, preset in hooks_config.formatter_presets.items():
-            doctor.add_formatter_preset_check(preset_name, preset)
+    # Check formatter presets.
+    # When config.hooks is None, use the built-in defaults (same as runtime does).
+    hooks_config = config.hooks if config.hooks is not None else _default_hooks_config()
+    for preset_name, preset in hooks_config.formatter_presets.items():
+        doctor.add_formatter_preset_check(preset_name, preset)
 
-    # Check LSP servers
+    # Check LSP servers (only when lsp.enabled is True).
     lsp_config = config.lsp
-    if lsp_config is not None and lsp_config.servers:
+    if lsp_config is not None and lsp_config.enabled is True and lsp_config.servers:
         from ..lsp.presets import get_builtin_lsp_server_preset
         from ..lsp.registry import resolve_lsp_server_config
 
         for server_name, server_override in lsp_config.servers.items():
-            # Resolve the effective config
             try:
                 resolved = resolve_lsp_server_config(server_name, server_override)
                 doctor.add_lsp_server_check(
@@ -224,15 +233,15 @@ def create_doctor_for_config(
                     resolved,
                     description=f"LSP server for {server_name}",
                 )
-            except Exception:
-                # If we can't resolve, try the builtin preset
+            except ValueError:
+                # Config-level error for this server; fall back to the builtin preset.
                 preset = get_builtin_lsp_server_preset(server_name)
                 if preset:
                     doctor.add_lsp_server_check(server_name, preset)
 
-    # Check MCP servers
+    # Check MCP servers (only when mcp.enabled is True).
     mcp_config = config.mcp
-    if mcp_config is not None and mcp_config.servers:
+    if mcp_config is not None and mcp_config.enabled is True and mcp_config.servers:
         for server_name, server_config in mcp_config.servers.items():
             doctor.add_mcp_server_check(server_name, server_config)
 

--- a/src/voidcode/doctor/reporter.py
+++ b/src/voidcode/doctor/reporter.py
@@ -1,0 +1,218 @@
+"""Capability doctor report formatting."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .checker import CapabilityCheckResult, CapabilityCheckStatus
+
+
+@dataclass
+class CapabilityReport:
+    """A structured report of all capability checks."""
+
+    workspace: Path | None
+    summary: dict[str, int]
+    results: list[CapabilityCheckResult]
+    errors: list[CapabilityCheckResult] = field(default_factory=list)
+
+    @property
+    def has_errors(self) -> bool:
+        """Return True if there are any errors or missing items."""
+        return bool(self.errors)
+
+    @property
+    def is_healthy(self) -> bool:
+        """Return True if all critical capabilities are ready."""
+        return self.summary["missing"] == 0 and self.summary["errors"] == 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert report to a dictionary suitable for JSON serialization."""
+        return {
+            "workspace": str(self.workspace) if self.workspace else None,
+            "summary": self.summary,
+            "results": [
+                {
+                    "name": r.name,
+                    "status": r.status.value,
+                    "check_type": r.check_type,
+                    "details": r.details,
+                    "error_message": r.error_message,
+                }
+                for r in self.results
+            ],
+            "has_errors": self.has_errors,
+            "is_healthy": self.is_healthy,
+        }
+
+
+def create_report(
+    results: list[CapabilityCheckResult],
+    workspace: Path | None = None,
+) -> CapabilityReport:
+    """Create a CapabilityReport from a list of check results.
+
+    Args:
+        results: List of CapabilityCheckResult objects
+        workspace: Optional workspace path
+
+    Returns:
+        A CapabilityReport with categorized results
+    """
+    errors = [r for r in results if r.status != CapabilityCheckStatus.READY]
+    summary = {
+        "total": len(results),
+        "ready": sum(1 for r in results if r.status == CapabilityCheckStatus.READY),
+        "missing": sum(1 for r in results if r.status == CapabilityCheckStatus.NOT_FOUND),
+        "errors": sum(1 for r in results if r.status == CapabilityCheckStatus.ERROR),
+        "not_configured": sum(
+            1 for r in results if r.status == CapabilityCheckStatus.NOT_CONFIGURED
+        ),
+    }
+    return CapabilityReport(
+        workspace=workspace,
+        summary=summary,
+        results=list(results),
+        errors=errors,
+    )
+
+
+def format_report(report: CapabilityReport, *, verbose: bool = False) -> str:
+    """Format a capability report for human-readable CLI output.
+
+    Args:
+        report: The CapabilityReport to format
+        verbose: If True, include all details including successful checks
+
+    Returns:
+        A formatted string suitable for CLI output
+    """
+    lines: list[str] = []
+
+    # Use ASCII-safe icons for better cross-platform compatibility
+    CHECK_ICON = "[+]"
+    CROSS_ICON = "[-]"
+    WARN_ICON = "[!]"
+    CIRCLE_ICON = "[o]"
+    LIGHTNING_ICON = "[*]"
+
+    # Header
+    workspace_str = f"workspace={report.workspace}" if report.workspace else "no workspace"
+    lines.append(f"VoidCode Capability Doctor [{workspace_str}]")
+    lines.append("=" * 60)
+
+    # Summary
+    lines.append("\nSummary:")
+    lines.append(f"  Total checks: {report.summary['total']}")
+    lines.append(f"  {CHECK_ICON} Ready: {report.summary['ready']}")
+    if report.summary["missing"] > 0:
+        lines.append(f"  {CROSS_ICON} Missing: {report.summary['missing']}")
+    if report.summary["errors"] > 0:
+        lines.append(f"  {WARN_ICON} Errors: {report.summary['errors']}")
+    if report.summary["not_configured"] > 0:
+        lines.append(f"  {CIRCLE_ICON} Not configured: {report.summary['not_configured']}")
+
+    # Detailed results
+    lines.append("\nResults:")
+
+    if not verbose:
+        # Only show problems by default
+        problem_results = [r for r in report.results if r.status != CapabilityCheckStatus.READY]
+        if not problem_results:
+            lines.append("  All capabilities are ready!")
+            return "\n".join(lines)
+
+        for result in problem_results:
+            lines.append(_format_result(result, CHECK_ICON, CROSS_ICON, WARN_ICON, CIRCLE_ICON))
+    else:
+        # Show all results
+        for result in report.results:
+            lines.append(_format_result(result, CHECK_ICON, CROSS_ICON, WARN_ICON, CIRCLE_ICON))
+
+    # Recommendations
+    if report.errors:
+        lines.append("\nRecommendations:")
+        for error in report.errors:
+            if error.error_message:
+                lines.append(f"  {LIGHTNING_ICON} {error.error_message}")
+
+    return "\n".join(lines)
+
+
+def _format_result(
+    result: CapabilityCheckResult,
+    check_icon: str = "[+]",
+    cross_icon: str = "[-]",
+    warn_icon: str = "[!]",
+    circle_icon: str = "[o]",
+) -> str:
+    """Format a single check result."""
+    status_icon_map = {
+        CapabilityCheckStatus.READY: check_icon,
+        CapabilityCheckStatus.NOT_FOUND: cross_icon,
+        CapabilityCheckStatus.ERROR: warn_icon,
+        CapabilityCheckStatus.NOT_CONFIGURED: circle_icon,
+    }
+    status_icon = status_icon_map.get(result.status, "?")
+
+    status_text = {
+        CapabilityCheckStatus.READY: "ready",
+        CapabilityCheckStatus.NOT_FOUND: "not found",
+        CapabilityCheckStatus.ERROR: "error",
+        CapabilityCheckStatus.NOT_CONFIGURED: "not configured",
+    }.get(result.status, "unknown")
+
+    lines = [f"  {status_icon} {result.name}: {status_text}"]
+
+    if result.error_message and result.status != CapabilityCheckStatus.READY:
+        # Indent error message
+        for line in result.error_message.split("\n"):
+            lines.append(f"    {line}")
+
+    if result.details:
+        # Show relevant details
+        details_lines = _format_details(result)
+        for detail in details_lines:
+            lines.append(f"    {detail}")
+
+    return "\n".join(lines)
+
+
+def _format_details(result: CapabilityCheckResult) -> list[str]:
+    """Format relevant details from a check result."""
+    details: list[str] = []
+    d = result.details
+
+    if "command" in d and result.status != CapabilityCheckStatus.READY:
+        details.append(f"command: {d['command']}")
+    if "available_commands" in d:
+        details.append(f"available: {', '.join(d['available_commands'])}")
+    if "languages" in d and d["languages"]:
+        details.append(f"languages: {', '.join(d['languages'])}")
+    if "extensions" in d and d["extensions"]:
+        ext_sample = d["extensions"][:5]
+        if len(d["extensions"]) > 5:
+            details.append(f"extensions: {', '.join(ext_sample)} +{len(d['extensions']) - 5} more")
+        else:
+            details.append(f"extensions: {', '.join(ext_sample)}")
+    if "preset_name" in d:
+        details.append(f"preset: {d['preset_name']}")
+    if "version_info" in d and d["version_info"]:
+        details.append(f"version: {d['version_info']}")
+
+    return details
+
+
+def format_report_json(report: CapabilityReport) -> str:
+    """Format a capability report as JSON.
+
+    Args:
+        report: The CapabilityReport to format
+
+    Returns:
+        A JSON string representation
+    """
+    return json.dumps(report.to_dict(), indent=2)

--- a/tests/unit/doctor/__init__.py
+++ b/tests/unit/doctor/__init__.py
@@ -1,0 +1,55 @@
+"""Tests for the voidcode.doctor package."""
+
+from __future__ import annotations
+
+from voidcode import doctor as doctor
+from voidcode.doctor import (
+    CapabilityCheckResult,
+    CapabilityCheckStatus,
+    CapabilityDoctor,
+    CapabilityReport,
+    DoctorCheck,
+    DoctorCheckType,
+    ExecutableChecker,
+    FormatterPresetChecker,
+    LspServerChecker,
+    McpServerChecker,
+    create_doctor_for_config,
+    create_report,
+    format_report,
+    format_report_json,
+)
+
+
+def test_module_exports() -> None:
+    """Test that all expected exports are available."""
+    assert CapabilityCheckResult is not None
+    assert CapabilityCheckStatus is not None
+    assert CapabilityDoctor is not None
+    assert CapabilityReport is not None
+    assert DoctorCheck is not None
+    assert DoctorCheckType is not None
+    assert ExecutableChecker is not None
+    assert FormatterPresetChecker is not None
+    assert LspServerChecker is not None
+    assert McpServerChecker is not None
+    assert create_doctor_for_config is not None
+    assert create_report is not None
+    assert format_report is not None
+    assert format_report_json is not None
+
+
+def test_check_status_enum() -> None:
+    """Test that all expected status values are available."""
+    assert CapabilityCheckStatus.READY.value == "ready"
+    assert CapabilityCheckStatus.NOT_FOUND.value == "not_found"
+    assert CapabilityCheckStatus.ERROR.value == "error"
+    assert CapabilityCheckStatus.NOT_CONFIGURED.value == "not_configured"
+
+
+def test_check_type_enum() -> None:
+    """Test that all expected check types are available."""
+    assert DoctorCheckType.EXECUTABLE.value == "executable"
+    assert DoctorCheckType.FORMATTER_PRESET.value == "formatter_preset"
+    assert DoctorCheckType.LSP_SERVER.value == "lsp_server"
+    assert DoctorCheckType.MCP_SERVER.value == "mcp_server"

--- a/tests/unit/doctor/test_checker.py
+++ b/tests/unit/doctor/test_checker.py
@@ -1,0 +1,181 @@
+"""Tests for the capability doctor checker module."""
+
+from __future__ import annotations
+
+from voidcode.doctor.checker import (
+    CapabilityCheckStatus,
+    DoctorCheckType,
+    ExecutableChecker,
+    FormatterPresetChecker,
+    LspServerChecker,
+    McpServerChecker,
+)
+
+
+class TestExecutableChecker:
+    """Tests for the ExecutableChecker class."""
+
+    def test_check_finds_existing_executable(self) -> None:
+        """Test that the checker finds an executable that exists in PATH."""
+        checker = ExecutableChecker("python", "python")
+        result = checker.check()
+
+        assert result.status == CapabilityCheckStatus.READY
+        assert result.name == "python"
+        assert result.check_type == DoctorCheckType.EXECUTABLE.value
+        assert "command" in result.details
+
+    def test_check_not_found_for_missing_executable(self) -> None:
+        """Test that the checker reports not found for missing executables."""
+        checker = ExecutableChecker(
+            "definitely-not-real-tool-xyz123",
+            "definitely-not-real-tool-xyz123",
+        )
+        result = checker.check()
+
+        assert result.status == CapabilityCheckStatus.NOT_FOUND
+        assert result.name == "definitely-not-real-tool-xyz123"
+        assert result.error_message is not None
+        assert "not found" in result.error_message.lower()
+
+    def test_check_tries_multiple_commands(self) -> None:
+        """Test that the checker tries multiple command names."""
+        checker = ExecutableChecker("python3", "python3", "python")
+        result = checker.check()
+
+        # python exists, so this should succeed
+        assert result.status == CapabilityCheckStatus.READY
+        assert "command" in result.details
+
+
+class TestFormatterPresetChecker:
+    """Tests for the FormatterPresetChecker class."""
+
+    def test_check_with_available_formatter(self) -> None:
+        """Test checker with an available formatter preset."""
+        from voidcode.hook.config import RuntimeFormatterPresetConfig
+
+        preset = RuntimeFormatterPresetConfig(
+            command=("python", "--version"),
+            extensions=(".py",),
+        )
+        checker = FormatterPresetChecker("python", preset)
+        result = checker.check()
+
+        assert result.status == CapabilityCheckStatus.READY
+        assert result.name == "formatter:python"
+        assert result.check_type == DoctorCheckType.FORMATTER_PRESET.value
+
+    def test_check_with_missing_formatter(self) -> None:
+        """Test checker with a missing formatter preset."""
+        from voidcode.hook.config import RuntimeFormatterPresetConfig
+
+        preset = RuntimeFormatterPresetConfig(
+            command=("definitely-not-a-formatter-xyz",),
+            extensions=(".xyz",),
+        )
+        checker = FormatterPresetChecker("custom", preset)
+        result = checker.check()
+
+        assert result.status == CapabilityCheckStatus.NOT_FOUND
+        assert result.error_message is not None
+
+
+class TestLspServerChecker:
+    """Tests for the LspServerChecker class."""
+
+    def test_check_with_available_lsp(self) -> None:
+        """Test checker with an available LSP server."""
+        from voidcode.lsp.presets import LspServerPreset
+
+        preset = LspServerPreset(
+            id="test-lsp",
+            command=("python", "--version"),
+            extensions=(".py",),
+            languages=("python",),
+        )
+        checker = LspServerChecker("test-lsp", preset)
+        result = checker.check()
+
+        # Python is available, so this should succeed
+        assert result.status == CapabilityCheckStatus.READY
+        assert result.name == "lsp:test-lsp"
+        assert result.check_type == DoctorCheckType.LSP_SERVER.value
+
+    def test_check_with_missing_lsp(self) -> None:
+        """Test checker with a missing LSP server."""
+        from voidcode.lsp.presets import LspServerPreset
+
+        preset = LspServerPreset(
+            id="missing-lsp",
+            command=("missing-lsp-binary-xyz",),
+            extensions=(".xyz",),
+        )
+        checker = LspServerChecker("missing-lsp", preset)
+        result = checker.check()
+
+        assert result.status == CapabilityCheckStatus.NOT_FOUND
+        assert result.error_message is not None
+
+    def test_check_with_no_command(self) -> None:
+        """Test checker with LSP preset that has no command."""
+        from voidcode.lsp.presets import LspServerPreset
+
+        preset = LspServerPreset(
+            id="no-command",
+            command=(),
+            extensions=(".py",),
+        )
+        checker = LspServerChecker("no-command", preset)
+        result = checker.check()
+
+        assert result.status == CapabilityCheckStatus.NOT_CONFIGURED
+        assert result.error_message is not None
+
+
+class TestMcpServerChecker:
+    """Tests for the McpServerChecker class."""
+
+    def test_check_with_available_mcp_server(self) -> None:
+        """Test checker with an available MCP server."""
+        from voidcode.mcp.config import McpServerConfig
+
+        config = McpServerConfig(
+            command=("python", "--version"),
+            transport="stdio",
+        )
+        checker = McpServerChecker("test-mcp", config)
+        result = checker.check()
+
+        # Python is available, so this should succeed
+        assert result.status == CapabilityCheckStatus.READY
+        assert result.name == "mcp:test-mcp"
+        assert result.check_type == DoctorCheckType.MCP_SERVER.value
+
+    def test_check_with_missing_mcp_server(self) -> None:
+        """Test checker with a missing MCP server."""
+        from voidcode.mcp.config import McpServerConfig
+
+        config = McpServerConfig(
+            command=("missing-mcp-server-xyz",),
+            transport="stdio",
+        )
+        checker = McpServerChecker("missing-mcp", config)
+        result = checker.check()
+
+        assert result.status == CapabilityCheckStatus.NOT_FOUND
+        assert result.error_message is not None
+
+    def test_check_with_no_command(self) -> None:
+        """Test checker with MCP config that has no command."""
+        from voidcode.mcp.config import McpServerConfig
+
+        config = McpServerConfig(
+            command=(),
+            transport="stdio",
+        )
+        checker = McpServerChecker("no-command", config)
+        result = checker.check()
+
+        assert result.status == CapabilityCheckStatus.NOT_CONFIGURED
+        assert result.error_message is not None

--- a/tests/unit/doctor/test_doctor.py
+++ b/tests/unit/doctor/test_doctor.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from voidcode.doctor import (
     CapabilityDoctor,
     create_doctor_for_config,
 )
 from voidcode.doctor.checker import (
+    CapabilityCheckStatus,
     DoctorCheckType,
 )
 
@@ -79,7 +80,11 @@ class TestCreateDoctorForConfig:
         config.lsp = None
         config.mcp = None
 
-        doctor = create_doctor_for_config(Path("/tmp"), config)
+        hooks = MagicMock()
+        hooks.enabled = True
+        hooks.formatter_presets = {}
+        with patch("voidcode.doctor.doctor._default_hooks_config", return_value=hooks):
+            doctor = create_doctor_for_config(Path("/tmp"), config)
 
         # Should have at least the ast-grep check
         ast_grep_results = [r for r in doctor.results if "ast-grep" in r.name.lower()]
@@ -92,7 +97,41 @@ class TestCreateDoctorForConfig:
         config.lsp = None
         config.mcp = None
 
-        doctor = create_doctor_for_config(Path("/tmp"), config)
+        hooks = MagicMock()
+        hooks.enabled = True
+        hooks.formatter_presets = {}
+        with patch("voidcode.doctor.doctor._default_hooks_config", return_value=hooks):
+            doctor = create_doctor_for_config(Path("/tmp"), config)
 
         # Should not raise and should have at least ast-grep
         assert len(doctor.results) >= 1
+
+    def test_skips_formatter_checks_when_hooks_disabled(self) -> None:
+        """Formatter checks should be skipped when hooks.enabled is False."""
+        hooks = MagicMock()
+        hooks.enabled = False
+        hooks.formatter_presets = {
+            "python": MagicMock(),
+            "typescript": MagicMock(),
+        }
+
+        config = MagicMock()
+        config.hooks = hooks
+        config.lsp = None
+        config.mcp = None
+
+        doctor = create_doctor_for_config(Path("/tmp"), config)
+
+        formatter_results = [
+            result
+            for result in doctor.results
+            if result.check_type == DoctorCheckType.FORMATTER_PRESET.value
+        ]
+        assert formatter_results == []
+
+        ast_grep_results = [result for result in doctor.results if result.name == "ast-grep"]
+        assert len(ast_grep_results) == 1
+        assert ast_grep_results[0].status in {
+            CapabilityCheckStatus.READY,
+            CapabilityCheckStatus.NOT_FOUND,
+        }

--- a/tests/unit/doctor/test_doctor.py
+++ b/tests/unit/doctor/test_doctor.py
@@ -1,0 +1,98 @@
+"""Tests for the capability doctor module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from voidcode.doctor import (
+    CapabilityDoctor,
+    create_doctor_for_config,
+)
+from voidcode.doctor.checker import (
+    DoctorCheckType,
+)
+
+
+class TestCapabilityDoctor:
+    """Tests for the CapabilityDoctor class."""
+
+    def test_add_executable_check(self) -> None:
+        """Test adding an executable check to the doctor."""
+        doctor = CapabilityDoctor()
+
+        # Check for python which should exist
+        doctor.add_executable_check(
+            "python",
+            "python",
+            description="Python interpreter",
+        )
+
+        assert len(doctor.results) == 1
+        result = doctor.results[0]
+        assert result.name == "python"
+        assert result.check_type == DoctorCheckType.EXECUTABLE.value
+
+    def test_doctor_summary(self) -> None:
+        """Test the doctor summary functionality."""
+        doctor = CapabilityDoctor()
+
+        # Add some checks
+        doctor.add_executable_check("python", "python")
+        doctor.add_executable_check("missing-tool", "missing-tool-xyz")
+
+        summary = doctor.summary()
+        assert summary["total"] == 2
+        assert summary["ready"] >= 1  # Python should be ready
+        assert summary["missing"] >= 1  # missing-tool should not be found
+
+    def test_doctor_ready_count(self) -> None:
+        """Test the ready count property."""
+        doctor = CapabilityDoctor()
+
+        # Add checks
+        doctor.add_executable_check("python", "python")
+        doctor.add_executable_check("missing", "missing-tool-xyz")
+
+        assert doctor.ready_count >= 1
+        assert doctor.missing_count >= 1
+
+    def test_reset_clears_results(self) -> None:
+        """Test that reset clears all checks and results."""
+        doctor = CapabilityDoctor()
+        doctor.add_executable_check("python", "python")
+
+        assert len(doctor.results) > 0
+
+        doctor.reset()
+
+        assert len(doctor.results) == 0
+
+
+class TestCreateDoctorForConfig:
+    """Tests for the create_doctor_for_config function."""
+
+    def test_creates_doctor_with_ast_grep_check(self) -> None:
+        """Test that the doctor includes ast-grep check."""
+        config = MagicMock()
+        config.hooks = None
+        config.lsp = None
+        config.mcp = None
+
+        doctor = create_doctor_for_config(Path("/tmp"), config)
+
+        # Should have at least the ast-grep check
+        ast_grep_results = [r for r in doctor.results if "ast-grep" in r.name.lower()]
+        assert len(ast_grep_results) >= 1
+
+    def test_handles_none_config_sections(self) -> None:
+        """Test that the function handles None config sections gracefully."""
+        config = MagicMock()
+        config.hooks = None
+        config.lsp = None
+        config.mcp = None
+
+        doctor = create_doctor_for_config(Path("/tmp"), config)
+
+        # Should not raise and should have at least ast-grep
+        assert len(doctor.results) >= 1

--- a/tests/unit/doctor/test_reporter.py
+++ b/tests/unit/doctor/test_reporter.py
@@ -68,6 +68,31 @@ class TestCreateReport:
         assert report.is_healthy is False
         assert report.has_errors is True
 
+    def test_create_report_with_runtime_config_error_is_unhealthy(self) -> None:
+        """Runtime config parse errors should mark report unhealthy."""
+        results = [
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.READY,
+                name="ast-grep",
+                check_type="executable",
+                details={"command": "ast-grep"},
+            ),
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.ERROR,
+                name="runtime.config",
+                check_type="runtime_config",
+                error_message="runtime config parse failed",
+            ),
+        ]
+
+        report = create_report(results)
+
+        assert report.summary["total"] == 2
+        assert report.summary["ready"] == 1
+        assert report.summary["errors"] == 1
+        assert report.is_healthy is False
+        assert report.has_errors is True
+
 
 class TestFormatReport:
     """Tests for the format_report function."""

--- a/tests/unit/doctor/test_reporter.py
+++ b/tests/unit/doctor/test_reporter.py
@@ -1,0 +1,184 @@
+"""Tests for the capability doctor reporter module."""
+
+from __future__ import annotations
+
+import json
+
+from voidcode.doctor import (
+    create_report,
+    format_report,
+    format_report_json,
+)
+from voidcode.doctor.checker import (
+    CapabilityCheckResult,
+    CapabilityCheckStatus,
+)
+
+
+class TestCreateReport:
+    """Tests for the create_report function."""
+
+    def test_create_report_with_all_ready(self) -> None:
+        """Test report creation with all checks ready."""
+        results = [
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.READY,
+                name="python",
+                check_type="executable",
+                details={"command": "python"},
+            ),
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.READY,
+                name="formatter:python",
+                check_type="formatter_preset",
+                details={"preset_name": "python"},
+            ),
+        ]
+
+        report = create_report(results)
+
+        assert report.summary["total"] == 2
+        assert report.summary["ready"] == 2
+        assert report.summary["missing"] == 0
+        assert report.is_healthy is True
+        assert report.has_errors is False
+
+    def test_create_report_with_missing(self) -> None:
+        """Test report creation with missing capabilities."""
+        results = [
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.READY,
+                name="python",
+                check_type="executable",
+                details={"command": "python"},
+            ),
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.NOT_FOUND,
+                name="missing-tool",
+                check_type="executable",
+                error_message="missing-tool not found",
+            ),
+        ]
+
+        report = create_report(results)
+
+        assert report.summary["total"] == 2
+        assert report.summary["ready"] == 1
+        assert report.summary["missing"] == 1
+        assert report.is_healthy is False
+        assert report.has_errors is True
+
+
+class TestFormatReport:
+    """Tests for the format_report function."""
+
+    def test_format_report_shows_problems_by_default(self) -> None:
+        """Test that format_report only shows problems by default."""
+        results = [
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.READY,
+                name="python",
+                check_type="executable",
+                details={"command": "python"},
+            ),
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.NOT_FOUND,
+                name="missing-tool",
+                check_type="executable",
+                error_message="missing-tool not found in PATH",
+            ),
+        ]
+
+        report = create_report(results)
+        output = format_report(report)
+
+        # Should contain the missing tool
+        assert "missing-tool" in output
+        # Should contain the header
+        assert "VoidCode Capability Doctor" in output
+        # Should contain summary
+        assert "Summary" in output
+
+    def test_format_report_verbose_shows_all(self) -> None:
+        """Test that verbose mode shows all capabilities."""
+        results = [
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.READY,
+                name="python",
+                check_type="executable",
+                details={"command": "python"},
+            ),
+        ]
+
+        report = create_report(results)
+        output = format_report(report, verbose=True)
+
+        assert "python" in output
+        assert "ready" in output.lower()
+
+    def test_format_report_healthy_message(self) -> None:
+        """Test that healthy reports show success message."""
+        results = [
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.READY,
+                name="python",
+                check_type="executable",
+                details={"command": "python"},
+            ),
+        ]
+
+        report = create_report(results)
+        output = format_report(report)
+
+        assert "ready" in output.lower() or "capabilities are ready" in output.lower()
+
+
+class TestFormatReportJson:
+    """Tests for the format_report_json function."""
+
+    def test_format_report_json_output(self) -> None:
+        """Test JSON output format."""
+        results = [
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.READY,
+                name="python",
+                check_type="executable",
+                details={"command": "python"},
+            ),
+        ]
+
+        report = create_report(results)
+        json_output = format_report_json(report)
+
+        # Should be valid JSON
+        parsed = json.loads(json_output)
+
+        assert "summary" in parsed
+        assert "results" in parsed
+        assert "is_healthy" in parsed
+        assert parsed["summary"]["ready"] == 1
+
+
+class TestCapabilityReport:
+    """Tests for the CapabilityReport class."""
+
+    def test_report_to_dict(self) -> None:
+        """Test report serialization to dict."""
+        results = [
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.READY,
+                name="test",
+                check_type="executable",
+                details={"key": "value"},
+            ),
+        ]
+
+        report = create_report(results)
+        dict_output = report.to_dict()
+
+        assert isinstance(dict_output, dict)
+        assert "workspace" in dict_output
+        assert "summary" in dict_output
+        assert "results" in dict_output
+        assert "is_healthy" in dict_output
+        assert "has_errors" in dict_output


### PR DESCRIPTION
PR 描述
Capability Doctor 功能实现 - Issue #122
描述
随着 VoidCode runtime-managed capability surface 的增长，用户和 agent 越来越依赖外部可用性判断（formatter、ast-grep、LSP servers、MCP servers），但这些状态分散在配置、工具实现和 manager 里，没有统一的 capability check surface。
本变更实现了一个统一的 CapabilityDoctor 模块，提供：
1. 检查能力：
   - ast-grep 二进制文件可用性
   - formatter presets 及其可执行文件
   - LSP server commands 配置
   - MCP server commands 配置
2. CLI 集成：
      uv run voidcode doctor --workspace .
   uv run voidcode doctor --verbose
   uv run voidcode doctor --json
   
3. 结构化输出：适合 CLI 用户阅读，也适合 agent 消费
4. 非阻塞设计：给出清晰提示但不强制安装
变更类型
- [x] 新功能
核对清单
- [x] 本地测试通过 (24 tests passed)
- [x] Ruff/Ruff format 通过
- [x] Basedpyright 类型检查通过
- [x] 新增单元测试覆盖
- [x] 未包含无关的变更
---