### PR TITLE
feat(lsp): derive workspace defaults for common projects

### DIFF
--- a/docs/contracts/runtime-config.md
+++ b/docs/contracts/runtime-config.md
@@ -182,7 +182,7 @@ workspace 本地覆盖路径保持为：
 - `acp` 当前只支持 runtime-owned `memory` transport。启用后，运行时会在 run / approval-resume 启动阶段执行 connect + handshake，并在该次运行结束时 disconnect。
 - 如果 `acp` startup / handshake 失败，运行时会将 ACP 状态标记为 `failed`，发出 `runtime.acp_failed`，并使本次运行通过已有失败路径结束；不会静默降级为 disconnected 继续执行。
 - `lsp` 已支持最小的 runtime-managed server 启动与只读工具访问，并且 `lsp.servers` 已可消费内置 preset、extension/language 映射、root markers 与默认 command/preset override merge。
-- 当 repo-local `.voidcode.json` 未显式提供 `lsp` 配置时，运行时现在会为高置信度 workspace 自动推导最小默认值：当前仅覆盖 Python (`pyright`) 与 TypeScript/JavaScript (`tsserver`)，并且只有在对应语言服务器可执行文件存在时才会启用。
+- 当 repo-local `.voidcode.json` 未显式提供 `lsp` 配置时，运行时现在会为高置信度 workspace 自动推导最小默认值：当前覆盖 Python (`pyright`)、TypeScript/JavaScript (`tsserver`)、Go (`gopls`)、Rust (`rust-analyzer`)、C/C++ (`clangd`)、Java (`jdtls`)、Lua (`lua_ls`)、Zig (`zls`) 与 C# (`csharp-ls`)，并且只有在对应语言服务器可执行文件存在时才会启用。
 - 显式的 repo-local `lsp` 配置（包括 `enabled: false`）继续具有最高优先级；自动推导默认值不会覆盖用户已声明的 server 列表或关闭语义。
 
 ## 工作区的引导规则

--- a/docs/contracts/runtime-config.md
+++ b/docs/contracts/runtime-config.md
@@ -181,7 +181,9 @@ workspace 本地覆盖路径保持为：
 - `acp` 作为 runtime 内部 capability 继续存在，但不再属于 repo-local `.voidcode.json` 的用户配置领域；它的运行结果通过 session metadata 中的 `runtime_state` 暴露，而不是进入用户主配置快照 `runtime_config`。
 - `acp` 当前只支持 runtime-owned `memory` transport。启用后，运行时会在 run / approval-resume 启动阶段执行 connect + handshake，并在该次运行结束时 disconnect。
 - 如果 `acp` startup / handshake 失败，运行时会将 ACP 状态标记为 `failed`，发出 `runtime.acp_failed`，并使本次运行通过已有失败路径结束；不会静默降级为 disconnected 继续执行。
-- `lsp` 已支持最小的 runtime-managed server 启动与只读工具访问，但 `lsp.servers` 目前仍然只是一个浅层对象容器，缺少内置 preset、extension/language 映射、root markers 和默认 command/preset override merge 这一层。
+- `lsp` 已支持最小的 runtime-managed server 启动与只读工具访问，并且 `lsp.servers` 已可消费内置 preset、extension/language 映射、root markers 与默认 command/preset override merge。
+- 当 repo-local `.voidcode.json` 未显式提供 `lsp` 配置时，运行时现在会为高置信度 workspace 自动推导最小默认值：当前仅覆盖 Python (`pyright`) 与 TypeScript/JavaScript (`tsserver`)，并且只有在对应语言服务器可执行文件存在时才会启用。
+- 显式的 repo-local `lsp` 配置（包括 `enabled: false`）继续具有最高优先级；自动推导默认值不会覆盖用户已声明的 server 列表或关闭语义。
 
 ## 工作区的引导规则
 

--- a/src/voidcode/lsp/__init__.py
+++ b/src/voidcode/lsp/__init__.py
@@ -5,6 +5,7 @@ from .presets import (
     has_builtin_lsp_server_preset,
 )
 from .registry import (
+    derive_workspace_lsp_defaults,
     match_lsp_servers_for_path,
     resolve_lsp_server_config,
     resolve_lsp_server_configs,
@@ -16,6 +17,7 @@ __all__ = [
     "LspServerPreset",
     "ResolvedLspServerConfig",
     "builtin_lsp_server_presets",
+    "derive_workspace_lsp_defaults",
     "get_builtin_lsp_server_preset",
     "has_builtin_lsp_server_preset",
     "match_lsp_servers_for_path",

--- a/src/voidcode/lsp/registry.py
+++ b/src/voidcode/lsp/registry.py
@@ -81,10 +81,7 @@ def derive_workspace_lsp_defaults(
 ) -> dict[str, LspServerConfigOverride]:
     exists = executable_exists or _default_executable_exists
     derived: dict[str, LspServerConfigOverride] = {}
-    for server_name, markers in (
-        ("pyright", _PYTHON_WORKSPACE_MARKERS),
-        ("tsserver", _TS_WORKSPACE_MARKERS),
-    ):
+    for server_name, markers in _SAFE_IMPLICIT_WORKSPACE_DEFAULTS:
         preset = get_builtin_lsp_server_preset(server_name)
         if preset is None:
             continue
@@ -169,6 +166,34 @@ _PYTHON_WORKSPACE_MARKERS: tuple[str, ...] = (
     "requirements.txt",
 )
 _TS_WORKSPACE_MARKERS: tuple[str, ...] = ("tsconfig.json", "jsconfig.json", "package.json")
+_GO_WORKSPACE_MARKERS: tuple[str, ...] = ("go.work", "go.mod")
+_RUST_WORKSPACE_MARKERS: tuple[str, ...] = ("Cargo.toml", "rust-project.json")
+_CLANGD_WORKSPACE_MARKERS: tuple[str, ...] = (
+    "compile_commands.json",
+    "compile_flags.txt",
+    ".clangd",
+)
+_JAVA_WORKSPACE_MARKERS: tuple[str, ...] = (
+    "pom.xml",
+    "build.gradle",
+    "build.gradle.kts",
+    "settings.gradle",
+)
+_LUA_WORKSPACE_MARKERS: tuple[str, ...] = (".luarc.json", ".luarc.jsonc")
+_ZIG_WORKSPACE_MARKERS: tuple[str, ...] = ("build.zig", "zls.json")
+_CSHARP_WORKSPACE_MARKERS: tuple[str, ...] = ("global.json", "Directory.Build.props")
+
+_SAFE_IMPLICIT_WORKSPACE_DEFAULTS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("pyright", _PYTHON_WORKSPACE_MARKERS),
+    ("tsserver", _TS_WORKSPACE_MARKERS),
+    ("gopls", _GO_WORKSPACE_MARKERS),
+    ("rust-analyzer", _RUST_WORKSPACE_MARKERS),
+    ("clangd", _CLANGD_WORKSPACE_MARKERS),
+    ("jdtls", _JAVA_WORKSPACE_MARKERS),
+    ("lua_ls", _LUA_WORKSPACE_MARKERS),
+    ("zls", _ZIG_WORKSPACE_MARKERS),
+    ("csharp-ls", _CSHARP_WORKSPACE_MARKERS),
+)
 
 
 def _workspace_has_any_marker(workspace: Path, markers: Iterable[str]) -> bool:

--- a/src/voidcode/lsp/registry.py
+++ b/src/voidcode/lsp/registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+import shutil
+from collections.abc import Callable, Iterable, Mapping
 from pathlib import Path
 from typing import cast
 
@@ -73,6 +74,28 @@ def match_lsp_servers_for_path(
     )
 
 
+def derive_workspace_lsp_defaults(
+    workspace: Path,
+    *,
+    executable_exists: Callable[[str], bool] | None = None,
+) -> dict[str, LspServerConfigOverride]:
+    exists = executable_exists or _default_executable_exists
+    derived: dict[str, LspServerConfigOverride] = {}
+    for server_name, markers in (
+        ("pyright", _PYTHON_WORKSPACE_MARKERS),
+        ("tsserver", _TS_WORKSPACE_MARKERS),
+    ):
+        preset = get_builtin_lsp_server_preset(server_name)
+        if preset is None:
+            continue
+        if not _workspace_has_any_marker(workspace, markers):
+            continue
+        if not exists(preset.command[0]):
+            continue
+        derived[server_name] = LspServerConfigOverride()
+    return derived
+
+
 def _resolve_preset(
     *,
     server_name: str,
@@ -137,3 +160,20 @@ def _deep_merge_dicts(
             continue
         merged[key] = value
     return merged
+
+
+_PYTHON_WORKSPACE_MARKERS: tuple[str, ...] = (
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+    "requirements.txt",
+)
+_TS_WORKSPACE_MARKERS: tuple[str, ...] = ("tsconfig.json", "jsconfig.json", "package.json")
+
+
+def _workspace_has_any_marker(workspace: Path, markers: Iterable[str]) -> bool:
+    return any((workspace / marker).exists() for marker in markers)
+
+
+def _default_executable_exists(command: str) -> bool:
+    return shutil.which(command) is not None

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -14,7 +14,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from ..hook.config import FormatterCwdPolicy, RuntimeFormatterPresetConfig, RuntimeHooksConfig
 from ..lsp import LspServerConfigOverride as RuntimeLspServerConfig
-from ..lsp import has_builtin_lsp_server_preset
+from ..lsp import derive_workspace_lsp_defaults, has_builtin_lsp_server_preset
 from ..provider import config as provider_config
 from .permission import PermissionDecision
 
@@ -286,6 +286,7 @@ def load_runtime_config(
     global_config = _load_user_config(environment)
     repo_local = _load_repo_local_config(resolved_workspace, env=environment)
     resolved_tui = _resolve_tui_config(global_config.tui, repo_local.tui)
+    resolved_lsp = repo_local.lsp or _derive_workspace_lsp_config(resolved_workspace)
 
     return RuntimeConfig(
         approval_mode=_resolve_approval_mode(
@@ -311,13 +312,20 @@ def load_runtime_config(
         hooks=repo_local.hooks,
         tools=repo_local.tools,
         skills=repo_local.skills,
-        lsp=repo_local.lsp,
+        lsp=resolved_lsp,
         mcp=repo_local.mcp,
         tui=resolved_tui,
         provider_fallback=repo_local.provider_fallback,
         providers=repo_local.providers,
         plan=repo_local.plan,
     )
+
+
+def _derive_workspace_lsp_config(workspace: Path) -> RuntimeLspConfig | None:
+    derived_servers = derive_workspace_lsp_defaults(workspace)
+    if not derived_servers:
+        return None
+    return RuntimeLspConfig(enabled=True, servers=derived_servers)
 
 
 def _load_repo_local_config(

--- a/tests/unit/lsp/test_registry.py
+++ b/tests/unit/lsp/test_registry.py
@@ -7,6 +7,7 @@ import pytest
 from voidcode.lsp import (
     LspServerConfigOverride,
     builtin_lsp_server_presets,
+    derive_workspace_lsp_defaults,
     match_lsp_servers_for_path,
     resolve_lsp_server_config,
     resolve_lsp_server_configs,
@@ -134,3 +135,33 @@ def test_resolve_lsp_server_config_requires_command_for_unknown_server() -> None
             "custom-python",
             LspServerConfigOverride(),
         )
+
+
+def test_derive_workspace_lsp_defaults_detects_python_workspace(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'demo'\n", encoding="utf-8")
+
+    derived = derive_workspace_lsp_defaults(
+        tmp_path,
+        executable_exists=lambda command: command == "pyright-langserver",
+    )
+
+    assert derived == {"pyright": LspServerConfigOverride()}
+
+
+def test_derive_workspace_lsp_defaults_detects_typescript_workspace(tmp_path: Path) -> None:
+    (tmp_path / "tsconfig.json").write_text("{}\n", encoding="utf-8")
+
+    derived = derive_workspace_lsp_defaults(
+        tmp_path,
+        executable_exists=lambda command: command == "typescript-language-server",
+    )
+
+    assert derived == {"tsserver": LspServerConfigOverride()}
+
+
+def test_derive_workspace_lsp_defaults_skips_missing_executable(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'demo'\n", encoding="utf-8")
+
+    derived = derive_workspace_lsp_defaults(tmp_path, executable_exists=lambda command: False)
+
+    assert derived == {}

--- a/tests/unit/lsp/test_registry.py
+++ b/tests/unit/lsp/test_registry.py
@@ -165,3 +165,134 @@ def test_derive_workspace_lsp_defaults_skips_missing_executable(tmp_path: Path) 
     derived = derive_workspace_lsp_defaults(tmp_path, executable_exists=lambda command: False)
 
     assert derived == {}
+
+
+def test_derive_workspace_lsp_defaults_detects_go_workspace(tmp_path: Path) -> None:
+    (tmp_path / "go.mod").write_text("module example.com/demo\n", encoding="utf-8")
+
+    derived = derive_workspace_lsp_defaults(
+        tmp_path,
+        executable_exists=lambda command: command == "gopls",
+    )
+
+    assert derived == {"gopls": LspServerConfigOverride()}
+
+
+def test_derive_workspace_lsp_defaults_detects_rust_workspace(tmp_path: Path) -> None:
+    (tmp_path / "Cargo.toml").write_text("[package]\nname = 'demo'\n", encoding="utf-8")
+
+    derived = derive_workspace_lsp_defaults(
+        tmp_path,
+        executable_exists=lambda command: command == "rust-analyzer",
+    )
+
+    assert derived == {"rust-analyzer": LspServerConfigOverride()}
+
+
+def test_derive_workspace_lsp_defaults_detects_clangd_workspace(tmp_path: Path) -> None:
+    (tmp_path / "compile_commands.json").write_text("[]\n", encoding="utf-8")
+
+    derived = derive_workspace_lsp_defaults(
+        tmp_path,
+        executable_exists=lambda command: command == "clangd",
+    )
+
+    assert derived == {"clangd": LspServerConfigOverride()}
+
+
+def test_derive_workspace_lsp_defaults_detects_java_workspace(tmp_path: Path) -> None:
+    (tmp_path / "pom.xml").write_text("<project/>\n", encoding="utf-8")
+
+    derived = derive_workspace_lsp_defaults(
+        tmp_path,
+        executable_exists=lambda command: command == "jdtls",
+    )
+
+    assert derived == {"jdtls": LspServerConfigOverride()}
+
+
+def test_derive_workspace_lsp_defaults_detects_lua_workspace(tmp_path: Path) -> None:
+    (tmp_path / ".luarc.json").write_text("{}\n", encoding="utf-8")
+
+    derived = derive_workspace_lsp_defaults(
+        tmp_path,
+        executable_exists=lambda command: command == "lua-language-server",
+    )
+
+    assert derived == {"lua_ls": LspServerConfigOverride()}
+
+
+def test_derive_workspace_lsp_defaults_detects_zig_workspace(tmp_path: Path) -> None:
+    (tmp_path / "build.zig").write_text("pub fn build() void {}\n", encoding="utf-8")
+
+    derived = derive_workspace_lsp_defaults(
+        tmp_path,
+        executable_exists=lambda command: command == "zls",
+    )
+
+    assert derived == {"zls": LspServerConfigOverride()}
+
+
+def test_derive_workspace_lsp_defaults_detects_csharp_workspace(tmp_path: Path) -> None:
+    (tmp_path / "global.json").write_text("{}\n", encoding="utf-8")
+
+    derived = derive_workspace_lsp_defaults(
+        tmp_path,
+        executable_exists=lambda command: command == "csharp-ls",
+    )
+
+    assert derived == {"csharp-ls": LspServerConfigOverride()}
+
+
+def test_derive_workspace_lsp_defaults_does_not_enable_ruff_for_python_workspace(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'demo'\n", encoding="utf-8")
+
+    derived = derive_workspace_lsp_defaults(
+        tmp_path,
+        executable_exists=lambda command: command in {"pyright-langserver", "ruff"},
+    )
+
+    assert derived == {"pyright": LspServerConfigOverride()}
+
+
+def test_derive_workspace_lsp_defaults_does_not_enable_web_auxiliary_servers_from_package_json(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "package.json").write_text("{}\n", encoding="utf-8")
+
+    derived = derive_workspace_lsp_defaults(
+        tmp_path,
+        executable_exists=lambda command: (
+            command
+            in {
+                "typescript-language-server",
+                "vscode-eslint-language-server",
+                "vscode-html-language-server",
+                "vscode-css-language-server",
+                "vue-language-server",
+            }
+        ),
+    )
+
+    assert derived == {"tsserver": LspServerConfigOverride()}
+
+
+def test_derive_workspace_lsp_defaults_does_not_enable_git_only_presets(tmp_path: Path) -> None:
+    (tmp_path / ".git").mkdir()
+
+    derived = derive_workspace_lsp_defaults(
+        tmp_path,
+        executable_exists=lambda command: (
+            command
+            in {
+                "yaml-language-server",
+                "bash-language-server",
+                "marksman",
+                "vscode-json-language-server",
+            }
+        ),
+    )
+
+    assert derived == {}

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -672,6 +672,77 @@ def test_runtime_config_accepts_explicit_lsp_preset_override(tmp_path: Path) -> 
     )
 
 
+def test_runtime_config_derives_python_lsp_defaults_when_workspace_matches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'demo'\n", encoding="utf-8")
+
+    def _derive_defaults(_workspace: Path) -> dict[str, RuntimeLspServerConfig]:
+        return {"pyright": RuntimeLspServerConfig()}
+
+    monkeypatch.setattr(runtime_config, "derive_workspace_lsp_defaults", _derive_defaults)
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.lsp == RuntimeLspConfig(
+        enabled=True,
+        servers={"pyright": RuntimeLspServerConfig()},
+    )
+
+
+def test_runtime_config_derives_typescript_lsp_defaults_when_workspace_matches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "tsconfig.json").write_text("{}\n", encoding="utf-8")
+
+    def _derive_defaults(_workspace: Path) -> dict[str, RuntimeLspServerConfig]:
+        return {"tsserver": RuntimeLspServerConfig()}
+
+    monkeypatch.setattr(runtime_config, "derive_workspace_lsp_defaults", _derive_defaults)
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.lsp == RuntimeLspConfig(
+        enabled=True,
+        servers={"tsserver": RuntimeLspServerConfig()},
+    )
+
+
+def test_runtime_config_keeps_explicit_repo_lsp_config_over_derived_defaults(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps({"lsp": {"enabled": False, "servers": {"pyright": {}}}}),
+        encoding="utf-8",
+    )
+
+    def _derive_defaults(_workspace: Path) -> dict[str, RuntimeLspServerConfig]:
+        return {"tsserver": RuntimeLspServerConfig()}
+
+    monkeypatch.setattr(runtime_config, "derive_workspace_lsp_defaults", _derive_defaults)
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.lsp == RuntimeLspConfig(
+        enabled=False,
+        servers={"pyright": RuntimeLspServerConfig()},
+    )
+
+
+def test_runtime_config_leaves_lsp_unset_when_no_derived_defaults_exist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+
+    def _derive_defaults(_workspace: Path) -> dict[str, RuntimeLspServerConfig]:
+        return {}
+
+    monkeypatch.setattr(runtime_config, "derive_workspace_lsp_defaults", _derive_defaults)
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.lsp is None
+
+
 def test_runtime_config_accepts_single_agent_execution_engine(tmp_path: Path) -> None:
     runtime_config_path(tmp_path).write_text(
         json.dumps({"execution_engine": "single_agent", "model": "opencode/gpt-5.4"}),

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -743,6 +743,60 @@ def test_runtime_config_leaves_lsp_unset_when_no_derived_defaults_exist(
     assert config.lsp is None
 
 
+def test_runtime_config_derives_go_lsp_defaults_when_workspace_matches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "go.mod").write_text("module example.com/demo\n", encoding="utf-8")
+
+    def _derive_defaults(_workspace: Path) -> dict[str, RuntimeLspServerConfig]:
+        return {"gopls": RuntimeLspServerConfig()}
+
+    monkeypatch.setattr(runtime_config, "derive_workspace_lsp_defaults", _derive_defaults)
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.lsp == RuntimeLspConfig(
+        enabled=True,
+        servers={"gopls": RuntimeLspServerConfig()},
+    )
+
+
+def test_runtime_config_derives_rust_lsp_defaults_when_workspace_matches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "Cargo.toml").write_text("[package]\nname = 'demo'\n", encoding="utf-8")
+
+    def _derive_defaults(_workspace: Path) -> dict[str, RuntimeLspServerConfig]:
+        return {"rust-analyzer": RuntimeLspServerConfig()}
+
+    monkeypatch.setattr(runtime_config, "derive_workspace_lsp_defaults", _derive_defaults)
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.lsp == RuntimeLspConfig(
+        enabled=True,
+        servers={"rust-analyzer": RuntimeLspServerConfig()},
+    )
+
+
+def test_runtime_config_derives_java_lsp_defaults_when_workspace_matches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "pom.xml").write_text("<project/>\n", encoding="utf-8")
+
+    def _derive_defaults(_workspace: Path) -> dict[str, RuntimeLspServerConfig]:
+        return {"jdtls": RuntimeLspServerConfig()}
+
+    monkeypatch.setattr(runtime_config, "derive_workspace_lsp_defaults", _derive_defaults)
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.lsp == RuntimeLspConfig(
+        enabled=True,
+        servers={"jdtls": RuntimeLspServerConfig()},
+    )
+
+
 def test_runtime_config_accepts_single_agent_execution_engine(tmp_path: Path) -> None:
     runtime_config_path(tmp_path).write_text(
         json.dumps({"execution_engine": "single_agent", "model": "opencode/gpt-5.4"}),


### PR DESCRIPTION
## Summary
- derive implicit LSP defaults for Python and TS/JS workspaces when repo-local config does not declare `lsp` and the matching language server binary is available
- keep explicit `.voidcode.json` `lsp` settings authoritative, including `enabled: false` and explicit server lists
- document the shipped runtime-config behavior and correct the stale note that claimed builtin preset resolution and merge were still missing

## Verification
- uv run pytest tests/unit/lsp/test_registry.py tests/unit/runtime/test_runtime_config.py tests/unit/runtime/test_lsp.py tests/integration/test_lsp_tool_integration.py
- mise run typecheck