### PR TITLE
feat(agent): add declaration layer for leader config

### DIFF
--- a/src/voidcode/agent/__init__.py
+++ b/src/voidcode/agent/__init__.py
@@ -1,0 +1,12 @@
+from .builtin import LEADER_AGENT_MANIFEST, get_builtin_agent_manifest, list_builtin_agent_manifests
+from .models import AgentExecutionEngineName, AgentManifest, AgentManifestId, AgentMode
+
+__all__ = [
+    "AgentExecutionEngineName",
+    "AgentManifest",
+    "AgentManifestId",
+    "AgentMode",
+    "LEADER_AGENT_MANIFEST",
+    "get_builtin_agent_manifest",
+    "list_builtin_agent_manifests",
+]

--- a/src/voidcode/agent/builtin.py
+++ b/src/voidcode/agent/builtin.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from .models import AgentManifest, AgentManifestId
+
+LEADER_AGENT_MANIFEST = AgentManifest(
+    id="leader",
+    name="Leader",
+    mode="primary",
+    description="Primary user-facing agent preset mapped to the current single-agent path.",
+    prompt_profile="leader",
+    execution_engine="single_agent",
+)
+
+_BUILTIN_AGENT_MANIFESTS: dict[AgentManifestId, AgentManifest] = {
+    LEADER_AGENT_MANIFEST.id: LEADER_AGENT_MANIFEST
+}
+
+
+def get_builtin_agent_manifest(agent_id: str) -> AgentManifest | None:
+    if agent_id not in _BUILTIN_AGENT_MANIFESTS:
+        return None
+    return _BUILTIN_AGENT_MANIFESTS[agent_id]
+
+
+def list_builtin_agent_manifests() -> tuple[AgentManifest, ...]:
+    return tuple(_BUILTIN_AGENT_MANIFESTS.values())

--- a/src/voidcode/agent/models.py
+++ b/src/voidcode/agent/models.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+type AgentManifestId = Literal["leader"]
+type AgentMode = Literal["primary", "subagent", "all"]
+type AgentExecutionEngineName = Literal["deterministic", "single_agent"]
+
+
+@dataclass(frozen=True, slots=True)
+class AgentManifest:
+    id: AgentManifestId
+    name: str
+    mode: AgentMode
+    description: str
+    prompt_profile: str | None = None
+    execution_engine: AgentExecutionEngineName | None = None
+    model_preference: str | None = None
+    tool_allowlist: tuple[str, ...] = ()
+    skill_refs: tuple[str, ...] = ()
+    routing_hints: dict[str, object] = field(default_factory=dict)

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -12,6 +12,7 @@ from typing import Literal, Protocol, cast
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, ValidationInfo, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from ..agent import AgentManifestId, get_builtin_agent_manifest, list_builtin_agent_manifests
 from ..hook.config import FormatterCwdPolicy, RuntimeFormatterPresetConfig, RuntimeHooksConfig
 from ..lsp import LspServerConfigOverride as RuntimeLspServerConfig
 from ..lsp import derive_workspace_lsp_defaults, has_builtin_lsp_server_preset
@@ -34,7 +35,7 @@ _VALID_APPROVAL_MODES = ("allow", "deny", "ask")
 _VALID_TUI_COMMANDS = ("command_palette", "session_new", "session_resume")
 
 type ExecutionEngineName = Literal["deterministic", "single_agent"]
-type RuntimeAgentPresetId = Literal["leader"]
+type RuntimeAgentPresetId = AgentManifestId
 
 _VALID_EXECUTION_ENGINES: tuple[ExecutionEngineName, ...] = ("deterministic", "single_agent")
 _TOP_LEVEL_ENV_VARS = (
@@ -1146,9 +1147,28 @@ def _parse_agent_config(raw_agent: object) -> RuntimeAgentConfig | None:
         raise ValueError("runtime config field 'agent' must be an object when provided")
 
     payload = cast(dict[str, object], raw_agent)
+    if "preset" not in payload:
+        builtin_manifests = list_builtin_agent_manifests()
+        valid_ids = {manifest.id for manifest in builtin_manifests}
+        payload_keys = set(payload)
+        if payload_keys != valid_ids.intersection(payload_keys) or len(payload_keys) != 1:
+            valid_presets = ", ".join(manifest.id for manifest in builtin_manifests)
+            raise ValueError(
+                "runtime config field 'agent' must declare exactly one built-in agent key: "
+                f"{valid_presets}"
+            )
+        matching_id = next(iter(payload_keys))
+        nested_payload = payload.get(matching_id)
+        if not isinstance(nested_payload, dict):
+            raise ValueError(
+                f"runtime config field 'agent.{matching_id}' must be an object when provided"
+            )
+        payload = {"preset": matching_id, **cast(dict[str, object], nested_payload)}
+
     raw_preset = payload.get("preset")
-    if raw_preset != "leader":
-        raise ValueError("runtime config field 'agent.preset' must be one of: leader")
+    if not isinstance(raw_preset, str) or get_builtin_agent_manifest(raw_preset) is None:
+        valid_presets = ", ".join(manifest.id for manifest in list_builtin_agent_manifests())
+        raise ValueError(f"runtime config field 'agent.preset' must be one of: {valid_presets}")
 
     prompt_profile = payload.get("prompt_profile")
     if prompt_profile is not None and (
@@ -1169,7 +1189,7 @@ def _parse_agent_config(raw_agent: object) -> RuntimeAgentConfig | None:
     provider_fallback = _parse_provider_fallback_config(payload.get("provider_fallback"))
 
     return RuntimeAgentConfig(
-        preset="leader",
+        preset=cast(RuntimeAgentPresetId, raw_preset),
         prompt_profile=prompt_profile.strip() if isinstance(prompt_profile, str) else None,
         model=model.strip() if isinstance(model, str) else None,
         execution_engine=execution_engine,
@@ -1182,12 +1202,13 @@ def _parse_agent_config(raw_agent: object) -> RuntimeAgentConfig | None:
 def _resolve_agent_config(agent: RuntimeAgentConfig | None) -> RuntimeAgentConfig | None:
     if agent is None:
         return None
-    if agent.preset == "leader":
+    manifest = get_builtin_agent_manifest(agent.preset)
+    if manifest is not None:
         return RuntimeAgentConfig(
-            preset="leader",
-            prompt_profile=agent.prompt_profile or "leader",
-            model=agent.model,
-            execution_engine=agent.execution_engine or "single_agent",
+            preset=agent.preset,
+            prompt_profile=agent.prompt_profile or manifest.prompt_profile,
+            model=agent.model or manifest.model_preference,
+            execution_engine=agent.execution_engine or manifest.execution_engine,
             tools=agent.tools,
             skills=agent.skills,
             provider_fallback=agent.provider_fallback,

--- a/tests/unit/agent/test_builtin.py
+++ b/tests/unit/agent/test_builtin.py
@@ -1,0 +1,18 @@
+from voidcode.agent import LEADER_AGENT_MANIFEST, get_builtin_agent_manifest, list_builtin_agent_manifests
+
+
+def test_builtin_agent_registry_exposes_leader_manifest() -> None:
+    leader = get_builtin_agent_manifest("leader")
+
+    assert leader == LEADER_AGENT_MANIFEST
+    assert leader is not None
+    assert leader.name == "Leader"
+    assert leader.mode == "primary"
+    assert leader.prompt_profile == "leader"
+    assert leader.execution_engine == "single_agent"
+
+
+def test_builtin_agent_registry_lists_leader_manifest() -> None:
+    manifests = list_builtin_agent_manifests()
+
+    assert manifests == (LEADER_AGENT_MANIFEST,)

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -6,6 +6,7 @@ from typing import cast
 
 import pytest
 
+from voidcode.agent import LEADER_AGENT_MANIFEST, get_builtin_agent_manifest
 from voidcode.provider.config import (
     AnthropicProviderConfig,
     CopilotProviderAuthConfig,
@@ -821,13 +822,14 @@ def test_runtime_config_parses_leader_agent_preset_from_repo_file(tmp_path: Path
         json.dumps(
             {
                 "agent": {
-                    "preset": "leader",
-                    "model": "opencode/gpt-5.4",
-                    "tools": {"builtin": {"enabled": True}, "paths": [".voidcode/tools"]},
-                    "skills": {"enabled": True, "paths": [".voidcode/skills"]},
-                    "provider_fallback": {
-                        "preferred_model": "opencode/gpt-5.4",
-                        "fallback_models": ["custom/demo"],
+                    "leader": {
+                        "model": "opencode/gpt-5.4",
+                        "tools": {"builtin": {"enabled": True}, "paths": [".voidcode/tools"]},
+                        "skills": {"enabled": True, "paths": [".voidcode/skills"]},
+                        "provider_fallback": {
+                            "preferred_model": "opencode/gpt-5.4",
+                            "fallback_models": ["custom/demo"],
+                        },
                     },
                 }
             }
@@ -854,6 +856,28 @@ def test_runtime_config_parses_leader_agent_preset_from_repo_file(tmp_path: Path
     )
 
 
+def test_runtime_config_rejects_agent_maps_without_exactly_one_built_in_key(
+    tmp_path: Path,
+) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps(
+            {
+                "agent": {
+                    "leader": {"model": "opencode/gpt-5.4"},
+                    "unknown": {"model": "custom/demo"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="runtime config field 'agent' must declare exactly one built-in agent key: leader",
+    ):
+        _ = load_runtime_config(tmp_path, env={})
+
+
 def test_runtime_agent_payload_round_trips_through_serialization() -> None:
     agent = parse_runtime_agent_payload(
         {
@@ -874,6 +898,20 @@ def test_runtime_agent_payload_round_trips_through_serialization() -> None:
         "tools": {"builtin": {"enabled": True}, "paths": [".voidcode/tools"]},
         "skills": {"enabled": False, "paths": [".voidcode/skills"]},
     }
+
+
+def test_runtime_agent_payload_resolves_through_builtin_agent_manifest() -> None:
+    manifest = get_builtin_agent_manifest("leader")
+
+    assert manifest == LEADER_AGENT_MANIFEST
+
+    agent = parse_runtime_agent_payload({"preset": "leader"}, source="test payload")
+
+    assert agent == RuntimeAgentConfig(
+        preset="leader",
+        prompt_profile=LEADER_AGENT_MANIFEST.prompt_profile,
+        execution_engine=LEADER_AGENT_MANIFEST.execution_engine,
+    )
 
 
 def test_runtime_config_parses_repo_local_max_steps(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a real `voidcode.agent` declaration layer with a built-in `leader` manifest and registry
- route runtime agent default resolution through that declaration layer instead of hardcoded inline preset defaults
- accept `agent: { leader: { ... } }` for repo/user runtime config while keeping request/session/provider payload shapes unchanged

## Verification
- `rtk pytest tests/unit/runtime/test_runtime_config.py -k \"parses_leader_agent_preset_from_repo_file or rejects_agent_maps_without_exactly_one_built_in_key or agent_payload_resolves_through_builtin_agent_manifest or agent_payload_round_trips\"`
- manual QA: loaded `.voidcode.json` with `{"agent":{"leader":{}}}` and confirmed it resolved to `preset=leader`, `prompt_profile=leader`, `execution_engine=single_agent`
- `mise run check`