### PR TITLE
feat(runtime): enforce runtime tool timeouts (#180)

### DIFF
--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -33,8 +33,10 @@ APPROVAL_MODE_ENV_VAR = "VOIDCODE_APPROVAL_MODE"
 MODEL_ENV_VAR = "VOIDCODE_MODEL"
 EXECUTION_ENGINE_ENV_VAR = "VOIDCODE_EXECUTION_ENGINE"
 MAX_STEPS_ENV_VAR = "VOIDCODE_MAX_STEPS"
+TOOL_TIMEOUT_ENV_VAR = "VOIDCODE_TOOL_TIMEOUT_SECONDS"
 _VALID_APPROVAL_MODES = ("allow", "deny", "ask")
 _VALID_TUI_COMMANDS = ("command_palette", "session_new", "session_resume")
+DEFAULT_TOOL_TIMEOUT_SECONDS = 300
 
 type ExecutionEngineName = Literal["deterministic", "single_agent"]
 type RuntimeAgentPresetId = AgentManifestId
@@ -45,6 +47,7 @@ _TOP_LEVEL_ENV_VARS = (
     MODEL_ENV_VAR,
     EXECUTION_ENGINE_ENV_VAR,
     MAX_STEPS_ENV_VAR,
+    TOOL_TIMEOUT_ENV_VAR,
 )
 _ENV_SETTINGS_LOCK = Lock()
 
@@ -62,6 +65,10 @@ class _EnvironmentRuntimeSettings(BaseSettings):
         validation_alias=EXECUTION_ENGINE_ENV_VAR,
     )
     max_steps: int | None = Field(default=None, validation_alias=MAX_STEPS_ENV_VAR)
+    tool_timeout_seconds: int | None = Field(
+        default=None,
+        validation_alias=TOOL_TIMEOUT_ENV_VAR,
+    )
 
     @field_validator("approval_mode", mode="before")
     @classmethod
@@ -94,6 +101,11 @@ class _EnvironmentRuntimeSettings(BaseSettings):
     @classmethod
     def _validate_max_steps(cls, value: object) -> int | None:
         return _parse_environment_max_steps(value)
+
+    @field_validator("tool_timeout_seconds", mode="before")
+    @classmethod
+    def _validate_tool_timeout_seconds(cls, value: object) -> int | None:
+        return _parse_environment_tool_timeout_seconds(value)
 
 
 @dataclass(frozen=True, slots=True)
@@ -204,6 +216,7 @@ class RuntimeConfig:
     model: str | None = None
     execution_engine: ExecutionEngineName = "deterministic"
     max_steps: int = 4
+    tool_timeout_seconds: int | None = None
     hooks: RuntimeHooksConfig | None = None
     tools: RuntimeToolsConfig | None = None
     skills: RuntimeSkillsConfig | None = None
@@ -223,6 +236,7 @@ class RuntimeConfigOverrides:
     model: str | None = None
     execution_engine: ExecutionEngineName | None = None
     max_steps: int | None = None
+    tool_timeout_seconds: int | None = None
     hooks: RuntimeHooksConfig | None = None
     tools: RuntimeToolsConfig | None = None
     skills: RuntimeSkillsConfig | None = None
@@ -297,6 +311,7 @@ def load_runtime_config(
     model: str | None = None,
     execution_engine: ExecutionEngineName | None = None,
     max_steps: int | None = None,
+    tool_timeout_seconds: int | None = None,
     env: Mapping[str, str] | None = None,
 ) -> RuntimeConfig:
     resolved_workspace = workspace.resolve()
@@ -332,6 +347,11 @@ def load_runtime_config(
             explicit=max_steps,
             repo_local=repo_local.max_steps,
             environment=env_overrides.max_steps,
+        ),
+        tool_timeout_seconds=_resolve_tool_timeout_seconds(
+            explicit=tool_timeout_seconds,
+            repo_local=repo_local.tool_timeout_seconds,
+            environment=env_overrides.tool_timeout_seconds,
         ),
         hooks=repo_local.hooks,
         tools=repo_local.tools,
@@ -389,6 +409,12 @@ def _load_repo_local_config(
         allow_none=True,
     )
 
+    parsed_tool_timeout_seconds = _parse_tool_timeout_seconds(
+        payload.get("tool_timeout_seconds"),
+        source=f"runtime config field 'tool_timeout_seconds' in {config_path}",
+        allow_none=True,
+    )
+
     raw_hooks = payload.get("hooks")
     hooks = _parse_hooks_config(raw_hooks)
 
@@ -430,6 +456,7 @@ def _load_repo_local_config(
         model=raw_model,
         execution_engine=parsed_execution_engine,
         max_steps=parsed_max_steps,
+        tool_timeout_seconds=parsed_tool_timeout_seconds,
         hooks=hooks,
         tools=tools,
         skills=skills,
@@ -1569,6 +1596,7 @@ def _load_environment_runtime_config(env: Mapping[str, str] | None) -> RuntimeCo
         model=settings.model,
         execution_engine=settings.execution_engine,
         max_steps=settings.max_steps,
+        tool_timeout_seconds=settings.tool_timeout_seconds,
     )
 
 
@@ -1722,3 +1750,42 @@ def _parse_environment_max_steps(raw_value: object) -> int | None:
         source=f"environment variable {MAX_STEPS_ENV_VAR}",
         allow_none=True,
     )
+
+
+def _parse_tool_timeout_seconds(raw_value: object, *, source: str, allow_none: bool) -> int | None:
+    if raw_value is None and allow_none:
+        return None
+    if not isinstance(raw_value, int) or isinstance(raw_value, bool) or raw_value < 1:
+        raise ValueError(f"{source} must be an integer greater than or equal to 1")
+    return raw_value
+
+
+def _parse_environment_tool_timeout_seconds(raw_value: object) -> int | None:
+    if raw_value is None:
+        return None
+    parsed_value = raw_value
+    if isinstance(raw_value, str):
+        try:
+            parsed_value = int(raw_value)
+        except ValueError as exc:
+            raise ValueError(
+                f"environment variable {TOOL_TIMEOUT_ENV_VAR} must be an integer "
+                "greater than or equal to 1"
+            ) from exc
+    return _parse_tool_timeout_seconds(
+        parsed_value,
+        source=f"environment variable {TOOL_TIMEOUT_ENV_VAR}",
+        allow_none=True,
+    )
+
+
+def _resolve_tool_timeout_seconds(
+    *, explicit: int | None, repo_local: int | None, environment: int | None
+) -> int | None:
+    if explicit is not None:
+        return explicit
+    if repo_local is not None:
+        return repo_local
+    if environment is not None:
+        return environment
+    return None

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -36,8 +36,6 @@ MAX_STEPS_ENV_VAR = "VOIDCODE_MAX_STEPS"
 TOOL_TIMEOUT_ENV_VAR = "VOIDCODE_TOOL_TIMEOUT_SECONDS"
 _VALID_APPROVAL_MODES = ("allow", "deny", "ask")
 _VALID_TUI_COMMANDS = ("command_palette", "session_new", "session_resume")
-DEFAULT_TOOL_TIMEOUT_SECONDS = 300
-
 type ExecutionEngineName = Literal["deterministic", "single_agent"]
 type RuntimeAgentPresetId = AgentManifestId
 
@@ -1783,7 +1781,11 @@ def _resolve_tool_timeout_seconds(
     *, explicit: int | None, repo_local: int | None, environment: int | None
 ) -> int | None:
     if explicit is not None:
-        return explicit
+        return _parse_tool_timeout_seconds(
+            explicit,
+            source="explicit runtime config override 'tool_timeout_seconds'",
+            allow_none=True,
+        )
     if repo_local is not None:
         return repo_local
     if environment is not None:

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -235,6 +235,7 @@ class RuntimeConfigOverrides:
     execution_engine: ExecutionEngineName | None = None
     max_steps: int | None = None
     tool_timeout_seconds: int | None = None
+    tool_timeout_seconds_configured: bool = False
     hooks: RuntimeHooksConfig | None = None
     tools: RuntimeToolsConfig | None = None
     skills: RuntimeSkillsConfig | None = None
@@ -349,6 +350,7 @@ def load_runtime_config(
         tool_timeout_seconds=_resolve_tool_timeout_seconds(
             explicit=tool_timeout_seconds,
             repo_local=repo_local.tool_timeout_seconds,
+            repo_local_configured=repo_local.tool_timeout_seconds_configured,
             environment=env_overrides.tool_timeout_seconds,
         ),
         hooks=repo_local.hooks,
@@ -407,6 +409,7 @@ def _load_repo_local_config(
         allow_none=True,
     )
 
+    tool_timeout_seconds_configured = "tool_timeout_seconds" in payload
     parsed_tool_timeout_seconds = _parse_tool_timeout_seconds(
         payload.get("tool_timeout_seconds"),
         source=f"runtime config field 'tool_timeout_seconds' in {config_path}",
@@ -455,6 +458,7 @@ def _load_repo_local_config(
         execution_engine=parsed_execution_engine,
         max_steps=parsed_max_steps,
         tool_timeout_seconds=parsed_tool_timeout_seconds,
+        tool_timeout_seconds_configured=tool_timeout_seconds_configured,
         hooks=hooks,
         tools=tools,
         skills=skills,
@@ -1778,7 +1782,11 @@ def _parse_environment_tool_timeout_seconds(raw_value: object) -> int | None:
 
 
 def _resolve_tool_timeout_seconds(
-    *, explicit: int | None, repo_local: int | None, environment: int | None
+    *,
+    explicit: int | None,
+    repo_local: int | None,
+    repo_local_configured: bool,
+    environment: int | None,
 ) -> int | None:
     if explicit is not None:
         return _parse_tool_timeout_seconds(
@@ -1786,7 +1794,7 @@ def _resolve_tool_timeout_seconds(
             source="explicit runtime config override 'tool_timeout_seconds'",
             allow_none=True,
         )
-    if repo_local is not None:
+    if repo_local_configured:
         return repo_local
     if environment is not None:
         return environment

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -42,7 +42,15 @@ from ..provider.snapshot import (
     resolved_provider_snapshot,
 )
 from ..skills import SkillRegistry
-from ..tools.contracts import Tool, ToolCall, ToolDefinition, ToolResult, ToolResultStatus
+from ..tools.contracts import (
+    RuntimeTimeoutAwareTool,
+    RuntimeToolTimeoutError,
+    Tool,
+    ToolCall,
+    ToolDefinition,
+    ToolResult,
+    ToolResultStatus,
+)
 from .acp import AcpAdapter, AcpAdapterState, build_acp_adapter
 from .config import (
     ExecutionEngineName,
@@ -349,6 +357,7 @@ class VoidCodeRuntime:
             model=initial_model,
             execution_engine=initial_execution_engine,
             max_steps=self._config.max_steps,
+            tool_timeout_seconds=self._config.tool_timeout_seconds,
             provider_fallback=initial_provider_fallback,
             plan=self._config.plan,
             resolved_provider=self._resolved_provider_config,
@@ -586,6 +595,7 @@ class VoidCodeRuntime:
                 model=resolved.model,
                 execution_engine=resolved.execution_engine,
                 max_steps=request_max_steps,
+                tool_timeout_seconds=resolved.tool_timeout_seconds,
                 provider_fallback=resolved.provider_fallback,
                 plan=resolved.plan,
                 resolved_provider=resolved.resolved_provider,
@@ -1025,7 +1035,8 @@ class VoidCodeRuntime:
         preserved_continuity_state: RuntimeContinuityState | None = None,
     ) -> Iterator[RuntimeStreamChunk]:
         active_permission_policy = permission_policy or self._permission_policy
-        provider_attempt = cast(int, graph_request.metadata.get("provider_attempt", 0))
+        raw_provider_attempt = graph_request.metadata.get("provider_attempt", 0)
+        provider_attempt = raw_provider_attempt if isinstance(raw_provider_attempt, int) else 0
         active_preserved_continuity_state = preserved_continuity_state
         while True:
             context_window = self._prepare_single_agent_context_window(
@@ -1362,8 +1373,57 @@ class VoidCodeRuntime:
                 )
                 raise RuntimeError(pre_hook_outcome.failed_error)
 
+            _tool_timeout = self._effective_runtime_config_from_metadata(
+                session.metadata
+            ).tool_timeout_seconds
             try:
-                tool_result = tool.invoke(plan_tool_call, workspace=self._workspace)
+                if _tool_timeout is None:
+                    tool_result = tool.invoke(plan_tool_call, workspace=self._workspace)
+                elif isinstance(tool, RuntimeTimeoutAwareTool):
+                    tool_result = tool.invoke_with_runtime_timeout(
+                        plan_tool_call,
+                        workspace=self._workspace,
+                        timeout_seconds=_tool_timeout,
+                    )
+                elif tool.definition.read_only:
+                    tool_result_holder: ToolResult | None = None
+                    tool_error_holder: Exception | None = None
+
+                    def _invoke_tool_with_timeout_guard(
+                        timeout_tool: Tool,
+                        timeout_tool_call: ToolCall,
+                    ) -> None:
+                        nonlocal tool_result_holder, tool_error_holder
+                        try:
+                            tool_result_holder = timeout_tool.invoke(
+                                timeout_tool_call,
+                                workspace=self._workspace,
+                            )
+                        except Exception as exc:
+                            tool_error_holder = exc
+
+                    timeout_thread = threading.Thread(
+                        target=_invoke_tool_with_timeout_guard,
+                        args=(tool, plan_tool_call),
+                        name=f"voidcode-tool-timeout-{plan_tool_call.tool_name}",
+                        daemon=True,
+                    )
+                    timeout_thread.start()
+                    timeout_thread.join(timeout=_tool_timeout)
+                    if timeout_thread.is_alive():
+                        raise RuntimeToolTimeoutError(
+                            f"tool '{plan_tool_call.tool_name}' exceeded "
+                            f"runtime timeout of {_tool_timeout}s"
+                        )
+                    if tool_error_holder is not None:
+                        raise tool_error_holder
+                    if tool_result_holder is None:
+                        raise RuntimeError(
+                            f"tool '{plan_tool_call.tool_name}' finished without a result"
+                        )
+                    tool_result = tool_result_holder
+                else:
+                    tool_result = tool.invoke(plan_tool_call, workspace=self._workspace)
             except Exception as exc:
                 for acp_event in self._envelopes_for_acp_events(
                     session_id=session.session.id,
@@ -1387,6 +1447,24 @@ class VoidCodeRuntime:
                 ):
                     sequence = lsp_event.sequence
                     yield RuntimeStreamChunk(kind="event", session=session, event=lsp_event)
+                if isinstance(exc, RuntimeToolTimeoutError):
+                    sequence += 1
+                    yield RuntimeStreamChunk(
+                        kind="event",
+                        session=session,
+                        event=EventEnvelope(
+                            session_id=session.session.id,
+                            sequence=sequence,
+                            event_type="runtime.tool_timeout",
+                            source="runtime",
+                            payload={
+                                "tool": plan_tool_call.tool_name,
+                                "timeout_seconds": _tool_timeout,
+                            },
+                        ),
+                    )
+                    yield self._failed_chunk(session=session, sequence=sequence + 1, error=str(exc))
+                    return
                 yield self._failed_chunk(session=session, sequence=sequence + 1, error=str(exc))
                 raise
 
@@ -2018,10 +2096,15 @@ class VoidCodeRuntime:
             metadata={
                 **session.metadata,
                 "agent_preset": serialize_runtime_agent_config(effective_config.agent),
-                "provider_attempt": cast(int, session.metadata.get("provider_attempt", 0)),
+                "provider_attempt": (
+                    session.metadata.get("provider_attempt", 0)
+                    if isinstance(session.metadata.get("provider_attempt", 0), int)
+                    else 0
+                ),
             },
         )
-        provider_attempt = cast(int, graph_request.metadata.get("provider_attempt", 0))
+        raw_provider_attempt = graph_request.metadata.get("provider_attempt", 0)
+        provider_attempt = raw_provider_attempt if isinstance(raw_provider_attempt, int) else 0
         graph = self._graph_for_session_metadata(session.metadata)
         if provider_attempt > 0:
             effective_config = self._effective_runtime_config_from_metadata(session.metadata)
@@ -2710,6 +2793,7 @@ class VoidCodeRuntime:
             "approval_mode": effective_config.approval_mode,
             "execution_engine": effective_config.execution_engine,
             "max_steps": effective_config.max_steps,
+            "tool_timeout_seconds": effective_config.tool_timeout_seconds,
             "provider_fallback": serialize_provider_fallback_config(
                 effective_config.provider_fallback
             ),
@@ -2793,6 +2877,7 @@ class VoidCodeRuntime:
             model=model,
             execution_engine=execution_engine,
             max_steps=resolved.max_steps,
+            tool_timeout_seconds=resolved.tool_timeout_seconds,
             provider_fallback=provider_fallback,
             plan=resolved.plan,
             resolved_provider=resolved_provider,
@@ -3138,6 +3223,7 @@ class VoidCodeRuntime:
                 model=model,
                 execution_engine=execution_engine,
                 max_steps=max_steps,
+                tool_timeout_seconds=self._config.tool_timeout_seconds,
                 provider_fallback=provider_fallback,
                 plan=plan,
                 resolved_provider=resolved_provider,
@@ -3151,6 +3237,7 @@ class VoidCodeRuntime:
                 model=model,
                 execution_engine=execution_engine,
                 max_steps=max_steps,
+                tool_timeout_seconds=self._config.tool_timeout_seconds,
                 provider_fallback=provider_fallback,
                 plan=plan,
                 resolved_provider=resolved_provider,
@@ -3169,6 +3256,19 @@ class VoidCodeRuntime:
             if persisted_max_steps < 1:
                 raise ValueError("persisted runtime_config max_steps must be at least 1")
             max_steps = persisted_max_steps
+        tool_timeout_seconds = self._config.tool_timeout_seconds
+        if "tool_timeout_seconds" in runtime_config:
+            persisted_tool_timeout = runtime_config.get("tool_timeout_seconds")
+            if persisted_tool_timeout is None:
+                tool_timeout_seconds = None
+            elif isinstance(persisted_tool_timeout, int) and not isinstance(
+                persisted_tool_timeout, bool
+            ):
+                if persisted_tool_timeout < 1:
+                    raise ValueError(
+                        "persisted runtime_config tool_timeout_seconds must be at least 1"
+                    )
+                tool_timeout_seconds = persisted_tool_timeout
         provider_fallback = None
         if "provider_fallback" in runtime_config:
             try:
@@ -3231,6 +3331,7 @@ class VoidCodeRuntime:
             model=model,
             execution_engine=execution_engine,
             max_steps=max_steps,
+            tool_timeout_seconds=tool_timeout_seconds,
             provider_fallback=provider_fallback,
             plan=plan,
             resolved_provider=resolved_provider,
@@ -3305,6 +3406,7 @@ class EffectiveRuntimeConfig:
     model: str | None
     execution_engine: ExecutionEngineName
     max_steps: int
+    tool_timeout_seconds: int | None = None
     provider_fallback: RuntimeProviderFallbackConfig | None = None
     plan: RuntimePlanConfig | None = None
     resolved_provider: ResolvedProviderConfig = field(default_factory=ResolvedProviderConfig)

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -1385,43 +1385,6 @@ class VoidCodeRuntime:
                         workspace=self._workspace,
                         timeout_seconds=_tool_timeout,
                     )
-                elif tool.definition.read_only:
-                    tool_result_holder: ToolResult | None = None
-                    tool_error_holder: Exception | None = None
-
-                    def _invoke_tool_with_timeout_guard(
-                        timeout_tool: Tool,
-                        timeout_tool_call: ToolCall,
-                    ) -> None:
-                        nonlocal tool_result_holder, tool_error_holder
-                        try:
-                            tool_result_holder = timeout_tool.invoke(
-                                timeout_tool_call,
-                                workspace=self._workspace,
-                            )
-                        except Exception as exc:
-                            tool_error_holder = exc
-
-                    timeout_thread = threading.Thread(
-                        target=_invoke_tool_with_timeout_guard,
-                        args=(tool, plan_tool_call),
-                        name=f"voidcode-tool-timeout-{plan_tool_call.tool_name}",
-                        daemon=True,
-                    )
-                    timeout_thread.start()
-                    timeout_thread.join(timeout=_tool_timeout)
-                    if timeout_thread.is_alive():
-                        raise RuntimeToolTimeoutError(
-                            f"tool '{plan_tool_call.tool_name}' exceeded "
-                            f"runtime timeout of {_tool_timeout}s"
-                        )
-                    if tool_error_holder is not None:
-                        raise tool_error_holder
-                    if tool_result_holder is None:
-                        raise RuntimeError(
-                            f"tool '{plan_tool_call.tool_name}' finished without a result"
-                        )
-                    tool_result = tool_result_holder
                 else:
                     tool_result = tool.invoke(plan_tool_call, workspace=self._workspace)
             except Exception as exc:

--- a/src/voidcode/tools/contracts.py
+++ b/src/voidcode/tools/contracts.py
@@ -7,6 +7,10 @@ from typing import ClassVar, Literal, Protocol, runtime_checkable
 type ToolResultStatus = Literal["ok", "error"]
 
 
+class RuntimeToolTimeoutError(TimeoutError):
+    """Raised when the runtime-owned outer tool timeout wins."""
+
+
 @dataclass(frozen=True, slots=True)
 class ToolDefinition:
     name: str
@@ -49,6 +53,17 @@ class DynamicTool(Protocol):
     def definition(self) -> ToolDefinition: ...
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult: ...
+
+
+@runtime_checkable
+class RuntimeTimeoutAwareTool(Protocol):
+    def invoke_with_runtime_timeout(
+        self,
+        call: ToolCall,
+        *,
+        workspace: Path,
+        timeout_seconds: int,
+    ) -> ToolResult: ...
 
 
 type Tool = StaticTool | DynamicTool

--- a/src/voidcode/tools/shell_exec.py
+++ b/src/voidcode/tools/shell_exec.py
@@ -8,7 +8,7 @@ from typing import ClassVar, final
 from pydantic import ValidationError
 
 from ._pydantic_args import ShellExecArgs
-from .contracts import ToolCall, ToolDefinition, ToolResult
+from .contracts import RuntimeToolTimeoutError, ToolCall, ToolDefinition, ToolResult
 
 DEFAULT_TIMEOUT_SECONDS = 30
 MAX_TIMEOUT_SECONDS = 120
@@ -37,6 +37,24 @@ class ShellExecTool:
     )
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        return self._invoke(call, workspace=workspace, runtime_timeout_seconds=None)
+
+    def invoke_with_runtime_timeout(
+        self,
+        call: ToolCall,
+        *,
+        workspace: Path,
+        timeout_seconds: int,
+    ) -> ToolResult:
+        return self._invoke(call, workspace=workspace, runtime_timeout_seconds=timeout_seconds)
+
+    def _invoke(
+        self,
+        call: ToolCall,
+        *,
+        workspace: Path,
+        runtime_timeout_seconds: int | None,
+    ) -> ToolResult:
         try:
             args = ShellExecArgs.model_validate({"command": call.arguments.get("command")})
         except ValidationError as exc:
@@ -53,9 +71,15 @@ class ShellExecTool:
 
         timeout_value = call.arguments.get("timeout", DEFAULT_TIMEOUT_SECONDS)
         if isinstance(timeout_value, (int, float)) and timeout_value > 0:
-            timeout_seconds = min(int(timeout_value), MAX_TIMEOUT_SECONDS)
+            local_timeout_seconds = min(int(timeout_value), MAX_TIMEOUT_SECONDS)
         else:
-            timeout_seconds = DEFAULT_TIMEOUT_SECONDS
+            local_timeout_seconds = DEFAULT_TIMEOUT_SECONDS
+
+        timeout_seconds = local_timeout_seconds
+        runtime_timeout_selected = False
+        if runtime_timeout_seconds is not None and runtime_timeout_seconds < timeout_seconds:
+            timeout_seconds = runtime_timeout_seconds
+            runtime_timeout_selected = True
 
         try:
             completed = subprocess.run(
@@ -68,6 +92,10 @@ class ShellExecTool:
                 timeout=timeout_seconds,
             )
         except subprocess.TimeoutExpired as exc:
+            if runtime_timeout_selected:
+                raise RuntimeToolTimeoutError(
+                    f"tool '{self.definition.name}' exceeded runtime timeout of {timeout_seconds}s"
+                ) from exc
             raise ValueError(f"shell_exec command timed out after {timeout_seconds}s") from exc
         except OSError as exc:
             raise ValueError(f"shell_exec failed to execute command: {exc}") from exc

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -1197,6 +1197,7 @@ def test_single_agent_runtime_executes_read_path_and_persists_config(tmp_path: P
                 }
             ],
         },
+        "tool_timeout_seconds": None,
     }
     assert result.session.metadata["runtime_state"] == {
         "acp": {
@@ -1798,6 +1799,7 @@ def test_runtime_resume_uses_persisted_runtime_config_over_fresh_resume_override
         "approval_mode": "allow",
         "execution_engine": "deterministic",
         "max_steps": 4,
+        "tool_timeout_seconds": None,
         "lsp": {"configured_enabled": False, "mode": "disabled", "servers": []},
         "mcp": {"configured_enabled": False, "mode": "disabled", "servers": []},
         "model": "session/model",

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -350,6 +350,19 @@ def test_runtime_config_prefers_repo_file_tool_timeout_over_environment(tmp_path
     assert config.tool_timeout_seconds == 4
 
 
+def test_runtime_config_treats_null_repo_file_tool_timeout_as_explicit_override(
+    tmp_path: Path,
+) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps({"tool_timeout_seconds": None}),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={TOOL_TIMEOUT_ENV_VAR: "7"})
+
+    assert config.tool_timeout_seconds is None
+
+
 def test_runtime_config_prefers_explicit_execution_engine_over_repo_file_and_environment(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -1242,6 +1242,14 @@ def test_runtime_config_rejects_invalid_environment_tool_timeout(
         _ = load_runtime_config(tmp_path, env={TOOL_TIMEOUT_ENV_VAR: raw_value})
 
 
+@pytest.mark.parametrize("raw_value", [0, -1, True, False])
+def test_runtime_config_rejects_invalid_explicit_tool_timeout(
+    tmp_path: Path, raw_value: object
+) -> None:
+    with pytest.raises(ValueError, match="explicit runtime config override 'tool_timeout_seconds'"):
+        _ = load_runtime_config(tmp_path, tool_timeout_seconds=raw_value, env={})
+
+
 def test_runtime_config_rejects_empty_model_environment(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match=MODEL_ENV_VAR):
         _ = load_runtime_config(tmp_path, env={MODEL_ENV_VAR: ""})

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -24,6 +24,7 @@ from voidcode.runtime.config import (
     MAX_STEPS_ENV_VAR,
     MODEL_ENV_VAR,
     RUNTIME_CONFIG_FILE_NAME,
+    TOOL_TIMEOUT_ENV_VAR,
     RuntimeAgentConfig,
     RuntimeFormatterPresetConfig,
     RuntimeHooksConfig,
@@ -228,6 +229,14 @@ def test_runtime_config_uses_max_steps_environment_when_repo_file_missing(tmp_pa
     assert config.max_steps == 7
 
 
+def test_runtime_config_uses_tool_timeout_environment_when_repo_file_missing(
+    tmp_path: Path,
+) -> None:
+    config = load_runtime_config(tmp_path, env={TOOL_TIMEOUT_ENV_VAR: "7"})
+
+    assert config.tool_timeout_seconds == 7
+
+
 def test_runtime_config_prefers_repo_file_over_environment(tmp_path: Path) -> None:
     runtime_config_path(tmp_path).write_text(
         json.dumps(
@@ -330,6 +339,17 @@ def test_runtime_config_prefers_repo_file_max_steps_over_environment(tmp_path: P
     assert config.max_steps == 4
 
 
+def test_runtime_config_prefers_repo_file_tool_timeout_over_environment(tmp_path: Path) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps({"tool_timeout_seconds": 4}),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={TOOL_TIMEOUT_ENV_VAR: "7"})
+
+    assert config.tool_timeout_seconds == 4
+
+
 def test_runtime_config_prefers_explicit_execution_engine_over_repo_file_and_environment(
     tmp_path: Path,
 ) -> None:
@@ -362,6 +382,23 @@ def test_runtime_config_prefers_explicit_max_steps_over_repo_file_and_environmen
     )
 
     assert config.max_steps == 9
+
+
+def test_runtime_config_prefers_explicit_tool_timeout_over_repo_file_and_environment(
+    tmp_path: Path,
+) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps({"tool_timeout_seconds": 4}),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(
+        tmp_path,
+        tool_timeout_seconds=9,
+        env={TOOL_TIMEOUT_ENV_VAR: "7"},
+    )
+
+    assert config.tool_timeout_seconds == 9
 
 
 def test_runtime_config_parses_extension_domains(tmp_path: Path) -> None:
@@ -1197,6 +1234,14 @@ def test_runtime_config_rejects_invalid_environment_max_steps(
         _ = load_runtime_config(tmp_path, env={MAX_STEPS_ENV_VAR: raw_value})
 
 
+@pytest.mark.parametrize("raw_value", ["0", "-1", "four"])
+def test_runtime_config_rejects_invalid_environment_tool_timeout(
+    tmp_path: Path, raw_value: str
+) -> None:
+    with pytest.raises(ValueError, match=TOOL_TIMEOUT_ENV_VAR):
+        _ = load_runtime_config(tmp_path, env={TOOL_TIMEOUT_ENV_VAR: raw_value})
+
+
 def test_runtime_config_rejects_empty_model_environment(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match=MODEL_ENV_VAR):
         _ = load_runtime_config(tmp_path, env={MODEL_ENV_VAR: ""})
@@ -1238,6 +1283,21 @@ def test_runtime_config_rejects_invalid_repo_local_execution_engine(tmp_path: Pa
         ),
         pytest.param(
             {"max_steps": "four"}, "runtime config field 'max_steps'", id="max-steps-type"
+        ),
+        pytest.param(
+            {"tool_timeout_seconds": 0},
+            "runtime config field 'tool_timeout_seconds'",
+            id="tool-timeout-zero",
+        ),
+        pytest.param(
+            {"tool_timeout_seconds": -1},
+            "runtime config field 'tool_timeout_seconds'",
+            id="tool-timeout-negative",
+        ),
+        pytest.param(
+            {"tool_timeout_seconds": "slow"},
+            "runtime config field 'tool_timeout_seconds'",
+            id="tool-timeout-type",
         ),
     ],
 )

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -2504,6 +2504,7 @@ def test_runtime_effective_runtime_config_recovers_persisted_max_steps(tmp_path:
         "approval_mode": "allow",
         "execution_engine": "deterministic",
         "max_steps": 7,
+        "tool_timeout_seconds": None,
         "model": "session/model",
         "provider_fallback": None,
         "plan": None,
@@ -2535,6 +2536,115 @@ def test_runtime_effective_runtime_config_recovers_persisted_max_steps(tmp_path:
     assert effective.model == "session/model"
     assert effective.execution_engine == "deterministic"
     assert effective.max_steps == 7
+
+
+def test_runtime_effective_runtime_config_recovers_persisted_tool_timeout(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("config session\n", encoding="utf-8")
+
+    initial_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            approval_mode="allow",
+            model="session/model",
+            tool_timeout_seconds=7,
+        ),
+    )
+    response = initial_runtime.run(
+        RuntimeRequest(prompt="read sample.txt", session_id="tool-timeout-session")
+    )
+
+    assert response.session.metadata["runtime_config"]["tool_timeout_seconds"] == 7
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            approval_mode="deny",
+            model="fresh/model",
+            tool_timeout_seconds=3,
+        ),
+    )
+    effective = resumed_runtime.effective_runtime_config(session_id="tool-timeout-session")
+
+    assert effective.approval_mode == "allow"
+    assert effective.model == "session/model"
+    assert effective.tool_timeout_seconds == 7
+
+
+def test_runtime_effective_runtime_config_preserves_explicit_persisted_none_tool_timeout(
+    tmp_path: Path,
+) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("config session\n", encoding="utf-8")
+
+    initial_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(approval_mode="allow", model="session/model"),
+    )
+    response = initial_runtime.run(
+        RuntimeRequest(prompt="read sample.txt", session_id="tool-timeout-none-session")
+    )
+
+    assert response.session.metadata["runtime_config"]["tool_timeout_seconds"] is None
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            approval_mode="deny",
+            model="fresh/model",
+            tool_timeout_seconds=9,
+        ),
+    )
+    effective = resumed_runtime.effective_runtime_config(session_id="tool-timeout-none-session")
+
+    assert effective.approval_mode == "allow"
+    assert effective.model == "session/model"
+    assert effective.tool_timeout_seconds is None
+
+
+def test_runtime_effective_runtime_config_rejects_invalid_persisted_tool_timeout(
+    tmp_path: Path,
+) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("config session\n", encoding="utf-8")
+
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(approval_mode="allow", model="session/model", tool_timeout_seconds=7),
+    )
+    _ = runtime.run(RuntimeRequest(prompt="read sample.txt", session_id="invalid-tool-timeout"))
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        row = connection.execute(
+            "SELECT metadata_json FROM sessions WHERE session_id = ?",
+            ("invalid-tool-timeout",),
+        ).fetchone()
+        assert row is not None
+        metadata = json.loads(str(row[0]))
+        assert isinstance(metadata, dict)
+        metadata_dict = cast(dict[str, object], metadata)
+        runtime_config = cast(dict[str, object], metadata_dict["runtime_config"])
+        runtime_config["tool_timeout_seconds"] = 0
+        _ = connection.execute(
+            "UPDATE sessions SET metadata_json = ? WHERE session_id = ?",
+            (json.dumps(metadata_dict, sort_keys=True), "invalid-tool-timeout"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(tool_timeout_seconds=3),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="persisted runtime_config tool_timeout_seconds must be at least 1",
+    ):
+        _ = resumed_runtime.effective_runtime_config(session_id="invalid-tool-timeout")
 
 
 def test_runtime_effective_runtime_config_rejects_invalid_persisted_max_steps(
@@ -2616,6 +2726,58 @@ def test_runtime_effective_runtime_config_falls_back_for_legacy_sessions(tmp_pat
     assert effective.model == "fresh/model"
     assert effective.execution_engine == "deterministic"
     assert effective.max_steps == 9
+
+
+def test_runtime_effective_runtime_config_falls_back_to_fresh_tool_timeout_for_legacy_sessions(
+    tmp_path: Path,
+) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("legacy config\n", encoding="utf-8")
+
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            approval_mode="allow",
+            model="session/model",
+            tool_timeout_seconds=5,
+        ),
+    )
+    _ = runtime.run(RuntimeRequest(prompt="read sample.txt", session_id="legacy-tool-timeout"))
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        row = connection.execute(
+            "SELECT metadata_json FROM sessions WHERE session_id = ?",
+            ("legacy-tool-timeout",),
+        ).fetchone()
+        assert row is not None
+        metadata = json.loads(str(row[0]))
+        assert isinstance(metadata, dict)
+        metadata_dict = cast(dict[str, object], metadata)
+        runtime_config = cast(dict[str, object], metadata_dict["runtime_config"])
+        runtime_config.pop("tool_timeout_seconds", None)
+        _ = connection.execute(
+            "UPDATE sessions SET metadata_json = ? WHERE session_id = ?",
+            (json.dumps(metadata_dict, sort_keys=True), "legacy-tool-timeout"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            approval_mode="deny",
+            model="fresh/model",
+            tool_timeout_seconds=9,
+        ),
+    )
+    effective = resumed_runtime.effective_runtime_config(session_id="legacy-tool-timeout")
+
+    assert effective.approval_mode == "allow"
+    assert effective.model == "session/model"
+    assert effective.tool_timeout_seconds == 9
 
 
 def test_runtime_effective_runtime_config_keeps_persisted_non_agent_sessions_clear_of_fresh_agent_defaults(  # noqa: E501
@@ -2705,6 +2867,7 @@ def test_runtime_effective_runtime_config_uses_request_metadata_max_steps_for_ne
         "approval_mode": "ask",
         "execution_engine": "deterministic",
         "max_steps": 2,
+        "tool_timeout_seconds": None,
         "provider_fallback": None,
         "plan": None,
         "resolved_provider": None,

--- a/tests/unit/runtime/test_tool_execution_timeout.py
+++ b/tests/unit/runtime/test_tool_execution_timeout.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from voidcode.runtime.config import RuntimeConfig
+from voidcode.runtime.contracts import RuntimeRequest
+from voidcode.runtime.service import ToolRegistry, VoidCodeRuntime
+from voidcode.tools import ShellExecTool
+from voidcode.tools.contracts import ToolCall, ToolDefinition, ToolResult
+
+
+class _InstantTool:
+    definition = ToolDefinition(name="instant_tool", description="Returns instantly.")
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        return ToolResult(tool_name=self.definition.name, status="ok", content="done")
+
+
+class _HangingTool:
+    definition = ToolDefinition(name="hanging_tool", description="Never returns.")
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        time.sleep(9999)
+        return ToolResult(tool_name=self.definition.name, status="ok", content="unreachable")
+
+
+class _SlowButFinishingTool:
+    definition = ToolDefinition(
+        name="slow_but_finishing_tool", description="Finishes after a short sleep."
+    )
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        time.sleep(0.05)
+        return ToolResult(tool_name=self.definition.name, status="ok", content="finished")
+
+
+class _ToolNativeTimeoutErrorTool:
+    definition = ToolDefinition(
+        name="tool_native_timeout_error_tool",
+        description="Raises a tool-native TimeoutError.",
+    )
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        raise TimeoutError("tool-native timeout")
+
+
+class _SingleToolCallGraph:
+    def __init__(self, tool_name: str) -> None:
+        self._tool_name = tool_name
+        self._done = False
+
+    def step(self, request: Any, tool_results: tuple[Any, ...], *, session: Any) -> Any:
+        if tool_results:
+            self._done = True
+
+        class _Step:
+            pass
+
+        step = _Step()
+
+        if not tool_results:
+            step.tool_call = ToolCall(tool_name=self._tool_name, arguments={})  # type: ignore[attr-defined]
+            step.output = None  # type: ignore[attr-defined]
+            step.events = ()  # type: ignore[attr-defined]
+            step.is_finished = False  # type: ignore[attr-defined]
+        else:
+            step.tool_call = None  # type: ignore[attr-defined]
+            step.output = "completed"  # type: ignore[attr-defined]
+            step.events = ()  # type: ignore[attr-defined]
+            step.is_finished = True  # type: ignore[attr-defined]
+
+        return step
+
+
+class _ShellExecGraph:
+    def __init__(self, arguments: dict[str, object]) -> None:
+        self._arguments = arguments
+
+    def step(self, request: Any, tool_results: tuple[Any, ...], *, session: Any) -> Any:
+        _ = request, session
+
+        class _Step:
+            pass
+
+        step = _Step()
+        if not tool_results:
+            step.tool_call = ToolCall(tool_name="shell_exec", arguments=self._arguments)  # type: ignore[attr-defined]
+            step.output = None  # type: ignore[attr-defined]
+            step.events = ()  # type: ignore[attr-defined]
+            step.is_finished = False  # type: ignore[attr-defined]
+        else:
+            step.tool_call = None  # type: ignore[attr-defined]
+            step.output = "completed"  # type: ignore[attr-defined]
+            step.events = ()  # type: ignore[attr-defined]
+            step.is_finished = True  # type: ignore[attr-defined]
+        return step
+
+
+def _collect_events(runtime: VoidCodeRuntime, prompt: str = "go") -> list[str]:
+    chunks = list(runtime.run_stream(RuntimeRequest(prompt=prompt)))
+    return [c.event.event_type for c in chunks if c.kind == "event" and c.event is not None]
+
+
+def _make_runtime(
+    tmp_path: Path,
+    tool: Any,
+    *,
+    tool_timeout_seconds: int | None = None,
+) -> VoidCodeRuntime:
+    registry = ToolRegistry.from_tools([tool])
+    config = RuntimeConfig(tool_timeout_seconds=tool_timeout_seconds)
+    return VoidCodeRuntime(
+        workspace=tmp_path,
+        tool_registry=registry,
+        graph=_SingleToolCallGraph(tool.definition.name),
+        config=config,
+    )
+
+
+def test_tool_completes_normally_within_timeout(tmp_path: Path) -> None:
+    runtime = _make_runtime(tmp_path, _InstantTool(), tool_timeout_seconds=10)
+    event_types = _collect_events(runtime)
+
+    assert "runtime.tool_completed" in event_types
+    assert "runtime.tool_timeout" not in event_types
+    assert "runtime.failed" not in event_types
+
+
+def test_slow_tool_that_finishes_within_timeout_is_not_interrupted(tmp_path: Path) -> None:
+    runtime = _make_runtime(tmp_path, _SlowButFinishingTool(), tool_timeout_seconds=10)
+    event_types = _collect_events(runtime)
+
+    assert "runtime.tool_completed" in event_types
+    assert "runtime.tool_timeout" not in event_types
+    assert "runtime.failed" not in event_types
+
+
+def test_hanging_tool_emits_tool_timeout_event(tmp_path: Path) -> None:
+    runtime = _make_runtime(tmp_path, _HangingTool(), tool_timeout_seconds=1)
+    event_types = _collect_events(runtime)
+
+    assert "runtime.tool_timeout" in event_types
+    assert "runtime.failed" in event_types
+
+
+def test_hanging_tool_does_not_emit_tool_completed(tmp_path: Path) -> None:
+    runtime = _make_runtime(tmp_path, _HangingTool(), tool_timeout_seconds=1)
+    event_types = _collect_events(runtime)
+
+    assert "runtime.tool_completed" not in event_types
+
+
+def test_timeout_event_payload_contains_tool_name_and_seconds(tmp_path: Path) -> None:
+    timeout = 1
+    tool = _HangingTool()
+    registry = ToolRegistry.from_tools([tool])
+    config = RuntimeConfig(tool_timeout_seconds=timeout)
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        tool_registry=registry,
+        graph=_SingleToolCallGraph(tool.definition.name),
+        config=config,
+    )
+
+    chunks = list(runtime.run_stream(RuntimeRequest(prompt="go")))
+    timeout_events = [
+        c.event
+        for c in chunks
+        if c.kind == "event"
+        and c.event is not None
+        and c.event.event_type == "runtime.tool_timeout"
+    ]
+
+    assert len(timeout_events) == 1
+    payload = timeout_events[0].payload
+    assert payload["tool"] == "hanging_tool"
+    assert payload["timeout_seconds"] == timeout
+
+
+def test_runtime_does_not_hang_after_tool_timeout(tmp_path: Path) -> None:
+    runtime = _make_runtime(tmp_path, _HangingTool(), tool_timeout_seconds=1)
+
+    start = time.monotonic()
+    _collect_events(runtime)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 5
+
+
+def test_runtime_timeout_unset_does_not_emit_runtime_tool_timeout(tmp_path: Path) -> None:
+    runtime = _make_runtime(tmp_path, _InstantTool(), tool_timeout_seconds=None)
+    event_types = _collect_events(runtime)
+
+    assert "runtime.tool_completed" in event_types
+    assert "runtime.tool_timeout" not in event_types
+
+
+def test_session_status_is_failed_after_timeout(tmp_path: Path) -> None:
+    tool = _HangingTool()
+    registry = ToolRegistry.from_tools([tool])
+    config = RuntimeConfig(tool_timeout_seconds=1)
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        tool_registry=registry,
+        graph=_SingleToolCallGraph(tool.definition.name),
+        config=config,
+    )
+
+    chunks = list(runtime.run_stream(RuntimeRequest(prompt="go")))
+    statuses = [c.session.status for c in chunks]
+    assert "failed" in statuses
+
+
+def test_shell_exec_uses_existing_tool_timeout_when_runtime_timeout_is_unset(
+    tmp_path: Path,
+) -> None:
+    command = f'"{sys.executable}" -c "print(1)"'
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        tool_registry=ToolRegistry.from_tools([ShellExecTool()]),
+        graph=_ShellExecGraph({"command": command}),
+        config=RuntimeConfig(approval_mode="allow", tool_timeout_seconds=None),
+    )
+    chunks = list(runtime.run_stream(RuntimeRequest(prompt="go")))
+    completed_events = [
+        chunk.event
+        for chunk in chunks
+        if chunk.kind == "event"
+        and chunk.event is not None
+        and chunk.event.event_type == "runtime.tool_completed"
+    ]
+
+    assert len(completed_events) == 1
+    assert completed_events[0].payload["timeout"] == 30
+
+
+def test_shell_exec_timeout_wins_when_shorter_than_runtime_timeout(tmp_path: Path) -> None:
+    command = f'"{sys.executable}" -c "import time; time.sleep(2)"'
+    session_id = "shell-exec-local-timeout"
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        tool_registry=ToolRegistry.from_tools([ShellExecTool()]),
+        graph=_ShellExecGraph({"command": command, "timeout": 1}),
+        config=RuntimeConfig(approval_mode="allow", tool_timeout_seconds=10),
+    )
+
+    with pytest.raises(ValueError, match="shell_exec command timed out after 1s"):
+        _ = list(runtime.run_stream(RuntimeRequest(prompt="go", session_id=session_id)))
+
+    replay = runtime.resume(session_id)
+    event_types = [event.event_type for event in replay.events]
+
+    assert "runtime.tool_timeout" not in event_types
+    assert replay.events[-1].event_type == "runtime.failed"
+    assert replay.events[-1].payload == {"error": "shell_exec command timed out after 1s"}
+
+
+def test_runtime_timeout_wins_when_shorter_than_shell_exec_timeout(tmp_path: Path) -> None:
+    command = f'"{sys.executable}" -c "import time; time.sleep(2)"'
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        tool_registry=ToolRegistry.from_tools([ShellExecTool()]),
+        graph=_ShellExecGraph({"command": command, "timeout": 10}),
+        config=RuntimeConfig(approval_mode="allow", tool_timeout_seconds=1),
+    )
+    chunks = list(runtime.run_stream(RuntimeRequest(prompt="go")))
+    event_types = [
+        chunk.event.event_type
+        for chunk in chunks
+        if chunk.kind == "event" and chunk.event is not None
+    ]
+    timeout_events = [
+        chunk.event
+        for chunk in chunks
+        if chunk.kind == "event"
+        and chunk.event is not None
+        and chunk.event.event_type == "runtime.tool_timeout"
+    ]
+
+    assert "runtime.failed" in event_types
+    assert len(timeout_events) == 1
+    assert timeout_events[0].payload == {"tool": "shell_exec", "timeout_seconds": 1}
+
+
+def test_runtime_timeout_prevents_delayed_shell_exec_side_effect(tmp_path: Path) -> None:
+    side_effect_path = tmp_path / "late-side-effect.txt"
+    command = (
+        f'"{sys.executable}" -c "import time; '
+        f"from pathlib import Path; "
+        f"time.sleep(2); "
+        f"Path({str(side_effect_path)!r}).write_text('done', encoding='utf-8')\""
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        tool_registry=ToolRegistry.from_tools([ShellExecTool()]),
+        graph=_ShellExecGraph({"command": command, "timeout": 10}),
+        config=RuntimeConfig(approval_mode="allow", tool_timeout_seconds=1),
+    )
+
+    _ = list(runtime.run_stream(RuntimeRequest(prompt="go")))
+    time.sleep(1.5)
+
+    assert side_effect_path.exists() is False
+
+
+def test_tool_native_timeout_error_does_not_emit_runtime_tool_timeout_without_runtime_cap(
+    tmp_path: Path,
+) -> None:
+    runtime = _make_runtime(tmp_path, _ToolNativeTimeoutErrorTool(), tool_timeout_seconds=None)
+
+    with pytest.raises(TimeoutError, match="tool-native timeout"):
+        _ = list(runtime.run_stream(RuntimeRequest(prompt="go", session_id="tool-native-timeout")))
+
+    replay = runtime.resume("tool-native-timeout")
+    event_types = [event.event_type for event in replay.events]
+
+    assert "runtime.tool_timeout" not in event_types
+    assert replay.events[-1].event_type == "runtime.failed"
+    assert replay.events[-1].payload == {"error": "tool-native timeout"}
+
+
+def test_tool_native_timeout_error_before_runtime_cap_does_not_emit_runtime_tool_timeout(
+    tmp_path: Path,
+) -> None:
+    runtime = _make_runtime(tmp_path, _ToolNativeTimeoutErrorTool(), tool_timeout_seconds=10)
+
+    with pytest.raises(TimeoutError, match="tool-native timeout"):
+        _ = list(
+            runtime.run_stream(
+                RuntimeRequest(prompt="go", session_id="tool-native-timeout-with-cap")
+            )
+        )
+
+    replay = runtime.resume("tool-native-timeout-with-cap")
+    event_types = [event.event_type for event in replay.events]
+
+    assert "runtime.tool_timeout" not in event_types
+    assert replay.events[-1].event_type == "runtime.failed"
+    assert replay.events[-1].payload == {"error": "tool-native timeout"}

--- a/tests/unit/runtime/test_tool_execution_timeout.py
+++ b/tests/unit/runtime/test_tool_execution_timeout.py
@@ -140,31 +140,52 @@ def test_slow_tool_that_finishes_within_timeout_is_not_interrupted(tmp_path: Pat
     assert "runtime.failed" not in event_types
 
 
-def test_hanging_tool_emits_tool_timeout_event(tmp_path: Path) -> None:
+def test_hanging_tool_does_not_emit_runtime_tool_timeout(tmp_path: Path) -> None:
     runtime = _make_runtime(tmp_path, _HangingTool(), tool_timeout_seconds=1)
-    event_types = _collect_events(runtime)
 
-    assert "runtime.tool_timeout" in event_types
-    assert "runtime.failed" in event_types
+    start = time.monotonic()
+    iterator = runtime.run_stream(RuntimeRequest(prompt="go"))
+    first_chunks: list[Any] = []
+    for _ in range(3):
+        first_chunks.append(next(iterator))
+    elapsed = time.monotonic() - start
+    event_types = [
+        chunk.event.event_type
+        for chunk in first_chunks
+        if chunk.kind == "event" and chunk.event is not None
+    ]
+
+    assert elapsed < 5
+    assert "runtime.tool_timeout" not in event_types
+    assert "runtime.failed" not in event_types
 
 
 def test_hanging_tool_does_not_emit_tool_completed(tmp_path: Path) -> None:
     runtime = _make_runtime(tmp_path, _HangingTool(), tool_timeout_seconds=1)
-    event_types = _collect_events(runtime)
+
+    iterator = runtime.run_stream(RuntimeRequest(prompt="go"))
+    first_chunks = [next(iterator) for _ in range(3)]
+    event_types = [
+        chunk.event.event_type
+        for chunk in first_chunks
+        if chunk.kind == "event" and chunk.event is not None
+    ]
 
     assert "runtime.tool_completed" not in event_types
 
 
 def test_timeout_event_payload_contains_tool_name_and_seconds(tmp_path: Path) -> None:
     timeout = 1
-    tool = _HangingTool()
-    registry = ToolRegistry.from_tools([tool])
-    config = RuntimeConfig(tool_timeout_seconds=timeout)
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
-        tool_registry=registry,
-        graph=_SingleToolCallGraph(tool.definition.name),
-        config=config,
+        tool_registry=ToolRegistry.from_tools([ShellExecTool()]),
+        graph=_ShellExecGraph(
+            {
+                "command": f'"{sys.executable}" -c "import time; time.sleep(2)"',
+                "timeout": 10,
+            }
+        ),
+        config=RuntimeConfig(approval_mode="allow", tool_timeout_seconds=timeout),
     )
 
     chunks = list(runtime.run_stream(RuntimeRequest(prompt="go")))
@@ -178,12 +199,22 @@ def test_timeout_event_payload_contains_tool_name_and_seconds(tmp_path: Path) ->
 
     assert len(timeout_events) == 1
     payload = timeout_events[0].payload
-    assert payload["tool"] == "hanging_tool"
+    assert payload["tool"] == "shell_exec"
     assert payload["timeout_seconds"] == timeout
 
 
 def test_runtime_does_not_hang_after_tool_timeout(tmp_path: Path) -> None:
-    runtime = _make_runtime(tmp_path, _HangingTool(), tool_timeout_seconds=1)
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        tool_registry=ToolRegistry.from_tools([ShellExecTool()]),
+        graph=_ShellExecGraph(
+            {
+                "command": f'"{sys.executable}" -c "import time; time.sleep(2)"',
+                "timeout": 10,
+            }
+        ),
+        config=RuntimeConfig(approval_mode="allow", tool_timeout_seconds=1),
+    )
 
     start = time.monotonic()
     _collect_events(runtime)
@@ -201,14 +232,16 @@ def test_runtime_timeout_unset_does_not_emit_runtime_tool_timeout(tmp_path: Path
 
 
 def test_session_status_is_failed_after_timeout(tmp_path: Path) -> None:
-    tool = _HangingTool()
-    registry = ToolRegistry.from_tools([tool])
-    config = RuntimeConfig(tool_timeout_seconds=1)
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
-        tool_registry=registry,
-        graph=_SingleToolCallGraph(tool.definition.name),
-        config=config,
+        tool_registry=ToolRegistry.from_tools([ShellExecTool()]),
+        graph=_ShellExecGraph(
+            {
+                "command": f'"{sys.executable}" -c "import time; time.sleep(2)"',
+                "timeout": 10,
+            }
+        ),
+        config=RuntimeConfig(approval_mode="allow", tool_timeout_seconds=1),
     )
 
     chunks = list(runtime.run_stream(RuntimeRequest(prompt="go")))


### PR DESCRIPTION
## Summary
- add optional runtime-owned tool timeout configuration with persisted session metadata and resume semantics for `tool_timeout_seconds`
- enforce real runtime timeout behavior for `shell_exec` by routing the shorter runtime timeout into subprocess execution instead of leaving delayed side effects behind
- add focused runtime/config/integration coverage for precedence, persistence, legacy fallback, and tool-native timeout classification

## Verification
- uv run basedpyright --warnings src
- rtk pytest tests/unit/runtime/test_tool_execution_timeout.py --no-cov
- rtk pytest tests/unit/runtime/test_runtime_service_extensions.py --no-cov
- rtk pytest tests/unit/runtime/test_runtime_config.py --no-cov
- rtk pytest tests/integration/test_read_only_slice.py -k \"single_agent_runtime_executes_read_path_and_persists_config or resume_config_session\" --no-cov