### PR TITLE
feat(runtime): inject agent-facing tool guidance via sidecar files an…

### DIFF
--- a/docs/contracts/agent-tool-calling.md
+++ b/docs/contracts/agent-tool-calling.md
@@ -7,6 +7,7 @@
 本文档定义 VoidCode runtime / CLI / Web 主路径中 **agent 应如何理解、选择和调用工具**。它面向会生成 `ToolCall` 的 agent / execution engine，而不是面向 UI 组件或工具实现作者。
 
 For category-based, agent-facing usage guidance, continue with [`docs/tools/README.md`](../tools/README.md).
+For the runtime injection strategy for sidecar guidance, see [`docs/tools/guidance-injection.md`](../tools/guidance-injection.md).
 
 它回答以下问题：
 

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -15,6 +15,19 @@ These pages do not redefine runtime or tool-layer types. Instead, they answer th
 - [`src/voidcode/tools/contracts.py`](../../src/voidcode/tools/contracts.py): the code-level source of truth for `ToolDefinition`, `ToolCall`, and `ToolResult`.
 - [`src/voidcode/tools/README.md`](../../src/voidcode/tools/README.md): the capability-layer boundary for tools, not an agent usage guide.
 
+## Relationship to injected guidance
+
+Runtime-injected agent guidance lives next to tool implementations as sidecar `.txt` files in [`src/voidcode/tools/`](../../src/voidcode/tools/). Those sidecars are the source of truth for text that may be appended to agent-visible `ToolDefinition.description` values.
+
+This directory remains the human-readable guide:
+
+- it groups related tools,
+- it gives examples and longer explanations,
+- it links contract docs and implementation boundaries,
+- it should stay consistent with the sidecar guidance without becoming a second injected source of truth.
+
+See [`guidance-injection.md`](./guidance-injection.md) for the current injection strategy.
+
 ## Recommended reading order
 
 ### 1. Start with the global rules
@@ -33,20 +46,46 @@ These pages do not redefine runtime or tool-layer types. Instead, they answer th
   - `list`
   - `glob`
   - `grep`
+- [`ast-grep.md`](./ast-grep.md)
+  - `ast_grep_search`
+  - `ast_grep_preview`
+  - `ast_grep_replace`
+- [`lsp-format.md`](./lsp-format.md)
+  - `lsp`
 
 #### Editing / writing
 
 - [`edit.md`](./edit.md)
 - [`multi-edit.md`](./multi-edit.md)
 - [`apply-patch.md`](./apply-patch.md)
+- [`write-file.md`](./write-file.md)
+- [`lsp-format.md`](./lsp-format.md)
+  - `format_file`
 
 #### Execution / external commands
 
 - [`shell-exec.md`](./shell-exec.md)
 
-## Why the first wave only documents these tools
+#### External research
 
-The first priority is the tools that are easiest to misuse and most likely to affect correctness:
+- [`external-research.md`](./external-research.md)
+  - `web_search`
+  - `web_fetch`
+  - `code_search`
+
+#### Agent work state
+
+- [`todo-write.md`](./todo-write.md)
+  - `todo_write`
+
+#### Dynamic tools
+
+- [`mcp-dynamic.md`](./mcp-dynamic.md)
+  - `mcp/<server>/<tool>`
+
+## Coverage waves
+
+The first wave documented the tools that are easiest to misuse and most likely to affect correctness:
 
 - `edit`
 - `multi_edit`
@@ -61,14 +100,14 @@ These tools directly affect:
 - whether post-edit follow-up actions still rely on the real file state,
 - whether command execution becomes an overused escape hatch.
 
-After these pages settle, the next candidates are:
+The second wave adds guidance for the remaining built-in and runtime-managed tool surface:
 
 - `write_file`
 - `ast_grep_*`
 - `lsp` / `format_file`
 - `web_fetch` / `web_search` / `code_search`
 - `todo_write`
-- `mcp/*` (better documented as one dynamic-tool policy page than one page per MCP tool)
+- `mcp/*` as one dynamic-tool policy page rather than one page per MCP tool
 
 ## Hard usage rules for agents
 

--- a/docs/tools/ast-grep.md
+++ b/docs/tools/ast-grep.md
@@ -1,0 +1,65 @@
+# `ast_grep_*`
+
+The `ast_grep_*` tools are for structural code search and rewrite. They are useful when syntax shape matters more than literal text.
+
+This page covers:
+
+- `ast_grep_search`
+- `ast_grep_preview`
+- `ast_grep_replace`
+
+## Selection order
+
+### `ast_grep_search`
+
+Use when you need to find code by structure.
+
+Good fit:
+
+- finding classes, calls, imports, decorators, or expression shapes,
+- avoiding brittle literal search for syntax-aware patterns,
+- collecting candidate locations before editing.
+
+Bad fit:
+
+- plain text search,
+- documentation search,
+- searching one known file for a literal string.
+
+`ast_grep_search` is read-only.
+
+### `ast_grep_preview`
+
+Use before structural replacement. It previews a rewrite without changing files.
+
+Good fit:
+
+- checking the number of replacements,
+- inspecting matched locations,
+- deciding whether a rewrite is too broad.
+
+`ast_grep_preview` is read-only.
+
+### `ast_grep_replace`
+
+Use only after previewing the rewrite and confirming the scope is appropriate.
+
+`ast_grep_replace` is `read_only=false`, so it may trigger approval. It should be reserved for structural rewrite work, not ordinary text replacement.
+
+## Return value
+
+Important fields include:
+
+- `data.match_count`
+- `data.replacement_count`
+- `data.matches`
+- `data.applied`
+
+Prefer these structured fields over prose summaries when planning the next step.
+
+## Boundary with neighboring tools
+
+- Literal search in one known file: use `grep`
+- Structural search: use `ast_grep_search`
+- Small text replacement: use `edit`
+- Structural rewrite: preview with `ast_grep_preview`, then apply with `ast_grep_replace`

--- a/docs/tools/external-research.md
+++ b/docs/tools/external-research.md
@@ -1,0 +1,56 @@
+# Web / Code Research Tools
+
+This page covers external research tools:
+
+- `web_search`
+- `web_fetch`
+- `code_search`
+
+These tools collect external evidence. They do not describe the current workspace state.
+
+## `web_search`
+
+Use when you do not know the URL and need to discover web sources.
+
+Do not use it when the URL is already known; use `web_fetch` instead.
+
+Key fields:
+
+- `content`
+- `data.query`
+- `data.num_results`
+- `data.source`
+
+## `web_fetch`
+
+Use when you have a specific `http://` or `https://` URL and need page content.
+
+Do not use it for localhost, private network, link-local, reserved, metadata, or internal targets.
+
+Key fields:
+
+- `content`
+- `data.url`
+- `data.content_type`
+- `data.format`
+- `data.byte_count`
+
+## `code_search`
+
+Use for external programming examples or implementation references.
+
+Do not use it for repository search. Local code facts should come from `glob`, `grep`, `read_file`, `ast_grep_search`, or `lsp`.
+
+Key fields:
+
+- `content`
+- `data.sources`
+- `data.snippet_count`
+- `data.source`
+
+## Practical selection rules
+
+- Need to discover sources: use `web_search`
+- Already have a URL: use `web_fetch`
+- Need external code examples: use `code_search`
+- Need local repository facts: use workspace tools, not web tools

--- a/docs/tools/guidance-injection.md
+++ b/docs/tools/guidance-injection.md
@@ -1,0 +1,59 @@
+# Tool Guidance Injection
+
+Agent-facing tool guidance has two surfaces:
+
+- sidecar `.txt` files next to tool implementations under `src/voidcode/tools/`
+- human-readable grouping pages under `docs/tools/`
+
+The sidecar files are the source of truth for text that can be injected into agent-visible tool descriptions. The Markdown pages are reading and navigation entry points for humans.
+
+## Source of truth
+
+Use `ToolDefinition.description` for the short capability summary.
+
+Use sidecar guidance for:
+
+- when to choose the tool,
+- neighboring-tool boundaries,
+- common misuse,
+- approval and read-only expectations,
+- result fields that should guide the next step.
+
+Use `docs/tools/*.md` for:
+
+- longer explanation,
+- examples,
+- grouped reading order,
+- maintenance context.
+
+## Mapping strategy
+
+Static built-in tools map to sidecar files by tool name.
+
+Tool families can share a sidecar when separate files would duplicate policy:
+
+- `read_file`, `list`, `glob`, `grep` share `read_search.txt`
+- `ast_grep_search`, `ast_grep_preview`, `ast_grep_replace` share `ast_grep.txt`
+- `lsp` and `format_file` share `lsp.txt`
+
+Dynamic MCP tools share `mcp.txt` through the `mcp/*` name prefix.
+
+## Runtime behavior
+
+The runtime keeps tool implementations and execution unchanged. It decorates agent-visible `ToolDefinition` values when definitions are requested.
+
+This means:
+
+- `ToolRegistry.resolve()` still returns the original tool object,
+- `ToolRegistry.definitions()` returns descriptions with sidecar guidance appended when available,
+- missing sidecar files are ignored rather than breaking runtime startup,
+- dynamic MCP tools receive the shared MCP policy without duplicating long descriptions per server tool.
+
+## Maintenance rule
+
+When adding or changing a built-in tool, update:
+
+- the tool implementation and tests,
+- the sidecar guidance near the implementation,
+- the relevant `docs/tools` page or README entry,
+- contract docs only when the runtime/tool-calling contract changes.

--- a/docs/tools/lsp-format.md
+++ b/docs/tools/lsp-format.md
@@ -1,0 +1,50 @@
+# `lsp` / `format_file`
+
+`lsp` and `format_file` are runtime-managed code intelligence and formatting tools. They are exposed only when the corresponding runtime subsystem is available.
+
+## `lsp`
+
+Use `lsp` for language-server facts:
+
+- definition
+- references
+- hover
+- document symbols
+- workspace symbols
+- implementation
+- call hierarchy
+
+Do not use it for literal text search or directory discovery.
+
+`lsp` is read-only.
+
+## `format_file`
+
+Use `format_file` when the intended operation is only formatting a single file.
+
+Do not use it to make semantic content changes. Content changes should go through `edit`, `multi_edit`, or `apply_patch`, with formatting as a follow-up when needed.
+
+`format_file` is `read_only=false`, so it may trigger approval.
+
+## Return value
+
+For `lsp`, the key source of truth is:
+
+- `data.lsp_response`
+
+For `format_file`, important fields include:
+
+- `data.path`
+- `data.language`
+- `data.command`
+- `data.attempted_commands`
+- `data.stdout`
+- `data.stderr`
+
+## Boundary with neighboring tools
+
+- Literal text search: use `grep`
+- Structural code search: use `ast_grep_search`
+- Definition / references / hover: use `lsp`
+- Formatting only: use `format_file`
+- Semantic edits: use `edit`, `multi_edit`, or `apply_patch`

--- a/docs/tools/mcp-dynamic.md
+++ b/docs/tools/mcp-dynamic.md
@@ -1,0 +1,46 @@
+# Dynamic MCP Tools
+
+MCP tools are exposed as dynamic runtime tools named:
+
+```text
+mcp/<server>/<tool>
+```
+
+They are discovered from configured MCP servers. The available set can differ by workspace, runtime config, and server health.
+
+## How agents should understand them
+
+Use an MCP tool only when:
+
+- the runtime exposes it in the current tool registry,
+- its `ToolDefinition.input_schema` matches the arguments you plan to send,
+- built-in tools cannot express the needed capability,
+- you are prepared for approval or failure.
+
+Do not assume:
+
+- the same MCP tool is always available,
+- a dynamic tool is read-only,
+- a tool is idempotent or safe from its name alone,
+- all MCP responses have the same data shape.
+
+## Risk profile
+
+The current runtime wraps MCP tools as `read_only=false`, so they may trigger approval.
+
+This conservative policy is intentional. MCP servers can represent external systems, local side effects, or account-scoped actions that the runtime cannot classify reliably from the schema alone.
+
+## Return value
+
+Important fields include:
+
+- `data.server`
+- `data.tool`
+- `data.content`
+- `content`, when the MCP response includes text blocks
+
+Treat these as server-provided external results.
+
+## Injection policy
+
+MCP tools share one dynamic-tool policy instead of one guidance page per tool. Runtime-visible tool schemas still come from each MCP tool descriptor, but agent usage guidance is shared through the `mcp/*` policy.

--- a/docs/tools/todo-write.md
+++ b/docs/tools/todo-write.md
@@ -1,0 +1,58 @@
+# `todo_write`
+
+`todo_write` updates runtime-visible work state for the current agent task.
+
+It is not a project documentation tool, memory system, or replacement for user-facing progress updates.
+
+## When to use it
+
+Good fit:
+
+- tracking a multi-step task,
+- marking the current step as `in_progress`,
+- recording completed or cancelled steps for runtime continuity.
+
+Bad fit:
+
+- writing project plans that belong in docs,
+- storing long-term memory,
+- logging every small implementation detail,
+- replacing a concise user update.
+
+## Risk profile
+
+`todo_write` is `read_only=false`, so it may trigger approval.
+
+## Input
+
+```json
+{
+  "todos": [
+    {"content": "Implement sidecar guidance", "status": "in_progress", "priority": "high"}
+  ]
+}
+```
+
+Allowed statuses:
+
+- `pending`
+- `in_progress`
+- `completed`
+- `cancelled`
+
+Allowed priorities:
+
+- `high`
+- `medium`
+- `low`
+
+## Return value
+
+On success, expect:
+
+- `data.path`
+- `data.summary.total`
+- `data.summary.pending`
+- `data.summary.in_progress`
+- `data.summary.completed`
+- `data.summary.cancelled`

--- a/docs/tools/write-file.md
+++ b/docs/tools/write-file.md
@@ -1,0 +1,48 @@
+# `write_file`
+
+`write_file` writes a complete UTF-8 text file inside the workspace. It is the right tool when the whole target content is known and replacing the entire file is intentional.
+
+## When to use it
+
+Good fit:
+
+- creating a new file,
+- replacing a small file in full,
+- generating a complete standalone document or fixture,
+- writing content where partial replacement would be more fragile than full replacement.
+
+Bad fit:
+
+- focused changes in an existing file,
+- changing one function, paragraph, or config entry,
+- any case where you have not read an existing target before overwriting it.
+
+## Risk profile
+
+`write_file` is `read_only=false`, so it may trigger approval.
+
+The main risk is accidental overwrite. For existing files, prefer `edit`, `multi_edit`, or `apply_patch` unless the task is explicitly a full rewrite.
+
+## Input
+
+```json
+{
+  "path": "docs/new.md",
+  "content": "# New\n"
+}
+```
+
+## Return value
+
+On success, expect:
+
+- `content`: written file content
+- `data.path`
+- `data.byte_count`
+
+## Boundary with neighboring tools
+
+- New file or intentional full replacement: use `write_file`
+- One focused replacement: use `edit`
+- Several same-file replacements: use `multi_edit`
+- Multi-file or patch-shaped work: use `apply_patch`

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -51,6 +51,7 @@ from ..tools.contracts import (
     ToolResult,
     ToolResultStatus,
 )
+from ..tools.guidance import definition_with_guidance
 from .acp import AcpAdapter, AcpAdapterState, build_acp_adapter
 from .config import (
     ExecutionEngineName,
@@ -265,7 +266,7 @@ class ToolRegistry:
         )
 
     def definitions(self) -> tuple[ToolDefinition, ...]:
-        return tuple(tool.definition for tool in self.tools.values())
+        return tuple(definition_with_guidance(tool.definition) for tool in self.tools.values())
 
     def resolve(self, tool_name: str) -> Tool:
         try:

--- a/src/voidcode/tools/apply_patch.txt
+++ b/src/voidcode/tools/apply_patch.txt
@@ -1,0 +1,5 @@
+Use apply_patch for patch-level work: multi-file edits, file creation, deletion, rename, or changes that are clearest as a unified diff.
+
+Do not make it the default for small local replacements; edit or multi_edit is usually safer. Read the relevant files first so patch context is grounded.
+
+This tool is not read-only and may require approval. Use returned change summaries and affected paths as the source of truth for follow-up verification.

--- a/src/voidcode/tools/ast_grep.txt
+++ b/src/voidcode/tools/ast_grep.txt
@@ -1,0 +1,5 @@
+Use ast_grep_search for structural code search when syntax shape matters more than literal text.
+
+Use ast_grep_preview before any structural rewrite to inspect impact without changing files. Use ast_grep_replace only after the preview makes the replacement scope clear and the rewrite is truly structural.
+
+ast_grep_search and ast_grep_preview are read-only. ast_grep_replace is not read-only and may require approval. Prefer returned match and replacement counts over prose summaries when planning the next step.

--- a/src/voidcode/tools/code_search.txt
+++ b/src/voidcode/tools/code_search.txt
@@ -1,0 +1,5 @@
+Use code_search for external programming examples and implementation references.
+
+Do not use it for local repository search; use glob, grep, ast_grep_search, read_file, or lsp for workspace facts. Do not copy external code without checking fit, license expectations, and local style.
+
+This tool is read-only. Treat data.sources, data.snippet_count, and data.source as external research metadata, not project truth.

--- a/src/voidcode/tools/edit.txt
+++ b/src/voidcode/tools/edit.txt
@@ -1,0 +1,5 @@
+Use edit for one focused text replacement in one existing file after reading enough context.
+
+Prefer multi_edit when several ordered replacements are needed in the same file. Prefer apply_patch for cross-file changes, add/delete/rename operations, or patch-shaped work. Prefer write_file only for new files or complete rewrites.
+
+This tool is not read-only and may require approval. On success, treat the final on-disk file state and returned data.diff, data.additions, data.deletions, and data.match_count as the next source of truth.

--- a/src/voidcode/tools/guidance.py
+++ b/src/voidcode/tools/guidance.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from functools import cache
+from pathlib import Path
+
+from .contracts import ToolDefinition
+
+_GUIDANCE_DIR = Path(__file__).resolve().parent
+_GUIDANCE_SEPARATOR = "\n\nAgent usage guidance:\n"
+
+_TOOL_GUIDANCE_FILES = {
+    "apply_patch": "apply_patch.txt",
+    "ast_grep_preview": "ast_grep.txt",
+    "ast_grep_replace": "ast_grep.txt",
+    "ast_grep_search": "ast_grep.txt",
+    "code_search": "code_search.txt",
+    "edit": "edit.txt",
+    "format_file": "lsp.txt",
+    "glob": "read_search.txt",
+    "grep": "read_search.txt",
+    "list": "read_search.txt",
+    "lsp": "lsp.txt",
+    "multi_edit": "multi_edit.txt",
+    "read_file": "read_search.txt",
+    "shell_exec": "shell_exec.txt",
+    "todo_write": "todo_write.txt",
+    "web_fetch": "web_fetch.txt",
+    "web_search": "web_search.txt",
+    "write_file": "write_file.txt",
+}
+
+
+def guidance_filename_for_tool(tool_name: str) -> str | None:
+    if tool_name.startswith("mcp/"):
+        return "mcp.txt"
+    return _TOOL_GUIDANCE_FILES.get(tool_name)
+
+
+@cache
+def load_tool_guidance(filename: str) -> str:
+    path = _GUIDANCE_DIR / filename
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return ""
+
+
+def guidance_for_tool(tool_name: str) -> str:
+    filename = guidance_filename_for_tool(tool_name)
+    if filename is None:
+        return ""
+    return load_tool_guidance(filename)
+
+
+def definition_with_guidance(definition: ToolDefinition) -> ToolDefinition:
+    guidance = guidance_for_tool(definition.name)
+    if not guidance or guidance in definition.description:
+        return definition
+    return ToolDefinition(
+        name=definition.name,
+        description=f"{definition.description.rstrip()}{_GUIDANCE_SEPARATOR}{guidance}",
+        input_schema=definition.input_schema,
+        read_only=definition.read_only,
+    )

--- a/src/voidcode/tools/lsp.txt
+++ b/src/voidcode/tools/lsp.txt
@@ -1,0 +1,5 @@
+Use lsp for language-server facts such as definition, references, hover, document symbols, workspace symbols, implementation, and call hierarchy.
+
+Use format_file only when the intended operation is formatting a single file. Do not use lsp for literal text search, and do not use format_file to make semantic content changes.
+
+lsp is read-only. format_file is not read-only and may require approval. For lsp, treat data.lsp_response as the source of truth. For format_file, use data.path, data.language, data.command, stdout, and stderr for follow-up decisions.

--- a/src/voidcode/tools/mcp.txt
+++ b/src/voidcode/tools/mcp.txt
@@ -1,0 +1,5 @@
+Use mcp/<server>/<tool> only when a configured MCP server exposes a capability that built-in tools cannot express.
+
+Dynamic MCP tools are runtime-discovered, so rely on each ToolDefinition name and input_schema exactly as exposed for this session. Do not assume an MCP tool is always available, read-only, idempotent, or safe just because its name sounds harmless.
+
+The current runtime marks MCP tools as not read-only, so they may require approval. Treat returned data.server, data.tool, and data.content as server-provided external results.

--- a/src/voidcode/tools/multi_edit.txt
+++ b/src/voidcode/tools/multi_edit.txt
@@ -1,0 +1,5 @@
+Use multi_edit for several ordered text replacements in one existing file.
+
+Do not use it for multiple files; use apply_patch for cross-file changes. Do not split dependent same-file replacements into many separate edit calls when one ordered multi_edit call can avoid intermediate drift.
+
+This tool is not read-only and may require approval. Use returned per-edit metadata and the final diff as the source of truth before making follow-up edits.

--- a/src/voidcode/tools/read_search.txt
+++ b/src/voidcode/tools/read_search.txt
@@ -1,0 +1,5 @@
+Use this read/search family before writing when you need workspace facts.
+
+Choose read_file when the exact file path is known and full UTF-8 text is needed. Choose list for directory shape, glob for filename patterns, and grep only for literal search inside one known file.
+
+Do not use these tools for edits, broad shell-style discovery, or scanning generated directories. Prefer structured return data such as data.matches, data.count, data.line_count, and data.truncated when deciding the next step.

--- a/src/voidcode/tools/shell_exec.txt
+++ b/src/voidcode/tools/shell_exec.txt
@@ -1,0 +1,5 @@
+Use shell_exec for tests, builds, diagnostics, and local commands that cannot be expressed through narrower workspace tools.
+
+Do not use it as the default way to read files, list directories, search text, or edit files. Prefer read_file, list, glob, grep, edit, multi_edit, apply_patch, or format_file when they fit.
+
+This tool is not read-only and may require approval. Treat exit_code, stdout, stderr, timeout, and truncated as the stable result fields.

--- a/src/voidcode/tools/todo_write.txt
+++ b/src/voidcode/tools/todo_write.txt
@@ -1,0 +1,5 @@
+Use todo_write to update runtime-visible agent work state for the current task.
+
+Do not use it as project documentation, persistent memory, or a substitute for explaining progress to the user. Keep items concrete and current.
+
+This tool is not read-only and may require approval. Treat data.summary and data.path as the stable result fields.

--- a/src/voidcode/tools/web_fetch.txt
+++ b/src/voidcode/tools/web_fetch.txt
@@ -1,0 +1,5 @@
+Use web_fetch when you have a specific http or https URL and need page content.
+
+Do not use it for localhost, private network, link-local, metadata, or internal targets. Use web_search first when no URL is known.
+
+This tool is read-only. Treat returned content plus data.url, data.content_type, data.format, and data.byte_count as external evidence, not as repository state.

--- a/src/voidcode/tools/web_search.txt
+++ b/src/voidcode/tools/web_search.txt
@@ -1,0 +1,5 @@
+Use web_search when you do not know the exact URL and need to discover external web sources.
+
+Do not use it when the URL is already known; use web_fetch for page contents. Do not treat external search snippets as workspace truth.
+
+This tool is read-only. Use result URLs, snippets, data.query, data.num_results, and data.source to decide what to fetch or cite next.

--- a/src/voidcode/tools/write_file.txt
+++ b/src/voidcode/tools/write_file.txt
@@ -1,0 +1,5 @@
+Use write_file to create a new UTF-8 text file or completely rewrite a small file when full replacement is intentional.
+
+Do not use it for focused changes in existing files; prefer edit, multi_edit, or apply_patch so the change remains narrow and reviewable. Read existing files before overwriting them unless the user explicitly asked for a new file.
+
+This tool is not read-only and may require approval. Treat data.path and data.byte_count as the stable write result fields.

--- a/tests/unit/runtime/test_tool_provider.py
+++ b/tests/unit/runtime/test_tool_provider.py
@@ -44,6 +44,7 @@ from voidcode.tools import (
     WriteFileTool,
 )
 from voidcode.tools.contracts import ToolDefinition, ToolResult
+from voidcode.tools.guidance import guidance_filename_for_tool, guidance_for_tool
 
 
 @dataclass(slots=True)
@@ -275,6 +276,95 @@ def test_tool_registry_accepts_tools_from_provider_output() -> None:
     for tool_name in optional_tools:
         if tool_name in registry.tools:
             assert registry.resolve(tool_name).definition.name == tool_name
+
+
+def test_builtin_tool_definitions_include_sidecar_guidance() -> None:
+    registry = ToolRegistry.from_tools(BuiltinToolProvider().provide_tools())
+    definitions = {definition.name: definition for definition in registry.definitions()}
+
+    assert "Agent usage guidance:" in definitions["write_file"].description
+    assert "focused changes in existing files" in definitions["write_file"].description
+    assert "Agent usage guidance:" in definitions["ast_grep_search"].description
+    assert "structural code search" in definitions["ast_grep_search"].description
+    assert "Agent usage guidance:" in definitions["web_fetch"].description
+    assert "specific http or https URL" in definitions["web_fetch"].description
+
+
+def test_sidecar_guidance_mapping_covers_builtin_runtime_tool_names() -> None:
+    runtime_tool_names = {
+        "apply_patch",
+        "ast_grep_preview",
+        "ast_grep_replace",
+        "ast_grep_search",
+        "code_search",
+        "edit",
+        "format_file",
+        "glob",
+        "grep",
+        "list",
+        "lsp",
+        "multi_edit",
+        "read_file",
+        "shell_exec",
+        "todo_write",
+        "web_fetch",
+        "web_search",
+        "write_file",
+    }
+
+    for tool_name in runtime_tool_names:
+        filename = guidance_filename_for_tool(tool_name)
+        assert filename is not None, f"Missing guidance mapping for {tool_name}"
+        assert guidance_for_tool(tool_name), f"Missing sidecar content for {tool_name}"
+
+
+def test_agent_tool_docs_cover_runtime_tool_families() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    docs_dir = repo_root / "docs" / "tools"
+    expected_pages = {
+        "read-search.md",
+        "edit.md",
+        "multi-edit.md",
+        "apply-patch.md",
+        "shell-exec.md",
+        "write-file.md",
+        "ast-grep.md",
+        "lsp-format.md",
+        "external-research.md",
+        "todo-write.md",
+        "mcp-dynamic.md",
+        "guidance-injection.md",
+    }
+
+    for page in expected_pages:
+        assert (docs_dir / page).is_file(), f"Missing docs/tools/{page}"
+
+
+def test_dynamic_mcp_tool_definitions_include_shared_policy_guidance() -> None:
+    def _requester(
+        *,
+        server_name: str,
+        tool_name: str,
+        arguments: dict[str, object],
+        workspace: Path,
+    ) -> McpToolCallResult:
+        _ = server_name, tool_name, arguments, workspace
+        return McpToolCallResult(content=[{"type": "text", "text": "ok"}], is_error=False)
+
+    mcp_tool = McpTool(
+        server_name="echo",
+        tool_name="echo",
+        description="Echo input",
+        input_schema={"type": "object"},
+        requester=_requester,
+    )
+    registry = ToolRegistry.from_tools((mcp_tool,))
+
+    definition = registry.definitions()[0]
+
+    assert definition.name == "mcp/echo/echo"
+    assert "Agent usage guidance:" in definition.description
+    assert "Dynamic MCP tools are runtime-discovered" in definition.description
 
 
 def test_tool_registry_with_defaults_delegates_through_builtin_provider() -> None:


### PR DESCRIPTION
This PR introduces sidecar-based tool guidance injection and completes second-wave docs coverage.

Key changes:
- Add runtime guidance loader (src/voidcode/tools/guidance.py)
- Inject sidecar guidance into ToolDefinition.description via ToolRegistry.definitions()
- Add colocated *.txt guidance files for built-in tools
- Add shared policy for dynamic mcp/* tools
- Complete docs/tools second-wave pages
- Add focused tests for injection, coverage, and MCP policy behavior

Design:
- ToolDefinition.description: short summary
- sidecar .txt: agent-injectable guidance (source of truth)
- docs/tools/*.md: human-readable docs

Runtime behavior unchanged; only agent-visible descriptions are enriched.

Verification:
- pytest (tool_provider tests) passed
- ruff check passed
- compileall passed
- basedpyright clean for new helper