### PR TITLE
feat: add session continuity memory slice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ htmlcov/
 .sisyphus/
 .test_venv/
 agent/
+.omx/
+.codex

--- a/docs/memory-strategy.md
+++ b/docs/memory-strategy.md
@@ -251,6 +251,229 @@ VoidCode 当前更应该学习的是：
 3. 为 subagent handoff 定义稳定的 session-scoped 摘要与恢复边界
 4. 等到跨 session 的稳定知识复用真的成为高频需求，再引入长期 memory 层
 
+## 下一步应产出的设计对象
+
+如果当前阶段决定继续推进 memory，最合理的目标不是实现长期 memory，而是把 **Layer 1 / Layer 2** 设计收敛到可执行的 runtime design。
+
+更具体地说，下一步设计对象应当是：
+
+### Design A：Session Continuity Memory
+
+它解决的问题是：
+
+- 单个活跃 session 在 context 变长后如何继续工作
+- compaction 后如何保住执行主线
+- approval / resume 之后如何保持同一条 workstream 的连续性
+
+它不解决：
+
+- 新 session 如何继承长期偏好
+- 项目级长期知识如何跨 session 检索
+- 团队共享知识如何沉淀
+
+### Design B：Handoff / Coordination Memory
+
+它解决的问题是：
+
+- parent / child session 之间需要什么最小摘要
+- background / delegated work 完成后，leader 应该看到什么结构化结果
+- child transcript 如何继续通过现有 `resume(child_session_id)` 路径恢复，而不是复制进 leader session
+
+它不解决：
+
+- 完整 multi-agent orchestration runtime
+- agent-to-agent transport
+- 长期 memory retrieval
+
+## 当前代码基线意味着什么
+
+从当前实现出发，VoidCode 已经拥有以下 memory 相关基础：
+
+- session persistence / replay / resume
+- approval resume checkpoint
+- background task truth 与 parent/child linkage 基线
+- provider-backed execution 中的最小 context window compaction
+- `runtime.memory_refreshed` 事件词汇
+
+但当前缺失同样明确：
+
+- 语义化 compaction（现在只是 last-N tool results 截断）
+- compaction 后的 distilled memory 注入
+- leader-facing background result retrieval / notification 真相
+- 可执行的 skill-based memory distillation 机制
+- cross-session long-term memory store / retrieval / governance
+
+这意味着今天的“memory”不能被理解成一个已经存在的 subsystem；它更像是若干 runtime truth 的空缺交叉点。
+
+## Layer 1：Session Continuity Memory 设计要求
+
+这一层应当建立在现有 `run / stream / resume` 主路径之上，而不是建立第二套旁路状态。
+
+### 目标
+
+- 让长会话在 compaction 后继续可工作
+- 让 provider-backed execution 在上下文收缩后仍能保住当前任务主线
+- 让 approval / resume / replay 继续基于同一份 session truth
+
+### 应拥有的数据
+
+这层应只拥有 **session-scoped、可丢弃、与当前活跃工作直接相关** 的记忆材料，例如：
+
+- 当前任务目标摘要
+- 最近已完成的重要子结论
+- 仍然开放的未完成项
+- 必须保留的约束 / decision log
+- tool results 的 distilled summary，而不是完整原文重复注入
+
+### 不应拥有的数据
+
+这层不应承载：
+
+- 用户长期偏好
+- 项目级长期事实库
+- 历史 session 的完整摘要集合
+- todo / transcript / plan 的全量镜像
+- 与当前 workstream 无关的知识片段
+
+### 刷新触发点
+
+从当前 runtime 模型推导，Layer 1 最合理的刷新触发点应是：
+
+- context window 触发 compaction 时
+- approval wait 进入持久化 checkpoint 前
+- resume 重新进入 provider-backed execution 前
+- 明确的 runtime-owned memory refresh operation（如果后续需要暴露）
+
+其中最关键的一点是：
+
+> memory refresh 必须是 runtime-owned continuation machinery，而不是 provider prompt hack。
+
+### 与当前代码的最小映射
+
+今天最接近这个入口的是：
+
+- `src/voidcode/runtime/context_window.py`
+- `src/voidcode/runtime/service.py` 中对 `RUNTIME_MEMORY_REFRESHED` 的触发
+
+但它们当前只表达“发生了截断”，还没有表达“保留了什么 distilled state”。
+
+因此这一层未来最小实现切片的方向应是：
+
+1. 先把 compaction 从“机械截断”升级为“截断 + distilled summary shape”
+2. 再决定 distilled summary 是如何注入 provider-backed context
+3. 保持 replay / resume / approval semantics 不变
+
+## Layer 2：Handoff / Coordination Memory 设计要求
+
+这一层本质上是 session-scoped coordination memory，而不是 long-term memory。
+
+### 目标
+
+- 为 parent / child session 交接定义最小摘要
+- 让 leader 看见结构化结果，而不是完整 transcript copy
+- 让 delegated/background work 在恢复后仍然可追溯
+
+### 最小数据形状
+
+从 `docs/contracts/background-task-delegation.md` 推导，这层至少需要：
+
+- `task_id`
+- `parent_session_id`
+- `child_session_id`
+- status / approval_blocked
+- `summary_output`
+- result_available / error
+
+这层最重要的边界是：
+
+- parent session 持有 leader-facing notification 与 result summary
+- child session 持有完整 delegated execution history
+- 完整 child transcript 继续通过 `resume(child_session_id)` 恢复
+
+### 非目标
+
+这一层不应演变成：
+
+- 把 child transcript 复制到 parent
+- prompt 文本承载的伪 handoff
+- 客户端本地拼接的通知模型
+- 脱离 runtime truth 的“memory helper”
+
+## 为什么它还不能被当成统一实现项
+
+虽然 Layer 1 / Layer 2 都已经值得设计，但它们的前置条件并不相同，不能被写成同一组依赖。
+
+### Layer 1 的主要前置条件：更真实的 compaction contract
+
+Layer 1 已经拥有部分 substrate：
+
+- session persistence / replay / resume
+- approval resume checkpoint
+- `runtime.memory_refreshed` 事件词汇
+- provider-backed execution 中的最小 context window compaction
+
+但当前 `RuntimeContextWindow` 仍只是 last-N tool result retention。只在这之上谈“memory refreshed”还不够，因为它还没有 distinguished summary shape，也没有 durable injection semantics。
+
+因此，Layer 1 当前真正缺的不是长期 memory store，而是：
+
+- 更语义化的 compaction output
+- 可恢复的 distilled summary shape
+- 与 replay / resume 兼容的 reinjection boundary
+
+### Layer 2 的主要前置条件：Leader-facing background result truth
+
+Layer 2 直接依赖 `docs/contracts/background-task-delegation.md` 中仍处于 proposed 状态的那些能力：
+
+- leader notification
+- background result retrieval
+- parent / child linkage 之上的结构化 summary truth
+- restart / dedupe correctness
+
+当前仓库已经有 raw parent / child linkage 与 `resume(child_session_id)` 路径，但还没有 leader-facing structured result truth。因此 Layer 2 现在可以继续设计，但仍应保持 design-only 表述。
+
+### Skill execution 的位置
+
+如果未来希望 memory refresh / distillation 通过 skill 或相似 capability 参与，那么 `#153` 这类 runtime-managed skill execution 仍然非常重要。
+
+但它更像是：
+
+- Layer 1 的增强器 / 执行载体候选
+- 而不是 Layer 1 设计文档本身的硬前提
+
+也就是说，Layer 1 可以先把 shape 设计清楚；真正实现自动 distillation 时，skill execution 才会成为更直接的依赖。
+
+## 推荐的设计顺序（更新版）
+
+结合当前仓库状态，更稳妥的顺序应当是：
+
+1. 完成 runtime-managed skill execution（让 skill 不再只是 discovery / event / static payload）
+2. 完成 leader-facing background result / notification contract
+3. 基于现有 resume / replay truth，为 Layer 1 设计可持续工作的 compaction memory
+4. 基于 parent / child linkage，为 Layer 2 设计 handoff / coordination memory
+5. 最后才考虑 selective 的 long-term memory
+
+也就是说，memory 设计现在可以继续，但应当**严格以 Layer 1 / Layer 2 为范围**，并且不应被误写成当前主路径已经准备好立即实现 long-term memory。
+
+## 当前阶段最值得产出的文档结果
+
+如果继续推进本方向，当前最值得补出的不是长期 memory API，而是以下两份更具体的设计：
+
+1. `Session Continuity Memory Design`
+   - compaction 输入/输出 shape
+   - refresh trigger
+   - replay / resume compatibility
+   - provider context reinjection boundary
+   - 参考文档：[`session-continuity-memory-design.md`](./session-continuity-memory-design.md)
+   - 详见 [`docs/session-continuity-memory-design.md`](./session-continuity-memory-design.md)
+
+2. `Handoff Memory Contract`
+   - leader-facing summary shape
+   - parent / child ownership
+   - result retrieval vs transcript replay boundary
+   - restart / dedupe / approval-blocked behavior
+
+这两份设计会直接服务于未来 agent runtime 的真实连续性，而不是把精力提前消耗在长期 memory retrieval 上。
+
 ## 非目标
 
 本文档当前**不**主张以下方向：

--- a/docs/session-continuity-memory-design.md
+++ b/docs/session-continuity-memory-design.md
@@ -1,0 +1,269 @@
+# Session Continuity Memory 设计
+
+## 状态
+
+- 状态：proposed
+- 范围：design-only
+- 目标仓库：`voidcode`
+
+## 目的
+
+定义 VoidCode 当前最值得优先设计的 memory 层：**Session Continuity Memory**。
+
+这层 memory 的目标不是跨 session 记住越来越多事情，而是让一个**正在进行中的 workstream** 在以下场景里仍然保持可工作：
+
+- context window 收缩 / compaction
+- approval wait 与 approval resume
+- session replay / resume
+- provider-backed execution 的长会话推进
+
+## 背景
+
+当前仓库已经具备：
+
+- runtime-owned `run / stream / resume` 主路径
+- session persistence / replay / resume truth
+- approval resume checkpoint
+- provider-backed execution 中的最小 context window compaction
+- `runtime.memory_refreshed` 事件词汇
+
+但今天的“memory”仍然只停留在一个非常早期的状态：
+
+- `RuntimeContextWindow` 只会保留最后 N 个 tool results
+- compaction 触发时会发出 `runtime.memory_refreshed`
+- 但 runtime 还不会生成可恢复的 distilled summary
+- 也不会把这种 distilled state 重新注入 provider-backed context
+
+因此，当前最合理的下一步不是 long-term memory，而是先定义：
+
+> compaction 之后，什么信息必须以 runtime-owned 的方式被保留下来，才能让当前 session 继续工作。
+
+## 核心目标
+
+Session Continuity Memory 应满足以下目标：
+
+1. 在 compaction 之后保留当前任务主线，而不是只做机械截断。
+2. 继续服从现有 session truth、replay、resume 与 approval 语义。
+3. 不再发明第二套 execution truth。
+4. 为未来 provider-backed execution 的更长工作流提供稳定 continuation substrate。
+
+## 非目标
+
+本设计**不**覆盖：
+
+- cross-session long-term memory
+- user / project / team memory retrieval
+- multi-agent handoff contract
+- leader-facing background result summary
+- agent-to-agent transport
+- 独立的 memory daemon 或外部 memory service
+
+这些方向要么属于后置层，要么属于另外的设计对象。
+
+## Ownership Boundary
+
+Session Continuity Memory 必须继续由 **runtime** 拥有。
+
+这意味着：
+
+- compaction 的输入/输出语义属于 `runtime/`
+- distilled continuity state 的生成与注入边界属于 `runtime/`
+- replay / resume compatibility 属于 `runtime/`
+- provider context reinjection 属于 runtime execution path
+
+它**不能**由以下位置拥有：
+
+- provider prompt 自行推断
+- hook 脚本
+- Web / TUI / CLI 本地状态
+- future agent preset 文档
+- 外部 memory worker（至少在当前阶段不应作为 authority）
+
+## 当前代码基线
+
+今天最接近这层能力的代码是：
+
+- `src/voidcode/runtime/context_window.py`
+- `src/voidcode/runtime/service.py`
+
+当前行为可概括为：
+
+1. `prepare_single_agent_context()` 接收 prompt 与全部 tool results。
+2. 它根据 `ContextWindowPolicy.max_tool_results` 只保留最后 N 个 tool results。
+3. 如果发生截断，则 `RuntimeContextWindow.compacted == True`。
+4. `runtime/service.py` 在图执行前发出 `runtime.memory_refreshed`。
+
+这里的关键现实是：
+
+> `runtime.memory_refreshed` 目前只是 compaction 发生的信号，不是 memory retrieval 成功的信号。
+
+## 设计对象
+
+Session Continuity Memory 需要补出的不是“记住更多”，而是一个更明确的 **continuity state shape**。
+
+### 建议数据形状
+
+最小 continuity state 应只保存与当前活跃 workstream 直接相关、且在 compaction 后必须保留的内容，例如：
+
+```python
+@dataclass(frozen=True, slots=True)
+class SessionContinuityState:
+    objective_summary: str | None
+    active_constraints: tuple[str, ...]
+    open_questions: tuple[str, ...]
+    completed_milestones: tuple[str, ...]
+    retained_tool_result_refs: tuple[str, ...]
+    distilled_tool_result_summary: str | None
+    source_event_sequence: int | None
+```
+
+### 字段意图
+
+- `objective_summary`
+  - 当前任务的主目标摘要
+- `active_constraints`
+  - 当前仍然必须被遵守的限制条件
+- `open_questions`
+  - 尚未解决、会影响后续执行的问题
+- `completed_milestones`
+  - 已完成且不应在 compaction 后丢失的关键进展
+- `retained_tool_result_refs`
+  - 仍然保留在上下文窗口中的工具结果引用
+- `distilled_tool_result_summary`
+  - 被截断工具结果的压缩摘要，而不是全文重复
+- `source_event_sequence`
+  - 该 continuity state 基于哪个事件序列/上下文片段生成
+
+## 什么能进 continuity state，什么不能进
+
+### 可以进入
+
+- 当前 workstream 的目标与子目标
+- 影响后续执行的关键决策
+- 仍未解决的问题
+- 工具结果中真正会影响下一步动作的 distilled facts
+
+### 不能进入
+
+- 用户长期偏好
+- 项目长期事实库
+- 全量 transcript 镜像
+- todo / plan / tool result 的全文复制
+- 与当前 session 主线无关的探索结果
+
+## 触发点
+
+Session Continuity Memory 最合理的刷新触发点应当是：
+
+1. **Compaction 触发时**
+   - 当前最核心触发点
+2. **Approval wait 进入持久化 checkpoint 前**
+   - 避免 approval resume 后丢失主线
+3. **Resume 重新进入 provider-backed execution 前**
+   - 确保恢复时 continuity state 与当前上下文重新对齐
+4. **显式 runtime-owned refresh operation（后置）**
+   - 只有当 runtime 真正需要显式刷新入口时才考虑暴露
+
+这里最重要的约束是：
+
+> refresh 触发点必须继续服从现有 runtime 主路径，而不是通过独立 worker / client-side helper 私自生成。
+
+## 与 replay / resume 的兼容规则
+
+Session Continuity Memory 不能破坏现有的 replay / resume 契约。
+
+因此它必须满足：
+
+1. `resume(session_id)` 仍然以 session truth 为准。
+2. continuity state 只能作为 session truth 的派生补充，而不是新的 authority。
+3. approval resume checkpoint 的语义不能被 continuity state 替代。
+4. replay 时看到的事件流仍应保持现有模型；continuity refresh 如果被事件化，也必须作为 runtime-owned 事件进入同一条序列。
+
+## 与 provider-backed execution 的边界
+
+Session Continuity Memory 的价值最终必须体现在 provider-backed execution 上，但注入边界必须非常克制。
+
+### 应做的事
+
+- 在 provider 执行前，为当前上下文提供 distilled continuity state
+- 保留仍在窗口中的原始 tool results
+- 让模型在上下文收缩后仍理解“当前在做什么、哪些问题仍开着”
+
+### 不应做的事
+
+- 把 continuity state 当作新的系统 prompt 全量覆盖原上下文
+- 把被截断的 tool results 再完整塞回去
+- 让 provider 自己决定哪些 continuity facts 属于真相
+
+## 建议的演进切片
+
+### Phase 1：定义 continuity state shape
+
+先回答：
+
+- runtime 到底要保留哪些最小 continuity 字段
+- 哪些字段是可恢复且值得进入 session metadata / runtime state 的
+- 哪些字段必须继续只留在完整 transcript 中
+
+### Phase 2：把 compaction 从“截断”升级为“截断 + summary”
+
+让 `RuntimeContextWindow` 或相邻的 runtime-owned data structure 能表达：
+
+- 截断前数量
+- 截断后数量
+- continuity summary payload
+
+### Phase 3：定义 reinjection boundary
+
+明确 continuity state 何时、以什么 shape 进入 provider-backed execution path。
+
+### Phase 4：保持 replay / resume / approval 兼容
+
+任何实现都必须证明：
+
+- replay 语义不变
+- resume 语义不变
+- approval checkpoint 语义不变
+
+## 当前不应做什么
+
+这一层设计当前不应演变成：
+
+- long-term memory store
+- memory retrieval ranking / search
+- team/user/project memory taxonomy
+- future multi-agent handoff summary 的实现替代物
+- background worker 驱动的 memory pipeline
+
+## 与其他工作的关系
+
+### 与 skill execution 的关系
+
+skill execution 不是本设计存在的硬前提，但如果未来希望自动 distillation 通过 skill 参与，它会成为重要增强器。
+
+### 与 handoff memory 的关系
+
+Session Continuity Memory 只解决**当前 session 内部继续工作**的问题。
+
+当问题变成“parent / child session 之间怎么交接”时，就已经进入另一份设计对象：`Handoff / Coordination Memory`。
+
+### 与 long-term memory 的关系
+
+long-term memory 仍然是后置层。它的责任是跨 session recall，而不是当前 session 的 continuity。
+
+## 完成标准
+
+当这层设计足够成熟时，至少应能回答以下问题：
+
+1. compaction 之后，到底保留哪些最小 continuity facts？
+2. 这些 facts 属于 session truth 的哪一层？
+3. 它们何时刷新、何时持久化、何时注入？
+4. 它们如何不破坏 replay / resume / approval？
+5. 为什么这仍然不是 long-term memory？
+
+## 相关文档
+
+- [`memory-strategy.md`](./memory-strategy.md)
+- [`contracts/approval-flow.md`](./contracts/approval-flow.md)
+- [`contracts/background-task-delegation.md`](./contracts/background-task-delegation.md)
+- [`runtime-owned-scheduler-design.md`](./runtime-owned-scheduler-design.md)

--- a/src/voidcode/provider/protocol.py
+++ b/src/voidcode/provider/protocol.py
@@ -33,6 +33,9 @@ class SingleAgentContextWindow(Protocol):
     @property
     def retained_tool_result_count(self) -> int: ...
 
+    @property
+    def continuity_state(self) -> object | None: ...
+
 
 @dataclass(frozen=True, slots=True)
 class SingleAgentTurnRequest:

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -6,12 +6,34 @@ from ..tools.contracts import ToolResult
 
 
 @dataclass(frozen=True, slots=True)
+class RuntimeContinuityState:
+    summary_text: str | None = None
+    dropped_tool_result_count: int = 0
+    retained_tool_result_count: int = 0
+    source: str = "tool_result_window"
+
+    def metadata_payload(self) -> dict[str, object]:
+        return {
+            "summary_text": self.summary_text,
+            "dropped_tool_result_count": self.dropped_tool_result_count,
+            "retained_tool_result_count": self.retained_tool_result_count,
+            "source": self.source,
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class ContextWindowPolicy:
     max_tool_results: int = 4
+    continuity_preview_items: int = 3
+    continuity_preview_chars: int = 80
 
     def __post_init__(self) -> None:
         if self.max_tool_results < 0:
             raise ValueError("max_tool_results must be >= 0")
+        if self.continuity_preview_items < 1:
+            raise ValueError("continuity_preview_items must be >= 1")
+        if self.continuity_preview_chars < 1:
+            raise ValueError("continuity_preview_chars must be >= 1")
 
 
 @dataclass(frozen=True, slots=True)
@@ -23,15 +45,72 @@ class RuntimeContextWindow:
     original_tool_result_count: int = 0
     retained_tool_result_count: int = 0
     max_tool_result_count: int = 0
+    continuity_state: RuntimeContinuityState | None = None
 
     def metadata_payload(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "compacted": self.compacted,
             "compaction_reason": self.compaction_reason,
             "original_tool_result_count": self.original_tool_result_count,
             "retained_tool_result_count": self.retained_tool_result_count,
             "max_tool_result_count": self.max_tool_result_count,
         }
+        if self.continuity_state is not None:
+            payload["continuity_state"] = self.continuity_state.metadata_payload()
+        return payload
+
+
+def _tool_result_preview(result: ToolResult, *, max_preview_chars: int) -> str:
+    parts = [result.tool_name, result.status]
+    path = result.data.get("path")
+    if isinstance(path, str) and path:
+        parts.append(f"path={path}")
+    pattern = result.data.get("pattern")
+    if isinstance(pattern, str) and pattern:
+        parts.append(f"pattern={pattern}")
+    command = result.data.get("command")
+    if isinstance(command, str) and command:
+        parts.append(f"command={command}")
+
+    content = result.content.strip() if result.content else ""
+    error = result.error.strip() if result.error else ""
+    preview_source = content or error
+    if preview_source:
+        clipped = preview_source[:max_preview_chars]
+        if len(preview_source) > max_preview_chars:
+            clipped = f"{clipped}..."
+        preview_label = "content_preview" if content else "error_preview"
+        parts.append(f'{preview_label}="{clipped}"')
+    return " ".join(parts)
+
+
+def _build_continuity_state(
+    *,
+    dropped_results: tuple[ToolResult, ...],
+    retained_count: int,
+    preview_item_limit: int,
+    preview_char_limit: int,
+) -> RuntimeContinuityState:
+    dropped_count = len(dropped_results)
+    if dropped_count == 0:
+        return RuntimeContinuityState(retained_tool_result_count=retained_count)
+
+    preview_count = min(preview_item_limit, dropped_count)
+    lines = [f"Compacted {dropped_count} earlier tool results:"]
+    for index, result in enumerate(dropped_results[:preview_count], start=1):
+        lines.append(
+            f"{index}. {_tool_result_preview(result, max_preview_chars=preview_char_limit)}"
+        )
+    remaining = dropped_count - preview_count
+    if remaining > 0:
+        lines.append(f"... and {remaining} more")
+
+    return RuntimeContinuityState(
+        summary_text="\n".join(lines),
+        dropped_tool_result_count=dropped_count,
+        retained_tool_result_count=retained_count,
+        source="tool_result_window",
+    )
 
 
 def prepare_single_agent_context(
@@ -52,6 +131,7 @@ def prepare_single_agent_context(
 
     retained_count = len(retained_results)
     compacted = retained_count < original_count
+    dropped_results = tool_results[: original_count - retained_count]
 
     return RuntimeContextWindow(
         prompt=prompt,
@@ -61,4 +141,14 @@ def prepare_single_agent_context(
         original_tool_result_count=original_count,
         retained_tool_result_count=retained_count,
         max_tool_result_count=effective_policy.max_tool_results,
+        continuity_state=(
+            _build_continuity_state(
+                dropped_results=dropped_results,
+                retained_count=retained_count,
+                preview_item_limit=effective_policy.continuity_preview_items,
+                preview_char_limit=effective_policy.continuity_preview_chars,
+            )
+            if compacted
+            else None
+        ),
     )

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -50,7 +50,12 @@ from .config import (
     serialize_runtime_agent_config,
     serialize_runtime_plan_config,
 )
-from .context_window import ContextWindowPolicy, RuntimeContextWindow, prepare_single_agent_context
+from .context_window import (
+    ContextWindowPolicy,
+    RuntimeContextWindow,
+    RuntimeContinuityState,
+    prepare_single_agent_context,
+)
 from .contracts import (
     RuntimeNotification,
     RuntimeRequest,
@@ -257,6 +262,7 @@ class VoidCodeRuntime:
         lsp_manager: LspManager | None = None,
         mcp_manager: McpManager | None = None,
         acp_adapter: AcpAdapter | None = None,
+        context_window_policy: ContextWindowPolicy | None = None,
     ) -> None:
         self._workspace = workspace.resolve()
         self._config = config or load_runtime_config(self._workspace)
@@ -328,6 +334,7 @@ class VoidCodeRuntime:
         self._plan_contributor = build_plan_contributor(self._workspace, self._config.plan)
         self._background_task_threads = {}
         self._background_tasks_reconciled = False
+        self._default_context_window_policy = context_window_policy or ContextWindowPolicy()
 
     def __enter__(self) -> VoidCodeRuntime:
         return self
@@ -911,6 +918,7 @@ class VoidCodeRuntime:
         tool_results: list[ToolResult],
         approval_resolution: tuple[PendingApproval, PermissionResolution] | None = None,
         permission_policy: PermissionPolicy | None = None,
+        preserved_continuity_state: RuntimeContinuityState | None = None,
     ) -> Iterator[RuntimeStreamChunk]:
         active_permission_policy = permission_policy or self._permission_policy
         provider_attempt = cast(int, graph_request.metadata.get("provider_attempt", 0))
@@ -920,6 +928,17 @@ class VoidCodeRuntime:
                 tool_results=tuple(tool_results),
                 session_metadata=session.metadata,
             )
+            if preserved_continuity_state is not None:
+                context_window = RuntimeContextWindow(
+                    prompt=context_window.prompt,
+                    tool_results=context_window.tool_results,
+                    compacted=context_window.compacted,
+                    compaction_reason=context_window.compaction_reason,
+                    original_tool_result_count=context_window.original_tool_result_count,
+                    retained_tool_result_count=context_window.retained_tool_result_count,
+                    max_tool_result_count=context_window.max_tool_result_count,
+                    continuity_state=preserved_continuity_state,
+                )
             session = self._session_with_context_window_metadata(session, context_window)
             graph_request = GraphRunRequest(
                 session=session,
@@ -929,7 +948,7 @@ class VoidCodeRuntime:
                 context_window=context_window,
                 metadata=graph_request.metadata,
             )
-            if context_window.compacted:
+            if context_window.compacted and preserved_continuity_state is None:
                 sequence += 1
                 yield RuntimeStreamChunk(
                     kind="event",
@@ -944,6 +963,11 @@ class VoidCodeRuntime:
                             "original_tool_result_count": context_window.original_tool_result_count,
                             "retained_tool_result_count": context_window.retained_tool_result_count,
                             "compacted": True,
+                            "continuity_state": (
+                                context_window.continuity_state.metadata_payload()
+                                if context_window.continuity_state is not None
+                                else None
+                            ),
                         },
                     ),
                 )
@@ -1293,7 +1317,13 @@ class VoidCodeRuntime:
                     sequence=sequence,
                     event_type="runtime.tool_completed",
                     source="tool",
-                    payload=tool_result.data,
+                    payload={
+                        "tool": tool_result.tool_name,
+                        "status": tool_result.status,
+                        "content": tool_result.content,
+                        "error": tool_result.error,
+                        **tool_result.data,
+                    },
                 ),
             )
 
@@ -1801,6 +1831,8 @@ class VoidCodeRuntime:
                         )
                     )
 
+        preserved_continuity_state = self._continuity_state_from_session_metadata(session.metadata)
+
         graph_request = GraphRunRequest(
             session=session,
             prompt=prompt,
@@ -1902,6 +1934,7 @@ class VoidCodeRuntime:
                 tool_results=tool_results,
                 approval_resolution=(pending, approval_decision),
                 permission_policy=self._permission_policy_for_session(session.metadata),
+                preserved_continuity_state=preserved_continuity_state,
             ):
                 if deferred_startup_acp_events and (
                     (
@@ -2225,9 +2258,46 @@ class VoidCodeRuntime:
         )
 
     @staticmethod
+    def _continuity_state_from_session_metadata(
+        session_metadata: dict[str, object],
+    ) -> RuntimeContinuityState | None:
+        runtime_state = session_metadata.get("runtime_state")
+        if not isinstance(runtime_state, dict):
+            return None
+        runtime_state_payload = cast(dict[str, object], runtime_state)
+        continuity = runtime_state_payload.get("continuity")
+        if not isinstance(continuity, dict):
+            return None
+        continuity_payload = cast(dict[str, object], continuity)
+        summary_text = continuity_payload.get("summary_text")
+        dropped = continuity_payload.get("dropped_tool_result_count")
+        retained = continuity_payload.get("retained_tool_result_count")
+        source = continuity_payload.get("source")
+        if summary_text is not None and not isinstance(summary_text, str):
+            return None
+        if not isinstance(dropped, int) or isinstance(dropped, bool):
+            return None
+        if not isinstance(retained, int) or isinstance(retained, bool):
+            return None
+        if not isinstance(source, str):
+            return None
+        return RuntimeContinuityState(
+            summary_text=summary_text,
+            dropped_tool_result_count=dropped,
+            retained_tool_result_count=retained,
+            source=source,
+        )
+
+    @staticmethod
     def _session_with_context_window_metadata(
         session: SessionState, context_window: RuntimeContextWindow
     ) -> SessionState:
+        runtime_state = cast(dict[str, object], session.metadata.get("runtime_state", {}))
+        continuity_payload = (
+            context_window.continuity_state.metadata_payload()
+            if context_window.continuity_state is not None
+            else None
+        )
         return SessionState(
             session=session.session,
             status=session.status,
@@ -2235,6 +2305,12 @@ class VoidCodeRuntime:
             metadata={
                 **session.metadata,
                 "context_window": context_window.metadata_payload(),
+                "runtime_state": {
+                    **runtime_state,
+                    **(
+                        {"continuity": continuity_payload} if continuity_payload is not None else {}
+                    ),
+                },
             },
         )
 

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -365,7 +365,7 @@ class VoidCodeRuntime:
         elif isinstance(runtime_state, dict):
             runtime_state_metadata = dict(cast(dict[str, object], runtime_state))
         else:
-            return metadata
+            runtime_state_metadata = {}
         runtime_state_metadata["acp"] = {
             "mode": acp_state.mode,
             "configured_enabled": acp_state.configuration.configured_enabled,
@@ -1820,17 +1820,19 @@ class VoidCodeRuntime:
             tool_results = []
             for event in stored.events:
                 if event.event_type == "runtime.tool_completed":
-                    is_err = "error" in event.payload
+                    error_value = event.payload.get("error")
+                    is_err = error_value is not None
                     tool_results.append(
                         ToolResult(
                             tool_name=str(event.payload.get("tool", "unknown")),
                             content=str(event.payload.get("content", "")) if not is_err else None,
                             status="error" if is_err else "ok",
                             data=event.payload,
-                            error=str(event.payload["error"]) if is_err else None,
+                            error=str(error_value) if is_err else None,
                         )
                     )
 
+        session = self._session_with_current_acp_metadata(session)
         preserved_continuity_state = self._continuity_state_from_session_metadata(session.metadata)
 
         graph_request = GraphRunRequest(
@@ -2292,7 +2294,12 @@ class VoidCodeRuntime:
     def _session_with_context_window_metadata(
         session: SessionState, context_window: RuntimeContextWindow
     ) -> SessionState:
-        runtime_state = cast(dict[str, object], session.metadata.get("runtime_state", {}))
+        raw_runtime_state = session.metadata.get("runtime_state")
+        runtime_state = (
+            dict(cast(dict[str, object], raw_runtime_state))
+            if isinstance(raw_runtime_state, dict)
+            else {}
+        )
         continuity_payload = (
             context_window.continuity_state.metadata_payload()
             if context_window.continuity_state is not None

--- a/src/voidcode/runtime/storage.py
+++ b/src/voidcode/runtime/storage.py
@@ -575,14 +575,21 @@ class SqliteSessionStore:
             if event.event_type != "runtime.tool_completed":
                 continue
             payload = event.payload
-            is_err = "error" in payload
+            raw_status = payload.get("status")
+            is_err = raw_status == "error"
+            if raw_status not in {"ok", "error"}:
+                is_err = payload.get("error") is not None
+            raw_content = payload.get("content")
+            raw_error = payload.get("error")
             tool_results.append(
                 {
                     "tool_name": str(payload.get("tool", "unknown")),
-                    "content": str(payload.get("content", "")) if not is_err else None,
+                    "content": (
+                        str(raw_content) if raw_content is not None and not is_err else None
+                    ),
                     "status": "error" if is_err else "ok",
                     "data": payload,
-                    "error": str(payload["error"]) if is_err else None,
+                    "error": str(raw_error) if raw_error is not None and is_err else None,
                 }
             )
         return tool_results

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -1883,6 +1883,52 @@ def test_runtime_resume_accepts_legacy_sessions_without_runtime_config_metadata(
     }
 
 
+def test_runtime_resume_repairs_legacy_non_dict_runtime_state_metadata(tmp_path: Path) -> None:
+    runtime_request, runtime = _approval_runtime(tmp_path, mode="ask")
+    waiting = runtime.run(
+        runtime_request(prompt="write danger.txt approved later", session_id="legacy-runtime-state")
+    )
+    approval_request_id = cast(str, waiting.events[-1].payload["request_id"])
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        row = cast(
+            tuple[str],
+            connection.execute(
+                "SELECT metadata_json FROM sessions WHERE session_id = ?",
+                ("legacy-runtime-state",),
+            ).fetchone(),
+        )
+        metadata = cast(dict[str, object], json.loads(row[0]))
+        metadata["runtime_state"] = "broken"
+        _ = connection.execute(
+            "UPDATE sessions SET metadata_json = ? WHERE session_id = ?",
+            (json.dumps(metadata, sort_keys=True), "legacy-runtime-state"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    replay = runtime.resume(
+        "legacy-runtime-state",
+        approval_request_id=approval_request_id,
+        approval_decision="allow",
+    )
+
+    assert replay.session.status == "completed"
+    assert replay.output == "approved later"
+    assert replay.session.metadata["runtime_state"] == {
+        "acp": {
+            "available": False,
+            "configured_enabled": False,
+            "last_error": None,
+            "mode": "disabled",
+            "status": "disconnected",
+        }
+    }
+
+
 def test_runtime_denies_non_read_only_tool_on_resume(tmp_path: Path) -> None:
     runtime_request, runtime = _approval_runtime(tmp_path, mode="ask")
 

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -1360,6 +1360,10 @@ def test_runtime_executes_grep_read_only_slice_and_emits_events(tmp_path: Path) 
         "path": "sample.txt",
     }
     assert result.events[7].payload == {
+        "tool": "grep",
+        "status": "ok",
+        "content": "Found 2 match(es) for 'alpha' in sample.txt\n1: alpha\n2: beta alpha",
+        "error": None,
         "path": "sample.txt",
         "pattern": "alpha",
         "match_count": 2,
@@ -1558,6 +1562,10 @@ def test_runtime_resumes_multi_step_loop_with_approval_and_stable_replay(tmp_pat
         (event.sequence, event.event_type, event.payload) for event in resumed.events
     ]
     assert resumed.events[24].payload == {
+        "tool": "grep",
+        "status": "ok",
+        "content": "Found 1 match(es) for 'copied' in copied.txt\n1: copied marker",
+        "error": None,
         "path": "copied.txt",
         "pattern": "copied",
         "match_count": 1,

--- a/tests/unit/graph/test_single_agent_slice.py
+++ b/tests/unit/graph/test_single_agent_slice.py
@@ -6,7 +6,7 @@ from voidcode.graph.contracts import GraphRunRequest
 from voidcode.graph.single_agent_slice import ProviderSingleAgentGraph
 from voidcode.provider.registry import ModelProviderRegistry
 from voidcode.provider.resolution import resolve_provider_model
-from voidcode.runtime.context_window import RuntimeContextWindow
+from voidcode.runtime.context_window import RuntimeContextWindow, RuntimeContinuityState
 from voidcode.runtime.session import SessionRef, SessionState
 from voidcode.runtime.single_agent_provider import (
     ProviderExecutionError,
@@ -321,6 +321,16 @@ def test_provider_single_agent_graph_forwards_bounded_context_window_to_provider
         compaction_reason="tool_result_window",
         original_tool_result_count=3,
         retained_tool_result_count=1,
+        continuity_state=RuntimeContinuityState(
+            summary_text=(
+                "Compacted 2 earlier tool results:\n"
+                '1. read_file ok path=sample.txt content_preview="old\\n"\n'
+                '2. read_file ok path=sample.txt content_preview="older\\n"'
+            ),
+            dropped_tool_result_count=2,
+            retained_tool_result_count=1,
+            source="tool_result_window",
+        ),
     )
 
     _ = graph.step(
@@ -344,6 +354,16 @@ def test_provider_single_agent_graph_forwards_bounded_context_window_to_provider
     assert provider.requests[0].context_window is bounded_context
     assert provider.requests[0].context_window.compacted is True
     assert provider.requests[0].context_window.retained_tool_result_count == 1
+    assert provider.requests[0].context_window.continuity_state == RuntimeContinuityState(
+        summary_text=(
+            "Compacted 2 earlier tool results:\n"
+            '1. read_file ok path=sample.txt content_preview="old\\n"\n'
+            '2. read_file ok path=sample.txt content_preview="older\\n"'
+        ),
+        dropped_tool_result_count=2,
+        retained_tool_result_count=1,
+        source="tool_result_window",
+    )
 
 
 def test_provider_single_agent_graph_enforces_configured_max_steps() -> None:

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -28,6 +28,7 @@ def test_prepare_single_agent_context_keeps_results_within_limit() -> None:
     assert context.original_tool_result_count == 2
     assert context.retained_tool_result_count == 2
     assert context.max_tool_result_count == 3
+    assert context.continuity_state is None
 
 
 def test_prepare_single_agent_context_compacts_old_results_and_reports_metadata() -> None:
@@ -44,3 +45,37 @@ def test_prepare_single_agent_context_compacts_old_results_and_reports_metadata(
     assert context.original_tool_result_count == 4
     assert context.retained_tool_result_count == 2
     assert context.max_tool_result_count == 2
+    assert context.continuity_state is not None
+    assert context.continuity_state.dropped_tool_result_count == 2
+    assert context.continuity_state.retained_tool_result_count == 2
+    assert context.continuity_state.source == "tool_result_window"
+    assert context.continuity_state.summary_text is not None
+    assert "Compacted 2 earlier tool results:" in context.continuity_state.summary_text
+    assert 'content_preview="content-1"' in context.continuity_state.summary_text
+    assert 'content_preview="content-2"' in context.continuity_state.summary_text
+    assert context.metadata_payload()["continuity_state"] == {
+        "summary_text": context.continuity_state.summary_text,
+        "dropped_tool_result_count": 2,
+        "retained_tool_result_count": 2,
+        "source": "tool_result_window",
+    }
+
+
+def test_prepare_single_agent_context_uses_explicit_continuity_preview_policy() -> None:
+    context = prepare_single_agent_context(
+        prompt="read sample.txt",
+        tool_results=(_tool_result(1), _tool_result(2), _tool_result(3), _tool_result(4)),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=1,
+            continuity_preview_items=1,
+            continuity_preview_chars=5,
+        ),
+    )
+
+    assert context.continuity_state is not None
+    assert context.continuity_state.summary_text == (
+        "Compacted 3 earlier tool results:\n"
+        '1. read_file ok content_preview="conte..."\n'
+        "... and 2 more"
+    )

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -34,9 +34,11 @@ from voidcode.runtime.config import (
     RuntimeProvidersConfig,
     RuntimeSkillsConfig,
 )
+from voidcode.runtime.context_window import ContextWindowPolicy, RuntimeContinuityState
 from voidcode.runtime.events import (
     RUNTIME_MCP_SERVER_STARTED,
     RUNTIME_MCP_SERVER_STOPPED,
+    RUNTIME_MEMORY_REFRESHED,
     EventEnvelope,
 )
 from voidcode.runtime.lsp import DisabledLspManager
@@ -2113,9 +2115,93 @@ def test_runtime_resume_uses_persisted_approval_mode_for_follow_up_gated_tools(
 
     assert resumed.session.status == "waiting"
     assert resumed.events[-1].event_type == "runtime.approval_requested"
-    assert resumed.events[-1].payload["tool"] == "write_file"
-    assert resumed.events[-1].payload["arguments"] == {"path": "beta.txt", "content": "2"}
-    assert resumed.events[-1].payload["policy"] == {"mode": "ask"}
+
+
+def test_runtime_approval_resume_preserves_canonical_continuity_state(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("alpha\n", encoding="utf-8")
+    created_providers: list[_ScriptedSingleAgentProvider] = []
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    SingleAgentTurnResult(tool_call=ToolCall("read_file", {"path": "sample.txt"})),
+                    SingleAgentTurnResult(tool_call=ToolCall("read_file", {"path": "sample.txt"})),
+                    SingleAgentTurnResult(
+                        tool_call=ToolCall(
+                            "write_file",
+                            {"path": "beta.txt", "content": "2"},
+                        )
+                    ),
+                    SingleAgentTurnResult(
+                        tool_call=ToolCall(
+                            "write_file",
+                            {"path": "beta.txt", "content": "2"},
+                        )
+                    ),
+                    SingleAgentTurnResult(output="done"),
+                ),
+                created_providers=created_providers,
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            execution_engine="single_agent",
+            model="opencode/gpt-5.4",
+            approval_mode="ask",
+        ),
+        permission_policy=PermissionPolicy(mode="ask"),
+        model_provider_registry=registry,
+        context_window_policy=ContextWindowPolicy(max_tool_results=1),
+    )
+
+    waiting = runtime.run(
+        RuntimeRequest(
+            prompt="read sample.txt\nread sample.txt\nwrite beta.txt 2",
+            session_id="continuity-approval",
+        )
+    )
+    expected_continuity = {
+        "summary_text": (
+            "Compacted 1 earlier tool results:\n"
+            '1. read_file ok path=sample.txt content_preview="alpha"'
+        ),
+        "dropped_tool_result_count": 1,
+        "retained_tool_result_count": 1,
+        "source": "tool_result_window",
+    }
+
+    assert waiting.session.status == "waiting"
+    waiting_runtime_state = cast(dict[str, object], waiting.session.metadata["runtime_state"])
+    assert waiting_runtime_state["continuity"] == expected_continuity
+
+    approval_request_id = str(waiting.events[-1].payload["request_id"])
+    resumed = runtime.resume(
+        session_id="continuity-approval",
+        approval_request_id=approval_request_id,
+        approval_decision="allow",
+    )
+
+    resumed_runtime_state = cast(dict[str, object], resumed.session.metadata["runtime_state"])
+    assert resumed_runtime_state["continuity"] == expected_continuity
+    continuity_state = cast(
+        RuntimeContinuityState | None,
+        created_providers[-1].requests[-1].context_window.continuity_state,
+    )
+    assert continuity_state is not None
+    assert continuity_state.metadata_payload() == expected_continuity
+    resumed_event_types = [event.event_type for event in resumed.events]
+    assert resumed_event_types.count("runtime.approval_requested") == 1
+    assert resumed_event_types.count("runtime.approval_resolved") == 1
+    tool_completed_events = [
+        event for event in resumed.events if event.event_type == "runtime.tool_completed"
+    ]
+    assert tool_completed_events[-1].payload["tool"] == "write_file"
+    assert tool_completed_events[-1].payload["path"] == "beta.txt"
+    assert (tmp_path / "beta.txt").read_text(encoding="utf-8") == "2"
 
 
 def test_runtime_resume_falls_back_to_fresh_policy_for_legacy_sessions_without_runtime_config(
@@ -2624,25 +2710,70 @@ def test_runtime_classifies_provider_context_limit_failures(tmp_path: Path) -> N
     }
 
 
-def test_runtime_single_agent_compaction_emits_memory_refresh_and_persists_metadata(
+def test_runtime_single_agent_compaction_emits_continuity_state_and_persists_metadata(
     tmp_path: Path,
 ) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("alpha\n", encoding="utf-8")
+    created_providers: list[_ScriptedSingleAgentProvider] = []
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(SingleAgentTurnResult(output="done"),),
+                created_providers=created_providers,
+            )
+        }
+    )
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
-        graph=_SkillCapturingStubGraph(),
-        config=RuntimeConfig(execution_engine="single_agent", model="opencode/gpt-5.4"),
+        config=RuntimeConfig(model="opencode/gpt-5.4"),
+        model_provider_registry=registry,
+        context_window_policy=ContextWindowPolicy(max_tool_results=1),
     )
 
-    response = runtime.run(RuntimeRequest(prompt="hello", metadata={}))
+    response = runtime.run(
+        RuntimeRequest(
+            prompt="read sample.txt\nread sample.txt",
+            session_id="continuity-session",
+        )
+    )
+    replay = runtime.resume("continuity-session")
+
+    expected_continuity = {
+        "summary_text": (
+            "Compacted 1 earlier tool results:\n"
+            '1. read_file ok path=sample.txt content_preview="alpha"'
+        ),
+        "dropped_tool_result_count": 1,
+        "retained_tool_result_count": 1,
+        "source": "tool_result_window",
+    }
+    memory_events = [
+        event for event in response.events if event.event_type == RUNTIME_MEMORY_REFRESHED
+    ]
 
     assert response.session.status == "completed"
-    assert response.session.metadata["context_window"] == {
-        "compacted": False,
-        "compaction_reason": None,
-        "original_tool_result_count": 0,
-        "retained_tool_result_count": 0,
-        "max_tool_result_count": 4,
+    assert len(memory_events) == 1
+    assert memory_events[0].payload == {
+        "reason": "tool_result_window",
+        "original_tool_result_count": 2,
+        "retained_tool_result_count": 1,
+        "compacted": True,
+        "continuity_state": expected_continuity,
     }
+    assert response.session.metadata["context_window"] == {
+        "compacted": True,
+        "compaction_reason": "tool_result_window",
+        "original_tool_result_count": 2,
+        "retained_tool_result_count": 1,
+        "max_tool_result_count": 1,
+        "continuity_state": expected_continuity,
+    }
+    runtime_state = cast(dict[str, object], response.session.metadata["runtime_state"])
+    assert runtime_state["continuity"] == expected_continuity
+    replay_runtime_state = cast(dict[str, object], replay.session.metadata["runtime_state"])
+    assert replay_runtime_state["continuity"] == expected_continuity
 
 
 def test_runtime_rejects_single_agent_engine_without_model(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -3706,6 +3706,85 @@ def test_runtime_resume_falls_back_when_persisted_checkpoint_payload_is_not_obje
     assert resumed.output == "done"
 
 
+def test_runtime_resume_fallback_keeps_successful_tool_results_with_null_error(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_MultiStepStubGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    waiting = runtime.run(RuntimeRequest(prompt="go", session_id="checkpoint-null-error-session"))
+    first_approval_request_id = str(waiting.events[-1].payload["request_id"])
+
+    second_waiting = runtime.resume(
+        session_id="checkpoint-null-error-session",
+        approval_request_id=first_approval_request_id,
+        approval_decision="allow",
+    )
+
+    assert second_waiting.session.status == "waiting"
+    second_approval_request_id = str(second_waiting.events[-1].payload["request_id"])
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        _ = connection.execute(
+            "UPDATE sessions SET resume_checkpoint_json = NULL WHERE session_id = ?",
+            ("checkpoint-null-error-session",),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_MultiStepStubGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    resumed = resumed_runtime.resume(
+        session_id="checkpoint-null-error-session",
+        approval_request_id=second_approval_request_id,
+        approval_decision="allow",
+    )
+
+    assert resumed.session.status == "completed"
+    assert resumed.output == "done"
+
+
+def test_runtime_run_repairs_non_dict_runtime_state_metadata_when_acp_enabled(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_SkillCapturingStubGraph(),
+        config=RuntimeConfig(acp=RuntimeAcpConfig(enabled=True)),
+    )
+
+    response = runtime.run(
+        RuntimeRequest(
+            prompt="hello",
+            session_id="bad-runtime-state-session",
+            metadata={"runtime_state": "broken"},
+        )
+    )
+
+    runtime_state_metadata = cast(dict[str, object], response.session.metadata["runtime_state"])
+    assert runtime_state_metadata == {
+        "acp": {
+            "mode": "managed",
+            "configured_enabled": True,
+            "status": "disconnected",
+            "available": False,
+            "last_error": None,
+        }
+    }
+
+
 @pytest.mark.parametrize("error_kind", ["rate_limit", "invalid_model", "transient_failure"])
 def test_runtime_downgrades_to_next_provider_target_on_provider_failures(
     tmp_path: Path,

--- a/tests/unit/runtime/test_session_storage.py
+++ b/tests/unit/runtime/test_session_storage.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sqlite3
 from contextlib import closing
 from pathlib import Path
+from typing import Any
 
 from voidcode.runtime.contracts import RuntimeRequest, RuntimeResponse
 from voidcode.runtime.events import EventEnvelope
@@ -13,6 +14,10 @@ from voidcode.runtime.task import (
     BackgroundTaskRequestSnapshot,
     BackgroundTaskState,
 )
+
+
+def _private_attr(instance: object, name: str) -> Any:
+    return getattr(instance, name)
 
 
 def test_session_storage_persists_parent_lineage_across_read_surfaces(tmp_path: Path) -> None:
@@ -162,3 +167,40 @@ def test_session_storage_migrates_legacy_schema_for_parent_lineage(tmp_path: Pat
     assert "parent_session_id" in session_columns
     assert "request_parent_session_id" in background_task_columns
     assert loaded_task.request.parent_session_id == "leader-session"
+
+
+def test_tool_results_from_events_keeps_success_payloads_with_null_error() -> None:
+    tool_results_from_events: Any = _private_attr(SqliteSessionStore, "_tool_results_from_events")
+    tool_results = tool_results_from_events(
+        (
+            EventEnvelope(
+                session_id="s1",
+                sequence=1,
+                event_type="runtime.tool_completed",
+                source="runtime",
+                payload={
+                    "tool": "read_file",
+                    "status": "ok",
+                    "content": "alpha\n",
+                    "error": None,
+                    "path": "sample.txt",
+                },
+            ),
+        )
+    )
+
+    assert tool_results == [
+        {
+            "tool_name": "read_file",
+            "content": "alpha\n",
+            "status": "ok",
+            "data": {
+                "tool": "read_file",
+                "status": "ok",
+                "content": "alpha\n",
+                "error": None,
+                "path": "sample.txt",
+            },
+            "error": None,
+        }
+    ]


### PR DESCRIPTION
## Summary
- add Layer 1 Session Continuity Memory design docs and clarify that continuity remains runtime-owned rather than provider- or graph-owned
- extend runtime context windows with continuity state plumbing, provider exposure, and focused unit coverage for compaction summaries
- preserve canonical continuity across approval resume, improve tool-result checkpoint reconstruction, and update unit/integration regressions for the current runtime event contract

## Verification
- mise run check