### PR TITLE
feat(runtime): add parent-child session lineage

### DIFF
--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -9,6 +9,14 @@ from .session import SessionRef, SessionState
 from .task import BackgroundTaskState, StoredBackgroundTaskSummary
 
 
+class RuntimeRequestError(ValueError):
+    """Raised when a client-supplied runtime request is invalid."""
+
+
+class UnknownSessionError(ValueError):
+    """Raised when a referenced session does not exist in storage."""
+
+
 @dataclass(frozen=True, slots=True)
 class RuntimeRequest:
     prompt: str
@@ -20,9 +28,9 @@ class RuntimeRequest:
 
 def validate_session_reference_id(value: str, *, field_name: str = "session_id") -> str:
     if not value:
-        raise ValueError(f"{field_name} must be a non-empty string when provided")
+        raise RuntimeRequestError(f"{field_name} must be a non-empty string when provided")
     if "/" in value:
-        raise ValueError(f"{field_name} must not contain '/'")
+        raise RuntimeRequestError(f"{field_name} must not contain '/'")
     return value
 
 

--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -13,16 +13,21 @@ from .task import BackgroundTaskState, StoredBackgroundTaskSummary
 class RuntimeRequest:
     prompt: str
     session_id: str | None = None
+    parent_session_id: str | None = None
     metadata: dict[str, object] = field(default_factory=dict)
     allocate_session_id: bool = False
 
 
+def validate_session_reference_id(value: str, *, field_name: str = "session_id") -> str:
+    if not value:
+        raise ValueError(f"{field_name} must be a non-empty string when provided")
+    if "/" in value:
+        raise ValueError(f"{field_name} must not contain '/'")
+    return value
+
+
 def validate_session_id(session_id: str) -> str:
-    if not session_id:
-        raise ValueError("session_id must be a non-empty string when provided")
-    if "/" in session_id:
-        raise ValueError("session_id must not contain '/'")
-    return session_id
+    return validate_session_reference_id(session_id, field_name="session_id")
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/voidcode/runtime/http.py
+++ b/src/voidcode/runtime/http.py
@@ -13,6 +13,7 @@ from .config import RuntimeConfig
 from .contracts import (
     RuntimeNotification,
     RuntimeRequest,
+    RuntimeRequestError,
     RuntimeResponse,
     RuntimeSessionResult,
     RuntimeStreamChunk,
@@ -220,6 +221,37 @@ class RuntimeTransportApp:
             return
 
         runtime = self._runtime_factory()
+        stream = self._stream_runtime_chunks(runtime, request)
+        try:
+            first_chunk = await anext(stream)
+        except StopAsyncIteration:
+            logger.exception("runtime stream emitted no chunks before response start")
+            await self._json_response(send, status=500, payload={"error": "internal server error"})
+            return
+        except RuntimeRequestError as exc:
+            await self._json_response(send, status=400, payload={"error": str(exc)})
+            return
+        except Exception:
+            logger.exception("unexpected transport streaming failure")
+            await self._json_response(send, status=500, payload={"error": "internal server error"})
+            return
+
+        await self._send_stream_start(send)
+
+        emitted_failed_chunk = await self._send_runtime_stream_chunk(send, first_chunk)
+        try:
+            async for chunk in stream:
+                chunk_failed = await self._send_runtime_stream_chunk(send, chunk)
+                emitted_failed_chunk = emitted_failed_chunk or chunk_failed
+        except Exception:
+            if not emitted_failed_chunk:
+                logger.exception("unexpected transport streaming failure")
+            await send({"type": "http.response.body", "body": b"", "more_body": False})
+            return
+
+        await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+    async def _send_stream_start(self, send: Send) -> None:
         await send(
             {
                 "type": "http.response.start",
@@ -231,30 +263,21 @@ class RuntimeTransportApp:
             }
         )
 
-        emitted_failed_chunk = False
-        try:
-            async for chunk in self._stream_runtime_chunks(runtime, request):
-                payload = self._serialize_runtime_stream_chunk(chunk)
-                emitted_failed_chunk = emitted_failed_chunk or (
-                    chunk.event is not None and chunk.event.event_type == "runtime.failed"
-                )
-                data = json.dumps(payload, sort_keys=True).encode("utf-8")
-                await send(
-                    {
-                        "type": "http.response.body",
-                        "body": b"data: " + data + b"\n\n",
-                        "more_body": True,
-                    }
-                )
-        except Exception:
-            if not emitted_failed_chunk:
-                logger.exception("unexpected transport streaming failure")
-            await send({"type": "http.response.body", "body": b"", "more_body": False})
-            return
-        finally:
-            self._close_runtime(runtime)
-
-        await send({"type": "http.response.body", "body": b"", "more_body": False})
+    async def _send_runtime_stream_chunk(
+        self,
+        send: Send,
+        chunk: RuntimeStreamChunk,
+    ) -> bool:
+        payload = self._serialize_runtime_stream_chunk(chunk)
+        data = json.dumps(payload, sort_keys=True).encode("utf-8")
+        await send(
+            {
+                "type": "http.response.body",
+                "body": b"data: " + data + b"\n\n",
+                "more_body": True,
+            }
+        )
+        return chunk.event is not None and chunk.event.event_type == "runtime.failed"
 
     async def _handle_list_sessions(self, send: Send) -> None:
         runtime = self._runtime_factory()

--- a/src/voidcode/runtime/http.py
+++ b/src/voidcode/runtime/http.py
@@ -17,6 +17,7 @@ from .contracts import (
     RuntimeSessionResult,
     RuntimeStreamChunk,
     validate_session_id,
+    validate_session_reference_id,
 )
 from .events import EventEnvelope
 from .permission import PermissionResolution
@@ -400,6 +401,15 @@ class RuntimeTransportApp:
         if session_id is not None:
             validate_session_id(session_id)
 
+        parent_session_id = payload.get("parent_session_id")
+        if parent_session_id is not None and not isinstance(parent_session_id, str):
+            raise ValueError("parent_session_id must be a string when provided")
+        if parent_session_id is not None:
+            validate_session_reference_id(
+                parent_session_id,
+                field_name="parent_session_id",
+            )
+
         metadata = payload.get("metadata", {})
         if not isinstance(metadata, dict):
             raise ValueError("metadata must be an object when provided")
@@ -407,6 +417,7 @@ class RuntimeTransportApp:
         return RuntimeRequest(
             prompt=prompt,
             session_id=session_id,
+            parent_session_id=parent_session_id,
             metadata=cast(dict[str, object], metadata),
             allocate_session_id=session_id is None,
         )
@@ -492,7 +503,10 @@ class RuntimeTransportApp:
 
     @staticmethod
     def _serialize_session_ref(session_ref: SessionRef) -> dict[str, object]:
-        return {"id": session_ref.id}
+        payload: dict[str, object] = {"id": session_ref.id}
+        if session_ref.parent_id is not None:
+            payload["parent_id"] = session_ref.parent_id
+        return payload
 
     @staticmethod
     def _serialize_session_state(session: SessionState) -> dict[str, object]:

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -51,9 +51,11 @@ from .context_window import ContextWindowPolicy, RuntimeContextWindow, prepare_s
 from .contracts import (
     RuntimeNotification,
     RuntimeRequest,
+    RuntimeRequestError,
     RuntimeResponse,
     RuntimeSessionResult,
     RuntimeStreamChunk,
+    UnknownSessionError,
     validate_session_id,
     validate_session_reference_id,
 )
@@ -199,6 +201,8 @@ class VoidCodeRuntime:
     _plan_contributor: PlanContributor
     _background_task_threads: dict[str, threading.Thread]
     _background_tasks_reconciled: bool
+    _active_session_ids: set[str]
+    _active_session_ids_lock: threading.Lock
     _hook_recursion_env_var = "VOIDCODE_RUNNING_TOOL_HOOK"
     _default_context_window_policy = ContextWindowPolicy()
 
@@ -264,6 +268,8 @@ class VoidCodeRuntime:
         self._plan_contributor = build_plan_contributor(self._workspace, self._config.plan)
         self._background_task_threads = {}
         self._background_tasks_reconciled = False
+        self._active_session_ids = set()
+        self._active_session_ids_lock = threading.Lock()
 
     def __enter__(self) -> VoidCodeRuntime:
         return self
@@ -475,33 +481,38 @@ class VoidCodeRuntime:
 
     def _run_with_persistence(self, request: RuntimeRequest) -> Iterator[RuntimeStreamChunk]:
         request = self._validated_request(request)
-        events: list[EventEnvelope] = []
-        output: str | None = None
-        final_session: SessionState | None = None
-
+        session_id = self._resolve_session_id(request)
+        self._register_active_session_id(session_id)
         try:
-            for chunk in self._stream_chunks(request):
-                final_session = chunk.session
-                if chunk.event is not None:
-                    events.append(chunk.event)
-                if chunk.kind == "output":
-                    if output is not None:
-                        raise ValueError("runtime stream emitted multiple output chunks")
-                    output = chunk.output
-                yield chunk
-        except Exception:
-            if final_session is not None and final_session.status == "failed":
-                response = RuntimeResponse(
-                    session=final_session, events=tuple(events), output=output
-                )
-                self._persist_response(request=request, response=response)
-            raise
+            events: list[EventEnvelope] = []
+            output: str | None = None
+            final_session: SessionState | None = None
 
-        if final_session is None:
-            raise ValueError("runtime stream emitted no chunks")
+            try:
+                for chunk in self._stream_chunks(request, session_id=session_id):
+                    final_session = chunk.session
+                    if chunk.event is not None:
+                        events.append(chunk.event)
+                    if chunk.kind == "output":
+                        if output is not None:
+                            raise ValueError("runtime stream emitted multiple output chunks")
+                        output = chunk.output
+                    yield chunk
+            except Exception:
+                if final_session is not None and final_session.status == "failed":
+                    response = RuntimeResponse(
+                        session=final_session, events=tuple(events), output=output
+                    )
+                    self._persist_response(request=request, response=response)
+                raise
 
-        response = RuntimeResponse(session=final_session, events=tuple(events), output=output)
-        self._persist_response(request=request, response=response)
+            if final_session is None:
+                raise ValueError("runtime stream emitted no chunks")
+
+            response = RuntimeResponse(session=final_session, events=tuple(events), output=output)
+            self._persist_response(request=request, response=response)
+        finally:
+            self._unregister_active_session_id(session_id)
 
     def run(self, request: RuntimeRequest) -> RuntimeResponse:
         events: list[EventEnvelope] = []
@@ -533,12 +544,12 @@ class VoidCodeRuntime:
         )
         return self._run_with_persistence(request_with_stream)
 
-    def _stream_chunks(self, request: RuntimeRequest) -> Iterator[RuntimeStreamChunk]:
-        session_id = self._resolve_session_id(request)
+    def _stream_chunks(self, request: RuntimeRequest, *, session_id: str | None = None) -> Iterator[RuntimeStreamChunk]:
+        resolved_session_id = session_id or self._resolve_session_id(request)
         effective_config = self._runtime_config_for_request(request)
         self._refresh_mcp_tools()
         session = SessionState(
-            session=SessionRef(id=session_id, parent_id=request.parent_session_id),
+            session=SessionRef(id=resolved_session_id, parent_id=request.parent_session_id),
             status="running",
             turn=1,
             metadata={
@@ -1750,7 +1761,7 @@ class VoidCodeRuntime:
                 field_name="parent_session_id",
             )
         if session_id is not None and parent_session_id == session_id:
-            raise ValueError("parent_session_id must not match session_id")
+            raise RuntimeRequestError("parent_session_id must not match session_id")
 
         existing_session = (
             self._load_existing_session_if_present(session_id=session_id)
@@ -1759,8 +1770,10 @@ class VoidCodeRuntime:
         )
         if parent_session_id is not None:
             parent_session = self._load_existing_session_if_present(session_id=parent_session_id)
-            if parent_session is None:
-                raise ValueError(f"parent session does not exist: {parent_session_id}")
+            if parent_session is None and not self._is_active_session_id(parent_session_id):
+                raise RuntimeRequestError(
+                    f"parent session does not exist: {parent_session_id}"
+                )
 
         resolved_parent_session_id = parent_session_id
         if existing_session is not None:
@@ -1773,7 +1786,7 @@ class VoidCodeRuntime:
                     if existing_parent_session_id is not None
                     else "<top-level>"
                 )
-                raise ValueError(
+                raise RuntimeRequestError(
                     f"session {session_id} already belongs to {existing_parent_label} "
                     f"and cannot be rebound to parent session {parent_session_id}"
                 )
@@ -2302,12 +2315,24 @@ class VoidCodeRuntime:
                 workspace=self._workspace,
                 session_id=session_id,
             )
-        except ValueError as exc:
-            if str(exc) == f"unknown session: {session_id}":
-                return None
+        except UnknownSessionError:
+            return None
+        except ValueError:
             raise
         self._validate_session_workspace(response.session, session_id=session_id)
         return response
+
+    def _is_active_session_id(self, session_id: str) -> bool:
+        with self._active_session_ids_lock:
+            return session_id in self._active_session_ids
+
+    def _register_active_session_id(self, session_id: str) -> None:
+        with self._active_session_ids_lock:
+            self._active_session_ids.add(session_id)
+
+    def _unregister_active_session_id(self, session_id: str) -> None:
+        with self._active_session_ids_lock:
+            self._active_session_ids.discard(session_id)
 
     def _session_belongs_to_workspace(self, session_id: str) -> bool:
         try:

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -55,6 +55,7 @@ from .contracts import (
     RuntimeSessionResult,
     RuntimeStreamChunk,
     validate_session_id,
+    validate_session_reference_id,
 )
 from .events import (
     RUNTIME_ACP_CONNECTED,
@@ -526,6 +527,7 @@ class VoidCodeRuntime:
         request_with_stream = RuntimeRequest(
             prompt=request.prompt,
             session_id=request.session_id,
+            parent_session_id=request.parent_session_id,
             metadata={**request.metadata, "provider_stream": True},
             allocate_session_id=request.allocate_session_id,
         )
@@ -536,7 +538,7 @@ class VoidCodeRuntime:
         effective_config = self._runtime_config_for_request(request)
         self._refresh_mcp_tools()
         session = SessionState(
-            session=SessionRef(id=session_id),
+            session=SessionRef(id=session_id, parent_id=request.parent_session_id),
             status="running",
             turn=1,
             metadata={
@@ -1239,6 +1241,7 @@ class VoidCodeRuntime:
             request=BackgroundTaskRequestSnapshot(
                 prompt=validated_request.prompt,
                 session_id=validated_request.session_id,
+                parent_session_id=validated_request.parent_session_id,
                 metadata=dict(validated_request.metadata),
                 allocate_session_id=validated_request.allocate_session_id,
             ),
@@ -1585,6 +1588,7 @@ class VoidCodeRuntime:
                 request = RuntimeRequest(
                     prompt=prompt,
                     session_id=stored.session.session.id,
+                    parent_session_id=stored.session.session.parent_id,
                 )
                 self._persist_response(request=request, response=response)
                 return
@@ -1599,6 +1603,7 @@ class VoidCodeRuntime:
         request = RuntimeRequest(
             prompt=prompt,
             session_id=stored.session.session.id,
+            parent_session_id=stored.session.session.parent_id,
         )
         self._persist_response(request=request, response=response)
         return
@@ -1733,13 +1738,50 @@ class VoidCodeRuntime:
             status = "completed"
         return VoidCodeRuntime._session_with_status(response_session, status)
 
-    @staticmethod
-    def _validated_request(request: RuntimeRequest) -> RuntimeRequest:
-        if request.session_id is None:
-            return request
+    def _validated_request(self, request: RuntimeRequest) -> RuntimeRequest:
+        session_id = request.session_id
+        if session_id is not None:
+            session_id = validate_session_id(session_id)
+
+        parent_session_id = request.parent_session_id
+        if parent_session_id is not None:
+            parent_session_id = validate_session_reference_id(
+                parent_session_id,
+                field_name="parent_session_id",
+            )
+        if session_id is not None and parent_session_id == session_id:
+            raise ValueError("parent_session_id must not match session_id")
+
+        existing_session = (
+            self._load_existing_session_if_present(session_id=session_id)
+            if session_id is not None
+            else None
+        )
+        if parent_session_id is not None:
+            parent_session = self._load_existing_session_if_present(session_id=parent_session_id)
+            if parent_session is None:
+                raise ValueError(f"parent session does not exist: {parent_session_id}")
+
+        resolved_parent_session_id = parent_session_id
+        if existing_session is not None:
+            existing_parent_session_id = existing_session.session.session.parent_id
+            if parent_session_id is None:
+                resolved_parent_session_id = existing_parent_session_id
+            elif existing_parent_session_id != parent_session_id:
+                existing_parent_label = (
+                    existing_parent_session_id
+                    if existing_parent_session_id is not None
+                    else "<top-level>"
+                )
+                raise ValueError(
+                    f"session {session_id} already belongs to {existing_parent_label} "
+                    f"and cannot be rebound to parent session {parent_session_id}"
+                )
+
         return RuntimeRequest(
             prompt=request.prompt,
-            session_id=validate_session_id(request.session_id),
+            session_id=session_id,
+            parent_session_id=resolved_parent_session_id,
             metadata=request.metadata,
             allocate_session_id=request.allocate_session_id,
         )
@@ -1748,7 +1790,7 @@ class VoidCodeRuntime:
     def _resolve_session_id(request: RuntimeRequest) -> str:
         if request.session_id is not None:
             return request.session_id
-        if request.allocate_session_id:
+        if request.allocate_session_id or request.parent_session_id is not None:
             return f"session-{uuid4().hex}"
         return "local-cli-session"
 
@@ -2060,6 +2102,7 @@ class VoidCodeRuntime:
             request = RuntimeRequest(
                 prompt=task.request.prompt,
                 session_id=task.request.session_id,
+                parent_session_id=task.request.parent_session_id,
                 metadata=task.request.metadata,
                 allocate_session_id=task.request.allocate_session_id,
             )
@@ -2086,6 +2129,7 @@ class VoidCodeRuntime:
                 RuntimeRequest(
                     prompt=dispatch_task.request.prompt,
                     session_id=session_id,
+                    parent_session_id=dispatch_task.request.parent_session_id,
                     metadata={
                         **dispatch_task.request.metadata,
                         "background_task_id": task_id,
@@ -2252,17 +2296,25 @@ class VoidCodeRuntime:
         if session_workspace != str(self._workspace):
             raise ValueError(f"session {session_id} does not belong to workspace {self._workspace}")
 
-    def _session_belongs_to_workspace(self, session_id: str) -> bool:
+    def _load_existing_session_if_present(self, *, session_id: str) -> RuntimeResponse | None:
         try:
             response = self._session_store.load_session(
                 workspace=self._workspace,
                 session_id=session_id,
             )
+        except ValueError as exc:
+            if str(exc) == f"unknown session: {session_id}":
+                return None
+            raise
+        self._validate_session_workspace(response.session, session_id=session_id)
+        return response
+
+    def _session_belongs_to_workspace(self, session_id: str) -> bool:
+        try:
+            response = self._load_existing_session_if_present(session_id=session_id)
         except ValueError:
             return False
-        try:
-            self._validate_session_workspace(response.session, session_id=session_id)
-        except ValueError:
+        if response is None:
             return False
         return True
 

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -55,7 +55,6 @@ from .contracts import (
     RuntimeResponse,
     RuntimeSessionResult,
     RuntimeStreamChunk,
-    UnknownSessionError,
     validate_session_id,
     validate_session_reference_id,
 )
@@ -104,6 +103,42 @@ if TYPE_CHECKING:
     from ..tools.lsp import FormatTool
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class _ActiveSessionKey:
+    workspace: Path
+    session_id: str
+
+
+class _ActiveSessionRegistry:
+    def __init__(self) -> None:
+        self._counts: dict[_ActiveSessionKey, int] = {}
+        self._lock = threading.Lock()
+
+    def register(self, *, workspace: Path, session_id: str) -> None:
+        key = _ActiveSessionKey(workspace=workspace, session_id=session_id)
+        with self._lock:
+            self._counts[key] = self._counts.get(key, 0) + 1
+
+    def unregister(self, *, workspace: Path, session_id: str) -> None:
+        key = _ActiveSessionKey(workspace=workspace, session_id=session_id)
+        with self._lock:
+            count = self._counts.get(key)
+            if count is None:
+                return
+            if count <= 1:
+                self._counts.pop(key, None)
+                return
+            self._counts[key] = count - 1
+
+    def contains(self, *, workspace: Path, session_id: str) -> bool:
+        key = _ActiveSessionKey(workspace=workspace, session_id=session_id)
+        with self._lock:
+            return key in self._counts
+
+
+_ACTIVE_SESSION_REGISTRY = _ActiveSessionRegistry()
 
 
 def _coerce_bool_like(value: object | None, default: bool) -> bool:
@@ -201,8 +236,6 @@ class VoidCodeRuntime:
     _plan_contributor: PlanContributor
     _background_task_threads: dict[str, threading.Thread]
     _background_tasks_reconciled: bool
-    _active_session_ids: set[str]
-    _active_session_ids_lock: threading.Lock
     _hook_recursion_env_var = "VOIDCODE_RUNNING_TOOL_HOOK"
     _default_context_window_policy = ContextWindowPolicy()
 
@@ -268,8 +301,6 @@ class VoidCodeRuntime:
         self._plan_contributor = build_plan_contributor(self._workspace, self._config.plan)
         self._background_task_threads = {}
         self._background_tasks_reconciled = False
-        self._active_session_ids = set()
-        self._active_session_ids_lock = threading.Lock()
 
     def __enter__(self) -> VoidCodeRuntime:
         return self
@@ -544,7 +575,12 @@ class VoidCodeRuntime:
         )
         return self._run_with_persistence(request_with_stream)
 
-    def _stream_chunks(self, request: RuntimeRequest, *, session_id: str | None = None) -> Iterator[RuntimeStreamChunk]:
+    def _stream_chunks(
+        self,
+        request: RuntimeRequest,
+        *,
+        session_id: str | None = None,
+    ) -> Iterator[RuntimeStreamChunk]:
         resolved_session_id = session_id or self._resolve_session_id(request)
         effective_config = self._runtime_config_for_request(request)
         self._refresh_mcp_tools()
@@ -1771,9 +1807,7 @@ class VoidCodeRuntime:
         if parent_session_id is not None:
             parent_session = self._load_existing_session_if_present(session_id=parent_session_id)
             if parent_session is None and not self._is_active_session_id(parent_session_id):
-                raise RuntimeRequestError(
-                    f"parent session does not exist: {parent_session_id}"
-                )
+                raise RuntimeRequestError(f"parent session does not exist: {parent_session_id}")
 
         resolved_parent_session_id = parent_session_id
         if existing_session is not None:
@@ -2310,29 +2344,23 @@ class VoidCodeRuntime:
             raise ValueError(f"session {session_id} does not belong to workspace {self._workspace}")
 
     def _load_existing_session_if_present(self, *, session_id: str) -> RuntimeResponse | None:
-        try:
-            response = self._session_store.load_session(
-                workspace=self._workspace,
-                session_id=session_id,
-            )
-        except UnknownSessionError:
+        if not self._session_store.has_session(workspace=self._workspace, session_id=session_id):
             return None
-        except ValueError:
-            raise
+        response = self._session_store.load_session(
+            workspace=self._workspace,
+            session_id=session_id,
+        )
         self._validate_session_workspace(response.session, session_id=session_id)
         return response
 
     def _is_active_session_id(self, session_id: str) -> bool:
-        with self._active_session_ids_lock:
-            return session_id in self._active_session_ids
+        return _ACTIVE_SESSION_REGISTRY.contains(workspace=self._workspace, session_id=session_id)
 
     def _register_active_session_id(self, session_id: str) -> None:
-        with self._active_session_ids_lock:
-            self._active_session_ids.add(session_id)
+        _ACTIVE_SESSION_REGISTRY.register(workspace=self._workspace, session_id=session_id)
 
     def _unregister_active_session_id(self, session_id: str) -> None:
-        with self._active_session_ids_lock:
-            self._active_session_ids.discard(session_id)
+        _ACTIVE_SESSION_REGISTRY.unregister(workspace=self._workspace, session_id=session_id)
 
     def _session_belongs_to_workspace(self, session_id: str) -> bool:
         try:

--- a/src/voidcode/runtime/session.py
+++ b/src/voidcode/runtime/session.py
@@ -4,11 +4,25 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 type SessionStatus = Literal["idle", "running", "waiting", "completed", "failed"]
+type SessionKind = Literal["top_level", "child"]
 
 
 @dataclass(frozen=True, slots=True)
 class SessionRef:
     id: str
+    parent_id: str | None = None
+
+    @property
+    def kind(self) -> SessionKind:
+        return "child" if self.parent_id is not None else "top_level"
+
+    @property
+    def is_child(self) -> bool:
+        return self.parent_id is not None
+
+    @property
+    def is_top_level(self) -> bool:
+        return self.parent_id is None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/voidcode/runtime/storage.py
+++ b/src/voidcode/runtime/storage.py
@@ -43,6 +43,8 @@ class SessionStore(Protocol):
 
     def list_sessions(self, *, workspace: Path) -> tuple[StoredSessionSummary, ...]: ...
 
+    def has_session(self, *, workspace: Path, session_id: str) -> bool: ...
+
     def load_session(self, *, workspace: Path, session_id: str) -> RuntimeResponse: ...
 
     def load_session_result(self, *, workspace: Path, session_id: str) -> RuntimeSessionResult: ...
@@ -584,6 +586,21 @@ class SqliteSessionStore:
                 }
             )
         return tool_results
+
+    def has_session(self, *, workspace: Path, session_id: str) -> bool:
+        with self._connect(workspace) as connection:
+            row = cast(
+                sqlite3.Row | None,
+                connection.execute(
+                    """
+                    SELECT 1
+                    FROM sessions
+                    WHERE workspace = ? AND session_id = ?
+                    """,
+                    (str(workspace), session_id),
+                ).fetchone(),
+            )
+        return row is not None
 
     def load_session(self, *, workspace: Path, session_id: str) -> RuntimeResponse:
         with self._connect(workspace) as connection:

--- a/src/voidcode/runtime/storage.py
+++ b/src/voidcode/runtime/storage.py
@@ -15,6 +15,7 @@ from .contracts import (
     RuntimeRequest,
     RuntimeResponse,
     RuntimeSessionResult,
+    UnknownSessionError,
 )
 from .events import EventEnvelope, EventSource
 from .permission import PendingApproval
@@ -464,7 +465,7 @@ class SqliteSessionStore:
                 ).fetchone(),
             )
         if row is None:
-            raise ValueError(f"unknown session: {session_id}")
+            raise UnknownSessionError(f"unknown session: {session_id}")
         payload = cast(str | None, row["pending_approval_json"])
         if payload is None:
             return None
@@ -505,7 +506,7 @@ class SqliteSessionStore:
                 ).fetchone(),
             )
         if row is None:
-            raise ValueError(f"unknown session: {session_id}")
+            raise UnknownSessionError(f"unknown session: {session_id}")
         payload = cast(str | None, row["resume_checkpoint_json"])
         if payload is None:
             return None
@@ -598,7 +599,7 @@ class SqliteSessionStore:
                 ).fetchone(),
             )
             if session_row is None:
-                raise ValueError(f"unknown session: {session_id}")
+                raise UnknownSessionError(f"unknown session: {session_id}")
             event_rows = cast(
                 list[sqlite3.Row],
                 connection.execute(
@@ -649,7 +650,7 @@ class SqliteSessionStore:
                 ).fetchone(),
             )
         if row is None:
-            raise ValueError(f"unknown session: {session_id}")
+            raise UnknownSessionError(f"unknown session: {session_id}")
         prompt = cast(str, row["prompt"])
         summary, error = self._result_summary(response=response, prompt=prompt)
         return RuntimeSessionResult(

--- a/src/voidcode/runtime/storage.py
+++ b/src/voidcode/runtime/storage.py
@@ -145,6 +145,7 @@ class SqliteSessionStore:
             """
             CREATE TABLE IF NOT EXISTS sessions (
                 session_id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
                 workspace TEXT NOT NULL,
                 status TEXT NOT NULL,
                 turn INTEGER NOT NULL,
@@ -179,6 +180,7 @@ class SqliteSessionStore:
                 status TEXT NOT NULL,
                 prompt TEXT NOT NULL,
                 request_session_id TEXT,
+                request_parent_session_id TEXT,
                 request_metadata_json TEXT NOT NULL,
                 allocate_session_id INTEGER NOT NULL,
                 session_id TEXT,
@@ -216,19 +218,38 @@ class SqliteSessionStore:
                 list[sqlite3.Row], connection.execute("PRAGMA table_info(sessions)").fetchall()
             )
         }
+        background_task_columns = {
+            cast(str, row["name"])
+            for row in cast(
+                list[sqlite3.Row],
+                connection.execute("PRAGMA table_info(background_tasks)").fetchall(),
+            )
+        }
         target_user_version = user_version
+        if "parent_session_id" not in columns:
+            _ = connection.execute("ALTER TABLE sessions ADD COLUMN parent_session_id TEXT")
+            target_user_version = max(target_user_version, 5)
         if "pending_approval_json" not in columns:
             _ = connection.execute("ALTER TABLE sessions ADD COLUMN pending_approval_json TEXT")
             target_user_version = max(target_user_version, 1)
         if "resume_checkpoint_json" not in columns:
             _ = connection.execute("ALTER TABLE sessions ADD COLUMN resume_checkpoint_json TEXT")
             target_user_version = max(target_user_version, 3)
+        if "request_parent_session_id" not in background_task_columns:
+            _ = connection.execute(
+                "ALTER TABLE background_tasks ADD COLUMN request_parent_session_id TEXT"
+            )
+            target_user_version = max(target_user_version, 6)
         if user_version < 2:
             target_user_version = max(target_user_version, 2)
         if user_version < 3:
             target_user_version = max(target_user_version, 3)
         if user_version < 4:
             target_user_version = max(target_user_version, 4)
+        if user_version < 5:
+            target_user_version = max(target_user_version, 5)
+        if user_version < 6:
+            target_user_version = max(target_user_version, 6)
         if target_user_version != user_version:
             _ = connection.execute(f"PRAGMA user_version = {target_user_version}")
         connection.commit()
@@ -275,12 +296,13 @@ class SqliteSessionStore:
             _ = connection.execute(
                 """
                 INSERT OR REPLACE INTO sessions (
-                    session_id, workspace, status, turn, prompt, output,
+                    session_id, parent_session_id, workspace, status, turn, prompt, output,
                     metadata_json, pending_approval_json, resume_checkpoint_json, created_at, updated_at, last_event_sequence
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,  # noqa: E501
                 (
                     session_id,
+                    response.session.session.parent_id,
                     str(workspace),
                     response.session.status,
                     response.session.turn,
@@ -337,7 +359,7 @@ class SqliteSessionStore:
                 list[sqlite3.Row],
                 connection.execute(
                     """
-                SELECT session_id, status, turn, prompt, updated_at
+                SELECT session_id, parent_session_id, status, turn, prompt, updated_at
                 FROM sessions
                 WHERE workspace = ?
                 ORDER BY updated_at DESC, session_id ASC
@@ -347,7 +369,10 @@ class SqliteSessionStore:
             )
         return tuple(
             StoredSessionSummary(
-                session=SessionRef(id=cast(str, row["session_id"])),
+                session=SessionRef(
+                    id=cast(str, row["session_id"]),
+                    parent_id=cast(str | None, row["parent_session_id"]),
+                ),
                 status=self._parse_session_status(cast(str, row["status"])),
                 turn=cast(int, row["turn"]),
                 prompt=cast(str, row["prompt"]),
@@ -371,12 +396,13 @@ class SqliteSessionStore:
             _ = connection.execute(
                 """
                 INSERT OR REPLACE INTO sessions (
-                    session_id, workspace, status, turn, prompt, output,
+                    session_id, parent_session_id, workspace, status, turn, prompt, output,
                     metadata_json, pending_approval_json, resume_checkpoint_json, created_at, updated_at, last_event_sequence
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,  # noqa: E501
                 (
                     session_id,
+                    response.session.session.parent_id,
                     str(workspace),
                     response.session.status,
                     response.session.turn,
@@ -564,7 +590,7 @@ class SqliteSessionStore:
                 sqlite3.Row | None,
                 connection.execute(
                     """
-                SELECT session_id, status, turn, output, metadata_json
+                SELECT session_id, parent_session_id, status, turn, output, metadata_json
                 FROM sessions
                 WHERE workspace = ? AND session_id = ?
                 """,
@@ -586,7 +612,10 @@ class SqliteSessionStore:
                 ).fetchall(),
             )
         session = SessionState(
-            session=SessionRef(id=cast(str, session_row["session_id"])),
+            session=SessionRef(
+                id=cast(str, session_row["session_id"]),
+                parent_id=cast(str | None, session_row["parent_session_id"]),
+            ),
             status=self._parse_session_status(cast(str, session_row["status"])),
             turn=cast(int, session_row["turn"]),
             metadata=cast(dict[str, object], json.loads(cast(str, session_row["metadata_json"]))),
@@ -640,11 +669,16 @@ class SqliteSessionStore:
                 list[sqlite3.Row],
                 connection.execute(
                     """
-                    SELECT notification_id, session_id, kind, status, summary, payload_json,
-                           event_sequence, created_at, acknowledged_at
-                    FROM session_notifications
-                    WHERE workspace = ?
-                    ORDER BY created_at DESC, notification_id DESC
+                    SELECT notifications.notification_id, notifications.session_id,
+                           notifications.kind, notifications.status, notifications.summary,
+                           notifications.payload_json, notifications.event_sequence,
+                           notifications.created_at, notifications.acknowledged_at,
+                           sessions.parent_session_id
+                    FROM session_notifications AS notifications
+                    LEFT JOIN sessions ON sessions.session_id = notifications.session_id
+                                      AND sessions.workspace = notifications.workspace
+                    WHERE notifications.workspace = ?
+                    ORDER BY notifications.created_at DESC, notifications.notification_id DESC
                     """,
                     (str(workspace),),
                 ).fetchall(),
@@ -664,9 +698,10 @@ class SqliteSessionStore:
                 """
                 INSERT INTO background_tasks (
                     task_id, workspace, status, prompt, request_session_id,
-                    request_metadata_json, allocate_session_id, session_id, error,
-                    cancel_requested_at, created_at, updated_at, started_at, finished_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    request_parent_session_id, request_metadata_json,
+                    allocate_session_id, session_id, error, cancel_requested_at,
+                    created_at, updated_at, started_at, finished_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     task_id,
@@ -674,6 +709,7 @@ class SqliteSessionStore:
                     task.status,
                     task.request.prompt,
                     task.request.session_id,
+                    task.request.parent_session_id,
                     json.dumps(task.request.metadata, sort_keys=True),
                     1 if task.request.allocate_session_id else 0,
                     task.session_id,
@@ -870,6 +906,7 @@ class SqliteSessionStore:
             request=BackgroundTaskRequestSnapshot(
                 prompt=cast(str, row["prompt"]),
                 session_id=cast(str | None, row["request_session_id"]),
+                parent_session_id=cast(str | None, row["request_parent_session_id"]),
                 metadata=cast(dict[str, object], metadata),
                 allocate_session_id=bool(cast(int, row["allocate_session_id"])),
             ),
@@ -925,10 +962,15 @@ class SqliteSessionStore:
                 sqlite3.Row,
                 connection.execute(
                     """
-                    SELECT notification_id, session_id, kind, status, summary, payload_json,
-                           event_sequence, created_at, acknowledged_at
-                    FROM session_notifications
-                    WHERE workspace = ? AND notification_id = ?
+                    SELECT notifications.notification_id, notifications.session_id,
+                           notifications.kind, notifications.status, notifications.summary,
+                           notifications.payload_json, notifications.event_sequence,
+                           notifications.created_at, notifications.acknowledged_at,
+                           sessions.parent_session_id
+                    FROM session_notifications AS notifications
+                    LEFT JOIN sessions ON sessions.session_id = notifications.session_id
+                                      AND sessions.workspace = notifications.workspace
+                    WHERE notifications.workspace = ? AND notifications.notification_id = ?
                     """,
                     (str(workspace), notification_id),
                 ).fetchone(),
@@ -1093,7 +1135,10 @@ class SqliteSessionStore:
     def _notification_from_row(row: sqlite3.Row) -> RuntimeNotification:
         return RuntimeNotification(
             id=cast(str, row["notification_id"]),
-            session=SessionRef(id=cast(str, row["session_id"])),
+            session=SessionRef(
+                id=cast(str, row["session_id"]),
+                parent_id=cast(str | None, row["parent_session_id"]),
+            ),
             kind=cast(RuntimeNotificationKind, row["kind"]),
             status=cast(RuntimeNotificationStatus, row["status"]),
             summary=cast(str, row["summary"]),

--- a/src/voidcode/runtime/task.py
+++ b/src/voidcode/runtime/task.py
@@ -21,6 +21,7 @@ class BackgroundTaskRef:
 class BackgroundTaskRequestSnapshot:
     prompt: str
     session_id: str | None = None
+    parent_session_id: str | None = None
     metadata: dict[str, object] = field(default_factory=dict)
     allocate_session_id: bool = False
 
@@ -39,6 +40,10 @@ class BackgroundTaskState:
     started_at: int | None = None
     finished_at: int | None = None
     cancel_requested_at: int | None = None
+
+    @property
+    def parent_session_id(self) -> str | None:
+        return self.request.parent_session_id
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -589,6 +589,58 @@ def test_transport_lists_and_acknowledges_notifications(tmp_path: Path) -> None:
     assert ack_payload["acknowledged_at"] is not None
 
 
+def test_transport_round_trips_parent_session_lineage(tmp_path: Path) -> None:
+    create_runtime_app = _load_transport_app_factory()
+    runtime_module = importlib.import_module("voidcode.runtime")
+
+    class StubRuntime:
+        def run_stream(self, request: RuntimeRequestLike) -> Iterator[StreamChunkLike]:
+            assert request.prompt == "child task"
+            assert getattr(request, "parent_session_id", None) == "leader-session"
+            yield runtime_module.RuntimeStreamChunk(
+                kind="output",
+                session=runtime_module.SessionState(
+                    session=runtime_module.SessionRef(
+                        id="child-session",
+                        parent_id="leader-session",
+                    ),
+                    status="completed",
+                    turn=1,
+                    metadata={},
+                ),
+                output="done",
+            )
+
+        def list_sessions(self) -> tuple[StoredSessionSummaryLike, ...]:
+            raise AssertionError("list_sessions should not be called")
+
+        def resume(self, session_id: str) -> RuntimeResponseLike:
+            raise AssertionError(f"resume should not be called: {session_id}")
+
+    app = create_runtime_app(workspace=tmp_path, runtime_factory=lambda: StubRuntime())
+    response = _run_app(
+        app,
+        method="POST",
+        path="/api/runtime/run/stream",
+        body=json.dumps(
+            {
+                "prompt": "child task",
+                "parent_session_id": "leader-session",
+            }
+        ).encode("utf-8"),
+    )
+    payloads = _parse_sse_payloads(response)
+
+    assert response.status == 200
+    assert len(payloads) == 1
+    assert cast(dict[str, object], payloads[0]["session"])["session"] == {
+        "id": "child-session",
+        "parent_id": "leader-session",
+    }
+    assert cast(dict[str, object], payloads[0]["session"])["status"] == "completed"
+    assert payloads[0]["output"] == "done"
+
+
 def test_transport_serializes_hook_events_from_runtime_stream(tmp_path: Path) -> None:
     create_runtime_app = _load_transport_app_factory()
     runtime_stream_chunk, session_ref, session_state, event_envelope = _load_stream_types()

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -5,6 +5,7 @@ import importlib
 import json
 import logging
 import sys
+import threading
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -1624,6 +1625,73 @@ def test_transport_rejects_unknown_parent_session_in_run_stream_payload(tmp_path
 
     assert response.status == 400
     assert response.json() == {"error": "parent session does not exist: missing-parent"}
+
+
+def test_transport_allows_parent_session_while_parent_stream_request_is_active(
+    tmp_path: Path,
+) -> None:
+    _, runtime_class = _load_runtime_types()
+    create_runtime_app = _load_transport_app_factory()
+    service_module = importlib.import_module("voidcode.runtime.service")
+    active_registry = service_module._ACTIVE_SESSION_REGISTRY
+
+    app = create_runtime_app(
+        workspace=tmp_path,
+        runtime_factory=lambda: runtime_class(workspace=tmp_path),
+    )
+
+    parent_started = threading.Event()
+    allow_parent_to_finish = threading.Event()
+
+    original_register = active_registry.register
+
+    def _register_and_signal(*, workspace: Path, session_id: str) -> None:
+        original_register(workspace=workspace, session_id=session_id)
+        if session_id == "leader-session":
+            parent_started.set()
+            allow_parent_to_finish.wait(timeout=5)
+
+    parent_response_holder: dict[str, object] = {}
+
+    def _run_parent() -> None:
+        parent_response_holder["response"] = _run_app(
+            app,
+            method="POST",
+            path="/api/runtime/run/stream",
+            body=json.dumps(
+                {
+                    "prompt": "leader",
+                    "session_id": "leader-session",
+                }
+            ).encode("utf-8"),
+        )
+
+    parent_thread = threading.Thread(target=_run_parent, daemon=True)
+
+    with patch.object(active_registry, "register", _register_and_signal):
+        parent_thread.start()
+        assert parent_started.wait(timeout=5)
+        child_response = _run_app(
+            app,
+            method="POST",
+            path="/api/runtime/run/stream",
+            body=json.dumps(
+                {
+                    "prompt": "child",
+                    "parent_session_id": "leader-session",
+                }
+            ).encode("utf-8"),
+        )
+        allow_parent_to_finish.set()
+        parent_thread.join(timeout=5)
+
+    child_payloads = _parse_sse_payloads(child_response)
+    first_payload = child_payloads[0]
+    first_session = cast(dict[str, object], first_payload["session"])
+    first_session_ref = cast(dict[str, object], first_session["session"])
+
+    assert child_response.status == 200
+    assert first_session_ref["parent_id"] == "leader-session"
 
 
 def test_transport_rejects_empty_session_id_in_run_stream_payload() -> None:

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -1586,8 +1586,8 @@ def test_transport_logs_unexpected_streaming_errors(caplog: pytest.LogCaptureFix
             body=json.dumps({"prompt": "explode"}).encode("utf-8"),
         )
 
-    assert response.status == 200
-    assert response.body == b""
+    assert response.status == 500
+    assert response.json() == {"error": "internal server error"}
     assert "unexpected transport streaming failure" in caplog.text
 
 
@@ -1604,6 +1604,26 @@ def test_transport_rejects_invalid_run_stream_payload() -> None:
 
     assert response.status == 400
     assert response.json() == {"error": "prompt must be a non-empty string"}
+
+
+def test_transport_rejects_unknown_parent_session_in_run_stream_payload(tmp_path: Path) -> None:
+    create_runtime_app = _load_transport_app_factory()
+    app = create_runtime_app(workspace=tmp_path)
+
+    response = _run_app(
+        app,
+        method="POST",
+        path="/api/runtime/run/stream",
+        body=json.dumps(
+            {
+                "prompt": "child task",
+                "parent_session_id": "missing-parent",
+            }
+        ).encode("utf-8"),
+    )
+
+    assert response.status == 400
+    assert response.json() == {"error": "parent session does not exist: missing-parent"}
 
 
 def test_transport_rejects_empty_session_id_in_run_stream_payload() -> None:

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -1678,17 +1678,24 @@ def test_runtime_migrates_legacy_session_schema_for_pending_approval(tmp_path: P
 
     check = sqlite3.connect(database_path)
     try:
-        rows = cast(
+        session_rows = cast(
             list[tuple[object, ...]], check.execute("PRAGMA table_info(sessions)").fetchall()
         )
-        columns = [cast(str, row[1]) for row in rows]
+        background_task_rows = cast(
+            list[tuple[object, ...]],
+            check.execute("PRAGMA table_info(background_tasks)").fetchall(),
+        )
+        columns = [cast(str, row[1]) for row in session_rows]
+        background_task_columns = [cast(str, row[1]) for row in background_task_rows]
         user_version = cast(int, check.execute("PRAGMA user_version").fetchone()[0])
     finally:
         check.close()
 
+    assert "parent_session_id" in columns
     assert "pending_approval_json" in columns
     assert "resume_checkpoint_json" in columns
-    assert user_version == 4
+    assert "request_parent_session_id" in background_task_columns
+    assert user_version == 6
 
 
 def test_runtime_replay_is_unchanged_when_resume_checkpoint_exists(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_backend_contracts.py
+++ b/tests/unit/runtime/test_backend_contracts.py
@@ -26,7 +26,7 @@ def test_contract_modules_export_expected_symbols() -> None:
     graph = _graph_module()
     tools = _tools_module()
 
-    session_ref = runtime.SessionRef(id="session-1")
+    session_ref = runtime.SessionRef(id="session-1", parent_id="session-parent")
     session = runtime.SessionState(session=session_ref, status="running", turn=1)
     event = runtime.EventEnvelope(
         session_id="session-1",
@@ -42,11 +42,14 @@ def test_contract_modules_export_expected_symbols() -> None:
     call = tools.ToolCall(tool_name=tool.name, arguments={"path": "README.md"})
     result = tools.ToolResult(tool_name=tool.name, status="ok", content="hello")
     runtime_request = runtime.RuntimeRequest(
-        prompt="Inspect the repo", session_id=session.session.id
+        prompt="Inspect the repo",
+        session_id=session.session.id,
+        parent_session_id=session.session.parent_id,
     )
     background_task_request = runtime.BackgroundTaskRequestSnapshot(
         prompt=runtime_request.prompt,
         session_id=session.session.id,
+        parent_session_id=runtime_request.parent_session_id,
     )
     background_task = runtime.BackgroundTaskState(
         task=runtime.BackgroundTaskRef(id="task-1"),
@@ -67,6 +70,8 @@ def test_contract_modules_export_expected_symbols() -> None:
     graph_result = graph.GraphRunResult(session=session, events=(event,), tool_results=(result,))
 
     assert session.session.id == "session-1"
+    assert session.session.parent_id == "session-parent"
+    assert session.session.kind == "child"
     assert event.sequence == 1
     assert tool.read_only is True
     assert call.arguments == {"path": "README.md"}
@@ -74,6 +79,7 @@ def test_contract_modules_export_expected_symbols() -> None:
     assert stream_chunk.event == event
     assert background_task.task.id == "task-1"
     assert background_task.request.prompt == runtime_request.prompt
+    assert background_task.parent_session_id == "session-parent"
     assert session_summary.session.id == "session-1"
     assert graph_request.available_tools == ()
     assert graph_result.tool_results == (result,)
@@ -202,6 +208,7 @@ def test_contract_types_expose_explicit_annotations() -> None:
     graph_runner_hints = get_type_hints(graph.GraphRunner.run)
 
     assert runtime_request_hints["prompt"] is str
+    assert str(runtime_request_hints["parent_session_id"]) == "str | None"
     assert str(background_task_hints["status"]) == "BackgroundTaskStatus"
     assert tool_result_hints["tool_name"] is str
     assert str(tool_result_hints["status"]) == "ToolResultStatus"

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -424,6 +424,108 @@ def test_runtime_background_task_worker_uses_local_cli_session_when_no_session_i
     assert resumed.output == "background hello"
 
 
+def test_runtime_persists_child_session_lineage_across_list_resume_and_result(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    _ = runtime.run(RuntimeRequest(prompt="leader", session_id="leader-session"))
+
+    child = runtime.run(RuntimeRequest(prompt="child task", parent_session_id="leader-session"))
+    child_session_id = child.session.session.id
+    listed = runtime.list_sessions()
+    resumed = runtime.resume(child_session_id)
+    result = runtime.session_result(session_id=child_session_id)
+
+    assert child_session_id.startswith("session-")
+    assert child.session.session.parent_id == "leader-session"
+    assert listed[0].session.id == child_session_id
+    assert listed[0].session.parent_id == "leader-session"
+    assert resumed.session.session.parent_id == "leader-session"
+    assert result.session.session.parent_id == "leader-session"
+
+
+def test_runtime_rejects_unknown_parent_session_id(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+
+    with pytest.raises(ValueError, match="parent session does not exist: missing-parent"):
+        _ = runtime.run(RuntimeRequest(prompt="child task", parent_session_id="missing-parent"))
+
+
+def test_runtime_rejects_self_parenting_session_request(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+
+    with pytest.raises(ValueError, match="parent_session_id must not match session_id"):
+        _ = runtime.run(
+            RuntimeRequest(
+                prompt="child task",
+                session_id="same-session",
+                parent_session_id="same-session",
+            )
+        )
+
+
+def test_runtime_background_task_preserves_parent_session_lineage(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    _ = runtime.run(RuntimeRequest(prompt="leader", session_id="leader-session"))
+
+    started = runtime.start_background_task(
+        RuntimeRequest(prompt="background child", parent_session_id="leader-session")
+    )
+    completed = _wait_for_background_task(runtime, started.task.id)
+    child_session_id = cast(str, completed.session_id)
+    resumed = runtime.resume(child_session_id)
+
+    assert started.request.parent_session_id == "leader-session"
+    assert child_session_id.startswith("session-")
+    assert child_session_id != "local-cli-session"
+    assert resumed.session.session.parent_id == "leader-session"
+    assert resumed.session.metadata["background_task_id"] == started.task.id
+
+
+def test_runtime_reuses_existing_session_lineage_when_parent_is_omitted(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    _ = runtime.run(RuntimeRequest(prompt="leader", session_id="leader-session"))
+    first_child = runtime.run(
+        RuntimeRequest(
+            prompt="child task",
+            session_id="child-session",
+            parent_session_id="leader-session",
+        )
+    )
+
+    second_child = runtime.run(
+        RuntimeRequest(prompt="child task follow-up", session_id="child-session")
+    )
+
+    assert first_child.session.session.parent_id == "leader-session"
+    assert second_child.session.session.parent_id == "leader-session"
+
+
+def test_runtime_rejects_rebinding_existing_session_to_new_parent(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    _ = runtime.run(RuntimeRequest(prompt="leader one", session_id="leader-one"))
+    _ = runtime.run(RuntimeRequest(prompt="leader two", session_id="leader-two"))
+    _ = runtime.run(
+        RuntimeRequest(
+            prompt="child task",
+            session_id="child-session",
+            parent_session_id="leader-one",
+        )
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="session child-session already belongs to leader-one",
+    ):
+        _ = runtime.run(
+            RuntimeRequest(
+                prompt="child task rebound",
+                session_id="child-session",
+                parent_session_id="leader-two",
+            )
+        )
+
+
 def test_runtime_background_task_worker_allocates_session_id_when_requested_without_explicit_session(  # noqa: E501
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -43,6 +43,7 @@ from voidcode.runtime.permission import PermissionPolicy
 from voidcode.runtime.service import (
     GraphRunRequest,
     RuntimeRequest,
+    RuntimeResponse,
     SessionState,
     VoidCodeRuntime,
 )
@@ -449,6 +450,179 @@ def test_runtime_rejects_unknown_parent_session_id(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="parent session does not exist: missing-parent"):
         _ = runtime.run(RuntimeRequest(prompt="child task", parent_session_id="missing-parent"))
+
+
+def test_runtime_allows_child_session_while_parent_stream_is_active(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+
+    parent_stream = runtime.run_stream(RuntimeRequest(prompt="leader", session_id="leader-session"))
+    first_chunk = next(parent_stream)
+
+    child = runtime.run(RuntimeRequest(prompt="child task", parent_session_id="leader-session"))
+
+    assert first_chunk.session.session.id == "leader-session"
+    assert child.session.session.parent_id == "leader-session"
+    _ = list(parent_stream)
+
+
+def test_runtime_background_task_allows_parent_session_while_stream_is_active(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+
+    parent_stream = runtime.run_stream(RuntimeRequest(prompt="leader", session_id="leader-session"))
+    first_chunk = next(parent_stream)
+    started = runtime.start_background_task(
+        RuntimeRequest(prompt="background child", parent_session_id="leader-session")
+    )
+    completed = _wait_for_background_task(runtime, started.task.id)
+
+    assert first_chunk.session.session.id == "leader-session"
+    assert started.request.parent_session_id == "leader-session"
+    assert completed.parent_session_id == "leader-session"
+    _ = list(parent_stream)
+
+
+def test_runtime_keeps_parent_session_active_until_last_matching_stream_finishes(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+
+    first_stream = runtime.run_stream(
+        RuntimeRequest(prompt="leader one", session_id="leader-session")
+    )
+    second_stream = runtime.run_stream(
+        RuntimeRequest(prompt="leader two", session_id="leader-session")
+    )
+    _ = next(first_stream)
+    _ = next(second_stream)
+
+    _ = list(first_stream)
+    child = runtime.run(RuntimeRequest(prompt="child task", parent_session_id="leader-session"))
+
+    assert child.session.session.parent_id == "leader-session"
+    _ = list(second_stream)
+
+
+def test_runtime_uses_has_session_instead_of_missing_session_error_text(tmp_path: Path) -> None:
+    class _StoreWithNonCanonicalMissingSessionError:
+        def __init__(self) -> None:
+            self.saved_response: RuntimeResponse | None = None
+
+        def save_run(
+            self,
+            *,
+            workspace: Path,
+            request: RuntimeRequest,
+            response: RuntimeResponse,
+            clear_pending_approval: bool = True,
+        ) -> None:
+            _ = workspace, request, clear_pending_approval
+            self.saved_response = response
+
+        def list_sessions(self, *, workspace: Path) -> tuple[object, ...]:
+            _ = workspace
+            return ()
+
+        def has_session(self, *, workspace: Path, session_id: str) -> bool:
+            _ = workspace, session_id
+            return False
+
+        def load_session(self, *, workspace: Path, session_id: str) -> RuntimeResponse:
+            _ = workspace, session_id
+            raise ValueError("session store missing sentinel")
+
+        def load_session_result(self, *, workspace: Path, session_id: str) -> object:
+            _ = workspace, session_id
+            raise AssertionError("load_session_result should not be called")
+
+        def list_notifications(self, *, workspace: Path) -> tuple[object, ...]:
+            _ = workspace
+            return ()
+
+        def acknowledge_notification(self, *, workspace: Path, notification_id: str) -> object:
+            _ = workspace, notification_id
+            raise AssertionError("acknowledge_notification should not be called")
+
+        def save_pending_approval(
+            self,
+            *,
+            workspace: Path,
+            request: RuntimeRequest,
+            response: RuntimeResponse,
+            pending_approval: object,
+        ) -> None:
+            _ = workspace, request, response, pending_approval
+            raise AssertionError("save_pending_approval should not be called")
+
+        def load_pending_approval(self, *, workspace: Path, session_id: str) -> object:
+            _ = workspace, session_id
+            raise AssertionError("load_pending_approval should not be called")
+
+        def clear_pending_approval(self, *, workspace: Path, session_id: str) -> None:
+            _ = workspace, session_id
+
+        def load_resume_checkpoint(self, *, workspace: Path, session_id: str) -> object:
+            _ = workspace, session_id
+            raise AssertionError("load_resume_checkpoint should not be called")
+
+        def create_background_task(self, *, workspace: Path, task: object) -> None:
+            _ = workspace, task
+            raise AssertionError("create_background_task should not be called")
+
+        def load_background_task(self, *, workspace: Path, task_id: str) -> object:
+            _ = workspace, task_id
+            raise AssertionError("load_background_task should not be called")
+
+        def list_background_tasks(self, *, workspace: Path) -> tuple[object, ...]:
+            _ = workspace
+            return ()
+
+        def mark_background_task_running(
+            self,
+            *,
+            workspace: Path,
+            task_id: str,
+            session_id: str,
+        ) -> object:
+            _ = workspace, task_id, session_id
+            raise AssertionError("mark_background_task_running should not be called")
+
+        def mark_background_task_terminal(
+            self,
+            *,
+            workspace: Path,
+            task_id: str,
+            status: str,
+            error: str | None = None,
+        ) -> object:
+            _ = workspace, task_id, status, error
+            raise AssertionError("mark_background_task_terminal should not be called")
+
+        def request_background_task_cancel(self, *, workspace: Path, task_id: str) -> object:
+            _ = workspace, task_id
+            raise AssertionError("request_background_task_cancel should not be called")
+
+        def fail_incomplete_background_tasks(
+            self,
+            *,
+            workspace: Path,
+            message: str,
+        ) -> tuple[object, ...]:
+            _ = workspace, message
+            return ()
+
+    store = _StoreWithNonCanonicalMissingSessionError()
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_BackgroundTaskSuccessGraph(),
+        session_store=cast(Any, store),
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="child task", session_id="fresh-session"))
+
+    assert response.session.session.id == "fresh-session"
+    assert store.saved_response is not None
 
 
 def test_runtime_rejects_self_parenting_session_request(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_session_storage.py
+++ b/tests/unit/runtime/test_session_storage.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from voidcode.runtime.contracts import RuntimeRequest, RuntimeResponse
+from voidcode.runtime.events import EventEnvelope
+from voidcode.runtime.session import SessionRef, SessionState
+from voidcode.runtime.storage import SqliteSessionStore
+from voidcode.runtime.task import (
+    BackgroundTaskRef,
+    BackgroundTaskRequestSnapshot,
+    BackgroundTaskState,
+)
+
+
+def test_session_storage_persists_parent_lineage_across_read_surfaces(tmp_path: Path) -> None:
+    store = SqliteSessionStore()
+    request = RuntimeRequest(
+        prompt="child task",
+        session_id="child-session",
+        parent_session_id="leader-session",
+    )
+    response = RuntimeResponse(
+        session=SessionState(
+            session=SessionRef(id="child-session", parent_id="leader-session"),
+            status="completed",
+            turn=1,
+            metadata={},
+        ),
+        events=(
+            EventEnvelope(
+                session_id="child-session",
+                sequence=1,
+                event_type="graph.response_ready",
+                source="graph",
+            ),
+        ),
+        output="done",
+    )
+
+    store.save_run(workspace=tmp_path, request=request, response=response)
+
+    loaded = store.load_session(workspace=tmp_path, session_id="child-session")
+    listed = store.list_sessions(workspace=tmp_path)
+    result = store.load_session_result(workspace=tmp_path, session_id="child-session")
+    notifications = store.list_notifications(workspace=tmp_path)
+
+    assert loaded.session.session.parent_id == "leader-session"
+    assert listed[0].session.parent_id == "leader-session"
+    assert result.session.session.parent_id == "leader-session"
+    assert notifications[0].session.parent_id == "leader-session"
+
+
+def test_session_storage_migrates_legacy_schema_for_parent_lineage(tmp_path: Path) -> None:
+    database_path = tmp_path / "legacy-sessions.sqlite3"
+    with sqlite3.connect(database_path) as connection:
+        _ = connection.execute(
+            """
+            CREATE TABLE sessions (
+                session_id TEXT PRIMARY KEY,
+                workspace TEXT NOT NULL,
+                status TEXT NOT NULL,
+                turn INTEGER NOT NULL,
+                prompt TEXT NOT NULL,
+                output TEXT,
+                metadata_json TEXT NOT NULL,
+                pending_approval_json TEXT,
+                resume_checkpoint_json TEXT,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                last_event_sequence INTEGER NOT NULL
+            )
+            """
+        )
+        _ = connection.execute(
+            """
+            CREATE TABLE session_events (
+                session_id TEXT NOT NULL,
+                sequence INTEGER NOT NULL,
+                event_type TEXT NOT NULL,
+                source TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                PRIMARY KEY (session_id, sequence)
+            )
+            """
+        )
+        _ = connection.execute(
+            """
+            CREATE TABLE background_tasks (
+                task_id TEXT PRIMARY KEY,
+                workspace TEXT NOT NULL,
+                status TEXT NOT NULL,
+                prompt TEXT NOT NULL,
+                request_session_id TEXT,
+                request_metadata_json TEXT NOT NULL,
+                allocate_session_id INTEGER NOT NULL,
+                session_id TEXT,
+                error TEXT,
+                cancel_requested_at INTEGER,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                started_at INTEGER,
+                finished_at INTEGER
+            )
+            """
+        )
+        _ = connection.execute(
+            """
+            INSERT INTO sessions (
+                session_id, workspace, status, turn, prompt, output, metadata_json,
+                pending_approval_json, resume_checkpoint_json, created_at, updated_at,
+                last_event_sequence
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "legacy-session",
+                str(tmp_path),
+                "completed",
+                1,
+                "legacy",
+                "done",
+                "{}",
+                None,
+                None,
+                1,
+                1,
+                0,
+            ),
+        )
+        _ = connection.execute("PRAGMA user_version = 4")
+        connection.commit()
+
+    store = SqliteSessionStore(database_path=database_path)
+    loaded = store.load_session(workspace=tmp_path, session_id="legacy-session")
+    task = BackgroundTaskState(
+        task=BackgroundTaskRef(id="task-parent-lineage"),
+        request=BackgroundTaskRequestSnapshot(
+            prompt="child background task",
+            parent_session_id="leader-session",
+        ),
+        created_at=1,
+        updated_at=1,
+    )
+
+    store.create_background_task(workspace=tmp_path, task=task)
+    loaded_task = store.load_background_task(
+        workspace=tmp_path,
+        task_id="task-parent-lineage",
+    )
+
+    with sqlite3.connect(database_path) as connection:
+        session_columns = {
+            row[1] for row in connection.execute("PRAGMA table_info(sessions)").fetchall()
+        }
+        background_task_columns = {
+            row[1] for row in connection.execute("PRAGMA table_info(background_tasks)").fetchall()
+        }
+
+    assert loaded.session.session.parent_id is None
+    assert "parent_session_id" in session_columns
+    assert "request_parent_session_id" in background_task_columns
+    assert loaded_task.request.parent_session_id == "leader-session"


### PR DESCRIPTION
## Summary

- add runtime-owned parent-child session lineage to request and session contracts
- persist parent linkage across session storage, replay, session results, notifications, and HTTP serialization
- carry parent lineage through background task snapshots and worker-created child sessions

## Testing

- `uv run ruff check src/voidcode/runtime/contracts.py src/voidcode/runtime/http.py src/voidcode/runtime/service.py src/voidcode/runtime/session.py src/voidcode/runtime/storage.py src/voidcode/runtime/task.py tests/unit/runtime/test_backend_contracts.py tests/unit/runtime/test_runtime_service_extensions.py tests/unit/runtime/test_session_storage.py tests/integration/test_http_transport.py`
- `uv run basedpyright --warnings src`
- `uv run pytest -q -o addopts='' tests/unit/runtime/test_backend_contracts.py tests/unit/runtime/test_background_task_storage.py tests/unit/runtime/test_runtime_service_extensions.py tests/unit/runtime/test_session_storage.py tests/integration/test_http_transport.py`

Closes #140
