### PR TITLE
feat: expand builtin LSP preset catalog

### DIFF
--- a/src/voidcode/lsp/presets.py
+++ b/src/voidcode/lsp/presets.py
@@ -3,6 +3,25 @@ from __future__ import annotations
 from .contracts import LspServerPreset
 
 _PYTHON_ROOT_MARKERS = ("pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", ".git")
+_NODE_ROOT_MARKERS = ("package.json", ".git")
+_RUST_ROOT_MARKERS = ("Cargo.toml", "rust-project.json", ".git")
+_GO_ROOT_MARKERS = ("go.work", "go.mod", ".git")
+_C_CPP_ROOT_MARKERS = ("compile_commands.json", "compile_flags.txt", ".clangd", ".git")
+_JAVA_ROOT_MARKERS = ("pom.xml", "build.gradle", "build.gradle.kts", "settings.gradle", ".git")
+_DOTNET_ROOT_MARKERS = ("global.json", "Directory.Build.props", ".git")
+_RUBY_ROOT_MARKERS = ("Gemfile", ".ruby-version", ".git")
+_PHP_ROOT_MARKERS = ("composer.json", ".git")
+_LUA_ROOT_MARKERS = (".luarc.json", ".luarc.jsonc", ".git")
+_WEB_ROOT_MARKERS = ("package.json", "tsconfig.json", "jsconfig.json", ".git")
+_DOC_ROOT_MARKERS = (".git",)
+_XML_ROOT_MARKERS = ("pom.xml", "build.xml", ".git")
+_TOML_ROOT_MARKERS = ("pyproject.toml", "Cargo.toml", "taplo.toml", ".git")
+_KOTLIN_ROOT_MARKERS = ("build.gradle.kts", "settings.gradle.kts", "pom.xml", ".git")
+_BASH_ROOT_MARKERS = (".git",)
+_DOCKER_ROOT_MARKERS = ("Dockerfile", "docker-compose.yml", "docker-compose.yaml", ".git")
+_CMAKE_ROOT_MARKERS = ("CMakeLists.txt", ".git")
+_ZIG_ROOT_MARKERS = ("build.zig", "zls.json", ".git")
+_TEX_ROOT_MARKERS = ("latexmkrc", ".git")
 
 _BUILTIN_LSP_SERVER_PRESETS: tuple[LspServerPreset, ...] = (
     LspServerPreset(
@@ -20,18 +39,158 @@ _BUILTIN_LSP_SERVER_PRESETS: tuple[LspServerPreset, ...] = (
         root_markers=_PYTHON_ROOT_MARKERS,
     ),
     LspServerPreset(
+        id="bashls",
+        command=("bash-language-server", "start"),
+        extensions=(".sh", ".bash", ".zsh"),
+        languages=("bash", "shell", "zsh"),
+        root_markers=_BASH_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="clangd",
+        command=("clangd",),
+        extensions=(".c", ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp", ".hxx"),
+        languages=("c", "cpp", "objective-c", "objective-cpp"),
+        root_markers=_C_CPP_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="cmake",
+        command=("cmake-language-server",),
+        extensions=(".cmake",),
+        languages=("cmake",),
+        root_markers=_CMAKE_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="cssls",
+        command=("vscode-css-language-server", "--stdio"),
+        extensions=(".css", ".scss", ".less"),
+        languages=("css", "scss", "less"),
+        root_markers=_WEB_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="dockerls",
+        command=("docker-langserver", "--stdio"),
+        extensions=(".dockerfile",),
+        languages=("dockerfile",),
+        root_markers=_DOCKER_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="docker-compose-language-service",
+        command=("docker-compose-langserver", "--stdio"),
+        extensions=(".yml", ".yaml"),
+        languages=("dockercompose", "yaml"),
+        root_markers=("docker-compose.yml", "docker-compose.yaml", ".git"),
+    ),
+    LspServerPreset(
+        id="eslint",
+        command=("vscode-eslint-language-server", "--stdio"),
+        extensions=(".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts"),
+        languages=("javascript", "javascriptreact", "typescript", "typescriptreact"),
+        root_markers=_NODE_ROOT_MARKERS,
+    ),
+    LspServerPreset(
         id="gopls",
         command=("gopls",),
         extensions=(".go",),
         languages=("go",),
-        root_markers=("go.work", "go.mod", ".git"),
+        root_markers=_GO_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="html",
+        command=("vscode-html-language-server", "--stdio"),
+        extensions=(".html", ".htm"),
+        languages=("html",),
+        root_markers=_WEB_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="jsonls",
+        command=("vscode-json-language-server", "--stdio"),
+        extensions=(".json", ".jsonc"),
+        languages=("json", "jsonc"),
+        root_markers=_DOC_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="jdtls",
+        command=("jdtls",),
+        extensions=(".java",),
+        languages=("java",),
+        root_markers=_JAVA_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="kotlin-language-server",
+        command=("kotlin-language-server",),
+        extensions=(".kt", ".kts"),
+        languages=("kotlin",),
+        root_markers=_KOTLIN_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="lemminx",
+        command=("lemminx",),
+        extensions=(".xml", ".xsd", ".xsl", ".xslt", ".svg"),
+        languages=("xml", "xsd", "xsl", "xslt", "svg"),
+        root_markers=_XML_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="lua_ls",
+        command=("lua-language-server",),
+        extensions=(".lua",),
+        languages=("lua",),
+        root_markers=_LUA_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="marksman",
+        command=("marksman", "server"),
+        extensions=(".md", ".markdown", ".mdx"),
+        languages=("markdown", "mdx"),
+        root_markers=_DOC_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="intelephense",
+        command=("intelephense", "--stdio"),
+        extensions=(".php", ".phtml"),
+        languages=("php",),
+        root_markers=_PHP_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="phpactor",
+        command=("phpactor", "language-server"),
+        extensions=(".php", ".phtml"),
+        languages=("php",),
+        root_markers=_PHP_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="ruby-lsp",
+        command=("ruby-lsp",),
+        extensions=(".rb", ".rake", ".gemspec"),
+        languages=("ruby",),
+        root_markers=_RUBY_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="solargraph",
+        command=("solargraph", "stdio"),
+        extensions=(".rb", ".rake", ".gemspec"),
+        languages=("ruby",),
+        root_markers=_RUBY_ROOT_MARKERS,
     ),
     LspServerPreset(
         id="rust-analyzer",
         command=("rust-analyzer",),
         extensions=(".rs",),
         languages=("rust",),
-        root_markers=("Cargo.toml", "rust-project.json", ".git"),
+        root_markers=_RUST_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="taplo",
+        command=("taplo", "lsp", "stdio"),
+        extensions=(".toml",),
+        languages=("toml",),
+        root_markers=_TOML_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="texlab",
+        command=("texlab",),
+        extensions=(".tex", ".bib"),
+        languages=("tex", "bibtex"),
+        root_markers=_TEX_ROOT_MARKERS,
     ),
     LspServerPreset(
         id="tsserver",
@@ -39,6 +198,34 @@ _BUILTIN_LSP_SERVER_PRESETS: tuple[LspServerPreset, ...] = (
         extensions=(".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs"),
         languages=("typescript", "javascript"),
         root_markers=("tsconfig.json", "jsconfig.json", "package.json", ".git"),
+    ),
+    LspServerPreset(
+        id="vue-language-server",
+        command=("vue-language-server", "--stdio"),
+        extensions=(".vue",),
+        languages=("vue",),
+        root_markers=_WEB_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="yamlls",
+        command=("yaml-language-server", "--stdio"),
+        extensions=(".yaml", ".yml"),
+        languages=("yaml",),
+        root_markers=_DOC_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="zls",
+        command=("zls",),
+        extensions=(".zig", ".zon"),
+        languages=("zig",),
+        root_markers=_ZIG_ROOT_MARKERS,
+    ),
+    LspServerPreset(
+        id="csharp-ls",
+        command=("csharp-ls",),
+        extensions=(".cs", ".csx"),
+        languages=("csharp",),
+        root_markers=_DOTNET_ROOT_MARKERS,
     ),
 )
 

--- a/src/voidcode/runtime/lsp.py
+++ b/src/voidcode/runtime/lsp.py
@@ -229,13 +229,16 @@ class ManagedLspManager:
                 stderr=subprocess.DEVNULL,
             )
         except (FileNotFoundError, OSError) as exc:
-            message = f"failed to start LSP server {server_name}: {exc}"
+            message = self._startup_failure_message(
+                server_name=server_name,
+                server_config=server_config,
+                details=str(exc),
+            )
             logger.error(
-                "failed to start LSP server %s in %s with command %s: %s",
-                server_name,
+                "%s (workspace=%s, command=%s)",
+                message,
                 workspace_root,
                 list(server_config.command),
-                exc,
             )
             self._mark_failed(server_name=server_name, error=message)
             self._record_event(
@@ -251,10 +254,14 @@ class ManagedLspManager:
         if process.stdin is None or process.stdout is None:
             process.kill()
             process.wait(timeout=1)
-            message = f"failed to start LSP server {server_name}: missing stdio pipe"
+            message = self._startup_failure_message(
+                server_name=server_name,
+                server_config=server_config,
+                details="missing stdio pipe",
+            )
             logger.error(
-                "failed to start LSP server %s in %s with command %s: missing stdio pipe",
-                server_name,
+                "%s (workspace=%s, command=%s)",
+                message,
                 workspace_root,
                 list(server_config.command),
             )
@@ -381,6 +388,21 @@ class ManagedLspManager:
             status="failed",
             available=False,
             last_error=error,
+        )
+
+    @staticmethod
+    def _startup_failure_message(
+        *,
+        server_name: str,
+        server_config: ResolvedLspServerConfig,
+        details: str,
+    ) -> str:
+        binary_name = server_config.command[0] if server_config.command else server_name
+        config_path = f"lsp.servers.{server_name}.command"
+        return (
+            f"failed to start LSP server {server_name}: {details}. "
+            f"Ensure '{binary_name}' is installed and available on PATH, "
+            f"or override '{config_path}' in .voidcode.json with a custom command."
         )
 
     @staticmethod

--- a/tests/integration/test_lsp_tool_integration.py
+++ b/tests/integration/test_lsp_tool_integration.py
@@ -224,6 +224,7 @@ def test_runtime_managed_lsp_tool_surfaces_failed_startup_state(
 
     assert runtime.current_lsp_state().servers["pyright"].status == "failed"
     assert "failed to start LSP server pyright" in caplog.text
+    assert "installed and available on PATH" in caplog.text
 
 
 def test_runtime_managed_lsp_tool_uses_builtin_root_markers_for_workspace_selection(

--- a/tests/unit/lsp/test_registry.py
+++ b/tests/unit/lsp/test_registry.py
@@ -6,10 +6,29 @@ import pytest
 
 from voidcode.lsp import (
     LspServerConfigOverride,
+    builtin_lsp_server_presets,
     match_lsp_servers_for_path,
     resolve_lsp_server_config,
     resolve_lsp_server_configs,
 )
+
+
+def test_builtin_lsp_preset_catalog_covers_common_languages() -> None:
+    preset_ids = {preset.id for preset in builtin_lsp_server_presets()}
+
+    assert len(preset_ids) >= 20
+    assert {
+        "pyright",
+        "clangd",
+        "gopls",
+        "rust-analyzer",
+        "tsserver",
+        "jdtls",
+        "lua_ls",
+        "yamlls",
+        "bashls",
+        "csharp-ls",
+    }.issubset(preset_ids)
 
 
 def test_resolve_lsp_server_config_uses_builtin_preset_by_server_name() -> None:
@@ -62,6 +81,14 @@ def test_resolve_lsp_server_config_deep_merges_settings() -> None:
     assert config.settings == {
         "python": {"analysis": {"typeCheckingMode": "strict"}},
     }
+
+
+def test_resolve_lsp_server_config_supports_builtin_catalog_entry_for_clangd() -> None:
+    config = resolve_lsp_server_config("clangd", LspServerConfigOverride())
+
+    assert config.command == ("clangd",)
+    assert config.languages == ("c", "cpp", "objective-c", "objective-cpp")
+    assert config.matches_path(Path("main.cpp")) is True
 
 
 def test_resolve_lsp_server_configs_matches_servers_by_extension() -> None:

--- a/tests/unit/runtime/test_lsp.py
+++ b/tests/unit/runtime/test_lsp.py
@@ -155,6 +155,21 @@ def test_build_lsp_manager_accepts_builtin_preset_without_explicit_command() -> 
     assert manager.configuration.resolve("pyright").command == ("pyright-langserver", "--stdio")
 
 
+def test_build_lsp_manager_accepts_extended_builtin_catalog_entry() -> None:
+    manager = build_lsp_manager(
+        RuntimeLspConfig(
+            enabled=True,
+            servers={"clangd": RuntimeLspServerConfig()},
+        )
+    )
+
+    assert isinstance(manager, ManagedLspManager)
+    resolved = manager.configuration.resolve("clangd")
+    assert resolved is not None
+    assert resolved.command == ("clangd",)
+    assert resolved.matches_path(Path("main.cpp")) is True
+
+
 def test_managed_lsp_manager_marks_failed_startup_when_command_is_missing(tmp_path: Path) -> None:
     manager = ManagedLspManager(
         RuntimeLspConfig(
@@ -172,13 +187,15 @@ def test_managed_lsp_manager_marks_failed_startup_when_command_is_missing(tmp_pa
         workspace=tmp_path,
     )
 
-    with pytest.raises(ValueError, match="failed to start LSP server broken"):
+    with pytest.raises(ValueError, match="failed to start LSP server broken") as exc_info:
         _ = manager.request(request)
 
     state = manager.current_state()
     assert state.servers["broken"].status == "failed"
     assert state.servers["broken"].available is False
     assert state.servers["broken"].last_error is not None
+    assert "installed and available on PATH" in str(exc_info.value)
+    assert "lsp.servers.broken.command" in str(exc_info.value)
 
 
 def test_stop_running_server_cleans_up_after_shutdown_timeout(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -233,6 +233,23 @@ def test_runtime_config_accepts_builtin_lsp_preset_without_explicit_command(tmp_
     )
 
 
+def test_runtime_config_accepts_extended_builtin_lsp_catalog_entries(tmp_path: Path) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps({"lsp": {"enabled": True, "servers": {"clangd": {}, "yamlls": {}}}}),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.lsp == RuntimeLspConfig(
+        enabled=True,
+        servers={
+            "clangd": RuntimeLspServerConfig(),
+            "yamlls": RuntimeLspServerConfig(),
+        },
+    )
+
+
 def test_runtime_config_accepts_explicit_lsp_preset_override(tmp_path: Path) -> None:
     runtime_config_path(tmp_path).write_text(
         json.dumps(


### PR DESCRIPTION
## Summary
This PR implements the LSP preset work from issue 111 by expanding VoidCode's builtin server catalog while keeping the existing runtime-managed LSP architecture intact.

## What changed
- add builtin LSP presets for a broader set of common languages and ecosystems
- keep preset activation opt-in through repo-local LSP server config
- preserve custom LSP support through explicit command and preset override flows
- improve managed LSP startup failures with actionable PATH/custom-command guidance
- add unit and integration coverage for the expanded catalog and startup guidance

## Scope
This change is intentionally limited to the LSP capability layer, runtime LSP integration, and issue-related tests.
It does not add personal temp files or cache artifacts to the repository.

## Validation
- python -m ruff check src/voidcode/lsp/presets.py src/voidcode/runtime/lsp.py tests/unit/lsp/test_registry.py tests/unit/runtime/test_runtime_config.py tests/unit/runtime/test_lsp.py tests/integration/test_lsp_tool_integration.py
- python -m pytest tests/unit/lsp/test_registry.py tests/unit/runtime/test_runtime_config.py tests/unit/runtime/test_lsp.py tests/integration/test_lsp_tool_integration.py --basetemp C:\Users\dell\AppData\Local\Temp\voidcode-pytest

close #111 