### PR TITLE
feat(runtime): apply minimal leader agent preset slice (#152)

### DIFF
--- a/src/voidcode/graph/single_agent_slice.py
+++ b/src/voidcode/graph/single_agent_slice.py
@@ -118,6 +118,7 @@ class ProviderSingleAgentGraph:
             raw_model=self._provider_model.selection.raw_model,
             provider_name=self._provider_model.selection.provider,
             model_name=self._provider_model.selection.model,
+            agent_preset=cast(dict[str, object] | None, request.metadata.get("agent_preset")),
             attempt=cast(int, request.metadata.get("provider_attempt", 0)),
             abort_signal=cast(SingleAgentAbortSignal, self._abort_signal),
         )

--- a/src/voidcode/provider/protocol.py
+++ b/src/voidcode/provider/protocol.py
@@ -44,6 +44,7 @@ class SingleAgentTurnRequest:
     raw_model: str | None
     provider_name: str | None
     model_name: str | None
+    agent_preset: dict[str, object] | None = None
     attempt: int = 0
     abort_signal: SingleAgentAbortSignal | None = None
 

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -34,6 +34,7 @@ _VALID_APPROVAL_MODES = ("allow", "deny", "ask")
 _VALID_TUI_COMMANDS = ("command_palette", "session_new", "session_resume")
 
 type ExecutionEngineName = Literal["deterministic", "single_agent"]
+type RuntimeAgentPresetId = Literal["leader"]
 
 _VALID_EXECUTION_ENGINES: tuple[ExecutionEngineName, ...] = ("deterministic", "single_agent")
 _TOP_LEVEL_ENV_VARS = (
@@ -182,6 +183,17 @@ class RuntimePlanConfig:
 
 
 @dataclass(frozen=True, slots=True)
+class RuntimeAgentConfig:
+    preset: RuntimeAgentPresetId
+    prompt_profile: str | None = None
+    model: str | None = None
+    execution_engine: ExecutionEngineName | None = None
+    tools: RuntimeToolsConfig | None = None
+    skills: RuntimeSkillsConfig | None = None
+    provider_fallback: RuntimeProviderFallbackConfig | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class RuntimeConfig:
     approval_mode: PermissionDecision = "ask"
     model: str | None = None
@@ -197,6 +209,7 @@ class RuntimeConfig:
     provider_fallback: RuntimeProviderFallbackConfig | None = None
     providers: RuntimeProvidersConfig | None = None
     plan: RuntimePlanConfig | None = None
+    agent: RuntimeAgentConfig | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -215,6 +228,7 @@ class RuntimeConfigOverrides:
     provider_fallback: RuntimeProviderFallbackConfig | None = None
     providers: RuntimeProvidersConfig | None = None
     plan: RuntimePlanConfig | None = None
+    agent: RuntimeAgentConfig | None = None
 
 
 _VALID_TUI_THEME_MODES: tuple[RuntimeTuiThemeMode, ...] = ("auto", "light", "dark")
@@ -287,6 +301,7 @@ def load_runtime_config(
     repo_local = _load_repo_local_config(resolved_workspace, env=environment)
     resolved_tui = _resolve_tui_config(global_config.tui, repo_local.tui)
     resolved_lsp = repo_local.lsp or _derive_workspace_lsp_config(resolved_workspace)
+    resolved_agent = _resolve_agent_config(repo_local.agent)
 
     return RuntimeConfig(
         approval_mode=_resolve_approval_mode(
@@ -318,6 +333,7 @@ def load_runtime_config(
         provider_fallback=repo_local.provider_fallback,
         providers=repo_local.providers,
         plan=repo_local.plan,
+        agent=resolved_agent,
     )
 
 
@@ -390,6 +406,8 @@ def _load_repo_local_config(
 
     raw_plan = payload.get("plan")
     plan = _parse_plan_config(raw_plan)
+    raw_agent = payload.get("agent")
+    agent = _parse_agent_config(raw_agent)
 
     raw_approval_mode = payload.get("approval_mode")
     parsed_approval_mode = _parse_approval_mode(
@@ -412,6 +430,7 @@ def _load_repo_local_config(
         provider_fallback=provider_fallback,
         providers=providers,
         plan=plan,
+        agent=agent,
     )
 
 
@@ -1120,9 +1139,72 @@ def _parse_plan_config(raw_plan: object) -> RuntimePlanConfig | None:
     )
 
 
+def _parse_agent_config(raw_agent: object) -> RuntimeAgentConfig | None:
+    if raw_agent is None:
+        return None
+    if not isinstance(raw_agent, dict):
+        raise ValueError("runtime config field 'agent' must be an object when provided")
+
+    payload = cast(dict[str, object], raw_agent)
+    raw_preset = payload.get("preset")
+    if raw_preset != "leader":
+        raise ValueError("runtime config field 'agent.preset' must be one of: leader")
+
+    prompt_profile = payload.get("prompt_profile")
+    if prompt_profile is not None and (
+        not isinstance(prompt_profile, str) or not prompt_profile.strip()
+    ):
+        raise ValueError("runtime config field 'agent.prompt_profile' must be a non-empty string")
+
+    model = payload.get("model")
+    if model is not None and (not isinstance(model, str) or not model.strip()):
+        raise ValueError("runtime config field 'agent.model' must be a non-empty string")
+
+    execution_engine = _parse_execution_engine(
+        payload.get("execution_engine"),
+        source="runtime config field 'agent.execution_engine'",
+        allow_none=True,
+    )
+
+    provider_fallback = _parse_provider_fallback_config(payload.get("provider_fallback"))
+
+    return RuntimeAgentConfig(
+        preset="leader",
+        prompt_profile=prompt_profile.strip() if isinstance(prompt_profile, str) else None,
+        model=model.strip() if isinstance(model, str) else None,
+        execution_engine=execution_engine,
+        tools=_parse_tools_config(payload.get("tools")),
+        skills=_parse_skills_config(payload.get("skills")),
+        provider_fallback=provider_fallback,
+    )
+
+
+def _resolve_agent_config(agent: RuntimeAgentConfig | None) -> RuntimeAgentConfig | None:
+    if agent is None:
+        return None
+    if agent.preset == "leader":
+        return RuntimeAgentConfig(
+            preset="leader",
+            prompt_profile=agent.prompt_profile or "leader",
+            model=agent.model,
+            execution_engine=agent.execution_engine or "single_agent",
+            tools=agent.tools,
+            skills=agent.skills,
+            provider_fallback=agent.provider_fallback,
+        )
+    return agent
+
+
 def parse_runtime_plan_payload(raw_plan: object, *, source: str) -> RuntimePlanConfig | None:
     try:
         return _parse_plan_config(raw_plan)
+    except ValueError as exc:
+        raise ValueError(f"{source}: {exc}") from exc
+
+
+def parse_runtime_agent_payload(raw_agent: object, *, source: str) -> RuntimeAgentConfig | None:
+    try:
+        return _resolve_agent_config(_parse_agent_config(raw_agent))
     except ValueError as exc:
         raise ValueError(f"{source}: {exc}") from exc
 
@@ -1140,6 +1222,33 @@ def serialize_runtime_plan_config(plan: RuntimePlanConfig | None) -> dict[str, o
     if plan.options is not None:
         payload["options"] = dict(plan.options)
     return payload
+
+
+def serialize_runtime_agent_config(agent: RuntimeAgentConfig | None) -> dict[str, object] | None:
+    if agent is None:
+        return None
+    payload: dict[str, object] = {"preset": agent.preset}
+    if agent.prompt_profile is not None:
+        payload["prompt_profile"] = agent.prompt_profile
+    if agent.model is not None:
+        payload["model"] = agent.model
+    if agent.execution_engine is not None:
+        payload["execution_engine"] = agent.execution_engine
+    if agent.tools is not None:
+        payload["tools"] = {
+            "builtin": None
+            if agent.tools.builtin is None
+            else {"enabled": agent.tools.builtin.enabled},
+            "paths": list(agent.tools.paths) if agent.tools.paths else None,
+        }
+    if agent.skills is not None:
+        payload["skills"] = {
+            "enabled": agent.skills.enabled,
+            "paths": list(agent.skills.paths) if agent.skills.paths else None,
+        }
+    if agent.provider_fallback is not None:
+        payload["provider_fallback"] = serialize_provider_fallback_config(agent.provider_fallback)
+    return {key: value for key, value in payload.items() if value is not None}
 
 
 def _parse_runtime_config_section[TModel: BaseModel](

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -225,6 +225,7 @@ class VoidCodeRuntime:
     _graph: RuntimeGraph
     _graph_override: RuntimeGraph | None
     _config: RuntimeConfig
+    _initial_effective_config: EffectiveRuntimeConfig
     _permission_policy: PermissionPolicy
     _session_store: SessionStore
     _model_provider_registry: ModelProviderRegistry
@@ -305,17 +306,18 @@ class VoidCodeRuntime:
         self._tool_registry = self._base_tool_registry
         self._graph_override = graph
         self._graph_cache = {}
+        self._initial_effective_config = EffectiveRuntimeConfig(
+            approval_mode=self._config.approval_mode,
+            model=initial_model,
+            execution_engine=initial_execution_engine,
+            max_steps=self._config.max_steps,
+            provider_fallback=initial_provider_fallback,
+            plan=self._config.plan,
+            resolved_provider=self._resolved_provider_config,
+            agent=initial_agent,
+        )
         self._graph = graph or self._build_graph_for_engine_from_config(
-            EffectiveRuntimeConfig(
-                approval_mode=self._config.approval_mode,
-                model=initial_model,
-                execution_engine=initial_execution_engine,
-                max_steps=self._config.max_steps,
-                provider_fallback=initial_provider_fallback,
-                plan=self._config.plan,
-                resolved_provider=self._resolved_provider_config,
-                agent=initial_agent,
-            )
+            self._initial_effective_config
         )
         self._permission_policy = permission_policy or PermissionPolicy(
             mode=self._config.approval_mode
@@ -2763,10 +2765,12 @@ class VoidCodeRuntime:
 
         # Reuse self._graph if the session's config matches the runtime's config
         if (
-            effective_config.execution_engine == self._config.execution_engine
-            and effective_config.model == self._config.model
-            and effective_config.max_steps == self._config.max_steps
-            and effective_config.provider_fallback == self._config.provider_fallback
+            effective_config.execution_engine == self._initial_effective_config.execution_engine
+            and effective_config.model == self._initial_effective_config.model
+            and effective_config.max_steps == self._initial_effective_config.max_steps
+            and effective_config.provider_fallback
+            == self._initial_effective_config.provider_fallback
+            and effective_config.agent == self._initial_effective_config.agent
         ):
             return self._graph
 

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -2382,6 +2382,33 @@ class VoidCodeRuntime:
             if agent.provider_fallback is not None
             else resolved.provider_fallback
         )
+        merged_agent = RuntimeAgentConfig(
+            preset=agent.preset,
+            prompt_profile=(
+                agent.prompt_profile
+                if agent.prompt_profile is not None
+                else resolved.agent.prompt_profile
+                if resolved.agent is not None
+                else None
+            ),
+            model=model,
+            execution_engine=execution_engine,
+            tools=(
+                agent.tools
+                if agent.tools is not None
+                else resolved.agent.tools
+                if resolved.agent is not None
+                else None
+            ),
+            skills=(
+                agent.skills
+                if agent.skills is not None
+                else resolved.agent.skills
+                if resolved.agent is not None
+                else None
+            ),
+            provider_fallback=provider_fallback,
+        )
         resolved_provider = resolve_provider_config(
             model,
             provider_fallback,
@@ -2395,7 +2422,7 @@ class VoidCodeRuntime:
             provider_fallback=provider_fallback,
             plan=resolved.plan,
             resolved_provider=resolved_provider,
-            agent=agent,
+            agent=merged_agent,
         )
 
     def _runtime_state_metadata(self) -> dict[str, object]:

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -2343,7 +2343,9 @@ class VoidCodeRuntime:
         }
         if effective_config.model is not None:
             runtime_config_metadata["model"] = effective_config.model
-        runtime_config_metadata["agent"] = serialize_runtime_agent_config(effective_config.agent)
+        serialized_agent = serialize_runtime_agent_config(effective_config.agent)
+        if serialized_agent is not None:
+            runtime_config_metadata["agent"] = serialized_agent
         lsp_state = self._lsp_manager.current_state()
         runtime_config_metadata["lsp"] = {
             "mode": lsp_state.mode,
@@ -2716,6 +2718,8 @@ class VoidCodeRuntime:
                 runtime_config.get("agent"),
                 source="persisted runtime_config.agent",
             )
+        else:
+            agent = None
         persisted_execution_engine = runtime_config.get("execution_engine")
         if persisted_execution_engine in ("deterministic", "single_agent"):
             execution_engine = persisted_execution_engine

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -37,14 +37,17 @@ from ..tools.contracts import Tool, ToolCall, ToolDefinition, ToolResult, ToolRe
 from .acp import AcpAdapter, AcpAdapterState, build_acp_adapter
 from .config import (
     ExecutionEngineName,
+    RuntimeAgentConfig,
     RuntimeConfig,
     RuntimeHooksConfig,
     RuntimePlanConfig,
     RuntimeProviderFallbackConfig,
     load_runtime_config,
     parse_provider_fallback_payload,
+    parse_runtime_agent_payload,
     parse_runtime_plan_payload,
     serialize_provider_fallback_config,
+    serialize_runtime_agent_config,
     serialize_runtime_plan_config,
 )
 from .context_window import ContextWindowPolicy, RuntimeContextWindow, prepare_single_agent_context
@@ -260,9 +263,30 @@ class VoidCodeRuntime:
             model_provider_registry
             or ModelProviderRegistry.with_defaults(provider_configs=self._config.providers)
         )
+        initial_agent = self._config.agent
+        if initial_agent is not None:
+            initial_agent = parse_runtime_agent_payload(
+                serialize_runtime_agent_config(initial_agent),
+                source="runtime config agent",
+            )
+        initial_model = (
+            initial_agent.model
+            if initial_agent is not None and initial_agent.model is not None
+            else self._config.model
+        )
+        initial_execution_engine = (
+            initial_agent.execution_engine
+            if initial_agent is not None and initial_agent.execution_engine is not None
+            else self._config.execution_engine
+        )
+        initial_provider_fallback = (
+            initial_agent.provider_fallback
+            if initial_agent is not None and initial_agent.provider_fallback is not None
+            else self._config.provider_fallback
+        )
         self._resolved_provider_config = resolve_provider_config(
-            self._config.model,
-            self._config.provider_fallback,
+            initial_model,
+            initial_provider_fallback,
             registry=self._model_provider_registry,
         )
         self._provider_model = self._resolved_provider_config.active_target
@@ -284,12 +308,13 @@ class VoidCodeRuntime:
         self._graph = graph or self._build_graph_for_engine_from_config(
             EffectiveRuntimeConfig(
                 approval_mode=self._config.approval_mode,
-                model=self._config.model,
-                execution_engine=self._config.execution_engine,
+                model=initial_model,
+                execution_engine=initial_execution_engine,
                 max_steps=self._config.max_steps,
-                provider_fallback=self._config.provider_fallback,
+                provider_fallback=initial_provider_fallback,
                 plan=self._config.plan,
                 resolved_provider=self._resolved_provider_config,
+                agent=initial_agent,
             )
         )
         self._permission_policy = permission_policy or PermissionPolicy(
@@ -504,6 +529,9 @@ class VoidCodeRuntime:
 
     def _runtime_config_for_request(self, request: RuntimeRequest) -> EffectiveRuntimeConfig:
         resolved = self._effective_runtime_config_from_metadata(None)
+        request_agent = request.metadata.get("agent")
+        if request_agent is not None:
+            resolved = self._config_with_request_agent_override(resolved, request_agent)
         request_max_steps = request.metadata.get("max_steps")
         if request_max_steps is not None:
             if not isinstance(request_max_steps, int) or isinstance(request_max_steps, bool):
@@ -520,6 +548,7 @@ class VoidCodeRuntime:
                 provider_fallback=resolved.provider_fallback,
                 plan=resolved.plan,
                 resolved_provider=resolved.resolved_provider,
+                agent=resolved.agent,
             )
         return resolved
 
@@ -829,6 +858,9 @@ class VoidCodeRuntime:
             ),
             metadata={
                 **planned_metadata,
+                "agent_preset": serialize_runtime_agent_config(
+                    self._effective_runtime_config_from_metadata(session.metadata).agent
+                ),
                 "provider_attempt": 0,
                 "provider_stream": _coerce_bool_like(
                     planned_metadata.get("provider_stream", False),
@@ -1779,6 +1811,9 @@ class VoidCodeRuntime:
             ),
             metadata={
                 **session.metadata,
+                "agent_preset": serialize_runtime_agent_config(
+                    self._effective_runtime_config_from_metadata(session.metadata).agent
+                ),
                 "provider_attempt": cast(int, session.metadata.get("provider_attempt", 0)),
             },
         )
@@ -2308,6 +2343,7 @@ class VoidCodeRuntime:
         }
         if effective_config.model is not None:
             runtime_config_metadata["model"] = effective_config.model
+        runtime_config_metadata["agent"] = serialize_runtime_agent_config(effective_config.agent)
         lsp_state = self._lsp_manager.current_state()
         runtime_config_metadata["lsp"] = {
             "mode": lsp_state.mode,
@@ -2321,6 +2357,42 @@ class VoidCodeRuntime:
             "servers": list(mcp_state.configuration.servers),
         }
         return runtime_config_metadata
+
+    def _config_with_request_agent_override(
+        self,
+        resolved: EffectiveRuntimeConfig,
+        raw_agent: object,
+    ) -> EffectiveRuntimeConfig:
+        agent = parse_runtime_agent_payload(raw_agent, source="request metadata 'agent'")
+        if agent is None:
+            raise ValueError("request metadata 'agent' must be an object when provided")
+        assert agent is not None
+        model = agent.model if agent.model is not None else resolved.model
+        execution_engine = (
+            agent.execution_engine
+            if agent.execution_engine is not None
+            else resolved.execution_engine
+        )
+        provider_fallback = (
+            agent.provider_fallback
+            if agent.provider_fallback is not None
+            else resolved.provider_fallback
+        )
+        resolved_provider = resolve_provider_config(
+            model,
+            provider_fallback,
+            registry=self._model_provider_registry,
+        )
+        return EffectiveRuntimeConfig(
+            approval_mode=resolved.approval_mode,
+            model=model,
+            execution_engine=execution_engine,
+            max_steps=resolved.max_steps,
+            provider_fallback=provider_fallback,
+            plan=resolved.plan,
+            resolved_provider=resolved_provider,
+            agent=agent,
+        )
 
     def _runtime_state_metadata(self) -> dict[str, object]:
         acp_state = self._acp_adapter.current_state()
@@ -2547,7 +2619,34 @@ class VoidCodeRuntime:
         max_steps = self._config.max_steps
         provider_fallback = self._config.provider_fallback
         plan = self._config.plan
-        resolved_provider = self._resolved_provider_config
+        agent = self._config.agent
+        if agent is not None:
+            agent = parse_runtime_agent_payload(
+                serialize_runtime_agent_config(agent),
+                source="runtime config agent",
+            )
+        execution_engine_override = (
+            agent.execution_engine
+            if agent is not None and agent.execution_engine is not None
+            else None
+        )
+        model_override = agent.model if agent is not None and agent.model is not None else None
+        provider_fallback_override = (
+            agent.provider_fallback
+            if agent is not None and agent.provider_fallback is not None
+            else None
+        )
+        if execution_engine_override is not None:
+            execution_engine = execution_engine_override
+        if model_override is not None:
+            model = model_override
+        if provider_fallback_override is not None:
+            provider_fallback = provider_fallback_override
+        resolved_provider = resolve_provider_config(
+            model,
+            provider_fallback,
+            registry=self._model_provider_registry,
+        )
         if metadata is None:
             return EffectiveRuntimeConfig(
                 approval_mode=approval_mode,
@@ -2557,6 +2656,7 @@ class VoidCodeRuntime:
                 provider_fallback=provider_fallback,
                 plan=plan,
                 resolved_provider=resolved_provider,
+                agent=agent,
             )
 
         persisted_runtime_config = metadata.get("runtime_config")
@@ -2569,6 +2669,7 @@ class VoidCodeRuntime:
                 provider_fallback=provider_fallback,
                 plan=plan,
                 resolved_provider=resolved_provider,
+                agent=agent,
             )
 
         runtime_config = cast(dict[str, object], persisted_runtime_config)
@@ -2610,6 +2711,11 @@ class VoidCodeRuntime:
                         str(exc),
                     )
                 ) from exc
+        if "agent" in runtime_config:
+            agent = parse_runtime_agent_payload(
+                runtime_config.get("agent"),
+                source="persisted runtime_config.agent",
+            )
         persisted_execution_engine = runtime_config.get("execution_engine")
         if persisted_execution_engine in ("deterministic", "single_agent"):
             execution_engine = persisted_execution_engine
@@ -2636,6 +2742,7 @@ class VoidCodeRuntime:
             provider_fallback=provider_fallback,
             plan=plan,
             resolved_provider=resolved_provider,
+            agent=agent,
         )
 
     def _provider_chain_for_session_metadata(
@@ -2707,6 +2814,7 @@ class EffectiveRuntimeConfig:
     provider_fallback: RuntimeProviderFallbackConfig | None = None
     plan: RuntimePlanConfig | None = None
     resolved_provider: ResolvedProviderConfig = field(default_factory=ResolvedProviderConfig)
+    agent: RuntimeAgentConfig | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/unit/graph/test_single_agent_slice.py
+++ b/tests/unit/graph/test_single_agent_slice.py
@@ -263,6 +263,42 @@ def test_provider_single_agent_graph_passes_applied_skill_context_to_provider() 
     assert provider.requests[0].context_window.prompt == "read sample.txt"
 
 
+def test_provider_single_agent_graph_forwards_agent_preset_to_provider() -> None:
+    provider_model = resolve_provider_model(
+        "opencode/gpt-5.4",
+        registry=ModelProviderRegistry.with_defaults(),
+    )
+    provider = _CapturingSingleAgentProvider()
+    graph = ProviderSingleAgentGraph(provider=provider, provider_model=provider_model)
+
+    step = graph.step(
+        request=GraphRunRequest(
+            session=_session(),
+            prompt="read sample.txt",
+            available_tools=_tool_definitions(),
+            context_window=RuntimeContextWindow(prompt="read sample.txt"),
+            metadata={
+                "agent_preset": {
+                    "preset": "leader",
+                    "prompt_profile": "leader",
+                    "model": "opencode/gpt-5.4",
+                    "execution_engine": "single_agent",
+                }
+            },
+        ),
+        tool_results=(),
+        session=_session(),
+    )
+
+    assert step.output == "done"
+    assert provider.requests[0].agent_preset == {
+        "preset": "leader",
+        "prompt_profile": "leader",
+        "model": "opencode/gpt-5.4",
+        "execution_engine": "single_agent",
+    }
+
+
 def test_provider_single_agent_graph_forwards_bounded_context_window_to_provider() -> None:
     provider_model = resolve_provider_model(
         "opencode/gpt-5.4",

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -22,6 +22,7 @@ from voidcode.runtime.config import (
     MAX_STEPS_ENV_VAR,
     MODEL_ENV_VAR,
     RUNTIME_CONFIG_FILE_NAME,
+    RuntimeAgentConfig,
     RuntimeFormatterPresetConfig,
     RuntimeHooksConfig,
     RuntimeLspConfig,
@@ -38,9 +39,11 @@ from voidcode.runtime.config import (
     RuntimeTuiThemePreferences,
     effective_runtime_tui_preferences,
     load_runtime_config,
+    parse_runtime_agent_payload,
     runtime_config_path,
     save_global_tui_preferences,
     save_workspace_tui_preferences,
+    serialize_runtime_agent_config,
     user_runtime_config_path,
 )
 
@@ -811,6 +814,66 @@ def test_runtime_config_accepts_single_agent_execution_engine(tmp_path: Path) ->
 
     assert config.execution_engine == "single_agent"
     assert config.model == "opencode/gpt-5.4"
+
+
+def test_runtime_config_parses_leader_agent_preset_from_repo_file(tmp_path: Path) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps(
+            {
+                "agent": {
+                    "preset": "leader",
+                    "model": "opencode/gpt-5.4",
+                    "tools": {"builtin": {"enabled": True}, "paths": [".voidcode/tools"]},
+                    "skills": {"enabled": True, "paths": [".voidcode/skills"]},
+                    "provider_fallback": {
+                        "preferred_model": "opencode/gpt-5.4",
+                        "fallback_models": ["custom/demo"],
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.agent == RuntimeAgentConfig(
+        preset="leader",
+        prompt_profile="leader",
+        model="opencode/gpt-5.4",
+        execution_engine="single_agent",
+        tools=RuntimeToolsConfig(
+            builtin=RuntimeToolsBuiltinConfig(enabled=True),
+            paths=(".voidcode/tools",),
+        ),
+        skills=RuntimeSkillsConfig(enabled=True, paths=(".voidcode/skills",)),
+        provider_fallback=RuntimeProviderFallbackConfig(
+            preferred_model="opencode/gpt-5.4",
+            fallback_models=("custom/demo",),
+        ),
+    )
+
+
+def test_runtime_agent_payload_round_trips_through_serialization() -> None:
+    agent = parse_runtime_agent_payload(
+        {
+            "preset": "leader",
+            "model": "opencode/gpt-5.4",
+            "tools": {"builtin": {"enabled": True}, "paths": [".voidcode/tools"]},
+            "skills": {"enabled": False, "paths": [".voidcode/skills"]},
+        },
+        source="test payload",
+    )
+
+    assert agent is not None
+    assert serialize_runtime_agent_config(agent) == {
+        "preset": "leader",
+        "prompt_profile": "leader",
+        "model": "opencode/gpt-5.4",
+        "execution_engine": "single_agent",
+        "tools": {"builtin": {"enabled": True}, "paths": [".voidcode/tools"]},
+        "skills": {"enabled": False, "paths": [".voidcode/skills"]},
+    }
 
 
 def test_runtime_config_parses_repo_local_max_steps(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -13,6 +13,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from voidcode.graph.read_only_slice import DeterministicReadOnlyGraph
 from voidcode.provider.auth import ProviderAuthAuthorizeRequest
 from voidcode.provider.config import (
     CopilotProviderAuthConfig,
@@ -2353,6 +2354,45 @@ def test_runtime_effective_runtime_config_keeps_persisted_non_agent_sessions_cle
     assert effective.model == "session/model"
     assert effective.execution_engine == "deterministic"
     assert effective.agent is None
+
+
+def test_runtime_graph_selection_avoids_reusing_initial_single_agent_graph(
+    tmp_path: Path,
+) -> None:
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(SingleAgentTurnResult(output="unused"),),
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            agent=RuntimeAgentConfig(
+                preset="leader",
+                model="opencode/gpt-5.4",
+            )
+        ),
+        model_provider_registry=registry,
+    )
+
+    graph = runtime._graph_for_session_metadata(  # pyright: ignore[reportPrivateUsage]
+        {
+            "runtime_config": {
+                "approval_mode": "ask",
+                "execution_engine": "deterministic",
+                "max_steps": 4,
+                "provider_fallback": None,
+                "resolved_provider": None,
+                "plan": None,
+            }
+        }
+    )
+
+    assert graph is not _private_attr(runtime, "_graph")
+    assert isinstance(graph, DeterministicReadOnlyGraph)
 
 
 def test_runtime_effective_runtime_config_uses_request_metadata_max_steps_for_new_runs(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -2788,6 +2788,84 @@ def test_runtime_request_metadata_agent_override_persists_and_restores_agent_con
     )
 
 
+def test_runtime_partial_request_agent_override_preserves_inherited_agent_fields(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "sample.txt").write_text("leader partial override\n", encoding="utf-8")
+    created_providers: list[_ScriptedSingleAgentProvider] = []
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(SingleAgentTurnResult(output="partial override complete"),),
+                created_providers=created_providers,
+            )
+        }
+    )
+    fallback = RuntimeProviderFallbackConfig(
+        preferred_model="opencode/gpt-5.4",
+        fallback_models=("opencode/gpt-5.3",),
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            model="opencode/gpt-5.4",
+            provider_fallback=fallback,
+        ),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(
+        RuntimeRequest(
+            prompt="read sample.txt",
+            session_id="leader-agent-partial-request",
+            metadata={"agent": {"preset": "leader"}},
+        )
+    )
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(model="other/model"),
+        model_provider_registry=registry,
+    )
+    effective = resumed_runtime.effective_runtime_config(session_id="leader-agent-partial-request")
+
+    assert response.session.status == "completed"
+    assert response.output == "partial override complete"
+    assert created_providers
+    assert created_providers[0].requests[0].agent_preset == {
+        "preset": "leader",
+        "prompt_profile": "leader",
+        "model": "opencode/gpt-5.4",
+        "execution_engine": "single_agent",
+        "provider_fallback": {
+            "preferred_model": "opencode/gpt-5.4",
+            "fallback_models": ["opencode/gpt-5.3"],
+        },
+    }
+    runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
+    assert runtime_config["agent"] == {
+        "preset": "leader",
+        "prompt_profile": "leader",
+        "model": "opencode/gpt-5.4",
+        "execution_engine": "single_agent",
+        "provider_fallback": {
+            "preferred_model": "opencode/gpt-5.4",
+            "fallback_models": ["opencode/gpt-5.3"],
+        },
+    }
+    assert effective.execution_engine == "single_agent"
+    assert effective.model == "opencode/gpt-5.4"
+    assert effective.provider_fallback == fallback
+    assert effective.agent == RuntimeAgentConfig(
+        preset="leader",
+        prompt_profile="leader",
+        model="opencode/gpt-5.4",
+        execution_engine="single_agent",
+        provider_fallback=fallback,
+    )
+
+
 def test_runtime_effective_runtime_config_recovers_provider_fallback_chain(tmp_path: Path) -> None:
     sample_file = tmp_path / "sample.txt"
     sample_file.write_text("fallback chain\n", encoding="utf-8")

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -2210,7 +2210,6 @@ def test_runtime_effective_runtime_config_recovers_persisted_max_steps(tmp_path:
         "execution_engine": "deterministic",
         "max_steps": 7,
         "model": "session/model",
-        "agent": None,
         "provider_fallback": None,
         "plan": None,
         "resolved_provider": {
@@ -2324,6 +2323,38 @@ def test_runtime_effective_runtime_config_falls_back_for_legacy_sessions(tmp_pat
     assert effective.max_steps == 9
 
 
+def test_runtime_effective_runtime_config_keeps_persisted_non_agent_sessions_clear_of_fresh_agent_defaults(  # noqa: E501
+    tmp_path: Path,
+) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("non agent session\n", encoding="utf-8")
+
+    initial_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(approval_mode="allow", model="session/model"),
+    )
+    _ = initial_runtime.run(
+        RuntimeRequest(prompt="read sample.txt", session_id="non-agent-session")
+    )
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            model="fresh/model",
+            agent=RuntimeAgentConfig(
+                preset="leader",
+                model="opencode/gpt-5.4",
+            ),
+        ),
+    )
+    effective = resumed_runtime.effective_runtime_config(session_id="non-agent-session")
+
+    assert effective.approval_mode == "allow"
+    assert effective.model == "session/model"
+    assert effective.execution_engine == "deterministic"
+    assert effective.agent is None
+
+
 def test_runtime_effective_runtime_config_uses_request_metadata_max_steps_for_new_runs(
     tmp_path: Path,
 ) -> None:
@@ -2340,7 +2371,6 @@ def test_runtime_effective_runtime_config_uses_request_metadata_max_steps_for_ne
         "approval_mode": "ask",
         "execution_engine": "deterministic",
         "max_steps": 2,
-        "agent": None,
         "provider_fallback": None,
         "plan": None,
         "resolved_provider": None,

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -23,6 +23,7 @@ from voidcode.provider.registry import ModelProviderRegistry
 from voidcode.runtime.acp import DisabledAcpAdapter
 from voidcode.runtime.config import (
     RuntimeAcpConfig,
+    RuntimeAgentConfig,
     RuntimeConfig,
     RuntimeLspConfig,
     RuntimeLspServerConfig,
@@ -196,9 +197,10 @@ class _ScriptedSingleAgentProvider:
     def __init__(self, *, name: str, outcomes: tuple[object, ...]) -> None:
         self.name = name
         self._outcomes = list(outcomes)
+        self.requests: list[SingleAgentTurnRequest] = []
 
     def propose_turn(self, request: object) -> SingleAgentTurnResult:
-        _ = request
+        self.requests.append(cast(SingleAgentTurnRequest, request))
         if not self._outcomes:
             return SingleAgentTurnResult(output="done")
         outcome = self._outcomes.pop(0)
@@ -208,6 +210,7 @@ class _ScriptedSingleAgentProvider:
 
     def stream_turn(self, request: object):
         turn_request = cast(SingleAgentTurnRequest, request)
+        self.requests.append(turn_request)
         if turn_request.abort_signal is not None and turn_request.abort_signal.cancelled:
             return iter(
                 (
@@ -247,9 +250,13 @@ class _ScriptedSingleAgentProvider:
 class _ScriptedModelProvider:
     name: str
     outcomes: tuple[object, ...]
+    created_providers: list[_ScriptedSingleAgentProvider] | None = None
 
     def single_agent_provider(self) -> _ScriptedSingleAgentProvider:
-        return _ScriptedSingleAgentProvider(name=self.name, outcomes=self.outcomes)
+        provider = _ScriptedSingleAgentProvider(name=self.name, outcomes=self.outcomes)
+        if self.created_providers is not None:
+            self.created_providers.append(provider)
+        return provider
 
 
 class _AlwaysFailingModelProvider:
@@ -2203,6 +2210,7 @@ def test_runtime_effective_runtime_config_recovers_persisted_max_steps(tmp_path:
         "execution_engine": "deterministic",
         "max_steps": 7,
         "model": "session/model",
+        "agent": None,
         "provider_fallback": None,
         "plan": None,
         "resolved_provider": {
@@ -2332,6 +2340,7 @@ def test_runtime_effective_runtime_config_uses_request_metadata_max_steps_for_ne
         "approval_mode": "ask",
         "execution_engine": "deterministic",
         "max_steps": 2,
+        "agent": None,
         "provider_fallback": None,
         "plan": None,
         "resolved_provider": None,
@@ -2597,6 +2606,116 @@ def test_runtime_effective_runtime_config_recovers_single_agent_engine(tmp_path:
     assert effective.approval_mode == "allow"
     assert effective.execution_engine == "single_agent"
     assert effective.model == "opencode/gpt-5.4"
+
+
+def test_runtime_agent_config_selects_single_agent_graph_and_persists_agent_metadata(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "sample.txt").write_text("leader config\n", encoding="utf-8")
+    created_providers: list[_ScriptedSingleAgentProvider] = []
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(SingleAgentTurnResult(output="leader complete"),),
+                created_providers=created_providers,
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            agent=RuntimeAgentConfig(
+                preset="leader",
+                model="opencode/gpt-5.4",
+            )
+        ),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(
+        RuntimeRequest(prompt="read sample.txt", session_id="leader-agent-config")
+    )
+    effective = runtime.effective_runtime_config(session_id="leader-agent-config")
+
+    assert response.session.status == "completed"
+    assert response.output == "leader complete"
+    assert created_providers
+    assert created_providers[0].requests[0].agent_preset == {
+        "preset": "leader",
+        "prompt_profile": "leader",
+        "model": "opencode/gpt-5.4",
+        "execution_engine": "single_agent",
+    }
+    runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
+    assert runtime_config["agent"] == {
+        "preset": "leader",
+        "prompt_profile": "leader",
+        "model": "opencode/gpt-5.4",
+        "execution_engine": "single_agent",
+    }
+    assert effective.execution_engine == "single_agent"
+    assert effective.model == "opencode/gpt-5.4"
+    assert effective.agent == RuntimeAgentConfig(
+        preset="leader",
+        prompt_profile="leader",
+        model="opencode/gpt-5.4",
+        execution_engine="single_agent",
+    )
+
+
+def test_runtime_request_metadata_agent_override_persists_and_restores_agent_config(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "sample.txt").write_text("leader override\n", encoding="utf-8")
+    created_providers: list[_ScriptedSingleAgentProvider] = []
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(SingleAgentTurnResult(output="override complete"),),
+                created_providers=created_providers,
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(model="fresh/model"),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(
+        RuntimeRequest(
+            prompt="read sample.txt",
+            session_id="leader-agent-request",
+            metadata={"agent": {"preset": "leader", "model": "opencode/gpt-5.4"}},
+        )
+    )
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(model="other/model"),
+        model_provider_registry=registry,
+    )
+    effective = resumed_runtime.effective_runtime_config(session_id="leader-agent-request")
+
+    assert response.session.status == "completed"
+    assert response.output == "override complete"
+    assert created_providers
+    assert created_providers[0].requests[0].agent_preset == {
+        "preset": "leader",
+        "prompt_profile": "leader",
+        "model": "opencode/gpt-5.4",
+        "execution_engine": "single_agent",
+    }
+    assert effective.execution_engine == "single_agent"
+    assert effective.model == "opencode/gpt-5.4"
+    assert effective.agent == RuntimeAgentConfig(
+        preset="leader",
+        prompt_profile="leader",
+        model="opencode/gpt-5.4",
+        execution_engine="single_agent",
+    )
 
 
 def test_runtime_effective_runtime_config_recovers_provider_fallback_chain(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_session_storage.py
+++ b/tests/unit/runtime/test_session_storage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+from contextlib import closing
 from pathlib import Path
 
 from voidcode.runtime.contracts import RuntimeRequest, RuntimeResponse
@@ -54,7 +55,7 @@ def test_session_storage_persists_parent_lineage_across_read_surfaces(tmp_path: 
 
 def test_session_storage_migrates_legacy_schema_for_parent_lineage(tmp_path: Path) -> None:
     database_path = tmp_path / "legacy-sessions.sqlite3"
-    with sqlite3.connect(database_path) as connection:
+    with closing(sqlite3.connect(database_path)) as connection:
         _ = connection.execute(
             """
             CREATE TABLE sessions (
@@ -149,7 +150,7 @@ def test_session_storage_migrates_legacy_schema_for_parent_lineage(tmp_path: Pat
         task_id="task-parent-lineage",
     )
 
-    with sqlite3.connect(database_path) as connection:
+    with closing(sqlite3.connect(database_path)) as connection:
         session_columns = {
             row[1] for row in connection.execute("PRAGMA table_info(sessions)").fetchall()
         }


### PR DESCRIPTION
close #152
## Summary
- add runtime agent config parsing and normalization for the built-in `leader` preset, including serialization round-trips and repo config coverage
- apply the effective `leader` preset through runtime startup, request overrides, persistence, and restore so the single-agent path is selected consistently
- forward serialized agent preset metadata through the single-agent graph/provider boundary and cover the flow with focused runtime and graph tests

## Verification
- rtk pytest tests/unit/runtime/test_runtime_config.py tests/unit/runtime/test_runtime_service_extensions.py tests/unit/graph/test_single_agent_slice.py