### PR TITLE
feat(runtime): execute lifecycle hook surfaces

### DIFF
--- a/src/voidcode/hook/__init__.py
+++ b/src/voidcode/hook/__init__.py
@@ -1,14 +1,23 @@
 from __future__ import annotations
 
 from .config import RuntimeFormatterPresetConfig, RuntimeHooksConfig, RuntimeHookSurface
-from .executor import HookExecutionEvent, HookExecutionOutcome, HookExecutionRequest, run_tool_hooks
+from .executor import (
+    HookExecutionEvent,
+    HookExecutionOutcome,
+    HookExecutionRequest,
+    LifecycleHookExecutionRequest,
+    run_lifecycle_hooks,
+    run_tool_hooks,
+)
 
 __all__ = [
     "HookExecutionEvent",
     "HookExecutionOutcome",
     "HookExecutionRequest",
+    "LifecycleHookExecutionRequest",
     "RuntimeFormatterPresetConfig",
     "RuntimeHookSurface",
     "RuntimeHooksConfig",
+    "run_lifecycle_hooks",
     "run_tool_hooks",
 ]

--- a/src/voidcode/hook/executor.py
+++ b/src/voidcode/hook/executor.py
@@ -1,14 +1,29 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
-from ..runtime.events import RUNTIME_TOOL_HOOK_POST, RUNTIME_TOOL_HOOK_PRE
-from .config import RuntimeHooksConfig
+from ..runtime.events import (
+    RUNTIME_BACKGROUND_TASK_CANCELLED,
+    RUNTIME_BACKGROUND_TASK_COMPLETED,
+    RUNTIME_BACKGROUND_TASK_FAILED,
+    RUNTIME_DELEGATED_RESULT_AVAILABLE,
+    RUNTIME_SESSION_ENDED,
+    RUNTIME_SESSION_IDLE,
+    RUNTIME_SESSION_STARTED,
+    RUNTIME_TOOL_HOOK_POST,
+    RUNTIME_TOOL_HOOK_PRE,
+)
+from .config import RuntimeHooksConfig, RuntimeHookSurface
+
+
+def _empty_payload() -> Mapping[str, object]:
+    return {}
 
 
 @dataclass(frozen=True, slots=True)
@@ -35,6 +50,18 @@ class HookExecutionRequest:
     recursion_env_var: str
     environment: Mapping[str, str]
     sequence_start: int
+
+
+@dataclass(frozen=True, slots=True)
+class LifecycleHookExecutionRequest:
+    hooks: RuntimeHooksConfig | None
+    workspace: Path
+    session_id: str
+    surface: RuntimeHookSurface
+    recursion_env_var: str
+    environment: Mapping[str, str]
+    sequence_start: int
+    payload: Mapping[str, object] = field(default_factory=_empty_payload)
 
 
 def run_tool_hooks(request: HookExecutionRequest) -> HookExecutionOutcome:
@@ -94,5 +121,95 @@ def run_tool_hooks(request: HookExecutionRequest) -> HookExecutionOutcome:
     return HookExecutionOutcome(events=tuple(events), last_sequence=last_sequence)
 
 
+def run_lifecycle_hooks(request: LifecycleHookExecutionRequest) -> HookExecutionOutcome:
+    hooks = request.hooks
+    if hooks is None or hooks.enabled is not True:
+        return HookExecutionOutcome(events=(), last_sequence=request.sequence_start)
+    if request.environment.get(request.recursion_env_var) == "1":
+        return HookExecutionOutcome(events=(), last_sequence=request.sequence_start)
+    if request.surface in ("pre_tool", "post_tool"):
+        msg = f"tool hook surface must use run_tool_hooks: {request.surface}"
+        raise ValueError(msg)
+
+    commands = hooks.commands_for_surface(request.surface)
+    last_sequence = request.sequence_start
+    events: list[HookExecutionEvent] = []
+    base_payload = {
+        "surface": request.surface,
+        "session_id": request.session_id,
+        **dict(request.payload),
+    }
+    for command in commands:
+        last_sequence += 1
+        try:
+            subprocess.run(
+                list(command),
+                cwd=request.workspace,
+                capture_output=True,
+                text=True,
+                check=True,
+                env={
+                    **os.environ,
+                    **request.environment,
+                    **_lifecycle_hook_environment(request),
+                    request.recursion_env_var: "1",
+                },
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            error_text = f"lifecycle hook failed for {request.surface}: {exc}"
+            return HookExecutionOutcome(
+                events=(
+                    HookExecutionEvent(
+                        sequence=last_sequence,
+                        event_type=_event_type_for_surface(request.surface),
+                        payload={
+                            **base_payload,
+                            "hook_status": "error",
+                            "error": error_text,
+                        },
+                    ),
+                ),
+                last_sequence=last_sequence,
+                failed_error=error_text,
+            )
+
+        events.append(
+            HookExecutionEvent(
+                sequence=last_sequence,
+                event_type=_event_type_for_surface(request.surface),
+                payload={**base_payload, "hook_status": "ok"},
+            )
+        )
+
+    return HookExecutionOutcome(events=tuple(events), last_sequence=last_sequence)
+
+
 def _event_type_for_phase(phase: Literal["pre", "post"]) -> str:
     return RUNTIME_TOOL_HOOK_PRE if phase == "pre" else RUNTIME_TOOL_HOOK_POST
+
+
+def _event_type_for_surface(surface: RuntimeHookSurface) -> str:
+    return {
+        "session_start": RUNTIME_SESSION_STARTED,
+        "session_end": RUNTIME_SESSION_ENDED,
+        "session_idle": RUNTIME_SESSION_IDLE,
+        "background_task_completed": RUNTIME_BACKGROUND_TASK_COMPLETED,
+        "background_task_failed": RUNTIME_BACKGROUND_TASK_FAILED,
+        "background_task_cancelled": RUNTIME_BACKGROUND_TASK_CANCELLED,
+        "delegated_result_available": RUNTIME_DELEGATED_RESULT_AVAILABLE,
+    }[surface]
+
+
+def _lifecycle_hook_environment(request: LifecycleHookExecutionRequest) -> dict[str, str]:
+    environment = {
+        "VOIDCODE_HOOK_SURFACE": request.surface,
+        "VOIDCODE_SESSION_ID": request.session_id,
+    }
+    for key, value in request.payload.items():
+        if value is None:
+            continue
+        env_key = "VOIDCODE_" + re.sub(r"[^A-Z0-9]+", "_", key.upper()).strip("_")
+        if env_key == "VOIDCODE_":
+            continue
+        environment[env_key] = str(value)
+    return environment

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -15,7 +15,14 @@ from ..agent import get_builtin_agent_manifest
 from ..graph.contracts import GraphEvent, GraphRunRequest
 from ..graph.read_only_slice import DeterministicReadOnlyGraph
 from ..graph.single_agent_slice import ProviderSingleAgentGraph
-from ..hook.executor import HookExecutionOutcome, HookExecutionRequest, run_tool_hooks
+from ..hook.config import RuntimeHookSurface
+from ..hook.executor import (
+    HookExecutionOutcome,
+    HookExecutionRequest,
+    LifecycleHookExecutionRequest,
+    run_lifecycle_hooks,
+    run_tool_hooks,
+)
 from ..provider.auth import ProviderAuthResolver
 from ..provider.errors import (
     SingleAgentContextLimitError,
@@ -844,6 +851,22 @@ class VoidCodeRuntime:
             ),
         )
 
+        start_hook_outcome = self._run_lifecycle_hooks(
+            session=session,
+            sequence=sequence,
+            surface="session_start",
+            payload={"prompt": request.prompt},
+        )
+        yield from start_hook_outcome.chunks
+        sequence = start_hook_outcome.last_sequence
+        if start_hook_outcome.failed_error is not None:
+            yield self._failed_chunk(
+                session=session,
+                sequence=sequence + 1,
+                error=start_hook_outcome.failed_error,
+            )
+            return
+
         sequence += 1
         yield RuntimeStreamChunk(
             kind="event",
@@ -952,14 +975,40 @@ class VoidCodeRuntime:
             return
 
         if last_chunk.session.status == "waiting":
+            idle_hook_outcome = self._run_lifecycle_hooks(
+                session=last_chunk.session,
+                sequence=last_sequence,
+                surface="session_idle",
+                payload={"reason": "waiting_for_approval"},
+            )
+            yield from idle_hook_outcome.chunks
+            if idle_hook_outcome.failed_error is not None:
+                yield self._failed_chunk(
+                    session=last_chunk.session,
+                    sequence=idle_hook_outcome.last_sequence + 1,
+                    error=idle_hook_outcome.failed_error,
+                )
             return
 
-        final_chunks, _, _ = self._finalize_run_acp(
+        final_chunks, finalized_session, final_sequence = self._finalize_run_acp(
             session=last_chunk.session,
             sequence=last_sequence,
         )
         for chunk in final_chunks:
             yield chunk
+        end_hook_outcome = self._run_lifecycle_hooks(
+            session=finalized_session,
+            sequence=final_sequence,
+            surface="session_end",
+            payload={"session_status": finalized_session.status},
+        )
+        yield from end_hook_outcome.chunks
+        if end_hook_outcome.failed_error is not None:
+            yield self._failed_chunk(
+                session=finalized_session,
+                sequence=end_hook_outcome.last_sequence + 1,
+                error=end_hook_outcome.failed_error,
+            )
 
     def _execute_graph_loop(
         self,
@@ -1403,6 +1452,46 @@ class VoidCodeRuntime:
             tool_results.append(tool_result)
             active_preserved_continuity_state = None
 
+    def _run_lifecycle_hooks(
+        self,
+        *,
+        session: SessionState,
+        sequence: int,
+        surface: RuntimeHookSurface,
+        payload: dict[str, object] | None = None,
+    ) -> _HookOutcome:
+        outcome: HookExecutionOutcome = run_lifecycle_hooks(
+            LifecycleHookExecutionRequest(
+                hooks=self._config.hooks,
+                workspace=self._workspace,
+                session_id=session.session.id,
+                surface=surface,
+                recursion_env_var=self._hook_recursion_env_var,
+                environment=os.environ,
+                sequence_start=sequence,
+                payload=payload or {},
+            )
+        )
+        emitted_chunks = tuple(
+            RuntimeStreamChunk(
+                kind="event",
+                session=session,
+                event=EventEnvelope(
+                    session_id=session.session.id,
+                    sequence=event.sequence,
+                    event_type=event.event_type,
+                    source="runtime",
+                    payload=event.payload,
+                ),
+            )
+            for event in outcome.events
+        )
+        return _HookOutcome(
+            chunks=emitted_chunks,
+            last_sequence=outcome.last_sequence,
+            failed_error=outcome.failed_error,
+        )
+
     def _run_tool_hooks(
         self,
         *,
@@ -1634,10 +1723,13 @@ class VoidCodeRuntime:
     def cancel_background_task(self, task_id: str) -> BackgroundTaskState:
         validate_background_task_id(task_id)
         self._reconcile_background_tasks_if_needed()
-        return self._session_store.request_background_task_cancel(
+        task = self._session_store.request_background_task_cancel(
             workspace=self._workspace,
             task_id=task_id,
         )
+        if task.status == "cancelled":
+            self._run_background_task_lifecycle_hook(task)
+        return task
 
     def session_result(self, *, session_id: str) -> RuntimeSessionResult:
         validate_session_id(session_id)
@@ -1747,11 +1839,16 @@ class VoidCodeRuntime:
         )
 
     def _pending_approval_from_response(self, response: RuntimeResponse) -> PendingApproval:
-        if not response.events:
+        approval_event = next(
+            (
+                event
+                for event in reversed(response.events)
+                if event.event_type == "runtime.approval_requested"
+            ),
+            None,
+        )
+        if approval_event is None:
             raise ValueError("waiting runtime response must include an approval event")
-        approval_event = response.events[-1]
-        if approval_event.event_type != "runtime.approval_requested":
-            raise ValueError("waiting runtime response must end with approval request")
         payload = approval_event.payload
         raw_policy = cast(dict[str, object], payload.get("policy", {}))
         raw_policy_mode = raw_policy.get("mode", "ask")
@@ -1992,6 +2089,39 @@ class VoidCodeRuntime:
             yield failed_chunk
             return
 
+        resume_start_hook_outcome = self._run_lifecycle_hooks(
+            session=session,
+            sequence=emitted_sequence,
+            surface="session_start",
+            payload={"resume": True, "approval_request_id": pending.request_id},
+        )
+        for hook_chunk in resume_start_hook_outcome.chunks:
+            hook_event = cast(EventEnvelope, hook_chunk.event)
+            emitted_sequence = hook_event.sequence
+            loop_events.append(hook_event)
+            yield hook_chunk
+        if resume_start_hook_outcome.failed_error is not None:
+            failed_chunk = self._failed_chunk(
+                session=session,
+                sequence=resume_start_hook_outcome.last_sequence + 1,
+                error=resume_start_hook_outcome.failed_error,
+            )
+            failed_event = cast(EventEnvelope, failed_chunk.event)
+            loop_events.append(failed_event)
+            response = RuntimeResponse(
+                session=failed_chunk.session,
+                events=stored.events + tuple(loop_events),
+                output=output,
+            )
+            request = RuntimeRequest(
+                prompt=prompt,
+                session_id=stored.session.session.id,
+                parent_session_id=stored.session.session.parent_id,
+            )
+            self._persist_response(request=request, response=response)
+            yield failed_chunk
+            return
+
         sequence = max_stored_sequence
         try:
             for chunk in self._execute_graph_loop(
@@ -2081,6 +2211,27 @@ class VoidCodeRuntime:
         last_sequence = emitted_sequence
         if session.status == "waiting":
             session = self._disconnect_acp_for_session_state(session)
+            idle_hook_outcome = self._run_lifecycle_hooks(
+                session=session,
+                sequence=last_sequence,
+                surface="session_idle",
+                payload={"reason": "waiting_for_approval", "resume": True},
+            )
+            for hook_chunk in idle_hook_outcome.chunks:
+                hook_event = cast(EventEnvelope, hook_chunk.event)
+                emitted_sequence = hook_event.sequence
+                loop_events.append(hook_event)
+                yield hook_chunk
+            if idle_hook_outcome.failed_error is not None:
+                failed_chunk = self._failed_chunk(
+                    session=session,
+                    sequence=idle_hook_outcome.last_sequence + 1,
+                    error=idle_hook_outcome.failed_error,
+                )
+                failed_event = cast(EventEnvelope, failed_chunk.event)
+                loop_events.append(failed_event)
+                session = failed_chunk.session
+                yield failed_chunk
         else:
             final_chunks, session, _ = self._finalize_run_acp(
                 session=session,
@@ -2096,6 +2247,27 @@ class VoidCodeRuntime:
                     yield RuntimeStreamChunk(
                         kind="event", session=chunk.session, event=resequenced_event
                     )
+            end_hook_outcome = self._run_lifecycle_hooks(
+                session=session,
+                sequence=emitted_sequence,
+                surface="session_end",
+                payload={"session_status": session.status, "resume": True},
+            )
+            for hook_chunk in end_hook_outcome.chunks:
+                hook_event = cast(EventEnvelope, hook_chunk.event)
+                emitted_sequence = hook_event.sequence
+                loop_events.append(hook_event)
+                yield hook_chunk
+            if end_hook_outcome.failed_error is not None:
+                failed_chunk = self._failed_chunk(
+                    session=session,
+                    sequence=end_hook_outcome.last_sequence + 1,
+                    error=end_hook_outcome.failed_error,
+                )
+                failed_event = cast(EventEnvelope, failed_chunk.event)
+                loop_events.append(failed_event)
+                session = failed_chunk.session
+                yield failed_chunk
 
         response = RuntimeResponse(
             session=session,
@@ -2770,15 +2942,73 @@ class VoidCodeRuntime:
                     approval_mode = persisted_approval_mode
         return PermissionPolicy(mode=approval_mode)
 
+    def _run_background_task_lifecycle_hook(self, task: BackgroundTaskState) -> None:
+        surface_by_status: dict[BackgroundTaskStatus, RuntimeHookSurface] = {
+            "completed": "background_task_completed",
+            "failed": "background_task_failed",
+            "cancelled": "background_task_cancelled",
+        }
+        surface = surface_by_status.get(task.status)
+        if surface is None:
+            return
+        self._run_background_task_lifecycle_surface(
+            task=task,
+            surface=surface,
+            session_id=task.session_id or task.request.session_id or "runtime",
+        )
+        if task.status == "completed" and task.parent_session_id is not None:
+            self._run_background_task_lifecycle_surface(
+                task=task,
+                surface="delegated_result_available",
+                session_id=task.parent_session_id,
+                extra_payload={
+                    "delegated_session_id": task.session_id or "",
+                    "parent_session_id": task.parent_session_id,
+                },
+            )
+
+    def _run_background_task_lifecycle_surface(
+        self,
+        *,
+        task: BackgroundTaskState,
+        surface: RuntimeHookSurface,
+        session_id: str,
+        extra_payload: dict[str, object] | None = None,
+    ) -> None:
+        outcome = run_lifecycle_hooks(
+            LifecycleHookExecutionRequest(
+                hooks=self._config.hooks,
+                workspace=self._workspace,
+                session_id=session_id,
+                surface=surface,
+                recursion_env_var=self._hook_recursion_env_var,
+                environment=os.environ,
+                sequence_start=0,
+                payload={
+                    "background_task_id": task.task.id,
+                    "background_task_status": task.status,
+                    **({"background_task_error": task.error} if task.error is not None else {}),
+                    **(extra_payload or {}),
+                },
+            )
+        )
+        if outcome.failed_error is not None:
+            logger.warning("background task lifecycle hook failed: %s", outcome.failed_error)
+
     def _reconcile_background_tasks_if_needed(self) -> None:
         if self._background_tasks_reconciled:
             return
         fail_incomplete = getattr(self._session_store, "fail_incomplete_background_tasks", None)
         if callable(fail_incomplete):
-            fail_incomplete(
-                workspace=self._workspace,
-                message="background task interrupted before completion",
+            failed_tasks = cast(
+                tuple[BackgroundTaskState, ...],
+                fail_incomplete(
+                    workspace=self._workspace,
+                    message="background task interrupted before completion",
+                ),
             )
+            for failed_task in failed_tasks:
+                self._run_background_task_lifecycle_hook(failed_task)
         self._background_tasks_reconciled = True
 
     def _run_background_task_worker(self, task_id: str) -> None:
@@ -2805,12 +3035,13 @@ class VoidCodeRuntime:
             if dispatch_task.status != "running":
                 return
             if dispatch_task.cancel_requested_at is not None:
-                self._session_store.mark_background_task_terminal(
+                terminal_task = self._session_store.mark_background_task_terminal(
                     workspace=self._workspace,
                     task_id=task_id,
                     status="cancelled",
                     error="cancelled before dispatch",
                 )
+                self._run_background_task_lifecycle_hook(terminal_task)
                 return
             response = self.run(
                 RuntimeRequest(
@@ -2835,20 +3066,22 @@ class VoidCodeRuntime:
                         event_error = event.payload.get("error")
                         error = str(event_error) if event_error is not None else None
                         break
-            self._session_store.mark_background_task_terminal(
+            terminal_task = self._session_store.mark_background_task_terminal(
                 workspace=self._workspace,
                 task_id=task_id,
                 status=terminal_status,
                 error=error,
             )
+            self._run_background_task_lifecycle_hook(terminal_task)
         except Exception as exc:
             logger.exception("background task failed: %s", task_id)
-            self._session_store.mark_background_task_terminal(
+            terminal_task = self._session_store.mark_background_task_terminal(
                 workspace=self._workspace,
                 task_id=task_id,
                 status="failed",
                 error=str(exc),
             )
+            self._run_background_task_lifecycle_hook(terminal_task)
         finally:
             self._background_task_threads.pop(task_id, None)
 

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -983,8 +983,9 @@ class VoidCodeRuntime:
             )
             yield from idle_hook_outcome.chunks
             if idle_hook_outcome.failed_error is not None:
+                failed_session = self._disconnect_acp_for_session_state(last_chunk.session)
                 yield self._failed_chunk(
-                    session=last_chunk.session,
+                    session=failed_session,
                     sequence=idle_hook_outcome.last_sequence + 1,
                     error=idle_hook_outcome.failed_error,
                 )
@@ -1723,11 +1724,15 @@ class VoidCodeRuntime:
     def cancel_background_task(self, task_id: str) -> BackgroundTaskState:
         validate_background_task_id(task_id)
         self._reconcile_background_tasks_if_needed()
+        previous_task = self._session_store.load_background_task(
+            workspace=self._workspace,
+            task_id=task_id,
+        )
         task = self._session_store.request_background_task_cancel(
             workspace=self._workspace,
             task_id=task_id,
         )
-        if task.status == "cancelled":
+        if previous_task.status != "cancelled" and task.status == "cancelled":
             self._run_background_task_lifecycle_hook(task)
         return task
 

--- a/tests/unit/hook/test_executor.py
+++ b/tests/unit/hook/test_executor.py
@@ -4,7 +4,13 @@ import sys
 from pathlib import Path
 
 from voidcode.hook.config import RuntimeHooksConfig
-from voidcode.hook.executor import HookExecutionOutcome, HookExecutionRequest, run_tool_hooks
+from voidcode.hook.executor import (
+    HookExecutionOutcome,
+    HookExecutionRequest,
+    LifecycleHookExecutionRequest,
+    run_lifecycle_hooks,
+    run_tool_hooks,
+)
 
 
 def test_run_tool_hooks_executes_configured_pre_commands_and_reports_success(
@@ -68,3 +74,98 @@ def test_runtime_hooks_config_exposes_async_lifecycle_surfaces() -> None:
     assert hooks.commands_for_surface("delegated_result_available") == (
         ("python", "scripts/delegated_result.py"),
     )
+
+
+def test_run_lifecycle_hooks_executes_configured_session_command_and_reports_event(
+    tmp_path: Path,
+) -> None:
+    hooks = RuntimeHooksConfig(
+        enabled=True,
+        on_session_start=((sys.executable, "-c", ""),),
+    )
+
+    outcome: HookExecutionOutcome = run_lifecycle_hooks(
+        LifecycleHookExecutionRequest(
+            hooks=hooks,
+            workspace=tmp_path,
+            session_id="hook-session",
+            surface="session_start",
+            recursion_env_var="VOIDCODE_RUNNING_TOOL_HOOK",
+            environment={},
+            sequence_start=11,
+            payload={"prompt": "hello"},
+        )
+    )
+
+    assert outcome.failed_error is None
+    assert outcome.last_sequence == 12
+    assert len(outcome.events) == 1
+    event = outcome.events[0]
+    assert event.sequence == 12
+    assert event.event_type == "runtime.session_started"
+    assert event.payload == {
+        "surface": "session_start",
+        "session_id": "hook-session",
+        "prompt": "hello",
+        "hook_status": "ok",
+    }
+
+
+def test_run_lifecycle_hooks_exposes_context_as_environment(tmp_path: Path) -> None:
+    output_path = tmp_path / "hook-env.txt"
+    hooks = RuntimeHooksConfig(
+        enabled=True,
+        on_background_task_completed=(
+            (
+                sys.executable,
+                "-c",
+                "import os, pathlib; "
+                "pathlib.Path('hook-env.txt').write_text("
+                "os.environ['VOIDCODE_HOOK_SURFACE'] + ':' + "
+                "os.environ['VOIDCODE_BACKGROUND_TASK_ID'])",
+            ),
+        ),
+    )
+
+    outcome = run_lifecycle_hooks(
+        LifecycleHookExecutionRequest(
+            hooks=hooks,
+            workspace=tmp_path,
+            session_id="hook-session",
+            surface="background_task_completed",
+            recursion_env_var="VOIDCODE_RUNNING_TOOL_HOOK",
+            environment={},
+            sequence_start=0,
+            payload={"background_task_id": "task-1"},
+        )
+    )
+
+    assert outcome.failed_error is None
+    assert output_path.read_text() == "background_task_completed:task-1"
+
+
+def test_run_lifecycle_hooks_reports_failed_command(tmp_path: Path) -> None:
+    hooks = RuntimeHooksConfig(
+        enabled=True,
+        on_session_end=((sys.executable, "-c", "raise SystemExit(7)"),),
+    )
+
+    outcome = run_lifecycle_hooks(
+        LifecycleHookExecutionRequest(
+            hooks=hooks,
+            workspace=tmp_path,
+            session_id="hook-session",
+            surface="session_end",
+            recursion_env_var="VOIDCODE_RUNNING_TOOL_HOOK",
+            environment={},
+            sequence_start=4,
+        )
+    )
+
+    assert outcome.failed_error is not None
+    assert outcome.last_sequence == 5
+    assert len(outcome.events) == 1
+    event = outcome.events[0]
+    assert event.event_type == "runtime.session_ended"
+    assert event.payload["hook_status"] == "error"
+    assert "lifecycle hook failed for session_end" in str(event.payload["error"])

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -4946,6 +4946,34 @@ def test_runtime_executes_session_idle_hook_without_losing_pending_approval(
     assert idle.payload["hook_status"] == "ok"
 
 
+def test_runtime_disconnects_acp_before_failing_on_session_idle_hook_error(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(
+            acp=RuntimeAcpConfig(enabled=True),
+            approval_mode="ask",
+            hooks=RuntimeHooksConfig(
+                enabled=True,
+                on_session_idle=((sys.executable, "-c", "raise SystemExit(9)"),),
+            ),
+        ),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="needs approval", session_id="idle-acp-session"))
+
+    assert response.session.status == "failed"
+    assert response.events[-1].event_type == "runtime.failed"
+    assert "lifecycle hook failed for session_idle" in str(response.events[-1].payload["error"])
+    runtime_state_metadata = cast(dict[str, object], response.session.metadata["runtime_state"])
+    acp_runtime_state = cast(dict[str, object], runtime_state_metadata["acp"])
+    assert acp_runtime_state["status"] == "disconnected"
+    assert runtime.current_acp_state().status == "disconnected"
+
+
 def test_runtime_executes_background_task_completion_hook_with_task_context(
     tmp_path: Path,
 ) -> None:
@@ -4993,9 +5021,9 @@ def test_runtime_executes_background_task_cancelled_hook_for_queued_cancel(
                         sys.executable,
                         "-c",
                         "import os, pathlib; "
-                        "pathlib.Path('cancel-hook.txt').write_text("
+                        "pathlib.Path('cancel-hook.txt').open('a').write("
                         "os.environ['VOIDCODE_HOOK_SURFACE'] + ':' + "
-                        "os.environ['VOIDCODE_BACKGROUND_TASK_ID'])",
+                        "os.environ['VOIDCODE_BACKGROUND_TASK_ID'] + '\\n')",
                     ),
                 ),
             )
@@ -5015,11 +5043,13 @@ def test_runtime_executes_background_task_cancelled_hook_for_queued_cancel(
     )
 
     cancelled = runtime.cancel_background_task("task-cancel-hook")
+    repeated = runtime.cancel_background_task("task-cancel-hook")
 
     assert cancelled.status == "cancelled"
-    assert _wait_for_path_text(tmp_path / "cancel-hook.txt") == (
+    assert repeated.status == "cancelled"
+    assert _wait_for_path_text(tmp_path / "cancel-hook.txt").splitlines() == [
         "background_task_cancelled:task-cancel-hook"
-    )
+    ]
 
 
 def test_runtime_executes_delegated_result_hook_for_completed_background_child(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import sqlite3
+import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -26,6 +27,7 @@ from voidcode.runtime.config import (
     RuntimeAcpConfig,
     RuntimeAgentConfig,
     RuntimeConfig,
+    RuntimeHooksConfig,
     RuntimeLspConfig,
     RuntimeLspServerConfig,
     RuntimeMcpServerConfig,
@@ -40,6 +42,9 @@ from voidcode.runtime.events import (
     RUNTIME_MCP_SERVER_STARTED,
     RUNTIME_MCP_SERVER_STOPPED,
     RUNTIME_MEMORY_REFRESHED,
+    RUNTIME_SESSION_ENDED,
+    RUNTIME_SESSION_IDLE,
+    RUNTIME_SESSION_STARTED,
     EventEnvelope,
 )
 from voidcode.runtime.lsp import DisabledLspManager
@@ -361,6 +366,15 @@ def _wait_for_background_task(
             return task
         time.sleep(0.01)
     raise AssertionError(f"background task {task_id} did not reach terminal state")
+
+
+def _wait_for_path_text(path: Path, *, timeout_seconds: float = 2.0) -> str:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if path.exists():
+            return path.read_text()
+        time.sleep(0.01)
+    raise AssertionError(f"path was not written: {path}")
 
 
 def _write_demo_skill(skill_dir: Path, *, description: str = "Demo skill", content: str) -> None:
@@ -4872,3 +4886,175 @@ def test_runtime_provider_fallback_exhaustion_after_three_targets_reports_termin
         "model": "claude-3-7-sonnet",
         "fallback_exhausted": True,
     }
+
+
+def test_runtime_executes_session_start_and_end_hooks(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_BackgroundTaskSuccessGraph(),
+        config=RuntimeConfig(
+            hooks=RuntimeHooksConfig(
+                enabled=True,
+                on_session_start=((sys.executable, "-c", ""),),
+                on_session_end=((sys.executable, "-c", ""),),
+            )
+        ),
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="hello", session_id="hooked-session"))
+
+    event_types = [event.event_type for event in response.events]
+    assert RUNTIME_SESSION_STARTED in event_types
+    assert RUNTIME_SESSION_ENDED in event_types
+    started = next(
+        event for event in response.events if event.event_type == RUNTIME_SESSION_STARTED
+    )
+    ended = next(event for event in response.events if event.event_type == RUNTIME_SESSION_ENDED)
+    assert started.payload["surface"] == "session_start"
+    assert started.payload["prompt"] == "hello"
+    assert started.payload["hook_status"] == "ok"
+    assert ended.payload["surface"] == "session_end"
+    assert ended.payload["session_status"] == "completed"
+    assert ended.payload["hook_status"] == "ok"
+
+
+def test_runtime_executes_session_idle_hook_without_losing_pending_approval(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(
+            hooks=RuntimeHooksConfig(
+                enabled=True,
+                on_session_idle=((sys.executable, "-c", ""),),
+            )
+        ),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="needs approval", session_id="idle-session"))
+    replayed = runtime.resume("idle-session")
+
+    assert response.session.status == "waiting"
+    assert replayed.session.status == "waiting"
+    event_types = [event.event_type for event in response.events]
+    assert "runtime.approval_requested" in event_types
+    assert RUNTIME_SESSION_IDLE in event_types
+    idle = next(event for event in response.events if event.event_type == RUNTIME_SESSION_IDLE)
+    assert idle.payload["reason"] == "waiting_for_approval"
+    assert idle.payload["hook_status"] == "ok"
+
+
+def test_runtime_executes_background_task_completion_hook_with_task_context(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_BackgroundTaskSuccessGraph(),
+        config=RuntimeConfig(
+            hooks=RuntimeHooksConfig(
+                enabled=True,
+                on_background_task_completed=(
+                    (
+                        sys.executable,
+                        "-c",
+                        "import os, pathlib; "
+                        "pathlib.Path('background-hook.txt').write_text("
+                        "os.environ['VOIDCODE_HOOK_SURFACE'] + ':' + "
+                        "os.environ['VOIDCODE_BACKGROUND_TASK_ID'] + ':' + "
+                        "os.environ['VOIDCODE_BACKGROUND_TASK_STATUS'])",
+                    ),
+                ),
+            )
+        ),
+    )
+
+    started = runtime.start_background_task(RuntimeRequest(prompt="background hello"))
+    completed = _wait_for_background_task(runtime, started.task.id)
+
+    assert completed.status == "completed"
+    assert _wait_for_path_text(tmp_path / "background-hook.txt") == (
+        f"background_task_completed:{started.task.id}:completed"
+    )
+
+
+def test_runtime_executes_background_task_cancelled_hook_for_queued_cancel(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_BackgroundTaskSuccessGraph(),
+        config=RuntimeConfig(
+            hooks=RuntimeHooksConfig(
+                enabled=True,
+                on_background_task_cancelled=(
+                    (
+                        sys.executable,
+                        "-c",
+                        "import os, pathlib; "
+                        "pathlib.Path('cancel-hook.txt').write_text("
+                        "os.environ['VOIDCODE_HOOK_SURFACE'] + ':' + "
+                        "os.environ['VOIDCODE_BACKGROUND_TASK_ID'])",
+                    ),
+                ),
+            )
+        ),
+    )
+    runtime._background_tasks_reconciled = True  # pyright: ignore[reportPrivateUsage]
+    store = _private_attr(runtime, "_session_store")
+    task_module = importlib.import_module("voidcode.runtime.task")
+    store.create_background_task(
+        workspace=tmp_path,
+        task=task_module.BackgroundTaskState(
+            task=task_module.BackgroundTaskRef(id="task-cancel-hook"),
+            request=task_module.BackgroundTaskRequestSnapshot(prompt="background hello"),
+            created_at=1,
+            updated_at=1,
+        ),
+    )
+
+    cancelled = runtime.cancel_background_task("task-cancel-hook")
+
+    assert cancelled.status == "cancelled"
+    assert _wait_for_path_text(tmp_path / "cancel-hook.txt") == (
+        "background_task_cancelled:task-cancel-hook"
+    )
+
+
+def test_runtime_executes_delegated_result_hook_for_completed_background_child(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_BackgroundTaskSuccessGraph(),
+        config=RuntimeConfig(
+            hooks=RuntimeHooksConfig(
+                enabled=True,
+                on_delegated_result_available=(
+                    (
+                        sys.executable,
+                        "-c",
+                        "import os, pathlib; "
+                        "pathlib.Path('delegated-hook.txt').write_text("
+                        "os.environ['VOIDCODE_HOOK_SURFACE'] + ':' + "
+                        "os.environ['VOIDCODE_SESSION_ID'] + ':' + "
+                        "os.environ['VOIDCODE_BACKGROUND_TASK_ID'] + ':' + "
+                        "os.environ['VOIDCODE_DELEGATED_SESSION_ID'])",
+                    ),
+                ),
+            )
+        ),
+    )
+    _ = runtime.run(RuntimeRequest(prompt="leader", session_id="leader-session"))
+
+    started = runtime.start_background_task(
+        RuntimeRequest(prompt="background child", parent_session_id="leader-session")
+    )
+    completed = _wait_for_background_task(runtime, started.task.id)
+
+    assert completed.status == "completed"
+    delegated_session_id = completed.session_id or ""
+    assert _wait_for_path_text(tmp_path / "delegated-hook.txt") == (
+        f"delegated_result_available:leader-session:{started.task.id}:{delegated_session_id}"
+    )


### PR DESCRIPTION
## Summary
- Add a lifecycle hook executor for the non-tool `RuntimeHookSurface` phases with guarded subprocess execution, lifecycle event payloads, and environment context.
- Wire `session_start`, `session_end`, and `session_idle` hooks into run and approval-resume paths.
- Wire background task terminal hooks plus delegated-result hooks for completed background child tasks.
- Preserve pending approval lookup when `session_idle` hook events follow the approval request.

Closes #170.

## Verification
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run basedpyright --warnings src`
- `uv run pytest`