### PR TITLE
feat(runtime): recover delegated leader task visibility

### DIFF
--- a/src/voidcode/runtime/__init__.py
+++ b/src/voidcode/runtime/__init__.py
@@ -4,6 +4,7 @@ from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
 from .contracts import (
+    BackgroundTaskResult,
     BackgroundTaskRuntimeEntrypoint,
     RuntimeEntrypoint,
     RuntimeNotification,
@@ -38,6 +39,7 @@ __all__ = [
     "EventSource",
     "BackgroundTaskRef",
     "BackgroundTaskRequestSnapshot",
+    "BackgroundTaskResult",
     "BackgroundTaskRuntimeEntrypoint",
     "BackgroundTaskState",
     "BackgroundTaskStatus",

--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -6,7 +6,7 @@ from typing import Literal, Protocol, TypedDict, cast, runtime_checkable
 
 from .events import EventEnvelope
 from .session import SessionRef, SessionState
-from .task import BackgroundTaskState, StoredBackgroundTaskSummary
+from .task import BackgroundTaskState, BackgroundTaskStatus, StoredBackgroundTaskSummary
 
 
 class RuntimeRequestError(ValueError):
@@ -176,6 +176,18 @@ class RuntimeSessionResult:
 
 
 @dataclass(frozen=True, slots=True)
+class BackgroundTaskResult:
+    task_id: str
+    parent_session_id: str | None
+    child_session_id: str | None
+    status: BackgroundTaskStatus
+    approval_blocked: bool = False
+    summary_output: str | None = None
+    error: str | None = None
+    result_available: bool = False
+
+
+@dataclass(frozen=True, slots=True)
 class RuntimeNotification:
     id: str
     session: SessionRef
@@ -220,6 +232,8 @@ class BackgroundTaskRuntimeEntrypoint(Protocol):
     def start_background_task(self, request: RuntimeRequest) -> BackgroundTaskState: ...
 
     def load_background_task(self, task_id: str) -> BackgroundTaskState: ...
+
+    def load_background_task_result(self, task_id: str) -> BackgroundTaskResult: ...
 
     def list_background_tasks(self) -> tuple[StoredBackgroundTaskSummary, ...]: ...
 

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -75,6 +75,7 @@ from .context_window import (
     prepare_single_agent_context,
 )
 from .contracts import (
+    BackgroundTaskResult,
     InternalRuntimeRequestMetadata,
     RuntimeNotification,
     RuntimeRequest,
@@ -93,6 +94,9 @@ from .events import (
     RUNTIME_ACP_DISCONNECTED,
     RUNTIME_ACP_FAILED,
     RUNTIME_APPROVAL_REQUESTED,
+    RUNTIME_BACKGROUND_TASK_CANCELLED,
+    RUNTIME_BACKGROUND_TASK_COMPLETED,
+    RUNTIME_BACKGROUND_TASK_FAILED,
     RUNTIME_BACKGROUND_TASK_WAITING_APPROVAL,
     RUNTIME_FAILED,
     RUNTIME_LSP_SERVER_FAILED,
@@ -1826,6 +1830,11 @@ class VoidCodeRuntime:
         validate_background_task_id(task_id)
         return self._session_store.load_background_task(workspace=self._workspace, task_id=task_id)
 
+    def load_background_task_result(self, task_id: str) -> BackgroundTaskResult:
+        task = self.load_background_task(task_id)
+        self._backfill_parent_background_task_event(task=task)
+        return self._background_task_result(task=task)
+
     def list_background_tasks(self) -> tuple[StoredBackgroundTaskSummary, ...]:
         self._reconcile_background_tasks_if_needed()
         return self._session_store.list_background_tasks(workspace=self._workspace)
@@ -1860,6 +1869,7 @@ class VoidCodeRuntime:
 
     def session_result(self, *, session_id: str) -> RuntimeSessionResult:
         validate_session_id(session_id)
+        self._reconcile_parent_background_task_events_for_session(parent_session_id=session_id)
         result = self._session_store.load_session_result(
             workspace=self._workspace,
             session_id=session_id,
@@ -1931,6 +1941,7 @@ class VoidCodeRuntime:
     ) -> RuntimeResponse:
         validate_session_id(session_id)
         if approval_request_id is None and approval_decision is None:
+            self._reconcile_parent_background_task_events_for_session(parent_session_id=session_id)
             return self._session_store.load_session(
                 workspace=self._workspace, session_id=session_id
             )
@@ -1953,6 +1964,7 @@ class VoidCodeRuntime:
     ) -> Iterator[RuntimeStreamChunk]:
         validate_session_id(session_id)
         if approval_request_id is None and approval_decision is None:
+            self._reconcile_parent_background_task_events_for_session(parent_session_id=session_id)
             response = self._session_store.load_session(
                 workspace=self._workspace, session_id=session_id
             )
@@ -3204,6 +3216,142 @@ class VoidCodeRuntime:
             return str(request_id) if request_id is not None else None
         return None
 
+    def _load_background_task_child_response(
+        self,
+        *,
+        task: BackgroundTaskState,
+    ) -> RuntimeResponse | None:
+        child_session_id = task.session_id
+        if child_session_id is None:
+            return None
+        try:
+            response = self._session_store.load_session(
+                workspace=self._workspace,
+                session_id=child_session_id,
+            )
+        except UnknownSessionError:
+            return None
+        self._validate_session_workspace(response.session, session_id=child_session_id)
+        return response
+
+    def _load_background_task_child_result(
+        self,
+        *,
+        task: BackgroundTaskState,
+    ) -> RuntimeSessionResult | None:
+        child_session_id = task.session_id
+        if child_session_id is None:
+            return None
+        try:
+            result = self._session_store.load_session_result(
+                workspace=self._workspace,
+                session_id=child_session_id,
+            )
+        except UnknownSessionError:
+            return None
+        self._validate_session_workspace(result.session, session_id=child_session_id)
+        return result
+
+    def _background_task_result(self, *, task: BackgroundTaskState) -> BackgroundTaskResult:
+        child_result = self._load_background_task_child_result(task=task)
+        approval_blocked = child_result is not None and child_result.status == "waiting"
+        summary_output = child_result.summary if child_result is not None else None
+        error = (
+            child_result.error if child_result is not None and child_result.error else task.error
+        )
+        result_available = False
+        if task.status in ("completed", "failed"):
+            result_available = True
+        elif task.status != "cancelled" and child_result is not None:
+            result_available = True
+        return BackgroundTaskResult(
+            task_id=task.task.id,
+            parent_session_id=task.parent_session_id,
+            child_session_id=task.session_id,
+            status=task.status,
+            approval_blocked=approval_blocked,
+            summary_output=summary_output,
+            error=error,
+            result_available=result_available,
+        )
+
+    def _emit_background_task_parent_terminal_event(self, *, task: BackgroundTaskState) -> None:
+        parent_session_id = task.parent_session_id
+        if parent_session_id is None or task.status not in ("completed", "failed", "cancelled"):
+            return
+        session_event_appender = self._session_store
+        if not isinstance(session_event_appender, SessionEventAppender):
+            logger.debug(
+                "skipping background terminal parent event for session store without append support"
+            )
+            return
+        result = self._background_task_result(task=task)
+        event_type_by_status: dict[BackgroundTaskStatus, str] = {
+            "completed": RUNTIME_BACKGROUND_TASK_COMPLETED,
+            "failed": RUNTIME_BACKGROUND_TASK_FAILED,
+            "cancelled": RUNTIME_BACKGROUND_TASK_CANCELLED,
+        }
+        event_type = event_type_by_status[task.status]
+        payload: dict[str, object] = {
+            "task_id": task.task.id,
+            "parent_session_id": parent_session_id,
+            "status": task.status,
+            "result_available": result.result_available,
+        }
+        if result.child_session_id is not None:
+            payload["child_session_id"] = result.child_session_id
+        if task.status == "completed" and result.summary_output is not None:
+            payload["summary_output"] = result.summary_output
+        if task.status in ("failed", "cancelled") and result.error is not None:
+            payload["error"] = result.error
+        try:
+            _ = session_event_appender.append_session_event(
+                workspace=self._workspace,
+                session_id=parent_session_id,
+                event_type=event_type,
+                source="runtime",
+                payload=payload,
+                dedupe_key=f"{event_type}:{task.task.id}",
+            )
+        except UnknownSessionError:
+            logger.debug(
+                "skipping background terminal event for unavailable parent session: %s",
+                parent_session_id,
+            )
+
+    def _backfill_parent_background_task_event(self, *, task: BackgroundTaskState) -> None:
+        if task.parent_session_id is None:
+            return
+        if task.status in ("completed", "failed", "cancelled"):
+            self._emit_background_task_parent_terminal_event(task=task)
+            return
+        if task.status != "running":
+            return
+        child_response = self._load_background_task_child_response(task=task)
+        if child_response is None or child_response.session.status != "waiting":
+            return
+        self._emit_background_task_waiting_approval(
+            task=task,
+            child_response=child_response,
+        )
+
+    def _reconcile_parent_background_task_events_for_session(
+        self,
+        *,
+        parent_session_id: str,
+    ) -> None:
+        self._reconcile_background_tasks_if_needed()
+        task_summaries = self._session_store.list_background_tasks_by_parent_session(
+            workspace=self._workspace,
+            parent_session_id=parent_session_id,
+        )
+        for task_summary in task_summaries:
+            task = self._session_store.load_background_task(
+                workspace=self._workspace,
+                task_id=task_summary.task.id,
+            )
+            self._backfill_parent_background_task_event(task=task)
+
     def _emit_background_task_waiting_approval(
         self,
         *,
@@ -3301,6 +3449,7 @@ class VoidCodeRuntime:
             surface=surface,
             session_id=task.session_id or task.request.session_id or "runtime",
         )
+        self._emit_background_task_parent_terminal_event(task=task)
         if task.status == "completed" and task.parent_session_id is not None:
             self._run_background_task_lifecycle_surface(
                 task=task,
@@ -3343,6 +3492,21 @@ class VoidCodeRuntime:
     def _reconcile_background_tasks_if_needed(self) -> None:
         if self._background_tasks_reconciled:
             return
+        task_summaries = self._session_store.list_background_tasks(workspace=self._workspace)
+        for task_summary in task_summaries:
+            if task_summary.status != "running" or task_summary.session_id is None:
+                continue
+            task = self._session_store.load_background_task(
+                workspace=self._workspace,
+                task_id=task_summary.task.id,
+            )
+            child_response = self._load_background_task_child_response(task=task)
+            if child_response is None:
+                continue
+            if child_response.session.status in ("waiting", "completed", "failed"):
+                self._finalize_background_task_from_session_response(
+                    session_response=child_response
+                )
         fail_incomplete = getattr(self._session_store, "fail_incomplete_background_tasks", None)
         if callable(fail_incomplete):
             failed_tasks = cast(
@@ -3354,6 +3518,13 @@ class VoidCodeRuntime:
             )
             for failed_task in failed_tasks:
                 self._run_background_task_lifecycle_hook(failed_task)
+        task_summaries = self._session_store.list_background_tasks(workspace=self._workspace)
+        for task_summary in task_summaries:
+            task = self._session_store.load_background_task(
+                workspace=self._workspace,
+                task_id=task_summary.task.id,
+            )
+            self._backfill_parent_background_task_event(task=task)
         self._background_tasks_reconciled = True
 
     def _run_background_task_worker(self, task_id: str) -> None:

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -1869,6 +1869,11 @@ class VoidCodeRuntime:
 
     def session_result(self, *, session_id: str) -> RuntimeSessionResult:
         validate_session_id(session_id)
+        result = self._session_store.load_session_result(
+            workspace=self._workspace,
+            session_id=session_id,
+        )
+        self._validate_session_workspace(result.session, session_id=session_id)
         self._reconcile_parent_background_task_events_for_session(parent_session_id=session_id)
         result = self._session_store.load_session_result(
             workspace=self._workspace,
@@ -1941,10 +1946,16 @@ class VoidCodeRuntime:
     ) -> RuntimeResponse:
         validate_session_id(session_id)
         if approval_request_id is None and approval_decision is None:
-            self._reconcile_parent_background_task_events_for_session(parent_session_id=session_id)
-            return self._session_store.load_session(
+            response = self._session_store.load_session(
                 workspace=self._workspace, session_id=session_id
             )
+            self._validate_session_workspace(response.session, session_id=session_id)
+            self._reconcile_parent_background_task_events_for_session(parent_session_id=session_id)
+            response = self._session_store.load_session(
+                workspace=self._workspace, session_id=session_id
+            )
+            self._validate_session_workspace(response.session, session_id=session_id)
+            return response
         if approval_request_id is None or approval_decision is None:
             raise ValueError("approval resume requires request id and decision")
         _, response = self._resume_pending_approval_response(
@@ -1964,10 +1975,15 @@ class VoidCodeRuntime:
     ) -> Iterator[RuntimeStreamChunk]:
         validate_session_id(session_id)
         if approval_request_id is None and approval_decision is None:
+            response = self._session_store.load_session(
+                workspace=self._workspace, session_id=session_id
+            )
+            self._validate_session_workspace(response.session, session_id=session_id)
             self._reconcile_parent_background_task_events_for_session(parent_session_id=session_id)
             response = self._session_store.load_session(
                 workspace=self._workspace, session_id=session_id
             )
+            self._validate_session_workspace(response.session, session_id=session_id)
             yield from self._replay_response(response)
             return
         if approval_request_id is None or approval_decision is None:
@@ -3340,7 +3356,6 @@ class VoidCodeRuntime:
         *,
         parent_session_id: str,
     ) -> None:
-        self._reconcile_background_tasks_if_needed()
         task_summaries = self._session_store.list_background_tasks_by_parent_session(
             workspace=self._workspace,
             parent_session_id=parent_session_id,
@@ -3350,6 +3365,17 @@ class VoidCodeRuntime:
                 workspace=self._workspace,
                 task_id=task_summary.task.id,
             )
+            if task.status == "running" and task.session_id is not None:
+                child_response = self._load_background_task_child_response(task=task)
+                if child_response is not None and child_response.session.status in (
+                    "waiting",
+                    "completed",
+                    "failed",
+                ):
+                    self._finalize_background_task_from_session_response(
+                        session_response=child_response
+                    )
+                    continue
             self._backfill_parent_background_task_event(task=task)
 
     def _emit_background_task_waiting_approval(

--- a/tests/unit/runtime/test_backend_contracts.py
+++ b/tests/unit/runtime/test_backend_contracts.py
@@ -57,6 +57,12 @@ def test_contract_modules_export_expected_symbols() -> None:
         created_at=1,
         updated_at=1,
     )
+    background_task_result = runtime.BackgroundTaskResult(
+        task_id=background_task.task.id,
+        parent_session_id=background_task.parent_session_id,
+        child_session_id=background_task.session_id,
+        status=background_task.status,
+    )
     session_summary = runtime.StoredSessionSummary(
         session=session.session,
         status="completed",
@@ -80,6 +86,8 @@ def test_contract_modules_export_expected_symbols() -> None:
     assert background_task.task.id == "task-1"
     assert background_task.request.prompt == runtime_request.prompt
     assert background_task.parent_session_id == "session-parent"
+    assert background_task_result.task_id == "task-1"
+    assert background_task_result.result_available is False
     assert session_summary.session.id == "session-1"
     assert graph_request.available_tools == ()
     assert graph_result.tool_results == (result,)
@@ -203,11 +211,14 @@ def test_contract_types_expose_explicit_annotations() -> None:
     tools = _tools_module()
 
     runtime_request_hints = get_type_hints(runtime.RuntimeRequest)
+    background_task_result_hints = get_type_hints(runtime.BackgroundTaskResult)
     background_task_hints = get_type_hints(runtime.BackgroundTaskState)
     tool_result_hints = get_type_hints(tools.ToolResult)
     graph_runner_hints = get_type_hints(graph.GraphRunner.run)
 
     assert runtime_request_hints["prompt"] is str
+    assert background_task_result_hints["task_id"] is str
+    assert str(background_task_result_hints["status"]) == "BackgroundTaskStatus"
     assert str(runtime_request_hints["parent_session_id"]) == "str | None"
     assert str(background_task_hints["status"]) == "BackgroundTaskStatus"
     assert tool_result_hints["tool_name"] is str

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -42,6 +42,9 @@ from voidcode.runtime.config import (
 )
 from voidcode.runtime.context_window import ContextWindowPolicy, RuntimeContinuityState
 from voidcode.runtime.events import (
+    RUNTIME_BACKGROUND_TASK_CANCELLED,
+    RUNTIME_BACKGROUND_TASK_COMPLETED,
+    RUNTIME_BACKGROUND_TASK_FAILED,
     RUNTIME_BACKGROUND_TASK_WAITING_APPROVAL,
     RUNTIME_MCP_SERVER_STARTED,
     RUNTIME_MCP_SERVER_STOPPED,
@@ -819,6 +822,297 @@ def test_runtime_validates_parent_session_id_when_listing_background_tasks(tmp_p
 
     with pytest.raises(ValueError, match="parent_session_id must not contain '/'"):
         _ = runtime.list_background_tasks_by_parent_session(parent_session_id="leader/session")
+
+
+def test_runtime_load_background_task_result_exposes_completed_child_summary(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    _ = runtime.run(RuntimeRequest(prompt="leader", session_id="leader-session"))
+
+    started = runtime.start_background_task(
+        RuntimeRequest(prompt="background child", parent_session_id="leader-session")
+    )
+    completed = _wait_for_background_task(runtime, started.task.id)
+    result = runtime.load_background_task_result(started.task.id)
+
+    assert completed.status == "completed"
+    assert result.task_id == started.task.id
+    assert result.parent_session_id == "leader-session"
+    assert result.child_session_id == completed.session_id
+    assert result.status == "completed"
+    assert result.approval_blocked is False
+    assert result.summary_output == "Completed: background child"
+    assert result.error is None
+    assert result.result_available is True
+
+
+def test_runtime_load_background_task_result_marks_waiting_child_as_approval_blocked(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+    _ = runtime.run(RuntimeRequest(prompt="leader", session_id="leader-session"))
+
+    started = runtime.start_background_task(
+        RuntimeRequest(prompt="background child", parent_session_id="leader-session")
+    )
+    running = _wait_for_background_task_session(runtime, started.task.id)
+    child_session_id = cast(str, running.session_id)
+    _ = _wait_for_session_event(
+        runtime,
+        child_session_id,
+        "runtime.approval_requested",
+    )
+    result = runtime.load_background_task_result(started.task.id)
+
+    assert result.task_id == started.task.id
+    assert result.parent_session_id == "leader-session"
+    assert result.child_session_id == child_session_id
+    assert result.status == "running"
+    assert result.approval_blocked is True
+    assert result.summary_output == "Approval blocked on write_file: write_file alpha.txt"
+    assert result.error is None
+    assert result.result_available is True
+
+
+def test_runtime_background_task_completion_emits_parent_session_event_once(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    _ = runtime.run(RuntimeRequest(prompt="leader", session_id="leader-session"))
+
+    started = runtime.start_background_task(
+        RuntimeRequest(prompt="background child", parent_session_id="leader-session")
+    )
+    completed = _wait_for_background_task(runtime, started.task.id)
+    leader_response = _wait_for_session_event(
+        runtime,
+        "leader-session",
+        RUNTIME_BACKGROUND_TASK_COMPLETED,
+    )
+
+    completed_events = [
+        event
+        for event in leader_response.events
+        if event.event_type == RUNTIME_BACKGROUND_TASK_COMPLETED
+    ]
+
+    assert completed.status == "completed"
+    assert len(completed_events) == 1
+    assert completed_events[0].payload == {
+        "task_id": started.task.id,
+        "parent_session_id": "leader-session",
+        "child_session_id": cast(str, completed.session_id),
+        "status": "completed",
+        "summary_output": "Completed: background child",
+        "result_available": True,
+    }
+
+    deduped_response = runtime.resume("leader-session")
+
+    assert (
+        sum(
+            event.event_type == RUNTIME_BACKGROUND_TASK_COMPLETED
+            for event in deduped_response.events
+        )
+        == 1
+    )
+
+
+def test_runtime_background_task_failure_emits_parent_session_event_once(
+    tmp_path: Path,
+) -> None:
+    setup_runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    _ = setup_runtime.run(RuntimeRequest(prompt="leader", session_id="leader-session"))
+
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskFailureGraph())
+
+    started = runtime.start_background_task(
+        RuntimeRequest(prompt="background child", parent_session_id="leader-session")
+    )
+    failed = _wait_for_background_task(runtime, started.task.id)
+    leader_response = _wait_for_session_event(
+        runtime,
+        "leader-session",
+        RUNTIME_BACKGROUND_TASK_FAILED,
+    )
+
+    failed_events = [
+        event
+        for event in leader_response.events
+        if event.event_type == RUNTIME_BACKGROUND_TASK_FAILED
+    ]
+
+    assert failed.status == "failed"
+    assert len(failed_events) == 1
+    assert failed_events[0].payload == {
+        "task_id": started.task.id,
+        "parent_session_id": "leader-session",
+        "child_session_id": cast(str, failed.session_id),
+        "status": "failed",
+        "error": cast(str, failed.error),
+        "result_available": True,
+    }
+
+    deduped_response = runtime.resume("leader-session")
+
+    assert (
+        sum(event.event_type == RUNTIME_BACKGROUND_TASK_FAILED for event in deduped_response.events)
+        == 1
+    )
+
+
+def test_runtime_background_task_cancellation_emits_parent_session_event_once(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    _ = runtime.run(RuntimeRequest(prompt="leader", session_id="leader-session"))
+    runtime._background_tasks_reconciled = True  # pyright: ignore[reportPrivateUsage]
+    store = _private_attr(runtime, "_session_store")
+    task_module = importlib.import_module("voidcode.runtime.task")
+    store.create_background_task(
+        workspace=tmp_path,
+        task=task_module.BackgroundTaskState(
+            task=task_module.BackgroundTaskRef(id="task-parent-cancel"),
+            request=task_module.BackgroundTaskRequestSnapshot(
+                prompt="background child",
+                parent_session_id="leader-session",
+            ),
+            created_at=1,
+            updated_at=1,
+        ),
+    )
+
+    cancelled = runtime.cancel_background_task("task-parent-cancel")
+    leader_response = _wait_for_session_event(
+        runtime,
+        "leader-session",
+        RUNTIME_BACKGROUND_TASK_CANCELLED,
+    )
+
+    cancelled_events = [
+        event
+        for event in leader_response.events
+        if event.event_type == RUNTIME_BACKGROUND_TASK_CANCELLED
+    ]
+
+    assert cancelled.status == "cancelled"
+    assert len(cancelled_events) == 1
+    assert cancelled_events[0].payload == {
+        "task_id": "task-parent-cancel",
+        "parent_session_id": "leader-session",
+        "status": "cancelled",
+        "error": "cancelled before start",
+        "result_available": False,
+    }
+
+    deduped_response = runtime.resume("leader-session")
+
+    assert (
+        sum(
+            event.event_type == RUNTIME_BACKGROUND_TASK_CANCELLED
+            for event in deduped_response.events
+        )
+        == 1
+    )
+
+
+def test_runtime_reconciles_persisted_child_terminal_truth_and_backfills_parent_event(
+    tmp_path: Path,
+) -> None:
+    initial_runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    _ = initial_runtime.run(RuntimeRequest(prompt="leader", session_id="leader-session"))
+    store = _private_attr(initial_runtime, "_session_store")
+    task_module = importlib.import_module("voidcode.runtime.task")
+    store.create_background_task(
+        workspace=tmp_path,
+        task=task_module.BackgroundTaskState(
+            task=task_module.BackgroundTaskRef(id="task-recover"),
+            status="running",
+            request=task_module.BackgroundTaskRequestSnapshot(
+                prompt="background child",
+                parent_session_id="leader-session",
+            ),
+            session_id="child-session",
+            created_at=1,
+            updated_at=1,
+            started_at=1,
+        ),
+    )
+    store.save_run(
+        workspace=tmp_path,
+        request=RuntimeRequest(
+            prompt="background child",
+            session_id="child-session",
+            parent_session_id="leader-session",
+            metadata={
+                "background_run": True,
+                "background_task_id": "task-recover",
+            },
+        ),
+        response=RuntimeResponse(
+            session=SessionState(
+                session=runtime_service_module.SessionRef(
+                    id="child-session",
+                    parent_id="leader-session",
+                ),
+                status="completed",
+                turn=1,
+                metadata={
+                    "background_run": True,
+                    "background_task_id": "task-recover",
+                },
+            ),
+            events=(
+                EventEnvelope(
+                    session_id="child-session",
+                    sequence=1,
+                    event_type="runtime.request_received",
+                    source="runtime",
+                    payload={"prompt": "background child"},
+                ),
+                EventEnvelope(
+                    session_id="child-session",
+                    sequence=2,
+                    event_type="graph.response_ready",
+                    source="graph",
+                    payload={},
+                ),
+            ),
+            output="background child",
+        ),
+    )
+
+    resumed_runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    reconciled = resumed_runtime.load_background_task("task-recover")
+    leader_response = resumed_runtime.resume("leader-session")
+    replayed = resumed_runtime.resume("leader-session")
+
+    recovered_events = [
+        event
+        for event in leader_response.events
+        if event.event_type == RUNTIME_BACKGROUND_TASK_COMPLETED
+    ]
+
+    assert reconciled.status == "completed"
+    assert reconciled.session_id == "child-session"
+    assert len(recovered_events) == 1
+    assert recovered_events[0].payload == {
+        "task_id": "task-recover",
+        "parent_session_id": "leader-session",
+        "child_session_id": "child-session",
+        "status": "completed",
+        "summary_output": "Completed: background child",
+        "result_available": True,
+    }
+    assert (
+        sum(event.event_type == RUNTIME_BACKGROUND_TASK_COMPLETED for event in replayed.events) == 1
+    )
 
 
 def test_runtime_background_task_waiting_approval_emits_parent_session_event_once(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1115,6 +1115,62 @@ def test_runtime_reconciles_persisted_child_terminal_truth_and_backfills_parent_
     )
 
 
+def test_runtime_resume_does_not_fail_unrelated_background_tasks(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    store = _private_attr(runtime, "_session_store")
+    store.save_run(
+        workspace=tmp_path,
+        request=RuntimeRequest(prompt="leader", session_id="leader-session"),
+        response=RuntimeResponse(
+            session=SessionState(
+                session=runtime_service_module.SessionRef(id="leader-session"),
+                status="completed",
+                turn=1,
+            ),
+            events=(
+                EventEnvelope(
+                    session_id="leader-session",
+                    sequence=1,
+                    event_type="runtime.request_received",
+                    source="runtime",
+                    payload={"prompt": "leader"},
+                ),
+                EventEnvelope(
+                    session_id="leader-session",
+                    sequence=2,
+                    event_type="graph.response_ready",
+                    source="graph",
+                    payload={},
+                ),
+            ),
+            output="leader",
+        ),
+    )
+    task_module = importlib.import_module("voidcode.runtime.task")
+    store.create_background_task(
+        workspace=tmp_path,
+        task=task_module.BackgroundTaskState(
+            task=task_module.BackgroundTaskRef(id="task-unrelated"),
+            request=task_module.BackgroundTaskRequestSnapshot(
+                prompt="background child",
+                parent_session_id="other-parent",
+            ),
+            created_at=1,
+            updated_at=1,
+        ),
+    )
+
+    response = runtime.resume("leader-session")
+    unrelated = store.load_background_task(
+        workspace=tmp_path,
+        task_id="task-unrelated",
+    )
+
+    assert response.session.session.id == "leader-session"
+    assert unrelated.status == "queued"
+    assert unrelated.error is None
+
+
 def test_runtime_background_task_waiting_approval_emits_parent_session_event_once(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- add a leader-facing `load_background_task_result(task_id)` runtime surface
- emit parent-session background task terminal events for completed, failed, and cancelled delegated work
- backfill delegated leader visibility during runtime reconciliation and leader resume paths

## Testing

- `.\\.venv\\Scripts\\ruff.exe check src/voidcode/runtime/contracts.py src/voidcode/runtime/__init__.py src/voidcode/runtime/service.py tests/unit/runtime/test_backend_contracts.py tests/unit/runtime/test_runtime_service_extensions.py`
- `.\\.venv\\Scripts\\ruff.exe format --check src/voidcode/runtime/contracts.py src/voidcode/runtime/__init__.py src/voidcode/runtime/service.py tests/unit/runtime/test_backend_contracts.py tests/unit/runtime/test_runtime_service_extensions.py`
- `.\\.venv\\Scripts\\basedpyright.exe src`
- `.\\.venv\\Scripts\\pytest.exe -q -o addopts='' tests/unit/runtime/test_runtime_service_extensions.py`
- `.\\.venv\\Scripts\\pytest.exe -q -o addopts='' tests/unit/runtime/test_background_task_storage.py tests/unit/runtime/test_backend_contracts.py`

Closes #179
