### PR TITLE
docs: add agent-facing tools guide

### DIFF
--- a/docs/contracts/agent-tool-calling.md
+++ b/docs/contracts/agent-tool-calling.md
@@ -6,6 +6,8 @@
 
 本文档定义 VoidCode runtime / CLI / Web 主路径中 **agent 应如何理解、选择和调用工具**。它面向会生成 `ToolCall` 的 agent / execution engine，而不是面向 UI 组件或工具实现作者。
 
+For category-based, agent-facing usage guidance, continue with [`docs/tools/README.md`](../tools/README.md).
+
 它回答以下问题：
 
 - 当前 runtime 可暴露哪些工具，以及这些工具如何分组；

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,0 +1,79 @@
+# Agent-facing Tools Guide
+
+This directory is written for **agents that generate `ToolCall` objects**. It complements the shared contract in `docs/contracts/agent-tool-calling.md`.
+
+These pages do not redefine runtime or tool-layer types. Instead, they answer the questions an agent actually needs help with:
+
+- When should I choose one tool over another?
+- Which tools are read-only, and which ones may trigger approval?
+- How should I think about neighboring tools with overlapping use cases?
+- Which tool results are safe to treat as the source of truth for the next step?
+
+## Relationship to other docs
+
+- [`docs/contracts/agent-tool-calling.md`](../contracts/agent-tool-calling.md): the top-level contract for tool envelopes, approval expectations, and shared result shapes.
+- [`src/voidcode/tools/contracts.py`](../../src/voidcode/tools/contracts.py): the code-level source of truth for `ToolDefinition`, `ToolCall`, and `ToolResult`.
+- [`src/voidcode/tools/README.md`](../../src/voidcode/tools/README.md): the capability-layer boundary for tools, not an agent usage guide.
+
+## Recommended reading order
+
+### 1. Start with the global rules
+
+- Tools must be invoked through the runtime. Agents do not instantiate tools directly.
+- `read_only=true` tools normally do not enter approval.
+- `read_only=false` tools may pause in `ask` mode and require approval.
+- File paths are resolved relative to the workspace root. Path escape attempts fail.
+
+### 2. Then choose by task type
+
+#### Reading / searching
+
+- [`read-search.md`](./read-search.md)
+  - `read_file`
+  - `list`
+  - `glob`
+  - `grep`
+
+#### Editing / writing
+
+- [`edit.md`](./edit.md)
+- [`multi-edit.md`](./multi-edit.md)
+- [`apply-patch.md`](./apply-patch.md)
+
+#### Execution / external commands
+
+- [`shell-exec.md`](./shell-exec.md)
+
+## Why the first wave only documents these tools
+
+The first priority is the tools that are easiest to misuse and most likely to affect correctness:
+
+- `edit`
+- `multi_edit`
+- `apply_patch`
+- `shell_exec`
+- the core read/search tool family
+
+These tools directly affect:
+
+- whether the agent reads enough context before writing,
+- whether it chooses an unnecessarily destructive write path,
+- whether post-edit follow-up actions still rely on the real file state,
+- whether command execution becomes an overused escape hatch.
+
+After these pages settle, the next candidates are:
+
+- `write_file`
+- `ast_grep_*`
+- `lsp` / `format_file`
+- `web_fetch` / `web_search` / `code_search`
+- `todo_write`
+- `mcp/*` (better documented as one dynamic-tool policy page than one page per MCP tool)
+
+## Hard usage rules for agents
+
+1. **Read before you write.** Unless the user explicitly asked to create a new file, prefer read-only tools first.
+2. **Choose the narrowest tool that fits.** If you already know the file path, use `read_file` instead of `shell_exec cat ...`.
+3. **Prefer structured, recoverable results.** If you need diffs, replacement counts, or file-oriented edits, prefer `edit`, `multi_edit`, or `apply_patch` over `shell_exec`.
+4. **Treat post-formatter file state as truth.** For formatter-aware editing tools, future actions must rely on the final file state after the tool completes.
+5. **Do not use `shell_exec` as a search tool.** Reading and search should normally go through dedicated tools.

--- a/docs/tools/apply-patch.md
+++ b/docs/tools/apply-patch.md
@@ -1,0 +1,53 @@
+# `apply_patch`
+
+`apply_patch` is the right tool for **patch-level changes**:
+
+- multi-file edits,
+- file creation / deletion / rename,
+- changes that are easiest to express as unified diff text.
+
+It is not the default choice for everyday single-location replacements. If the change is small and local, `edit` or `multi_edit` is usually safer.
+
+## When to use it
+
+Good fit:
+
+- one operation needs to touch several files,
+- you need patch semantics rather than one local replacement,
+- you need add / delete / rename behavior.
+
+Bad fit:
+
+- a small edit in one file,
+- situations where you have not yet read enough file context,
+- cases where patch construction is more complex than the change itself.
+
+## Risk profile
+
+`apply_patch` is powerful, but it asks more from the agent:
+
+- the patch text must be structurally valid,
+- all paths must stay inside the workspace,
+- mistakes in local context understanding can make the patch fail harder than a simple `edit` would.
+
+So this is a high-power tool, not the default first choice.
+
+## Return value
+
+On success, expect structured change summaries such as:
+
+- affected paths,
+- change status (add / delete / modify / rename),
+- patch application outcome.
+
+## When it is better than `edit` / `multi_edit`
+
+- several files must change together,
+- you want to preserve a patch-shaped change,
+- rename / delete / add behavior is part of the request.
+
+## When it is worse than `edit` / `multi_edit`
+
+- the change is small and local,
+- you want to minimize patch construction complexity,
+- the agent is still converging on the exact change through file reads.

--- a/docs/tools/edit.md
+++ b/docs/tools/edit.md
@@ -1,0 +1,95 @@
+# `edit`
+
+`edit` is the default single-file text replacement tool. It is best when you already know the target file and can point to a stable piece of old text that should be replaced.
+
+## When to use it
+
+Good fit:
+
+- you have already read the target file,
+- you can provide a stable `oldString`,
+- you only need one focused replacement in one file,
+- you want structured diff output and replacement metadata.
+
+Bad fit:
+
+- you are writing before reading,
+- you need several dependent edits in the same file (prefer `multi_edit`),
+- you need a cross-file or patch-level change (prefer `apply_patch`).
+
+## Input
+
+```json
+{
+  "path": "src/example.py",
+  "oldString": "old text",
+  "newString": "new text",
+  "replaceAll": false
+}
+```
+
+Fields:
+
+- `path`: file path relative to the workspace
+- `oldString`: text to match and replace
+- `newString`: replacement text
+- `replaceAll`: optional, defaults to `false`
+
+## Matching behavior
+
+`edit` is more than a raw exact string replace. The current implementation tries several matching strategies, including:
+
+- exact matching
+- line-trimmed matching
+- block-anchor matching with small typo tolerance
+- whitespace-normalized matching
+- indentation-flexible matching
+- escape-normalized and context-aware fallbacks
+
+This makes it more forgiving than a naive string replacement, but it also means:
+
+- there is still risk if you did not read enough context first,
+- the tool refuses to guess if multiple matches are found and `replaceAll=false`.
+
+## Return value
+
+On success, expect:
+
+- `content`: `Edit applied successfully.` (with replacement count if needed)
+- `data.path`
+- `data.additions`
+- `data.deletions`
+- `data.match_count`
+- `data.diff`
+
+If formatter-aware closure is active, it may also return:
+
+- `data.formatter`
+- `data.diagnostics`
+
+## Formatter-aware closure
+
+The current implementation does the following:
+
+1. write the new content,
+2. if hooks / formatter presets are configured, try a formatter,
+3. read the file again,
+4. build the final diff and result from the **final on-disk file state**.
+
+The main rule for agents is:
+
+> The file state after `edit` finishes is the truth. Do not assume the pre-formatter text is still present.
+
+## Common failures
+
+- `Multiple matches found. Use replaceAll to replace all occurrences.`
+- `Could not find oldString in the file using replacers.`
+- `edit only allows paths inside the workspace`
+- `edit target does not exist: ...`
+
+## Boundary with neighboring tools
+
+- One focused replacement in one file: prefer `edit`
+- Several dependent edits in one file: prefer `multi_edit`
+- Patch-level or cross-file changes: prefer `apply_patch`
+- Creating a new file from scratch: prefer `write_file`

--- a/docs/tools/multi-edit.md
+++ b/docs/tools/multi-edit.md
@@ -1,0 +1,65 @@
+# `multi_edit`
+
+`multi_edit` is for **multiple sequential edits in the same file**. It is effectively a runtime-owned closure around repeated `edit` operations, which makes it useful when several related changes belong together.
+
+## When to use it
+
+Good fit:
+
+- the same file needs two or more related edits,
+- later edits depend on the file state produced by earlier edits,
+- you want to reduce drift from issuing several separate `edit` calls.
+
+Bad fit:
+
+- you only need a single replacement (`edit` is simpler),
+- you need cross-file changes (`apply_patch` or separate file-oriented operations are better).
+
+## Input
+
+```json
+{
+  "path": "src/example.py",
+  "edits": [
+    {"oldString": "a", "newString": "b"},
+    {"oldString": "c", "newString": "d", "replaceAll": true}
+  ]
+}
+```
+
+## Execution semantics
+
+- `multi_edit` applies edits in order
+- each step runs against the file state produced by the previous step
+- after all edits complete, it summarizes the diff from the original file to the final file
+- if formatter-aware closure is configured, formatting happens once after the sequence
+
+This makes `multi_edit` a better fit than “agent manually sends several `edit` calls” when the file-local change set is really one operation.
+
+## Return value
+
+On success it returns:
+
+- `data.path`
+- `data.applied`
+- `data.edits[]`: structured results for each inner edit
+- `data.additions`
+- `data.deletions`
+- `data.diff`
+
+If formatter-aware closure runs, it may also include:
+
+- `data.formatter`
+- `data.diagnostics`
+
+## When it is better than `edit`
+
+- you already know several edits belong to one file
+- you do not want the agent to manually reconstruct context between separate edits
+- you want one final aggregated diff
+
+## When not to use it
+
+- bundling unrelated edits into one large multi-step request
+- using it instead of a patch for cross-file changes
+- constructing a long edit array before reading the file carefully

--- a/docs/tools/read-search.md
+++ b/docs/tools/read-search.md
@@ -1,0 +1,80 @@
+# Read / Search Tools
+
+This page covers the most common read-only context collection tools:
+
+- `read_file`
+- `list`
+- `glob`
+- `grep`
+
+All of them are currently `read_only=true`, so they are the default low-risk tools for gathering context.
+
+## Selection order
+
+### `read_file`
+
+**Use when:** you already know which file you need and want the full file content.
+**Do not use when:** you need directory discovery, broad search, or fuzzy location.
+
+- Input: `{"path": "relative/path.txt"}`
+- Key return fields:
+  - `content`: full file contents
+  - `data.path`
+  - `data.line_count`
+
+### `list`
+
+**Use when:** you need an initial view of the directory structure.
+**Do not use when:** you already know the filename pattern or need content search.
+
+- Input:
+  - `path`: optional directory path
+  - `ignore`: optional extra ignore glob patterns
+- Key return fields:
+  - `content`: tree-like directory listing
+  - `data.path`: actual root that was listed
+  - `data.count`
+  - `data.truncated`
+
+### `glob`
+
+**Use when:** you know a filename or extension pattern and want matching files.
+**Do not use when:** you need to search file contents.
+
+- Input:
+  - `pattern`
+  - `path`: optional search root
+- Key return fields:
+  - `content`: matching relative paths
+  - `data.matches`
+  - `data.count`
+  - `data.truncated`
+
+By default, results are capped and common generated directories are skipped.
+
+### `grep`
+
+**Use when:** you know a single target file and want to search for a literal string inside it.
+**Do not use when:** you need repo-wide search or regex-style search.
+
+- Input:
+  - `pattern`
+  - `path`
+- Key return fields:
+  - `content`: summary plus a small preview
+  - `data.match_count`
+  - `data.matches[]`: `line`, `text`, and `columns`
+
+## Practical selection rules
+
+- Need the directory tree: start with `list`
+- Need files by pattern: use `glob`
+- Need literal search inside one known file: use `grep`
+- Need full contents of one known file: use `read_file`
+
+## Anti-patterns
+
+- Using `shell_exec ls` instead of `list`
+- Using `read_file` to scan a whole repository
+- Using `glob` to search contents
+- Using `grep` as if it were repo-wide search

--- a/docs/tools/shell-exec.md
+++ b/docs/tools/shell-exec.md
@@ -1,0 +1,69 @@
+# `shell_exec`
+
+`shell_exec` runs a command inside the current workspace. It is a high-power, high-risk tool and should not replace dedicated read/search/edit tools.
+
+## When to use it
+
+Good fit:
+
+- you truly need command execution,
+- you need build / test / lint / git / package-manager / script behavior,
+- you need a local CLI that is already installed on the machine.
+
+Bad fit:
+
+- reading files (prefer `read_file`),
+- finding files (prefer `list` or `glob`),
+- searching file contents (prefer `grep`),
+- simple file creation or editing (prefer `write_file`, `edit`, or `apply_patch`).
+
+## Input
+
+```json
+{
+  "command": "pytest tests/unit",
+  "timeout": 30
+}
+```
+
+## Key semantics
+
+- the command string is parsed with `shlex.split(...)`,
+- it runs through `subprocess.run(..., shell=False)`,
+- default timeout is 30 seconds, maximum is 120,
+- large output is truncated.
+
+That means:
+
+- this is **not** “send the whole string to a shell and hope for the best”,
+- complex shell pipelines and shell-specific syntax are not a safe default assumption,
+- agents should not treat `shell_exec` as a universal text interface.
+
+## Return value
+
+On success, `status` is still `ok` even if the command exits non-zero. The real fields that matter are:
+
+- `data.exit_code`
+- `data.stdout`
+- `data.stderr`
+- `data.timeout`
+- `data.truncated`
+
+The key rule is:
+
+> For `shell_exec`, the agent must inspect `exit_code`. `status="ok"` only means the tool itself ran, not that the command succeeded.
+
+## Common failures
+
+- `shell_exec requires a string command argument`
+- `shell_exec command must not be empty`
+- `shell_exec command timed out after ...`
+- `shell_exec failed to execute command: ...`
+
+## Usage guidance
+
+- Build / test / lint: appropriate
+- File reading: not appropriate
+- Directory discovery: not appropriate
+- Content search: not appropriate
+- Small edit / patch operations: not appropriate


### PR DESCRIPTION
## Summary
- add an English agent-facing tools guide under `docs/tools/` for the core read/search, edit, patch, and shell tool surfaces
- link `docs/contracts/agent-tool-calling.md` to the new usage guide without changing the contract meaning
- keep the change documentation-only with no runtime, tool, or contract behavior changes