### PR TITLE
feat(runtime): add background task substrate

### DIFF
--- a/src/voidcode/runtime/__init__.py
+++ b/src/voidcode/runtime/__init__.py
@@ -4,6 +4,7 @@ from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
 from .contracts import (
+    BackgroundTaskRuntimeEntrypoint,
     RuntimeEntrypoint,
     RuntimeRequest,
     RuntimeResponse,
@@ -15,6 +16,14 @@ from .events import EventEnvelope, EventSource
 from .permission import PendingApproval, PermissionDecision, PermissionPolicy, PermissionResolution
 from .session import SessionRef, SessionState, SessionStatus, StoredSessionSummary
 from .storage import SessionStore
+from .task import (
+    BackgroundTaskRef,
+    BackgroundTaskRequestSnapshot,
+    BackgroundTaskState,
+    BackgroundTaskStatus,
+    StoredBackgroundTaskSummary,
+    validate_background_task_id,
+)
 
 if TYPE_CHECKING:
     from .http import RuntimeTransportApp, create_runtime_app
@@ -23,6 +32,11 @@ if TYPE_CHECKING:
 __all__ = [
     "EventEnvelope",
     "EventSource",
+    "BackgroundTaskRef",
+    "BackgroundTaskRequestSnapshot",
+    "BackgroundTaskRuntimeEntrypoint",
+    "BackgroundTaskState",
+    "BackgroundTaskStatus",
     "PendingApproval",
     "PermissionDecision",
     "PermissionPolicy",
@@ -39,9 +53,11 @@ __all__ = [
     "SessionStatus",
     "SessionStore",
     "StoredSessionSummary",
+    "StoredBackgroundTaskSummary",
     "ToolRegistry",
     "VoidCodeRuntime",
     "create_runtime_app",
+    "validate_background_task_id",
 ]
 
 

--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -6,6 +6,7 @@ from typing import Literal, Protocol, runtime_checkable
 
 from .events import EventEnvelope
 from .session import SessionState
+from .task import BackgroundTaskState, StoredBackgroundTaskSummary
 
 
 @dataclass(frozen=True, slots=True)
@@ -56,3 +57,14 @@ class RuntimeEntrypoint(Protocol):
 @runtime_checkable
 class StreamingRuntimeEntrypoint(Protocol):
     def run_stream(self, request: RuntimeRequest) -> Iterator[RuntimeStreamChunk]: ...
+
+
+@runtime_checkable
+class BackgroundTaskRuntimeEntrypoint(Protocol):
+    def start_background_task(self, request: RuntimeRequest) -> BackgroundTaskState: ...
+
+    def load_background_task(self, task_id: str) -> BackgroundTaskState: ...
+
+    def list_background_tasks(self) -> tuple[StoredBackgroundTaskSummary, ...]: ...
+
+    def cancel_background_task(self, task_id: str) -> BackgroundTaskState: ...

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -75,6 +76,14 @@ from .session import SessionRef, SessionState, SessionStatus, StoredSessionSumma
 from .single_agent_provider import ProviderExecutionError
 from .skills import SkillRuntimeContext, build_runtime_contexts
 from .storage import SessionStore, SqliteSessionStore
+from .task import (
+    BackgroundTaskRef,
+    BackgroundTaskRequestSnapshot,
+    BackgroundTaskState,
+    BackgroundTaskStatus,
+    StoredBackgroundTaskSummary,
+    validate_background_task_id,
+)
 from .tool_provider import BuiltinToolProvider
 
 if TYPE_CHECKING:
@@ -176,6 +185,8 @@ class VoidCodeRuntime:
     _acp_adapter: AcpAdapter
     _graph_cache: dict[tuple[ExecutionEngineName, str], RuntimeGraph]
     _plan_contributor: PlanContributor
+    _background_task_threads: dict[str, threading.Thread]
+    _background_tasks_reconciled: bool
     _hook_recursion_env_var = "VOIDCODE_RUNNING_TOOL_HOOK"
     _default_context_window_policy = ContextWindowPolicy()
 
@@ -239,6 +250,8 @@ class VoidCodeRuntime:
         self._skill_registry = skill_registry or self._build_skill_registry()
         self._acp_adapter = acp_adapter or build_acp_adapter(self._config.acp)
         self._plan_contributor = build_plan_contributor(self._workspace, self._config.plan)
+        self._background_task_threads = {}
+        self._background_tasks_reconciled = False
 
     def __enter__(self) -> VoidCodeRuntime:
         return self
@@ -1206,6 +1219,50 @@ class VoidCodeRuntime:
     def list_sessions(self) -> tuple[StoredSessionSummary, ...]:
         return self._session_store.list_sessions(workspace=self._workspace)
 
+    def start_background_task(self, request: RuntimeRequest) -> BackgroundTaskState:
+        self._reconcile_background_tasks_if_needed()
+        validated_request = self._validated_request(request)
+        task_id = f"task-{uuid4().hex}"
+        initial_state = BackgroundTaskState(
+            task=BackgroundTaskRef(id=task_id),
+            status="queued",
+            request=BackgroundTaskRequestSnapshot(
+                prompt=validated_request.prompt,
+                session_id=validated_request.session_id,
+                metadata=dict(validated_request.metadata),
+                allocate_session_id=validated_request.allocate_session_id,
+            ),
+            created_at=1,
+            updated_at=1,
+        )
+        self._session_store.create_background_task(workspace=self._workspace, task=initial_state)
+        worker = threading.Thread(
+            target=self._run_background_task_worker,
+            args=(task_id,),
+            name=f"voidcode-background-task-{task_id}",
+            daemon=True,
+        )
+        self._background_task_threads[task_id] = worker
+        worker.start()
+        return self.load_background_task(task_id)
+
+    def load_background_task(self, task_id: str) -> BackgroundTaskState:
+        self._reconcile_background_tasks_if_needed()
+        validate_background_task_id(task_id)
+        return self._session_store.load_background_task(workspace=self._workspace, task_id=task_id)
+
+    def list_background_tasks(self) -> tuple[StoredBackgroundTaskSummary, ...]:
+        self._reconcile_background_tasks_if_needed()
+        return self._session_store.list_background_tasks(workspace=self._workspace)
+
+    def cancel_background_task(self, task_id: str) -> BackgroundTaskState:
+        validate_background_task_id(task_id)
+        self._reconcile_background_tasks_if_needed()
+        return self._session_store.request_background_task_cancel(
+            workspace=self._workspace,
+            task_id=task_id,
+        )
+
     def effective_runtime_config(self, *, session_id: str | None = None) -> EffectiveRuntimeConfig:
         if session_id is None:
             return self._effective_runtime_config_from_metadata(None)
@@ -1945,6 +2002,79 @@ class VoidCodeRuntime:
                 if persisted_approval_mode in ("allow", "deny", "ask"):
                     approval_mode = persisted_approval_mode
         return PermissionPolicy(mode=approval_mode)
+
+    def _reconcile_background_tasks_if_needed(self) -> None:
+        if self._background_tasks_reconciled:
+            return
+        fail_incomplete = getattr(self._session_store, "fail_incomplete_background_tasks", None)
+        if callable(fail_incomplete):
+            fail_incomplete(
+                workspace=self._workspace,
+                message="background task interrupted before completion",
+            )
+        self._background_tasks_reconciled = True
+
+    def _run_background_task_worker(self, task_id: str) -> None:
+        try:
+            task = self.load_background_task(task_id)
+            if task.status == "cancelled":
+                return
+            session_id = task.request.session_id
+            if session_id is None:
+                session_id = f"session-{uuid4().hex}"
+            running_task = self._session_store.mark_background_task_running(
+                workspace=self._workspace,
+                task_id=task_id,
+                session_id=session_id,
+            )
+            if running_task.status != "running":
+                return
+            if running_task.cancel_requested_at is not None:
+                self._session_store.mark_background_task_terminal(
+                    workspace=self._workspace,
+                    task_id=task_id,
+                    status="cancelled",
+                    error="cancelled before dispatch",
+                )
+                return
+            response = self.run(
+                RuntimeRequest(
+                    prompt=running_task.request.prompt,
+                    session_id=session_id,
+                    metadata={
+                        **running_task.request.metadata,
+                        "background_task_id": task_id,
+                        "background_run": True,
+                    },
+                    allocate_session_id=False,
+                )
+            )
+            terminal_status: BackgroundTaskStatus = (
+                "completed" if response.session.status == "completed" else "failed"
+            )
+            error: str | None = None
+            if terminal_status == "failed":
+                for event in reversed(response.events):
+                    if event.event_type == "runtime.failed":
+                        event_error = event.payload.get("error")
+                        error = str(event_error) if event_error is not None else None
+                        break
+            self._session_store.mark_background_task_terminal(
+                workspace=self._workspace,
+                task_id=task_id,
+                status=terminal_status,
+                error=error,
+            )
+        except Exception as exc:
+            logger.exception("background task failed: %s", task_id)
+            self._session_store.mark_background_task_terminal(
+                workspace=self._workspace,
+                task_id=task_id,
+                status="failed",
+                error=str(exc),
+            )
+        finally:
+            self._background_task_threads.pop(task_id, None)
 
     def _effective_runtime_config_from_metadata(
         self, metadata: dict[str, object] | None

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -279,7 +279,6 @@ class VoidCodeRuntime:
                 provider_model=provider_model,
                 max_steps=max_steps,
             )
-        raise ValueError(f"unknown execution engine: {engine_name}")
 
     def _build_graph_for_engine_from_config(self, config: EffectiveRuntimeConfig) -> RuntimeGraph:
         # Generate cache key from config

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -52,6 +52,7 @@ from .events import (
     RUNTIME_ACP_CONNECTED,
     RUNTIME_ACP_DISCONNECTED,
     RUNTIME_ACP_FAILED,
+    RUNTIME_FAILED,
     RUNTIME_LSP_SERVER_FAILED,
     RUNTIME_LSP_SERVER_STARTED,
     RUNTIME_LSP_SERVER_STOPPED,
@@ -1232,8 +1233,6 @@ class VoidCodeRuntime:
                 metadata=dict(validated_request.metadata),
                 allocate_session_id=validated_request.allocate_session_id,
             ),
-            created_at=1,
-            updated_at=1,
         )
         self._session_store.create_background_task(workspace=self._workspace, task=initial_state)
         worker = threading.Thread(
@@ -2019,9 +2018,13 @@ class VoidCodeRuntime:
             task = self.load_background_task(task_id)
             if task.status == "cancelled":
                 return
-            session_id = task.request.session_id
-            if session_id is None:
-                session_id = f"session-{uuid4().hex}"
+            request = RuntimeRequest(
+                prompt=task.request.prompt,
+                session_id=task.request.session_id,
+                metadata=task.request.metadata,
+                allocate_session_id=task.request.allocate_session_id,
+            )
+            session_id = self._resolve_session_id(request)
             running_task = self._session_store.mark_background_task_running(
                 workspace=self._workspace,
                 task_id=task_id,
@@ -2055,7 +2058,7 @@ class VoidCodeRuntime:
             error: str | None = None
             if terminal_status == "failed":
                 for event in reversed(response.events):
-                    if event.event_type == "runtime.failed":
+                    if event.event_type == RUNTIME_FAILED:
                         event_error = event.payload.get("error")
                         error = str(event_error) if event_error is not None else None
                         break

--- a/src/voidcode/runtime/storage.py
+++ b/src/voidcode/runtime/storage.py
@@ -12,6 +12,14 @@ from .contracts import RuntimeRequest, RuntimeResponse
 from .events import EventEnvelope, EventSource
 from .permission import PendingApproval
 from .session import SessionRef, SessionState, SessionStatus, StoredSessionSummary
+from .task import (
+    BackgroundTaskRef,
+    BackgroundTaskRequestSnapshot,
+    BackgroundTaskState,
+    BackgroundTaskStatus,
+    StoredBackgroundTaskSummary,
+    validate_background_task_id,
+)
 
 
 @runtime_checkable
@@ -47,6 +55,50 @@ class SessionStore(Protocol):
     def load_resume_checkpoint(
         self, *, workspace: Path, session_id: str
     ) -> dict[str, object] | None: ...
+
+    def create_background_task(
+        self,
+        *,
+        workspace: Path,
+        task: BackgroundTaskState,
+    ) -> None: ...
+
+    def load_background_task(self, *, workspace: Path, task_id: str) -> BackgroundTaskState: ...
+
+    def list_background_tasks(
+        self, *, workspace: Path
+    ) -> tuple[StoredBackgroundTaskSummary, ...]: ...
+
+    def mark_background_task_running(
+        self,
+        *,
+        workspace: Path,
+        task_id: str,
+        session_id: str,
+    ) -> BackgroundTaskState: ...
+
+    def mark_background_task_terminal(
+        self,
+        *,
+        workspace: Path,
+        task_id: str,
+        status: BackgroundTaskStatus,
+        error: str | None = None,
+    ) -> BackgroundTaskState: ...
+
+    def request_background_task_cancel(
+        self,
+        *,
+        workspace: Path,
+        task_id: str,
+    ) -> BackgroundTaskState: ...
+
+    def fail_incomplete_background_tasks(
+        self,
+        *,
+        workspace: Path,
+        message: str,
+    ) -> tuple[BackgroundTaskState, ...]: ...
 
 
 @final
@@ -104,6 +156,26 @@ class SqliteSessionStore:
             )
             """
         )
+        _ = connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS background_tasks (
+                task_id TEXT PRIMARY KEY,
+                workspace TEXT NOT NULL,
+                status TEXT NOT NULL,
+                prompt TEXT NOT NULL,
+                request_session_id TEXT,
+                request_metadata_json TEXT NOT NULL,
+                allocate_session_id INTEGER NOT NULL,
+                session_id TEXT,
+                error TEXT,
+                cancel_requested_at INTEGER,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                started_at INTEGER,
+                finished_at INTEGER
+            )
+            """
+        )
         user_version = self._read_user_version(connection=connection)
         columns = {
             cast(str, row["name"])
@@ -122,6 +194,8 @@ class SqliteSessionStore:
             target_user_version = max(target_user_version, 2)
         if user_version < 3:
             target_user_version = max(target_user_version, 3)
+        if user_version < 4:
+            target_user_version = max(target_user_version, 4)
         if target_user_version != user_version:
             _ = connection.execute(f"PRAGMA user_version = {target_user_version}")
         connection.commit()
@@ -138,6 +212,19 @@ class SqliteSessionStore:
         allowed: tuple[EventSource, ...] = ("runtime", "graph", "tool")
         if value not in allowed:
             raise ValueError(f"invalid event source: {value}")
+        return value
+
+    @staticmethod
+    def _parse_background_task_status(value: str) -> BackgroundTaskStatus:
+        allowed: tuple[BackgroundTaskStatus, ...] = (
+            "queued",
+            "running",
+            "completed",
+            "failed",
+            "cancelled",
+        )
+        if value not in allowed:
+            raise ValueError(f"invalid background task status: {value}")
         return value
 
     def save_run(
@@ -468,6 +555,230 @@ class SqliteSessionStore:
         return RuntimeResponse(
             session=session, events=events, output=cast(str | None, session_row["output"])
         )
+
+    def create_background_task(
+        self,
+        *,
+        workspace: Path,
+        task: BackgroundTaskState,
+    ) -> None:
+        task_id = validate_background_task_id(task.task.id)
+        with self._connect(workspace) as connection:
+            _ = connection.execute(
+                """
+                INSERT INTO background_tasks (
+                    task_id, workspace, status, prompt, request_session_id,
+                    request_metadata_json, allocate_session_id, session_id, error,
+                    cancel_requested_at, created_at, updated_at, started_at, finished_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    task_id,
+                    str(workspace),
+                    task.status,
+                    task.request.prompt,
+                    task.request.session_id,
+                    json.dumps(task.request.metadata, sort_keys=True),
+                    1 if task.request.allocate_session_id else 0,
+                    task.session_id,
+                    task.error,
+                    task.cancel_requested_at,
+                    task.created_at,
+                    task.updated_at,
+                    task.started_at,
+                    task.finished_at,
+                ),
+            )
+            connection.commit()
+
+    def load_background_task(self, *, workspace: Path, task_id: str) -> BackgroundTaskState:
+        task_id = validate_background_task_id(task_id)
+        with self._connect(workspace) as connection:
+            row = cast(
+                sqlite3.Row | None,
+                connection.execute(
+                    """
+                    SELECT * FROM background_tasks
+                    WHERE workspace = ? AND task_id = ?
+                    """,
+                    (str(workspace), task_id),
+                ).fetchone(),
+            )
+        if row is None:
+            raise ValueError(f"unknown background task: {task_id}")
+        return self._background_task_state_from_row(row)
+
+    def list_background_tasks(self, *, workspace: Path) -> tuple[StoredBackgroundTaskSummary, ...]:
+        with self._connect(workspace) as connection:
+            rows = cast(
+                list[sqlite3.Row],
+                connection.execute(
+                    """
+                    SELECT task_id, status, prompt, session_id, error, created_at, updated_at
+                    FROM background_tasks
+                    WHERE workspace = ?
+                    ORDER BY updated_at DESC, task_id ASC
+                    """,
+                    (str(workspace),),
+                ).fetchall(),
+            )
+        return tuple(
+            StoredBackgroundTaskSummary(
+                task=BackgroundTaskRef(id=cast(str, row["task_id"])),
+                status=self._parse_background_task_status(cast(str, row["status"])),
+                prompt=cast(str, row["prompt"]),
+                session_id=cast(str | None, row["session_id"]),
+                error=cast(str | None, row["error"]),
+                created_at=cast(int, row["created_at"]),
+                updated_at=cast(int, row["updated_at"]),
+            )
+            for row in rows
+        )
+
+    def mark_background_task_running(
+        self,
+        *,
+        workspace: Path,
+        task_id: str,
+        session_id: str,
+    ) -> BackgroundTaskState:
+        task_id = validate_background_task_id(task_id)
+        with self._connect(workspace) as connection:
+            updated_at = self._next_background_task_timestamp(connection=connection)
+            updated = connection.execute(
+                """
+                UPDATE background_tasks
+                SET status = ?, session_id = ?, started_at = COALESCE(started_at, ?), updated_at = ?
+                WHERE workspace = ? AND task_id = ? AND status = 'queued'
+                """,
+                ("running", session_id, updated_at, updated_at, str(workspace), task_id),
+            ).rowcount
+            connection.commit()
+        if updated == 0:
+            return self.load_background_task(workspace=workspace, task_id=task_id)
+        return self.load_background_task(workspace=workspace, task_id=task_id)
+
+    def mark_background_task_terminal(
+        self,
+        *,
+        workspace: Path,
+        task_id: str,
+        status: BackgroundTaskStatus,
+        error: str | None = None,
+    ) -> BackgroundTaskState:
+        if status not in ("completed", "failed", "cancelled"):
+            raise ValueError(
+                "background task terminal status must be completed, failed, or cancelled"
+            )
+        task_id = validate_background_task_id(task_id)
+        with self._connect(workspace) as connection:
+            updated_at = self._next_background_task_timestamp(connection=connection)
+            _ = connection.execute(
+                """
+                UPDATE background_tasks
+                SET status = ?, error = ?, finished_at = ?, updated_at = ?
+                WHERE workspace = ? AND task_id = ?
+                """,
+                (status, error, updated_at, updated_at, str(workspace), task_id),
+            )
+            connection.commit()
+        return self.load_background_task(workspace=workspace, task_id=task_id)
+
+    def request_background_task_cancel(
+        self,
+        *,
+        workspace: Path,
+        task_id: str,
+    ) -> BackgroundTaskState:
+        task_id = validate_background_task_id(task_id)
+        current = self.load_background_task(workspace=workspace, task_id=task_id)
+        if current.status == "queued":
+            return self.mark_background_task_terminal(
+                workspace=workspace,
+                task_id=task_id,
+                status="cancelled",
+                error="cancelled before start",
+            )
+        if current.status in ("completed", "failed", "cancelled"):
+            return current
+        with self._connect(workspace) as connection:
+            updated_at = self._next_background_task_timestamp(connection=connection)
+            _ = connection.execute(
+                """
+                UPDATE background_tasks
+                SET cancel_requested_at = ?, updated_at = ?
+                WHERE workspace = ? AND task_id = ?
+                """,
+                (updated_at, updated_at, str(workspace), task_id),
+            )
+            connection.commit()
+        return self.load_background_task(workspace=workspace, task_id=task_id)
+
+    def fail_incomplete_background_tasks(
+        self,
+        *,
+        workspace: Path,
+        message: str,
+    ) -> tuple[BackgroundTaskState, ...]:
+        with self._connect(workspace) as connection:
+            rows = cast(
+                list[sqlite3.Row],
+                connection.execute(
+                    """
+                    SELECT task_id FROM background_tasks
+                    WHERE workspace = ? AND status IN ('queued', 'running')
+                    ORDER BY updated_at ASC, task_id ASC
+                    """,
+                    (str(workspace),),
+                ).fetchall(),
+            )
+            if not rows:
+                return ()
+            updated_at = self._next_background_task_timestamp(connection=connection)
+            _ = connection.execute(
+                """
+                UPDATE background_tasks
+                SET status = 'failed', error = ?, finished_at = ?, updated_at = ?
+                WHERE workspace = ? AND status IN ('queued', 'running')
+                """,
+                (message, updated_at, updated_at, str(workspace)),
+            )
+            connection.commit()
+        return tuple(
+            self.load_background_task(workspace=workspace, task_id=cast(str, row["task_id"]))
+            for row in rows
+        )
+
+    def _background_task_state_from_row(self, row: sqlite3.Row) -> BackgroundTaskState:
+        metadata = json.loads(cast(str, row["request_metadata_json"]))
+        if not isinstance(metadata, dict):
+            raise ValueError("background task metadata must decode to an object")
+        return BackgroundTaskState(
+            task=BackgroundTaskRef(id=cast(str, row["task_id"])),
+            status=self._parse_background_task_status(cast(str, row["status"])),
+            request=BackgroundTaskRequestSnapshot(
+                prompt=cast(str, row["prompt"]),
+                session_id=cast(str | None, row["request_session_id"]),
+                metadata=cast(dict[str, object], metadata),
+                allocate_session_id=bool(cast(int, row["allocate_session_id"])),
+            ),
+            session_id=cast(str | None, row["session_id"]),
+            error=cast(str | None, row["error"]),
+            created_at=cast(int, row["created_at"]),
+            updated_at=cast(int, row["updated_at"]),
+            started_at=cast(int | None, row["started_at"]),
+            finished_at=cast(int | None, row["finished_at"]),
+            cancel_requested_at=cast(int | None, row["cancel_requested_at"]),
+        )
+
+    def _next_background_task_timestamp(self, *, connection: sqlite3.Connection) -> int:
+        row = cast(
+            sqlite3.Row,
+            connection.execute(
+                "SELECT COALESCE(MAX(updated_at), 0) + 1 AS next_ts FROM background_tasks"
+            ).fetchone(),
+        )
+        return cast(int, row["next_ts"])
 
     def _read_user_version(self, *, connection: sqlite3.Connection) -> int:
         row = cast(

--- a/src/voidcode/runtime/storage.py
+++ b/src/voidcode/runtime/storage.py
@@ -564,6 +564,7 @@ class SqliteSessionStore:
     ) -> None:
         task_id = validate_background_task_id(task.task.id)
         with self._connect(workspace) as connection:
+            timestamp = self._next_background_task_timestamp(connection=connection)
             _ = connection.execute(
                 """
                 INSERT INTO background_tasks (
@@ -583,8 +584,8 @@ class SqliteSessionStore:
                     task.session_id,
                     task.error,
                     task.cancel_requested_at,
-                    task.created_at,
-                    task.updated_at,
+                    timestamp,
+                    timestamp,
                     task.started_at,
                     task.finished_at,
                 ),
@@ -707,7 +708,8 @@ class SqliteSessionStore:
                 """
                 UPDATE background_tasks
                 SET cancel_requested_at = ?, updated_at = ?
-                WHERE workspace = ? AND task_id = ?
+                WHERE workspace = ? AND task_id = ? AND status = 'running'
+                    AND cancel_requested_at IS NULL
                 """,
                 (updated_at, updated_at, str(workspace), task_id),
             )

--- a/src/voidcode/runtime/task.py
+++ b/src/voidcode/runtime/task.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+type BackgroundTaskStatus = Literal[
+    "queued",
+    "running",
+    "completed",
+    "failed",
+    "cancelled",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class BackgroundTaskRef:
+    id: str
+
+
+@dataclass(frozen=True, slots=True)
+class BackgroundTaskRequestSnapshot:
+    prompt: str
+    session_id: str | None = None
+    metadata: dict[str, object] = field(default_factory=dict)
+    allocate_session_id: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class BackgroundTaskState:
+    task: BackgroundTaskRef
+    status: BackgroundTaskStatus = "queued"
+    request: BackgroundTaskRequestSnapshot = field(
+        default_factory=lambda: BackgroundTaskRequestSnapshot(prompt="")
+    )
+    session_id: str | None = None
+    error: str | None = None
+    created_at: int = 0
+    updated_at: int = 0
+    started_at: int | None = None
+    finished_at: int | None = None
+    cancel_requested_at: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class StoredBackgroundTaskSummary:
+    task: BackgroundTaskRef
+    status: BackgroundTaskStatus
+    prompt: str
+    session_id: str | None
+    error: str | None
+    created_at: int
+    updated_at: int
+
+
+def validate_background_task_id(task_id: str) -> str:
+    if not task_id:
+        raise ValueError("task_id must be a non-empty string")
+    if "/" in task_id:
+        raise ValueError("task_id must not contain '/'")
+    return task_id

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -71,6 +71,23 @@ class RuntimeRequestFactory(Protocol):
     def __call__(self, *, prompt: str, session_id: str | None = None) -> RuntimeRequestLike: ...
 
 
+class BackgroundTaskRefLike(Protocol):
+    id: str
+
+
+class BackgroundTaskStateLike(Protocol):
+    task: BackgroundTaskRefLike
+    status: str
+    session_id: str | None
+    error: str | None
+    cancel_requested_at: int | None
+
+
+class StoredBackgroundTaskSummaryLike(Protocol):
+    task: BackgroundTaskRefLike
+    status: str
+
+
 class RuntimeRunner(Protocol):
     def run(self, request: RuntimeRequestLike) -> RuntimeResponseLike: ...
 
@@ -93,6 +110,14 @@ class RuntimeRunner(Protocol):
         approval_request_id: str | None = None,
         approval_decision: str | None = None,
     ) -> RuntimeResponseLike: ...
+
+    def start_background_task(self, request: RuntimeRequestLike) -> BackgroundTaskStateLike: ...
+
+    def load_background_task(self, task_id: str) -> BackgroundTaskStateLike: ...
+
+    def list_background_tasks(self) -> tuple[StoredBackgroundTaskSummaryLike, ...]: ...
+
+    def cancel_background_task(self, task_id: str) -> BackgroundTaskStateLike: ...
 
 
 class RuntimeFactory(Protocol):
@@ -158,6 +183,8 @@ class SessionStoreLike(Protocol):
     def load_pending_approval(self, *, workspace: Path, session_id: str) -> object: ...
 
     def clear_pending_approval(self, *, workspace: Path, session_id: str) -> None: ...
+
+    def create_background_task(self, *, workspace: Path, task: object) -> None: ...
 
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
@@ -1242,6 +1269,65 @@ def test_runtime_uses_environment_config_to_allow_write_requests_without_code_ch
     assert (tmp_path / "env.txt").read_text(encoding="utf-8") == "env approved"
 
 
+def test_runtime_background_task_persists_and_can_be_loaded_from_fresh_runtime(
+    tmp_path: Path,
+) -> None:
+    runtime_request, runtime_class = _load_runtime_types()
+
+    first_runtime = cast(RuntimeRunner, cast(object, runtime_class(workspace=tmp_path)))
+    task = first_runtime.start_background_task(runtime_request(prompt="read missing.txt"))
+
+    deadline = time.time() + 2
+    terminal_task = None
+    while time.time() < deadline:
+        current = first_runtime.load_background_task(task.task.id)
+        if current.status in ("completed", "failed", "cancelled"):
+            terminal_task = current
+            break
+        time.sleep(0.01)
+
+    assert terminal_task is not None
+    second_runtime = cast(RuntimeRunner, cast(object, runtime_class(workspace=tmp_path)))
+    reloaded = second_runtime.load_background_task(task.task.id)
+    listed = second_runtime.list_background_tasks()
+
+    assert reloaded.task.id == task.task.id
+    assert reloaded.status == terminal_task.status
+    assert any(item.task.id == task.task.id for item in listed)
+    if reloaded.session_id is not None:
+        replay = second_runtime.resume(reloaded.session_id)
+        assert replay.session.metadata["background_task_id"] == task.task.id
+        assert replay.session.metadata["background_run"] is True
+
+
+def test_runtime_background_task_cancel_reconciles_orphaned_task_from_fresh_runtime(
+    tmp_path: Path,
+) -> None:
+    _, runtime_class = _load_runtime_types()
+    task_module = importlib.import_module("voidcode.runtime.task")
+    storage_module = importlib.import_module("voidcode.runtime.storage")
+
+    first_runtime = cast(RuntimeRunner, cast(object, runtime_class(workspace=tmp_path)))
+    _ = first_runtime
+    store = cast(SessionStoreLike, storage_module.SqliteSessionStore())
+    store.create_background_task(
+        workspace=tmp_path,
+        task=task_module.BackgroundTaskState(
+            task=task_module.BackgroundTaskRef(id="task-fresh-cancel"),
+            request=task_module.BackgroundTaskRequestSnapshot(prompt="read sample.txt"),
+            created_at=1,
+            updated_at=1,
+        ),
+    )
+
+    second_runtime = cast(RuntimeRunner, cast(object, runtime_class(workspace=tmp_path)))
+    cancelled = second_runtime.cancel_background_task("task-fresh-cancel")
+
+    assert cancelled.status == "failed"
+    assert cancelled.error == "background task interrupted before completion"
+    assert cancelled.cancel_requested_at is None
+
+
 def test_runtime_executes_grep_read_only_slice_and_emits_events(tmp_path: Path) -> None:
     sample_file = tmp_path / "sample.txt"
     _ = sample_file.write_text("alpha\nbeta alpha\n", encoding="utf-8")
@@ -1602,7 +1688,7 @@ def test_runtime_migrates_legacy_session_schema_for_pending_approval(tmp_path: P
 
     assert "pending_approval_json" in columns
     assert "resume_checkpoint_json" in columns
-    assert user_version == 3
+    assert user_version == 4
 
 
 def test_runtime_replay_is_unchanged_when_resume_checkpoint_exists(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_backend_contracts.py
+++ b/tests/unit/runtime/test_backend_contracts.py
@@ -44,6 +44,16 @@ def test_contract_modules_export_expected_symbols() -> None:
     runtime_request = runtime.RuntimeRequest(
         prompt="Inspect the repo", session_id=session.session.id
     )
+    background_task_request = runtime.BackgroundTaskRequestSnapshot(
+        prompt=runtime_request.prompt,
+        session_id=session.session.id,
+    )
+    background_task = runtime.BackgroundTaskState(
+        task=runtime.BackgroundTaskRef(id="task-1"),
+        request=background_task_request,
+        created_at=1,
+        updated_at=1,
+    )
     session_summary = runtime.StoredSessionSummary(
         session=session.session,
         status="completed",
@@ -62,6 +72,8 @@ def test_contract_modules_export_expected_symbols() -> None:
     assert call.arguments == {"path": "README.md"}
     assert runtime_response.events == (event,)
     assert stream_chunk.event == event
+    assert background_task.task.id == "task-1"
+    assert background_task.request.prompt == runtime_request.prompt
     assert session_summary.session.id == "session-1"
     assert graph_request.available_tools == ()
     assert graph_result.tool_results == (result,)
@@ -72,10 +84,20 @@ def test_contracts_are_frozen_and_isolate_default_state() -> None:
 
     first_session = runtime.SessionState(session=runtime.SessionRef(id="session-1"))
     second_session = runtime.SessionState(session=runtime.SessionRef(id="session-2"))
+    first_task = runtime.BackgroundTaskState(
+        task=runtime.BackgroundTaskRef(id="task-1"),
+        request=runtime.BackgroundTaskRequestSnapshot(prompt="go"),
+    )
+    second_task = runtime.BackgroundTaskState(
+        task=runtime.BackgroundTaskRef(id="task-2"),
+        request=runtime.BackgroundTaskRequestSnapshot(prompt="go"),
+    )
 
     first_session.metadata["workspace"] = "/tmp/project"
+    first_task.request.metadata["workspace"] = "/tmp/project"
 
     assert second_session.metadata == {}
+    assert second_task.request.metadata == {}
 
     with pytest.raises(FrozenInstanceError):
         first_session.turn = 3
@@ -175,10 +197,12 @@ def test_contract_types_expose_explicit_annotations() -> None:
     tools = _tools_module()
 
     runtime_request_hints = get_type_hints(runtime.RuntimeRequest)
+    background_task_hints = get_type_hints(runtime.BackgroundTaskState)
     tool_result_hints = get_type_hints(tools.ToolResult)
     graph_runner_hints = get_type_hints(graph.GraphRunner.run)
 
     assert runtime_request_hints["prompt"] is str
+    assert str(background_task_hints["status"]) == "BackgroundTaskStatus"
     assert tool_result_hints["tool_name"] is str
     assert str(tool_result_hints["status"]) == "ToolResultStatus"
     assert graph_runner_hints["request"] is graph.GraphRunRequest

--- a/tests/unit/runtime/test_background_task_storage.py
+++ b/tests/unit/runtime/test_background_task_storage.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from voidcode.runtime.storage import SqliteSessionStore
+from voidcode.runtime.task import (
+    BackgroundTaskRef,
+    BackgroundTaskRequestSnapshot,
+    BackgroundTaskState,
+    BackgroundTaskStatus,
+    validate_background_task_id,
+)
+
+
+def _task(*, task_id: str = "task-1", prompt: str = "read sample.txt") -> BackgroundTaskState:
+    return BackgroundTaskState(
+        task=BackgroundTaskRef(id=task_id),
+        request=BackgroundTaskRequestSnapshot(prompt=prompt),
+        created_at=1,
+        updated_at=1,
+    )
+
+
+def test_validate_background_task_id_rejects_empty_and_slash() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        validate_background_task_id("")
+
+    with pytest.raises(ValueError, match="must not contain '/'"):
+        validate_background_task_id("task/1")
+
+
+def test_background_task_storage_create_load_and_list(tmp_path: Path) -> None:
+    store = SqliteSessionStore()
+    task = _task(task_id="task-a")
+
+    store.create_background_task(workspace=tmp_path, task=task)
+
+    loaded = store.load_background_task(workspace=tmp_path, task_id="task-a")
+    listed = store.list_background_tasks(workspace=tmp_path)
+
+    assert loaded == task
+    assert len(listed) == 1
+    assert listed[0].task.id == "task-a"
+    assert listed[0].status == "queued"
+    assert listed[0].prompt == "read sample.txt"
+
+
+def test_background_task_storage_marks_running_and_terminal(tmp_path: Path) -> None:
+    store = SqliteSessionStore()
+    store.create_background_task(workspace=tmp_path, task=_task(task_id="task-b"))
+
+    running = store.mark_background_task_running(
+        workspace=tmp_path,
+        task_id="task-b",
+        session_id="session-b",
+    )
+    completed = store.mark_background_task_terminal(
+        workspace=tmp_path,
+        task_id="task-b",
+        status="completed",
+    )
+
+    assert running.status == "running"
+    assert running.session_id == "session-b"
+    assert running.started_at is not None
+    assert completed.status == "completed"
+    assert completed.session_id == "session-b"
+    assert completed.finished_at is not None
+
+
+def test_background_task_storage_cancel_semantics(tmp_path: Path) -> None:
+    store = SqliteSessionStore()
+    store.create_background_task(workspace=tmp_path, task=_task(task_id="task-c"))
+
+    cancelled = store.request_background_task_cancel(workspace=tmp_path, task_id="task-c")
+
+    assert cancelled.status == "cancelled"
+    assert cancelled.error == "cancelled before start"
+
+
+def test_background_task_storage_running_cancel_records_request(tmp_path: Path) -> None:
+    store = SqliteSessionStore()
+    store.create_background_task(workspace=tmp_path, task=_task(task_id="task-d"))
+    _ = store.mark_background_task_running(
+        workspace=tmp_path,
+        task_id="task-d",
+        session_id="session-d",
+    )
+
+    cancelled = store.request_background_task_cancel(workspace=tmp_path, task_id="task-d")
+
+    assert cancelled.status == "running"
+    assert cancelled.cancel_requested_at is not None
+
+
+def test_background_task_storage_does_not_overwrite_queued_cancelled_task_when_marking_running(
+    tmp_path: Path,
+) -> None:
+    store = SqliteSessionStore()
+    store.create_background_task(workspace=tmp_path, task=_task(task_id="task-race"))
+    cancelled = store.request_background_task_cancel(workspace=tmp_path, task_id="task-race")
+
+    running = store.mark_background_task_running(
+        workspace=tmp_path,
+        task_id="task-race",
+        session_id="session-race",
+    )
+
+    assert cancelled.status == "cancelled"
+    assert running.status == "cancelled"
+    assert running.session_id is None
+    assert running.started_at is None
+    assert running.finished_at is not None
+
+
+@pytest.mark.parametrize(
+    "status",
+    cast(tuple[BackgroundTaskStatus, ...], ("completed", "failed", "cancelled")),
+)
+def test_background_task_storage_does_not_overwrite_terminal_task_when_marking_running(
+    tmp_path: Path,
+    status: BackgroundTaskStatus,
+) -> None:
+    store = SqliteSessionStore()
+    store.create_background_task(workspace=tmp_path, task=_task(task_id=f"task-{status}"))
+    terminal = store.mark_background_task_terminal(
+        workspace=tmp_path,
+        task_id=f"task-{status}",
+        status=status,
+        error="terminal state",
+    )
+
+    running = store.mark_background_task_running(
+        workspace=tmp_path,
+        task_id=f"task-{status}",
+        session_id="session-terminal",
+    )
+
+    assert terminal.status == status
+    assert running == terminal
+    assert running.session_id is None
+    assert running.started_at is None
+
+
+def test_background_task_storage_reconciles_incomplete_tasks_on_restart(tmp_path: Path) -> None:
+    store = SqliteSessionStore()
+    store.create_background_task(workspace=tmp_path, task=_task(task_id="task-e"))
+    store.create_background_task(workspace=tmp_path, task=_task(task_id="task-f"))
+    _ = store.mark_background_task_running(
+        workspace=tmp_path,
+        task_id="task-f",
+        session_id="session-f",
+    )
+
+    reconciled = store.fail_incomplete_background_tasks(
+        workspace=tmp_path,
+        message="background task interrupted before completion",
+    )
+
+    assert [task.task.id for task in reconciled] == ["task-e", "task-f"]
+    assert all(task.status == "failed" for task in reconciled)
+    assert all(task.error == "background task interrupted before completion" for task in reconciled)

--- a/tests/unit/runtime/test_background_task_storage.py
+++ b/tests/unit/runtime/test_background_task_storage.py
@@ -48,6 +48,39 @@ def test_background_task_storage_create_load_and_list(tmp_path: Path) -> None:
     assert listed[0].prompt == "read sample.txt"
 
 
+def test_background_task_storage_create_assigns_store_timestamps_and_orders_by_latest_update(
+    tmp_path: Path,
+) -> None:
+    store = SqliteSessionStore()
+    first = BackgroundTaskState(
+        task=BackgroundTaskRef(id="task-ts-1"),
+        request=BackgroundTaskRequestSnapshot(prompt="first"),
+        created_at=99,
+        updated_at=42,
+    )
+    second = BackgroundTaskState(
+        task=BackgroundTaskRef(id="task-ts-2"),
+        request=BackgroundTaskRequestSnapshot(prompt="second"),
+        created_at=500,
+        updated_at=400,
+    )
+
+    store.create_background_task(workspace=tmp_path, task=first)
+    store.create_background_task(workspace=tmp_path, task=second)
+
+    loaded_first = store.load_background_task(workspace=tmp_path, task_id="task-ts-1")
+    loaded_second = store.load_background_task(workspace=tmp_path, task_id="task-ts-2")
+    listed = store.list_background_tasks(workspace=tmp_path)
+
+    assert loaded_first.created_at == 1
+    assert loaded_first.updated_at == 1
+    assert loaded_second.created_at == 2
+    assert loaded_second.updated_at == 2
+    assert loaded_first.created_at != first.created_at
+    assert loaded_second.updated_at != second.updated_at
+    assert [task.task.id for task in listed] == ["task-ts-2", "task-ts-1"]
+
+
 def test_background_task_storage_marks_running_and_terminal(tmp_path: Path) -> None:
     store = SqliteSessionStore()
     store.create_background_task(workspace=tmp_path, task=_task(task_id="task-b"))
@@ -94,6 +127,85 @@ def test_background_task_storage_running_cancel_records_request(tmp_path: Path) 
 
     assert cancelled.status == "running"
     assert cancelled.cancel_requested_at is not None
+
+
+def test_background_task_storage_running_cancel_is_idempotent_on_repeat_requests(
+    tmp_path: Path,
+) -> None:
+    store = SqliteSessionStore()
+    store.create_background_task(workspace=tmp_path, task=_task(task_id="task-d-repeat"))
+    _ = store.mark_background_task_running(
+        workspace=tmp_path,
+        task_id="task-d-repeat",
+        session_id="session-d-repeat",
+    )
+
+    first_cancel = store.request_background_task_cancel(
+        workspace=tmp_path,
+        task_id="task-d-repeat",
+    )
+    second_cancel = store.request_background_task_cancel(
+        workspace=tmp_path,
+        task_id="task-d-repeat",
+    )
+
+    assert first_cancel.status == "running"
+    assert first_cancel.cancel_requested_at is not None
+    assert second_cancel.status == "running"
+    assert second_cancel.cancel_requested_at == first_cancel.cancel_requested_at
+    assert second_cancel.updated_at == first_cancel.updated_at
+    assert second_cancel.session_id == "session-d-repeat"
+    assert second_cancel.finished_at is None
+
+
+def test_background_task_storage_running_cancel_race_does_not_overwrite_terminal_state(
+    tmp_path: Path,
+) -> None:
+    store = SqliteSessionStore()
+    store.create_background_task(workspace=tmp_path, task=_task(task_id="task-d-race"))
+    running = store.mark_background_task_running(
+        workspace=tmp_path,
+        task_id="task-d-race",
+        session_id="session-d-race",
+    )
+    terminal = store.mark_background_task_terminal(
+        workspace=tmp_path,
+        task_id="task-d-race",
+        status="completed",
+    )
+    original_load_background_task = store.load_background_task
+    stale_reads_remaining = 1
+
+    def _stale_running_load(*, workspace: Path, task_id: str) -> BackgroundTaskState:
+        nonlocal stale_reads_remaining
+        if stale_reads_remaining > 0:
+            stale_reads_remaining -= 1
+            return BackgroundTaskState(
+                task=running.task,
+                status="running",
+                request=running.request,
+                session_id=running.session_id,
+                error=running.error,
+                created_at=running.created_at,
+                updated_at=running.updated_at,
+                started_at=running.started_at,
+                finished_at=running.finished_at,
+                cancel_requested_at=running.cancel_requested_at,
+            )
+        return original_load_background_task(workspace=workspace, task_id=task_id)
+
+    store.load_background_task = _stale_running_load
+
+    cancelled = store.request_background_task_cancel(
+        workspace=tmp_path,
+        task_id="task-d-race",
+    )
+
+    assert terminal.status == "completed"
+    assert cancelled.status == "completed"
+    assert cancelled.cancel_requested_at is None
+    assert cancelled.finished_at == terminal.finished_at
+    assert cancelled.updated_at == terminal.updated_at
 
 
 def test_background_task_storage_does_not_overwrite_queued_cancelled_task_when_marking_running(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import importlib
 import json
 import logging
 import os
 import sqlite3
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, cast
+from unittest.mock import Mock
 
 import pytest
 
@@ -49,6 +52,7 @@ from voidcode.runtime.single_agent_provider import (
     SingleAgentTurnRequest,
     SingleAgentTurnResult,
 )
+from voidcode.runtime.task import BackgroundTaskState
 from voidcode.skills import SkillRegistry
 from voidcode.tools import ToolCall
 
@@ -270,6 +274,45 @@ class _ApprovalResumeFallbackSingleAgentProvider:
         return SingleAgentTurnResult(output="done")
 
 
+class _BackgroundTaskSuccessGraph:
+    def step(
+        self,
+        request: GraphRunRequest,
+        tool_results: tuple[object, ...],
+        *,
+        session: SessionState,
+    ) -> _StubStep:
+        _ = tool_results, session
+        return _StubStep(output=request.prompt, is_finished=True)
+
+
+class _BackgroundTaskFailureGraph:
+    def step(
+        self,
+        request: GraphRunRequest,
+        tool_results: tuple[object, ...],
+        *,
+        session: SessionState,
+    ) -> _StubStep:
+        _ = request, tool_results, session
+        raise RuntimeError("background boom")
+
+
+def _wait_for_background_task(
+    runtime: VoidCodeRuntime,
+    task_id: str,
+    *,
+    timeout_seconds: float = 2.0,
+) -> BackgroundTaskState:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        task = runtime.load_background_task(task_id)
+        if task.status in ("completed", "failed", "cancelled"):
+            return task
+        time.sleep(0.01)
+    raise AssertionError(f"background task {task_id} did not reach terminal state")
+
+
 def _write_demo_skill(skill_dir: Path, *, description: str = "Demo skill", content: str) -> None:
     skill_dir.mkdir(parents=True, exist_ok=True)
     (skill_dir / "SKILL.md").write_text(
@@ -319,6 +362,115 @@ def test_runtime_initializes_empty_extension_state_by_default(tmp_path: Path) ->
             os.environ.pop("GITHUB_COPILOT_TOKEN", None)
         else:
             os.environ["GITHUB_COPILOT_TOKEN"] = previous_copilot_token
+
+
+def test_runtime_background_task_executes_through_existing_runtime_path(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+
+    started = runtime.start_background_task(RuntimeRequest(prompt="background hello"))
+    completed = _wait_for_background_task(runtime, started.task.id)
+    loaded = runtime.load_background_task(started.task.id)
+    linked_session_id = cast(str, loaded.session_id)
+    resumed = runtime.resume(linked_session_id)
+
+    assert started.status == "queued"
+    assert loaded.status == "completed"
+    assert loaded.session_id is not None
+    assert resumed.session.metadata["background_task_id"] == started.task.id
+    assert resumed.session.metadata["background_run"] is True
+    assert resumed.output == "background hello"
+    assert completed == loaded
+
+
+def test_runtime_background_task_persists_failure_state(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskFailureGraph())
+
+    started = runtime.start_background_task(RuntimeRequest(prompt="background fail"))
+    _ = runtime.load_background_task(started.task.id)
+    failed = _wait_for_background_task(runtime, started.task.id)
+
+    assert failed.status == "failed"
+    assert failed.error is not None
+    assert "background boom" in failed.error
+
+
+def test_runtime_cancel_background_task_reconciles_orphaned_queued_task(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    store = _private_attr(runtime, "_session_store")
+    task_module = importlib.import_module("voidcode.runtime.task")
+    store.create_background_task(
+        workspace=tmp_path,
+        task=task_module.BackgroundTaskState(
+            task=task_module.BackgroundTaskRef(id="task-pre-cancel"),
+            request=task_module.BackgroundTaskRequestSnapshot(prompt="background hello"),
+            created_at=1,
+            updated_at=1,
+        ),
+    )
+
+    cancelled = runtime.cancel_background_task("task-pre-cancel")
+
+    assert cancelled.status == "failed"
+    assert cancelled.error == "background task interrupted before completion"
+    assert cancelled.cancel_requested_at is None
+
+
+def test_runtime_reconciles_incomplete_background_tasks_on_init(tmp_path: Path) -> None:
+    first_runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    store = _private_attr(first_runtime, "_session_store")
+    task_module = importlib.import_module("voidcode.runtime.task")
+    store.create_background_task(
+        workspace=tmp_path,
+        task=task_module.BackgroundTaskState(
+            task=task_module.BackgroundTaskRef(id="task-orphan"),
+            request=task_module.BackgroundTaskRequestSnapshot(prompt="orphan"),
+            created_at=1,
+            updated_at=1,
+        ),
+    )
+
+    second_runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    reconciled = second_runtime.load_background_task("task-orphan")
+
+    assert reconciled.status == "failed"
+    assert reconciled.error == "background task interrupted before completion"
+
+
+def test_runtime_background_task_worker_exits_when_task_is_cancelled_before_start_transition(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    runtime._background_tasks_reconciled = True  # pyright: ignore[reportPrivateUsage]
+    store = _private_attr(runtime, "_session_store")
+    task_module = importlib.import_module("voidcode.runtime.task")
+    store.create_background_task(
+        workspace=tmp_path,
+        task=task_module.BackgroundTaskState(
+            task=task_module.BackgroundTaskRef(id="task-race-cancel"),
+            request=task_module.BackgroundTaskRequestSnapshot(prompt="background hello"),
+            created_at=1,
+            updated_at=1,
+        ),
+    )
+
+    original_mark_running = store.mark_background_task_running
+
+    def _cancel_before_mark_running(
+        *, workspace: Path, task_id: str, session_id: str
+    ) -> BackgroundTaskState:
+        _ = store.request_background_task_cancel(workspace=workspace, task_id=task_id)
+        return original_mark_running(workspace=workspace, task_id=task_id, session_id=session_id)
+
+    store.mark_background_task_running = _cancel_before_mark_running
+    run_mock = Mock(side_effect=AssertionError("runtime.run must not be called"))
+    runtime.run = run_mock
+
+    runtime._run_background_task_worker("task-race-cancel")  # pyright: ignore[reportPrivateUsage]
+
+    final_task = runtime.load_background_task("task-race-cancel")
+    assert final_task.status == "cancelled"
+    assert final_task.error == "cancelled before start"
+    run_mock.assert_not_called()
 
 
 def test_runtime_initializes_extension_state_from_config_when_enabled(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -382,6 +382,44 @@ def test_runtime_background_task_executes_through_existing_runtime_path(tmp_path
     assert completed == loaded
 
 
+def test_runtime_background_task_worker_uses_local_cli_session_when_no_session_id_and_allocate_session_id_is_false(  # noqa: E501
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+
+    started = runtime.start_background_task(RuntimeRequest(prompt="background hello"))
+    completed = _wait_for_background_task(runtime, started.task.id)
+    resumed = runtime.resume("local-cli-session")
+
+    assert completed.session_id == "local-cli-session"
+    assert resumed.session.session.id == "local-cli-session"
+    assert resumed.session.metadata["background_task_id"] == started.task.id
+    assert resumed.session.metadata["background_run"] is True
+    assert resumed.output == "background hello"
+
+
+def test_runtime_background_task_worker_allocates_session_id_when_requested_without_explicit_session(  # noqa: E501
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+
+    started = runtime.start_background_task(
+        RuntimeRequest(prompt="background hello", allocate_session_id=True)
+    )
+    completed = _wait_for_background_task(runtime, started.task.id)
+    allocated_session_id = cast(str, completed.session_id)
+    resumed = runtime.resume(allocated_session_id)
+
+    assert completed.session_id is not None
+    assert allocated_session_id != "local-cli-session"
+    assert allocated_session_id.startswith("session-")
+    assert len(allocated_session_id) == len("session-") + 32
+    assert resumed.session.session.id == allocated_session_id
+    assert resumed.session.metadata["background_task_id"] == started.task.id
+    assert resumed.session.metadata["background_run"] is True
+    assert resumed.output == "background hello"
+
+
 def test_runtime_background_task_persists_failure_state(tmp_path: Path) -> None:
     runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskFailureGraph())
 


### PR DESCRIPTION
close #142 
## Summary
- add a runtime-owned background task substrate with explicit task contracts, storage persistence, and runtime entrypoints
- run background tasks through the existing runtime path and reconcile orphaned queued/running tasks on background-task surface access
- guard queued-to-running transitions and add regressions for cancel races, fresh-runtime reconciliation, and persisted background task replay

## Scope
- includes only the minimal substrate for issue #142
- does not add a scheduler, notifications, child-session orchestration, or async multi-agent behavior

## Verification
- `mise run typecheck`
- `uv run pytest tests/unit/runtime/test_background_task_storage.py tests/unit/runtime/test_runtime_service_extensions.py tests/integration/test_read_only_slice.py -k background_task`
- `mise run test` (729 passed)
- manual QA: real background task completed and resumed with expected output; fresh-runtime orphan cancel returned `failed` with `background task interrupted before completion`