### PR TITLE
Issue166

### DIFF
--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -11,6 +11,11 @@ class RuntimeContinuityState:
     dropped_tool_result_count: int = 0
     retained_tool_result_count: int = 0
     source: str = "tool_result_window"
+    # Lightweight versioning for continuity state to aid reinjection/refresh
+    # semantics. This is incremented when the shape evolves and is included
+    # in the serialized payload so consumers can decide how to handle newer
+    # fields.
+    version: int = 1
 
     def metadata_payload(self) -> dict[str, object]:
         return {
@@ -18,6 +23,7 @@ class RuntimeContinuityState:
             "dropped_tool_result_count": self.dropped_tool_result_count,
             "retained_tool_result_count": self.retained_tool_result_count,
             "source": self.source,
+            "version": self.version,
         }
 
 

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -1108,7 +1108,6 @@ class VoidCodeRuntime:
         continuity_to_reinject: RuntimeContinuityState | None = preserved_continuity_state
         raw_provider_attempt = graph_request.metadata.get("provider_attempt", 0)
         provider_attempt = raw_provider_attempt if isinstance(raw_provider_attempt, int) else 0
-        active_preserved_continuity_state = preserved_continuity_state
         while True:
             base_context = self._prepare_single_agent_context_window(
                 prompt=graph_request.prompt,
@@ -1128,19 +1127,9 @@ class VoidCodeRuntime:
                     max_tool_result_count=base_context.max_tool_result_count,
                     continuity_state=continuity_to_reinject,
                 )
-            elif active_preserved_continuity_state is not None:
-                context_window = RuntimeContextWindow(
-                    prompt=base_context.prompt,
-                    tool_results=base_context.tool_results,
-                    compacted=base_context.compacted,
-                    compaction_reason=base_context.compaction_reason,
-                    original_tool_result_count=base_context.original_tool_result_count,
-                    retained_tool_result_count=base_context.retained_tool_result_count,
-                    max_tool_result_count=base_context.max_tool_result_count,
-                    continuity_state=active_preserved_continuity_state,
-                )
             else:
                 context_window = base_context
+            continuity_to_reinject = None
             session = self._session_with_context_window_metadata(session, context_window)
             graph_request = GraphRunRequest(
                 session=session,
@@ -1578,7 +1567,6 @@ class VoidCodeRuntime:
                 raise RuntimeError(post_hook_outcome.failed_error)
 
             tool_results.append(tool_result)
-            active_preserved_continuity_state = None
 
     def _run_lifecycle_hooks(
         self,

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -1114,9 +1114,10 @@ class VoidCodeRuntime:
                 tool_results=tuple(tool_results),
                 session_metadata=session.metadata,
             )
+            reinjected_continuity = continuity_to_reinject
             # Apply reinjected continuity state if present, giving reinjection
             # semantics after a compaction boundary.
-            if continuity_to_reinject is not None:
+            if reinjected_continuity is not None:
                 context_window = RuntimeContextWindow(
                     prompt=base_context.prompt,
                     tool_results=base_context.tool_results,
@@ -1125,7 +1126,7 @@ class VoidCodeRuntime:
                     original_tool_result_count=base_context.original_tool_result_count,
                     retained_tool_result_count=base_context.retained_tool_result_count,
                     max_tool_result_count=base_context.max_tool_result_count,
-                    continuity_state=continuity_to_reinject,
+                    continuity_state=reinjected_continuity,
                 )
             else:
                 context_window = base_context
@@ -1140,7 +1141,7 @@ class VoidCodeRuntime:
                 context_window=context_window,
                 metadata=graph_request.metadata,
             )
-            if context_window.compacted and continuity_to_reinject is None:
+            if context_window.compacted and reinjected_continuity is None:
                 sequence += 1
                 yield RuntimeStreamChunk(
                     kind="event",
@@ -2708,12 +2709,14 @@ class VoidCodeRuntime:
         if not isinstance(source, str):
             return None
         version = continuity_payload.get("version")
+        if version is not None and (not isinstance(version, int) or isinstance(version, bool)):
+            return None
         return RuntimeContinuityState(
             summary_text=summary_text,
             dropped_tool_result_count=dropped,
             retained_tool_result_count=retained,
             source=source,
-            version=version if isinstance(version, int) else 1,
+            version=version if version is not None else 1,
         )
 
     @staticmethod

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -1103,26 +1103,44 @@ class VoidCodeRuntime:
         preserved_continuity_state: RuntimeContinuityState | None = None,
     ) -> Iterator[RuntimeStreamChunk]:
         active_permission_policy = permission_policy or self._permission_policy
+        # Continuity memory reinjection boundary: allow a continuity state to be
+        # carried into the next iteration after a memory compaction (if any).
+        continuity_to_reinject: RuntimeContinuityState | None = preserved_continuity_state
         raw_provider_attempt = graph_request.metadata.get("provider_attempt", 0)
         provider_attempt = raw_provider_attempt if isinstance(raw_provider_attempt, int) else 0
         active_preserved_continuity_state = preserved_continuity_state
         while True:
-            context_window = self._prepare_single_agent_context_window(
+            base_context = self._prepare_single_agent_context_window(
                 prompt=graph_request.prompt,
                 tool_results=tuple(tool_results),
                 session_metadata=session.metadata,
             )
-            if active_preserved_continuity_state is not None:
+            # Apply reinjected continuity state if present, giving reinjection
+            # semantics after a compaction boundary.
+            if continuity_to_reinject is not None:
                 context_window = RuntimeContextWindow(
-                    prompt=context_window.prompt,
-                    tool_results=context_window.tool_results,
-                    compacted=context_window.compacted,
-                    compaction_reason=context_window.compaction_reason,
-                    original_tool_result_count=context_window.original_tool_result_count,
-                    retained_tool_result_count=context_window.retained_tool_result_count,
-                    max_tool_result_count=context_window.max_tool_result_count,
+                    prompt=base_context.prompt,
+                    tool_results=base_context.tool_results,
+                    compacted=base_context.compacted,
+                    compaction_reason=base_context.compaction_reason,
+                    original_tool_result_count=base_context.original_tool_result_count,
+                    retained_tool_result_count=base_context.retained_tool_result_count,
+                    max_tool_result_count=base_context.max_tool_result_count,
+                    continuity_state=continuity_to_reinject,
+                )
+            elif active_preserved_continuity_state is not None:
+                context_window = RuntimeContextWindow(
+                    prompt=base_context.prompt,
+                    tool_results=base_context.tool_results,
+                    compacted=base_context.compacted,
+                    compaction_reason=base_context.compaction_reason,
+                    original_tool_result_count=base_context.original_tool_result_count,
+                    retained_tool_result_count=base_context.retained_tool_result_count,
+                    max_tool_result_count=base_context.max_tool_result_count,
                     continuity_state=active_preserved_continuity_state,
                 )
+            else:
+                context_window = base_context
             session = self._session_with_context_window_metadata(session, context_window)
             graph_request = GraphRunRequest(
                 session=session,
@@ -1133,7 +1151,7 @@ class VoidCodeRuntime:
                 context_window=context_window,
                 metadata=graph_request.metadata,
             )
-            if context_window.compacted and active_preserved_continuity_state is None:
+            if context_window.compacted and continuity_to_reinject is None:
                 sequence += 1
                 yield RuntimeStreamChunk(
                     kind="event",
@@ -2701,11 +2719,13 @@ class VoidCodeRuntime:
             return None
         if not isinstance(source, str):
             return None
+        version = continuity_payload.get("version")
         return RuntimeContinuityState(
             summary_text=summary_text,
             dropped_tool_result_count=dropped,
             retained_tool_result_count=retained,
             source=source,
+            version=version if isinstance(version, int) else 1,
         )
 
     @staticmethod

--- a/tests/test_continuity_state.py
+++ b/tests/test_continuity_state.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from voidcode.runtime.context_window import (
+    RuntimeContinuityState,
+    _build_continuity_state,
+)
+from voidcode.tools.contracts import ToolResult
+
+
+def _make_toolresult(kind: str, content: str | None = None) -> ToolResult:
+    return ToolResult(
+        tool_name="fake_tool",
+        status=kind,
+        content=content,
+        data={},
+        error=None,
+    )
+
+
+def test_continuity_state_includes_version_in_metadata_payload():
+    # Create a dropped/retained scenario to exercise the continuity builder
+    dropped = (_make_toolresult("ok"),)
+    retained_count = 1
+    state: RuntimeContinuityState = _build_continuity_state(
+        dropped_results=dropped,
+        retained_count=retained_count,
+        preview_item_limit=2,
+        preview_char_limit=80,
+    )
+
+    payload = state.metadata_payload()
+    # Ensure the new version field is present and defaults to 1
+    assert payload.get("version") == 1
+    # Also ensure the other fields are present and sensible
+    assert payload.get("source") == "tool_result_window"
+    assert payload.get("dropped_tool_result_count") == 1
+    assert payload.get("retained_tool_result_count") == retained_count

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -58,6 +58,7 @@ def test_prepare_single_agent_context_compacts_old_results_and_reports_metadata(
         "dropped_tool_result_count": 2,
         "retained_tool_result_count": 2,
         "source": "tool_result_window",
+        "version": 1,
     }
 
 

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -2883,6 +2883,7 @@ def test_runtime_approval_resume_preserves_canonical_continuity_state(tmp_path: 
         "dropped_tool_result_count": 1,
         "retained_tool_result_count": 1,
         "source": "tool_result_window",
+        "version": 1,
     }
 
     assert waiting.session.status == "waiting"
@@ -2898,13 +2899,13 @@ def test_runtime_approval_resume_preserves_canonical_continuity_state(tmp_path: 
 
     expected_resumed_continuity = {
         "summary_text": (
-            "Compacted 2 earlier tool results:\n"
-            '1. read_file ok path=sample.txt content_preview="alpha"\n'
-            '2. read_file ok path=sample.txt content_preview="alpha"'
+            "Compacted 1 earlier tool results:\n"
+            '1. read_file ok path=sample.txt content_preview="alpha"'
         ),
-        "dropped_tool_result_count": 2,
+        "dropped_tool_result_count": 1,
         "retained_tool_result_count": 1,
         "source": "tool_result_window",
+        "version": 1,
     }
     resumed_runtime_state = cast(dict[str, object], resumed.session.metadata["runtime_state"])
     assert resumed_runtime_state["continuity"] == expected_resumed_continuity
@@ -3643,6 +3644,7 @@ def test_runtime_single_agent_compaction_emits_continuity_state_and_persists_met
         "dropped_tool_result_count": 1,
         "retained_tool_result_count": 1,
         "source": "tool_result_window",
+        "version": 1,
     }
     memory_events = [
         event for event in response.events if event.event_type == RUNTIME_MEMORY_REFRESHED

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -2922,6 +2922,8 @@ def test_runtime_approval_resume_preserves_canonical_continuity_state(tmp_path: 
     memory_refreshed_events = [
         event for event in resumed.events if event.event_type == RUNTIME_MEMORY_REFRESHED
     ]
+    assert len(memory_refreshed_events) == 2
+    assert memory_refreshed_events[0].payload["continuity_state"] == initial_continuity
     assert memory_refreshed_events[-1].payload["continuity_state"] == expected_resumed_continuity
     tool_completed_events = [
         event for event in resumed.events if event.event_type == "runtime.tool_completed"
@@ -2984,6 +2986,27 @@ def test_runtime_resume_falls_back_to_fresh_policy_for_legacy_sessions_without_r
     assert resumed.events[-2].payload["decision"] == "deny"
     assert resumed.events[-1].event_type == "runtime.failed"
     assert resumed.events[-1].payload == {"error": "permission denied for tool: write_file"}
+
+
+def test_runtime_rejects_boolean_continuity_version_in_session_metadata() -> None:
+    continuity_from_metadata = _private_attr(
+        VoidCodeRuntime, "_continuity_state_from_session_metadata"
+    )
+    continuity = continuity_from_metadata(
+        {
+            "runtime_state": {
+                "continuity": {
+                    "summary_text": "summary",
+                    "dropped_tool_result_count": 1,
+                    "retained_tool_result_count": 1,
+                    "source": "tool_result_window",
+                    "version": True,
+                }
+            }
+        }
+    )
+
+    assert continuity is None
 
 
 def test_runtime_effective_runtime_config_prefers_persisted_session_values(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -2899,10 +2899,11 @@ def test_runtime_approval_resume_preserves_canonical_continuity_state(tmp_path: 
 
     expected_resumed_continuity = {
         "summary_text": (
-            "Compacted 1 earlier tool results:\n"
-            '1. read_file ok path=sample.txt content_preview="alpha"'
+            "Compacted 2 earlier tool results:\n"
+            '1. read_file ok path=sample.txt content_preview="alpha"\n'
+            '2. read_file ok path=sample.txt content_preview="alpha"'
         ),
-        "dropped_tool_result_count": 1,
+        "dropped_tool_result_count": 2,
         "retained_tool_result_count": 1,
         "source": "tool_result_window",
         "version": 1,


### PR DESCRIPTION
描述
为 continuity_state 增加 version 字段，并同步修正相关运行时与测试断言，使 session continuity 的 payload 形状在 compaction、resume、replay 场景下保持一致。  
这样做是为了让 continuity state 具备更清晰的演进能力，同时避免旧测试继续按过时 schema 断言导致回归。
变更类型
- [x] Bug 修复
- [ ] 新功能
- [ ] 破坏性变更
- [ ] 文档更新
- [ ] 重构
- [ ] 仅测试变更
- [ ] CI / 工具链变更
核对清单
- [x] 本地测试通过
- [ ] 如有必要，已更新相关文档
- [x] 相关的 lint 检查和类型检查已通过
- [x] 未包含无关的变更

close #166 