### PR TITLE
refactor: consolidate boundary-layer parsing with Pydantic models

### DIFF
--- a/src/voidcode/provider/config.py
+++ b/src/voidcode/provider/config.py
@@ -2,7 +2,173 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Literal, cast
+from typing import Annotated, Literal, cast
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic.functional_validators import BeforeValidator
+
+
+def _parse_optional_boundary_string(value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("must be a string when provided")
+    return value
+
+
+def _parse_required_boundary_string(value: object) -> str:
+    if not isinstance(value, str):
+        raise ValueError("must be a string")
+    return value
+
+
+def _parse_optional_boundary_timeout(value: object) -> float | None:
+    if value is None:
+        return None
+    if not isinstance(value, int | float) or isinstance(value, bool) or value <= 0:
+        raise ValueError("must be a number greater than 0 when provided")
+    return float(value)
+
+
+def _parse_optional_boundary_positive_int(value: object) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise ValueError("must be an integer greater than or equal to 1 when provided")
+    return value
+
+
+def _parse_boundary_string_list(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise ValueError("must be an array when provided")
+    parsed_items: list[str] = []
+    for index, item in enumerate(cast(list[object], value)):
+        if not isinstance(item, str):
+            raise ValueError(f"[{index}] must be a string")
+        parsed_items.append(item)
+    return tuple(parsed_items)
+
+
+def _parse_boundary_string_mapping(value: object) -> dict[str, str]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError("must be an object when provided")
+    mapping: dict[str, str] = {}
+    for raw_key, raw_item in cast(dict[object, object], value).items():
+        if not isinstance(raw_key, str):
+            raise ValueError(" keys must be strings")
+        if not raw_key:
+            raise ValueError(" keys must not be empty")
+        if not isinstance(raw_item, str):
+            raise ValueError(f".{raw_key} must be a string")
+        if not raw_item:
+            raise ValueError(f".{raw_key} must not be empty")
+        mapping[raw_key] = raw_item
+    return mapping
+
+
+BoundaryOptionalString = Annotated[str | None, BeforeValidator(_parse_optional_boundary_string)]
+BoundaryRequiredString = Annotated[str, BeforeValidator(_parse_required_boundary_string)]
+BoundaryOptionalTimeout = Annotated[float | None, BeforeValidator(_parse_optional_boundary_timeout)]
+BoundaryOptionalPositiveInt = Annotated[
+    int | None, BeforeValidator(_parse_optional_boundary_positive_int)
+]
+BoundaryStringList = Annotated[tuple[str, ...], BeforeValidator(_parse_boundary_string_list)]
+BoundaryStringMapping = Annotated[dict[str, str], BeforeValidator(_parse_boundary_string_mapping)]
+
+
+class _ProviderPayloadModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class _OpenAIProviderConfigPayload(_ProviderPayloadModel):
+    api_key: BoundaryOptionalString = None
+    base_url: BoundaryOptionalString = None
+    discovery_base_url: BoundaryOptionalString = None
+    organization: BoundaryOptionalString = None
+    project: BoundaryOptionalString = None
+    timeout_seconds: BoundaryOptionalTimeout = None
+
+
+class _AnthropicProviderConfigPayload(_ProviderPayloadModel):
+    api_key: BoundaryOptionalString = None
+    base_url: BoundaryOptionalString = None
+    discovery_base_url: BoundaryOptionalString = None
+    version: BoundaryOptionalString = None
+    beta_headers: BoundaryStringList = ()
+    timeout_seconds: BoundaryOptionalTimeout = None
+
+
+class _GoogleProviderAuthConfigPayload(_ProviderPayloadModel):
+    method: BoundaryRequiredString
+    api_key: BoundaryOptionalString = None
+    access_token: BoundaryOptionalString = None
+    service_account_json_path: BoundaryOptionalString = None
+
+
+class _GoogleProviderConfigPayload(_ProviderPayloadModel):
+    auth: _GoogleProviderAuthConfigPayload | None = None
+    base_url: BoundaryOptionalString = None
+    discovery_base_url: BoundaryOptionalString = None
+    project: BoundaryOptionalString = None
+    region: BoundaryOptionalString = None
+    timeout_seconds: BoundaryOptionalTimeout = None
+
+
+class _CopilotProviderAuthConfigPayload(_ProviderPayloadModel):
+    method: BoundaryRequiredString
+    token: BoundaryOptionalString = None
+    token_env_var: BoundaryOptionalString = None
+    refresh_token: BoundaryOptionalString = None
+    refresh_leeway_seconds: BoundaryOptionalPositiveInt = None
+
+
+class _CopilotProviderConfigPayload(_ProviderPayloadModel):
+    auth: _CopilotProviderAuthConfigPayload | None = None
+    base_url: BoundaryOptionalString = None
+    timeout_seconds: BoundaryOptionalTimeout = None
+
+
+class _LiteLLMProviderConfigPayload(_ProviderPayloadModel):
+    api_key: BoundaryOptionalString = None
+    api_key_env_var: BoundaryOptionalString = None
+    base_url: BoundaryOptionalString = None
+    discovery_base_url: BoundaryOptionalString = None
+    auth_header: BoundaryOptionalString = None
+    auth_scheme: BoundaryOptionalString = "bearer"
+    timeout_seconds: BoundaryOptionalTimeout = None
+    model_map: BoundaryStringMapping = Field(default_factory=dict)
+
+
+class _SimplifiedProviderConfigPayload(_ProviderPayloadModel):
+    api_key: BoundaryOptionalString = None
+    api_key_env_var: BoundaryOptionalString = None
+    base_url: BoundaryOptionalString = None
+    discovery_base_url: BoundaryOptionalString = None
+    timeout_seconds: BoundaryOptionalTimeout = None
+    model_map: BoundaryStringMapping = Field(default_factory=dict)
+
+
+class _ProviderConfigsPayload(_ProviderPayloadModel):
+    openai: _OpenAIProviderConfigPayload | None = None
+    anthropic: _AnthropicProviderConfigPayload | None = None
+    google: _GoogleProviderConfigPayload | None = None
+    copilot: _CopilotProviderConfigPayload | None = None
+    litellm: _LiteLLMProviderConfigPayload | None = None
+    glm: _SimplifiedProviderConfigPayload | None = None
+    minimax: _SimplifiedProviderConfigPayload | None = None
+    kimi: _SimplifiedProviderConfigPayload | None = None
+    opencode_go: _SimplifiedProviderConfigPayload | None = Field(default=None, alias="opencode-go")
+    qwen: _SimplifiedProviderConfigPayload | None = None
+    custom: dict[str, _LiteLLMProviderConfigPayload] = Field(default_factory=dict)
+
+
+class _ProviderFallbackPayload(_ProviderPayloadModel):
+    preferred_model: BoundaryRequiredString
+    fallback_models: BoundaryStringList = ()
 
 # =============================================================================
 # Simplified Provider Config for Chinese AI Providers
@@ -387,6 +553,81 @@ def _provider_configs_has_entries(providers: ProviderConfigs) -> bool:
     )
 
 
+def _runtime_config_field_name(field_path: str) -> str | None:
+    runtime_field_prefix = "runtime config field '"
+    if field_path.startswith(runtime_field_prefix) and field_path.endswith("'"):
+        return field_path[len(runtime_field_prefix) : -1]
+    return None
+
+
+def _append_config_field_suffix(field_path: str, suffix: str) -> str:
+    runtime_field_name = _runtime_config_field_name(field_path)
+    if runtime_field_name is not None:
+        return _format_runtime_config_field_error(f"{runtime_field_name}{suffix}")
+    return f"{field_path}{suffix}"
+
+
+def _extend_config_field_path(field_path: str, loc: tuple[object, ...]) -> str:
+    extended = field_path
+    for item in loc:
+        if isinstance(item, int):
+            extended = _append_config_field_suffix(extended, f"[{item}]")
+            continue
+        extended = _nested_config_field(extended, str(item))
+    return extended
+
+
+def _validation_reason_from_error(error: dict[str, object]) -> str:
+    error_type = cast(str, error.get("type", ""))
+    if error_type == "value_error":
+        context = error.get("ctx")
+        if isinstance(context, dict):
+            nested_error = cast(dict[str, object], context).get("error")
+            if isinstance(nested_error, ValueError):
+                return str(nested_error)
+    return cast(str, error.get("msg", "is invalid"))
+
+
+def _format_provider_payload_validation_error(
+    *,
+    field_path: str,
+    error: dict[str, object],
+    object_when_provided: bool = True,
+) -> str:
+    loc = tuple(cast(tuple[object, ...], error.get("loc", ())))
+    error_type = cast(str, error.get("type", ""))
+    target = _extend_config_field_path(field_path, loc)
+    if error_type in {"model_type", "dict_type"}:
+        suffix = " when provided" if object_when_provided else ""
+        return f"{target} must be an object{suffix}"
+    if error_type == "extra_forbidden":
+        return f"{target} is not supported"
+    reason = _validation_reason_from_error(error)
+    if reason.startswith("[") or reason.startswith("."):
+        if " " in reason:
+            suffix, nested_reason = reason.split(" ", maxsplit=1)
+            return f"{_append_config_field_suffix(target, suffix)} {nested_reason}"
+        return _append_config_field_suffix(target, reason)
+    if reason.startswith(" keys"):
+        return f"{target}{reason}"
+    return f"{target} {reason}"
+
+
+def _validate_provider_payload_model[TModel: BaseModel](
+    raw_value: object,
+    *,
+    field_path: str,
+    model_type: type[TModel],
+) -> TModel:
+    try:
+        return model_type.model_validate(raw_value)
+    except ValidationError as exc:
+        error = cast(dict[str, object], exc.errors(include_url=False)[0])
+        raise ValueError(
+            _format_provider_payload_validation_error(field_path=field_path, error=error)
+        ) from exc
+
+
 def parse_provider_configs_payload(
     raw_providers: object,
     *,
@@ -395,88 +636,72 @@ def parse_provider_configs_payload(
 ) -> ProviderConfigs | None:
     if raw_providers is None:
         return None
-    if not isinstance(raw_providers, dict):
-        raise ValueError(f"{source} must be an object when provided")
-
-    payload = cast(dict[str, object], raw_providers)
-    _reject_unknown_keys(
-        payload=payload,
-        source=source,
-        allowed_keys=(
-            "openai",
-            "anthropic",
-            "google",
-            "copilot",
-            "litellm",
-            "glm",
-            "minimax",
-            "kimi",
-            "opencode-go",
-            "qwen",
-            "custom",
-        ),
+    payload = _validate_provider_payload_model(
+        raw_providers,
+        field_path=source,
+        model_type=_ProviderConfigsPayload,
     )
 
     environment: Mapping[str, str] = {} if env is None else env
 
     return ProviderConfigs(
         openai=_parse_openai_provider_config(
-            payload.get("openai"),
+            payload.openai,
             field_path=_nested_config_field(source, "openai"),
             env=environment,
         ),
         anthropic=_parse_anthropic_provider_config(
-            payload.get("anthropic"),
+            payload.anthropic,
             field_path=_nested_config_field(source, "anthropic"),
             env=environment,
         ),
         google=_parse_google_provider_config(
-            payload.get("google"),
+            payload.google,
             field_path=_nested_config_field(source, "google"),
             env=environment,
         ),
         copilot=_parse_copilot_provider_config(
-            payload.get("copilot"),
+            payload.copilot,
             field_path=_nested_config_field(source, "copilot"),
             env=environment,
         ),
         litellm=_parse_litellm_provider_config(
-            payload.get("litellm"),
+            payload.litellm,
             field_path=_nested_config_field(source, "litellm"),
             env=environment,
         ),
         glm=_parse_simplified_provider_config(
-            payload.get("glm"),
+            payload.glm,
             field_path=_nested_config_field(source, "glm"),
             env=environment,
             api_key_env_var=_GLM_API_KEY_ENV_VAR,
         ),
         minimax=_parse_simplified_provider_config(
-            payload.get("minimax"),
+            payload.minimax,
             field_path=_nested_config_field(source, "minimax"),
             env=environment,
             api_key_env_var=_MINIMAX_API_KEY_ENV_VAR,
         ),
         kimi=_parse_simplified_provider_config(
-            payload.get("kimi"),
+            payload.kimi,
             field_path=_nested_config_field(source, "kimi"),
             env=environment,
             api_key_env_var=_KIMI_API_KEY_ENV_VAR,
         ),
         opencode_go=_parse_simplified_provider_config(
-            payload.get("opencode-go"),
+            payload.opencode_go,
             field_path=_nested_config_field(source, "opencode-go"),
             env=environment,
             api_key_env_var=_OPENCODE_API_KEY_ENV_VAR,
         ),
         qwen=_parse_simplified_provider_config(
-            payload.get("qwen"),
+            payload.qwen,
             field_path=_nested_config_field(source, "qwen"),
             env=environment,
             api_key_env_var="DASHSCOPE_API_KEY",
         ),
         custom=_parse_custom_litellm_provider_configs(
-            payload.get("custom"),
+            payload.custom,
             field_path=_nested_config_field(source, "custom"),
             env=environment,
         ),
@@ -559,17 +784,13 @@ def parse_provider_fallback_payload(
 ) -> ProviderFallbackConfig | None:
     if raw_provider_fallback is None:
         return None
-    if not isinstance(raw_provider_fallback, dict):
-        raise ValueError(f"{source} must be an object when provided")
-
-    payload = cast(dict[str, object], raw_provider_fallback)
-    preferred_model = payload.get("preferred_model")
-    if not isinstance(preferred_model, str):
-        raise ValueError(f"{_nested_config_field(source, 'preferred_model')} must be a string")
-    fallback_models = _parse_string_list(
-        payload.get("fallback_models"),
-        field_path=_nested_config_field(source, "fallback_models"),
+    payload = _validate_provider_payload_model(
+        raw_provider_fallback,
+        field_path=source,
+        model_type=_ProviderFallbackPayload,
     )
+    preferred_model = payload.preferred_model
+    fallback_models = payload.fallback_models
     ordered_models = (preferred_model, *fallback_models)
     if len(set(ordered_models)) != len(ordered_models):
         raise ValueError("provider fallback chain must not contain duplicate models")
@@ -598,43 +819,26 @@ def _parse_openai_provider_config(
 ) -> OpenAIProviderConfig | None:
     if raw_value is None:
         return None
-    if not isinstance(raw_value, dict):
-        raise ValueError(f"{field_path} must be an object when provided")
-    payload = cast(dict[str, object], raw_value)
-
-    api_key = _parse_optional_str(
-        payload.get("api_key"),
-        field_path=_nested_config_field(field_path, "api_key"),
+    payload = (
+        raw_value
+        if isinstance(raw_value, _OpenAIProviderConfigPayload)
+        else _validate_provider_payload_model(
+            raw_value,
+            field_path=field_path,
+            model_type=_OpenAIProviderConfigPayload,
+        )
     )
+
+    api_key = payload.api_key
     if api_key is None:
         api_key = env.get(_OPENAI_API_KEY_ENV_VAR)
-    base_url = _parse_optional_str(
-        payload.get("base_url"),
-        field_path=_nested_config_field(field_path, "base_url"),
-    )
-    discovery_base_url = _parse_optional_str(
-        payload.get("discovery_base_url"),
-        field_path=_nested_config_field(field_path, "discovery_base_url"),
-    )
-    organization = _parse_optional_str(
-        payload.get("organization"),
-        field_path=_nested_config_field(field_path, "organization"),
-    )
-    project = _parse_optional_str(
-        payload.get("project"),
-        field_path=_nested_config_field(field_path, "project"),
-    )
-    timeout_seconds = _parse_optional_timeout_seconds(
-        payload.get("timeout_seconds"),
-        field_path=_nested_config_field(field_path, "timeout_seconds"),
-    )
     return OpenAIProviderConfig(
         api_key=api_key,
-        base_url=base_url,
-        discovery_base_url=discovery_base_url,
-        organization=organization,
-        project=project,
-        timeout_seconds=timeout_seconds,
+        base_url=payload.base_url,
+        discovery_base_url=payload.discovery_base_url,
+        organization=payload.organization,
+        project=payload.project,
+        timeout_seconds=payload.timeout_seconds,
     )
 
 
@@ -646,43 +850,26 @@ def _parse_anthropic_provider_config(
 ) -> AnthropicProviderConfig | None:
     if raw_value is None:
         return None
-    if not isinstance(raw_value, dict):
-        raise ValueError(f"{field_path} must be an object when provided")
-    payload = cast(dict[str, object], raw_value)
-
-    api_key = _parse_optional_str(
-        payload.get("api_key"),
-        field_path=_nested_config_field(field_path, "api_key"),
+    payload = (
+        raw_value
+        if isinstance(raw_value, _AnthropicProviderConfigPayload)
+        else _validate_provider_payload_model(
+            raw_value,
+            field_path=field_path,
+            model_type=_AnthropicProviderConfigPayload,
+        )
     )
+
+    api_key = payload.api_key
     if api_key is None:
         api_key = env.get(_ANTHROPIC_API_KEY_ENV_VAR)
-    base_url = _parse_optional_str(
-        payload.get("base_url"),
-        field_path=_nested_config_field(field_path, "base_url"),
-    )
-    discovery_base_url = _parse_optional_str(
-        payload.get("discovery_base_url"),
-        field_path=_nested_config_field(field_path, "discovery_base_url"),
-    )
-    version = _parse_optional_str(
-        payload.get("version"),
-        field_path=_nested_config_field(field_path, "version"),
-    )
-    beta_headers = _parse_string_list(
-        payload.get("beta_headers"),
-        field_path=_nested_config_field(field_path, "beta_headers"),
-    )
-    timeout_seconds = _parse_optional_timeout_seconds(
-        payload.get("timeout_seconds"),
-        field_path=_nested_config_field(field_path, "timeout_seconds"),
-    )
     return AnthropicProviderConfig(
         api_key=api_key,
-        base_url=base_url,
-        discovery_base_url=discovery_base_url,
-        version=version,
-        beta_headers=beta_headers,
-        timeout_seconds=timeout_seconds,
+        base_url=payload.base_url,
+        discovery_base_url=payload.discovery_base_url,
+        version=payload.version,
+        beta_headers=payload.beta_headers,
+        timeout_seconds=payload.timeout_seconds,
     )
 
 
@@ -694,42 +881,28 @@ def _parse_google_provider_config(
 ) -> GoogleProviderConfig | None:
     if raw_value is None:
         return None
-    if not isinstance(raw_value, dict):
-        raise ValueError(f"{field_path} must be an object when provided")
-    payload = cast(dict[str, object], raw_value)
+    payload = (
+        raw_value
+        if isinstance(raw_value, _GoogleProviderConfigPayload)
+        else _validate_provider_payload_model(
+            raw_value,
+            field_path=field_path,
+            model_type=_GoogleProviderConfigPayload,
+        )
+    )
 
     auth = _parse_google_auth_config(
-        payload.get("auth"),
+        payload.auth,
         field_path=_nested_config_field(field_path, "auth"),
         env=env,
     )
-    base_url = _parse_optional_str(
-        payload.get("base_url"),
-        field_path=_nested_config_field(field_path, "base_url"),
-    )
-    discovery_base_url = _parse_optional_str(
-        payload.get("discovery_base_url"),
-        field_path=_nested_config_field(field_path, "discovery_base_url"),
-    )
-    project = _parse_optional_str(
-        payload.get("project"),
-        field_path=_nested_config_field(field_path, "project"),
-    )
-    region = _parse_optional_str(
-        payload.get("region"),
-        field_path=_nested_config_field(field_path, "region"),
-    )
-    timeout_seconds = _parse_optional_timeout_seconds(
-        payload.get("timeout_seconds"),
-        field_path=_nested_config_field(field_path, "timeout_seconds"),
-    )
     return GoogleProviderConfig(
         auth=auth,
-        base_url=base_url,
-        discovery_base_url=discovery_base_url,
-        project=project,
-        region=region,
-        timeout_seconds=timeout_seconds,
+        base_url=payload.base_url,
+        discovery_base_url=payload.discovery_base_url,
+        project=payload.project,
+        region=payload.region,
+        timeout_seconds=payload.timeout_seconds,
     )
 
 
@@ -741,30 +914,27 @@ def _parse_google_auth_config(
 ) -> GoogleProviderAuthConfig | None:
     if raw_value is None:
         return None
-    if not isinstance(raw_value, dict):
-        raise ValueError(f"{field_path} must be an object when provided")
-    payload = cast(dict[str, object], raw_value)
+    payload = (
+        raw_value
+        if isinstance(raw_value, _GoogleProviderAuthConfigPayload)
+        else _validate_provider_payload_model(
+            raw_value,
+            field_path=field_path,
+            model_type=_GoogleProviderAuthConfigPayload,
+        )
+    )
 
-    raw_method = payload.get("method")
+    raw_method = payload.method
     if raw_method not in _VALID_GOOGLE_AUTH_METHODS:
         allowed = ", ".join(_VALID_GOOGLE_AUTH_METHODS)
         raise ValueError(f"{_nested_config_field(field_path, 'method')} must be one of: {allowed}")
     method = raw_method
 
-    api_key = _parse_optional_str(
-        payload.get("api_key"),
-        field_path=_nested_config_field(field_path, "api_key"),
-    )
+    api_key = payload.api_key
     if api_key is None:
         api_key = env.get(_GOOGLE_API_KEY_ENV_VAR)
-    access_token = _parse_optional_str(
-        payload.get("access_token"),
-        field_path=_nested_config_field(field_path, "access_token"),
-    )
-    service_account_json_path = _parse_optional_str(
-        payload.get("service_account_json_path"),
-        field_path=_nested_config_field(field_path, "service_account_json_path"),
-    )
+    access_token = payload.access_token
+    service_account_json_path = payload.service_account_json_path
 
     if method == "api_key":
         if api_key is None:
@@ -830,24 +1000,26 @@ def _parse_copilot_provider_config(
 ) -> CopilotProviderConfig | None:
     if raw_value is None:
         return None
-    if not isinstance(raw_value, dict):
-        raise ValueError(f"{field_path} must be an object when provided")
-    payload = cast(dict[str, object], raw_value)
+    payload = (
+        raw_value
+        if isinstance(raw_value, _CopilotProviderConfigPayload)
+        else _validate_provider_payload_model(
+            raw_value,
+            field_path=field_path,
+            model_type=_CopilotProviderConfigPayload,
+        )
+    )
 
     auth = _parse_copilot_auth_config(
-        payload.get("auth"),
+        payload.auth,
         field_path=_nested_config_field(field_path, "auth"),
         env=env,
     )
-    base_url = _parse_optional_str(
-        payload.get("base_url"),
-        field_path=_nested_config_field(field_path, "base_url"),
+    return CopilotProviderConfig(
+        auth=auth,
+        base_url=payload.base_url,
+        timeout_seconds=payload.timeout_seconds,
     )
-    timeout_seconds = _parse_optional_timeout_seconds(
-        payload.get("timeout_seconds"),
-        field_path=_nested_config_field(field_path, "timeout_seconds"),
-    )
-    return CopilotProviderConfig(auth=auth, base_url=base_url, timeout_seconds=timeout_seconds)
 
 
 def _parse_copilot_auth_config(
@@ -858,36 +1030,30 @@ def _parse_copilot_auth_config(
 ) -> CopilotProviderAuthConfig | None:
     if raw_value is None:
         return None
-    if not isinstance(raw_value, dict):
-        raise ValueError(f"{field_path} must be an object when provided")
-    payload = cast(dict[str, object], raw_value)
+    payload = (
+        raw_value
+        if isinstance(raw_value, _CopilotProviderAuthConfigPayload)
+        else _validate_provider_payload_model(
+            raw_value,
+            field_path=field_path,
+            model_type=_CopilotProviderAuthConfigPayload,
+        )
+    )
 
-    raw_method = payload.get("method")
+    raw_method = payload.method
     if raw_method not in _VALID_COPILOT_AUTH_METHODS:
         allowed = ", ".join(_VALID_COPILOT_AUTH_METHODS)
         raise ValueError(f"{_nested_config_field(field_path, 'method')} must be one of: {allowed}")
     method = raw_method
 
-    token = _parse_optional_str(
-        payload.get("token"),
-        field_path=_nested_config_field(field_path, "token"),
-    )
-    token_env_var = _parse_optional_str(
-        payload.get("token_env_var"),
-        field_path=_nested_config_field(field_path, "token_env_var"),
-    )
+    token = payload.token
+    token_env_var = payload.token_env_var
     if token is None and token_env_var is None:
         token = env.get(_COPILOT_TOKEN_ENV_VAR)
         if token is not None:
             token_env_var = _COPILOT_TOKEN_ENV_VAR
-    refresh_token = _parse_optional_str(
-        payload.get("refresh_token"),
-        field_path=_nested_config_field(field_path, "refresh_token"),
-    )
-    refresh_leeway_seconds = _parse_optional_positive_int(
-        payload.get("refresh_leeway_seconds"),
-        field_path=_nested_config_field(field_path, "refresh_leeway_seconds"),
-    )
+    refresh_token = payload.refresh_token
+    refresh_leeway_seconds = payload.refresh_leeway_seconds
 
     if method == "token":
         if token is None and token_env_var is None:
@@ -937,37 +1103,29 @@ def _parse_litellm_provider_config(
 ) -> LiteLLMProviderConfig | None:
     if raw_value is None:
         return None
-    if not isinstance(raw_value, dict):
-        raise ValueError(f"{field_path} must be an object when provided")
-    payload = cast(dict[str, object], raw_value)
+    payload = (
+        raw_value
+        if isinstance(raw_value, _LiteLLMProviderConfigPayload)
+        else _validate_provider_payload_model(
+            raw_value,
+            field_path=field_path,
+            model_type=_LiteLLMProviderConfigPayload,
+        )
+    )
 
-    api_key = _parse_optional_str(
-        payload.get("api_key"),
-        field_path=_nested_config_field(field_path, "api_key"),
-    )
-    api_key_env_var = _parse_optional_str(
-        payload.get("api_key_env_var"),
-        field_path=_nested_config_field(field_path, "api_key_env_var"),
-    )
+    api_key = payload.api_key
+    api_key_env_var = payload.api_key_env_var
     if api_key is None:
         if api_key_env_var is not None:
             api_key = env.get(api_key_env_var)
         else:
             api_key = env.get(_LITELLM_API_KEY_ENV_VAR) or env.get(_LITELLM_PROXY_API_KEY_ENV_VAR)
 
-    base_url = _parse_optional_str(
-        payload.get("base_url"),
-        field_path=_nested_config_field(field_path, "base_url"),
-    )
+    base_url = payload.base_url
     if base_url is None:
         base_url = env.get(_LITELLM_BASE_URL_ENV_VAR) or env.get(_LITELLM_PROXY_URL_ENV_VAR)
 
-    auth_header = _parse_optional_str(
-        payload.get("auth_header"),
-        field_path=_nested_config_field(field_path, "auth_header"),
-    )
-
-    raw_auth_scheme = payload.get("auth_scheme")
+    raw_auth_scheme = payload.auth_scheme
     auth_scheme: Literal["bearer", "token", "none"] = "bearer"
     if raw_auth_scheme is not None:
         if raw_auth_scheme not in _VALID_LITELLM_AUTH_SCHEMES:
@@ -977,27 +1135,15 @@ def _parse_litellm_provider_config(
             )
         auth_scheme = raw_auth_scheme
 
-    timeout_seconds = _parse_optional_timeout_seconds(
-        payload.get("timeout_seconds"),
-        field_path=_nested_config_field(field_path, "timeout_seconds"),
-    )
-    discovery_base_url = _parse_optional_str(
-        payload.get("discovery_base_url"),
-        field_path=_nested_config_field(field_path, "discovery_base_url"),
-    )
-    model_map = _parse_string_mapping(
-        payload.get("model_map"),
-        field_path=_nested_config_field(field_path, "model_map"),
-    )
     return LiteLLMProviderConfig(
         api_key=api_key,
         api_key_env_var=api_key_env_var,
         base_url=base_url,
-        discovery_base_url=discovery_base_url,
-        auth_header=auth_header,
+        discovery_base_url=payload.discovery_base_url,
+        auth_header=payload.auth_header,
         auth_scheme=auth_scheme,
-        timeout_seconds=timeout_seconds,
-        model_map=model_map,
+        timeout_seconds=payload.timeout_seconds,
+        model_map=payload.model_map,
     )
 
 
@@ -1010,47 +1156,31 @@ def _parse_simplified_provider_config(
 ) -> SimplifiedProviderConfig | None:
     if raw_value is None:
         return None
-    if not isinstance(raw_value, dict):
-        raise ValueError(f"{field_path} must be an object when provided")
-    payload = cast(dict[str, object], raw_value)
+    payload = (
+        raw_value
+        if isinstance(raw_value, _SimplifiedProviderConfigPayload)
+        else _validate_provider_payload_model(
+            raw_value,
+            field_path=field_path,
+            model_type=_SimplifiedProviderConfigPayload,
+        )
+    )
 
-    api_key = _parse_optional_str(
-        payload.get("api_key"),
-        field_path=_nested_config_field(field_path, "api_key"),
-    )
-    api_key_env = _parse_optional_str(
-        payload.get("api_key_env_var"),
-        field_path=_nested_config_field(field_path, "api_key_env_var"),
-    )
+    api_key = payload.api_key
+    api_key_env = payload.api_key_env_var
     if api_key is None:
         if api_key_env is not None:
             api_key = env.get(api_key_env)
         else:
             api_key = env.get(api_key_env_var)
 
-    base_url = _parse_optional_str(
-        payload.get("base_url"),
-        field_path=_nested_config_field(field_path, "base_url"),
-    )
-    timeout_seconds = _parse_optional_timeout_seconds(
-        payload.get("timeout_seconds"),
-        field_path=_nested_config_field(field_path, "timeout_seconds"),
-    )
-    discovery_base_url = _parse_optional_str(
-        payload.get("discovery_base_url"),
-        field_path=_nested_config_field(field_path, "discovery_base_url"),
-    )
-    model_map = _parse_string_mapping(
-        payload.get("model_map"),
-        field_path=_nested_config_field(field_path, "model_map"),
-    )
     return SimplifiedProviderConfig(
         api_key=api_key,
         api_key_env_var=api_key_env,
-        base_url=base_url,
-        discovery_base_url=discovery_base_url,
-        timeout_seconds=timeout_seconds,
-        model_map=model_map,
+        base_url=payload.base_url,
+        discovery_base_url=payload.discovery_base_url,
+        timeout_seconds=payload.timeout_seconds,
+        model_map=payload.model_map,
     )
 
 
@@ -1256,82 +1386,6 @@ def _parse_custom_litellm_provider_configs(
             continue
         parsed[raw_provider_name] = parsed_config
     return parsed
-
-
-def _parse_string_mapping(raw_value: object, *, field_path: str) -> dict[str, str]:
-    if raw_value is None:
-        return {}
-    if not isinstance(raw_value, dict):
-        raise ValueError(f"{field_path} must be an object when provided")
-    mapping: dict[str, str] = {}
-    for raw_key, raw_item in cast(dict[object, object], raw_value).items():
-        if not isinstance(raw_key, str):
-            raise ValueError(f"{field_path} keys must be strings")
-        if not isinstance(raw_item, str):
-            raise ValueError(f"{_nested_config_field(field_path, raw_key)} must be a string")
-        if not raw_key:
-            raise ValueError(f"{field_path} keys must not be empty")
-        if not raw_item:
-            raise ValueError(f"{_nested_config_field(field_path, raw_key)} must not be empty")
-        mapping[raw_key] = raw_item
-    return mapping
-
-
-def _parse_optional_str(raw_value: object, *, field_path: str) -> str | None:
-    if raw_value is None:
-        return None
-    if not isinstance(raw_value, str):
-        raise ValueError(f"{field_path} must be a string when provided")
-    return raw_value
-
-
-def _parse_optional_timeout_seconds(raw_value: object, *, field_path: str) -> float | None:
-    if raw_value is None:
-        return None
-    if not isinstance(raw_value, int | float) or isinstance(raw_value, bool) or raw_value <= 0:
-        raise ValueError(f"{field_path} must be a number greater than 0 when provided")
-    return float(raw_value)
-
-
-def _parse_optional_positive_int(raw_value: object, *, field_path: str) -> int | None:
-    if raw_value is None:
-        return None
-    if not isinstance(raw_value, int) or isinstance(raw_value, bool) or raw_value < 1:
-        raise ValueError(
-            f"{field_path} must be an integer greater than or equal to 1 when provided"
-        )
-    return raw_value
-
-
-def _reject_unknown_keys(
-    *,
-    payload: dict[str, object],
-    source: str,
-    allowed_keys: tuple[str, ...],
-) -> None:
-    allowed = set(allowed_keys)
-    for key in payload:
-        if key not in allowed:
-            raise ValueError(f"{_nested_config_field(source, key)} is not supported")
-
-
-def _parse_string_list(raw_value: object, *, field_path: str) -> tuple[str, ...]:
-    if raw_value is None:
-        return ()
-    if not isinstance(raw_value, list):
-        raise ValueError(
-            f"{_format_runtime_config_field_error(field_path)} must be an array when provided"
-        )
-
-    raw_items = cast(list[object], raw_value)
-    parsed_items: list[str] = []
-    for index, item in enumerate(raw_items):
-        if not isinstance(item, str):
-            raise ValueError(
-                f"{_format_runtime_config_field_error(f'{field_path}[{index}]')} must be a string"
-            )
-        parsed_items.append(item)
-    return tuple(parsed_items)
 
 
 def _nested_config_field(source: str, nested: str) -> str:

--- a/src/voidcode/provider/config.py
+++ b/src/voidcode/provider/config.py
@@ -170,6 +170,7 @@ class _ProviderFallbackPayload(_ProviderPayloadModel):
     preferred_model: BoundaryRequiredString
     fallback_models: BoundaryStringList = ()
 
+
 # =============================================================================
 # Simplified Provider Config for Chinese AI Providers
 # Provides a unified, minimal configuration interface for GLM, MiniMax, Kimi, OpenCode Go, and Qwen

--- a/src/voidcode/provider/model_catalog.py
+++ b/src/voidcode/provider/model_catalog.py
@@ -9,6 +9,8 @@ from urllib.error import URLError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
 
+from pydantic import BaseModel, ConfigDict, ValidationError
+
 from .config import LiteLLMProviderConfig
 
 
@@ -64,6 +66,30 @@ class ModelDiscoveryPlan:
     ]
     request: DiscoveryRequest | None
     skip_reason: str | None = None
+
+
+class _DiscoveryPayloadModel(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+
+class _OpenAICompatibleModelItem(_DiscoveryPayloadModel):
+    id: str | None = None
+
+
+class _OpenAICompatibleDiscoveryPayload(_DiscoveryPayloadModel):
+    data: list[str | _OpenAICompatibleModelItem] | None = None
+
+
+class _AnthropicDiscoveryPayload(_DiscoveryPayloadModel):
+    data: list[_OpenAICompatibleModelItem] | None = None
+
+
+class _GoogleModelItem(_DiscoveryPayloadModel):
+    name: str | None = None
+
+
+class _GoogleDiscoveryPayload(_DiscoveryPayloadModel):
+    models: list[_GoogleModelItem] | None = None
 
 
 def discover_available_models(
@@ -207,6 +233,50 @@ def _fetch_models(request: DiscoveryRequest) -> tuple[str, ...]:
     return _fetch_openai_compatible_models(request)
 
 
+def _parse_openai_compatible_discovery_payload(payload: object) -> tuple[str, ...]:
+    try:
+        parsed = _OpenAICompatibleDiscoveryPayload.model_validate(payload)
+    except ValidationError as exc:
+        raise ValueError("provider model discovery response must be an object") from exc
+    if parsed.data is None:
+        return ()
+    model_ids: list[str] = []
+    for item in parsed.data:
+        if isinstance(item, str) and item:
+            model_ids.append(item)
+            continue
+        if isinstance(item, _OpenAICompatibleModelItem) and item.id:
+            model_ids.append(item.id)
+    return tuple(model_ids)
+
+
+def _parse_anthropic_discovery_payload(payload: object) -> tuple[str, ...]:
+    try:
+        parsed = _AnthropicDiscoveryPayload.model_validate(payload)
+    except ValidationError:
+        return ()
+    if parsed.data is None:
+        return ()
+    return tuple(item.id for item in parsed.data if item.id)
+
+
+def _parse_google_discovery_payload(payload: object) -> tuple[str, ...]:
+    try:
+        parsed = _GoogleDiscoveryPayload.model_validate(payload)
+    except ValidationError:
+        return ()
+    if parsed.models is None:
+        return ()
+
+    model_ids: list[str] = []
+    for item in parsed.models:
+        raw_name = item.name
+        if isinstance(raw_name, str) and raw_name:
+            normalized = raw_name[len("models/") :] if raw_name.startswith("models/") else raw_name
+            model_ids.append(normalized)
+    return tuple(model_ids)
+
+
 def _fetch_openai_compatible_models(
     request: DiscoveryRequest,
 ) -> tuple[str, ...]:
@@ -224,24 +294,7 @@ def _fetch_openai_compatible_models(
     with urlopen(http_request, timeout=request.timeout_seconds) as response:  # noqa: S310
         payload = json.loads(response.read().decode("utf-8"))
 
-    if not isinstance(payload, dict):
-        raise ValueError("provider model discovery response must be an object")
-    payload_dict = cast(dict[str, object], payload)
-    raw_data = payload_dict.get("data")
-    if not isinstance(raw_data, list):
-        return ()
-    raw_items = cast(list[object], raw_data)
-
-    model_ids: list[str] = []
-    for item in raw_items:
-        if isinstance(item, str) and item:
-            model_ids.append(item)
-            continue
-        if isinstance(item, dict):
-            raw_id = cast(dict[str, object], item).get("id")
-            if isinstance(raw_id, str) and raw_id:
-                model_ids.append(raw_id)
-    return tuple(model_ids)
+    return _parse_openai_compatible_discovery_payload(payload)
 
 
 def _fetch_anthropic_models(request: DiscoveryRequest) -> tuple[str, ...]:
@@ -251,21 +304,7 @@ def _fetch_anthropic_models(request: DiscoveryRequest) -> tuple[str, ...]:
     with urlopen(http_request, timeout=request.timeout_seconds) as response:  # noqa: S310
         payload = json.loads(response.read().decode("utf-8"))
 
-    if not isinstance(payload, dict):
-        return ()
-    payload_dict = cast(dict[str, object], payload)
-    raw_data = payload_dict.get("data")
-    if not isinstance(raw_data, list):
-        return ()
-
-    model_ids: list[str] = []
-    for item in cast(list[object], raw_data):
-        if not isinstance(item, dict):
-            continue
-        raw_id = cast(dict[str, object], item).get("id")
-        if isinstance(raw_id, str) and raw_id:
-            model_ids.append(raw_id)
-    return tuple(model_ids)
+    return _parse_anthropic_discovery_payload(payload)
 
 
 def _fetch_google_models(request: DiscoveryRequest) -> tuple[str, ...]:
@@ -294,19 +333,4 @@ def _fetch_google_models(request: DiscoveryRequest) -> tuple[str, ...]:
     with urlopen(http_request, timeout=request.timeout_seconds) as response:  # noqa: S310
         payload = json.loads(response.read().decode("utf-8"))
 
-    if not isinstance(payload, dict):
-        return ()
-    payload_dict = cast(dict[str, object], payload)
-    raw_models = payload_dict.get("models")
-    if not isinstance(raw_models, list):
-        return ()
-
-    model_ids: list[str] = []
-    for item in cast(list[object], raw_models):
-        if not isinstance(item, dict):
-            continue
-        raw_name = cast(dict[str, object], item).get("name")
-        if isinstance(raw_name, str) and raw_name:
-            normalized = raw_name[len("models/") :] if raw_name.startswith("models/") else raw_name
-            model_ids.append(normalized)
-    return tuple(model_ids)
+    return _parse_google_discovery_payload(payload)

--- a/src/voidcode/provider/model_catalog.py
+++ b/src/voidcode/provider/model_catalog.py
@@ -4,7 +4,7 @@ import json
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Literal, cast
+from typing import Literal
 from urllib.error import URLError
 from urllib.parse import quote
 from urllib.request import Request, urlopen

--- a/src/voidcode/provider/snapshot.py
+++ b/src/voidcode/provider/snapshot.py
@@ -3,11 +3,73 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import cast
 
+from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
+
 from .config import ProviderFallbackConfig
 from .errors import format_invalid_provider_config_error
 from .models import ResolvedProviderChain, ResolvedProviderConfig, ResolvedProviderModel
 from .registry import ModelProviderRegistry
 from .resolution import resolve_provider_model
+
+
+class _ResolvedProviderTargetSnapshotPayload(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    raw_model: str
+    provider: str
+    model: str
+
+    @field_validator("raw_model", "provider", "model", mode="before")
+    @classmethod
+    def _validate_required_string(cls, value: object) -> str:
+        if not isinstance(value, str):
+            raise ValueError("must be a string")
+        return value
+
+
+class _ResolvedProviderSnapshotPayload(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    active_target: _ResolvedProviderTargetSnapshotPayload
+    targets: tuple[_ResolvedProviderTargetSnapshotPayload, ...]
+
+    @field_validator("targets", mode="before")
+    @classmethod
+    def _validate_targets_array(cls, value: object) -> list[object]:
+        if not isinstance(value, list):
+            raise ValueError("must be an array")
+        return cast(list[object], value)
+
+    @field_validator("targets", mode="after")
+    @classmethod
+    def _validate_targets_not_empty(
+        cls,
+        value: tuple[_ResolvedProviderTargetSnapshotPayload, ...],
+    ) -> tuple[_ResolvedProviderTargetSnapshotPayload, ...]:
+        if not value:
+            raise ValueError("must not be empty")
+        return value
+
+
+def _format_snapshot_validation_error(*, source: str, error: dict[str, object]) -> str:
+    loc = tuple(cast(tuple[object, ...], error.get("loc", ())))
+    error_type = cast(str, error.get("type", ""))
+    field_path = source
+    for item in loc:
+        if isinstance(item, int):
+            field_path = f"{field_path}[{item}]"
+            continue
+        field_path = f"{field_path}.{item}"
+    if error_type in {"model_type", "dict_type"}:
+        return format_invalid_provider_config_error(field_path, "must be an object")
+    reason = cast(str, error.get("msg", "is invalid"))
+    if error_type == "value_error":
+        context = error.get("ctx")
+        if isinstance(context, dict):
+            nested_error = cast(dict[str, object], context).get("error")
+            if isinstance(nested_error, ValueError):
+                reason = str(nested_error)
+    return format_invalid_provider_config_error(field_path, reason)
 
 
 def resolved_provider_snapshot(
@@ -60,29 +122,19 @@ def parse_resolved_provider_snapshot(
     source: str,
     registry: ModelProviderRegistry,
 ) -> ResolvedProviderConfig:
-    if not isinstance(raw_snapshot, dict):
-        raise ValueError(format_invalid_provider_config_error(source, "must be an object"))
+    try:
+        snapshot = _ResolvedProviderSnapshotPayload.model_validate(raw_snapshot)
+    except ValidationError as exc:
+        error = cast(dict[str, object], exc.errors(include_url=False)[0])
+        raise ValueError(_format_snapshot_validation_error(source=source, error=error)) from exc
 
-    snapshot = cast(dict[str, object], raw_snapshot)
-    raw_active_target = snapshot.get("active_target")
-    raw_targets = snapshot.get("targets")
-    if not isinstance(raw_active_target, dict):
-        raise ValueError(
-            format_invalid_provider_config_error(f"{source}.active_target", "must be an object")
-        )
-    if not isinstance(raw_targets, list):
-        raise ValueError(
-            format_invalid_provider_config_error(f"{source}.targets", "must be an array")
-        )
-
-    raw_targets_list = cast(list[object], raw_targets)
     resolved_targets_list = [
         _resolved_provider_model_from_snapshot(
             item,
             source=f"{source}.targets[{index}]",
             registry=registry,
         )
-        for index, item in enumerate(raw_targets_list)
+        for index, item in enumerate(snapshot.targets)
     ]
     if not resolved_targets_list:
         raise ValueError(
@@ -102,7 +154,7 @@ def parse_resolved_provider_snapshot(
     resolved_targets: tuple[ResolvedProviderModel, ...] = tuple(resolved_targets_list)
 
     resolved_active_target = _resolved_provider_model_from_snapshot(
-        cast(object, raw_active_target),
+        snapshot.active_target,
         source=f"{source}.active_target",
         registry=registry,
     )
@@ -195,26 +247,14 @@ def _resolved_provider_model_from_snapshot(
     source: str,
     registry: ModelProviderRegistry,
 ) -> ResolvedProviderModel:
-    if not isinstance(raw_value, dict):
-        raise ValueError(format_invalid_provider_config_error(source, "must be an object"))
-    payload = cast(dict[str, object], raw_value)
-    raw_model = payload.get("raw_model")
-    provider = payload.get("provider")
-    model = payload.get("model")
-    if (
-        not isinstance(raw_model, str)
-        or not isinstance(provider, str)
-        or not isinstance(model, str)
-    ):
-        raise ValueError(
-            format_invalid_provider_config_error(
-                source,
-                "must include string raw_model, provider, and model fields",
-            )
-        )
+    try:
+        payload = _ResolvedProviderTargetSnapshotPayload.model_validate(raw_value)
+    except ValidationError as exc:
+        error = cast(dict[str, object], exc.errors(include_url=False)[0])
+        raise ValueError(_format_snapshot_validation_error(source=source, error=error)) from exc
 
-    resolved = resolve_provider_model(raw_model, registry=registry)
-    if resolved.selection.provider != provider or resolved.selection.model != model:
+    resolved = resolve_provider_model(payload.raw_model, registry=registry)
+    if resolved.selection.provider != payload.provider or resolved.selection.model != payload.model:
         raise ValueError(
             format_invalid_provider_config_error(
                 source,

--- a/src/voidcode/runtime/http.py
+++ b/src/voidcode/runtime/http.py
@@ -9,6 +9,8 @@ from collections.abc import AsyncIterator, Callable, Iterator
 from pathlib import Path
 from typing import Protocol, cast, final
 
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
 from .config import RuntimeConfig
 from .contracts import (
     BackgroundTaskResult,
@@ -97,6 +99,173 @@ class Receive(Protocol):
 
 class Send(Protocol):
     async def __call__(self, message: dict[str, object]) -> None: ...
+
+
+class _HttpBoundaryModel(BaseModel):
+    model_config = ConfigDict(extra="ignore", validate_default=True)
+
+
+class _RunStreamRequestPayload(_HttpBoundaryModel):
+    prompt: str | None = None
+    session_id: str | None = None
+    parent_session_id: str | None = None
+    metadata: dict[str, object] = Field(default_factory=dict)
+
+    @field_validator("prompt", mode="before")
+    @classmethod
+    def _validate_prompt(cls, value: object) -> str:
+        if not isinstance(value, str) or not value:
+            raise ValueError("must be a non-empty string")
+        return value
+
+    @field_validator("session_id", "parent_session_id", mode="before")
+    @classmethod
+    def _validate_optional_string(cls, value: object) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise ValueError("must be a string when provided")
+        return value
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def _validate_metadata(cls, value: object) -> dict[str, object]:
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            raise ValueError("must be an object when provided")
+        return cast(dict[str, object], value)
+
+
+class _ApprovalResolutionRequestPayload(_HttpBoundaryModel):
+    request_id: str | None = None
+    decision: str | None = None
+
+    @field_validator("request_id", mode="before")
+    @classmethod
+    def _validate_request_id(cls, value: object) -> str:
+        if not isinstance(value, str) or not value:
+            raise ValueError("must be a non-empty string")
+        return value
+
+    @field_validator("decision", mode="before")
+    @classmethod
+    def _validate_decision(cls, value: object) -> str:
+        if value not in ("allow", "deny"):
+            raise ValueError("must be 'allow' or 'deny'")
+        return cast(str, value)
+
+
+class _SettingsRequestPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    provider: str | None = None
+    provider_api_key: str | None = None
+    model: str | None = None
+
+    @field_validator("provider", "provider_api_key", "model", mode="before")
+    @classmethod
+    def _validate_optional_string(cls, value: object) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise ValueError("must be a string when provided")
+        stripped = value.strip()
+        return stripped or None
+
+
+class _QuestionResponsePayload(_HttpBoundaryModel):
+    header: str | None = None
+    answers: tuple[str, ...] | None = None
+
+    @field_validator("header", mode="before")
+    @classmethod
+    def _validate_header(cls, value: object) -> str:
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError("must be a non-empty string")
+        return value
+
+    @field_validator("answers", mode="before")
+    @classmethod
+    def _validate_answers(cls, value: object) -> tuple[str, ...]:
+        if not isinstance(value, list) or not value:
+            raise ValueError("must be a non-empty array")
+        answer_items = cast(list[object], value)
+        answers: list[str] = []
+        for index, raw_answer in enumerate(answer_items):
+            if not isinstance(raw_answer, str) or not raw_answer.strip():
+                raise ValueError(f"[{index}] must be a non-empty string")
+            answers.append(raw_answer)
+        return tuple(answers)
+
+
+class _QuestionAnswerRequestPayload(_HttpBoundaryModel):
+    request_id: str | None = None
+    responses: tuple[_QuestionResponsePayload, ...] | None = None
+
+    @field_validator("request_id", mode="before")
+    @classmethod
+    def _validate_request_id(cls, value: object) -> str:
+        if not isinstance(value, str) or not value:
+            raise ValueError("must be a non-empty string")
+        return value
+
+    @field_validator("responses", mode="before")
+    @classmethod
+    def _validate_responses(cls, value: object) -> list[object]:
+        if not isinstance(value, list) or not value:
+            raise ValueError("must be a non-empty array")
+        return cast(list[object], value)
+
+
+def _parse_json_body(body: bytes) -> object:
+    try:
+        return json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("request body must be valid JSON") from exc
+
+
+def _http_path_from_loc(loc: tuple[object, ...]) -> str:
+    parts: list[str] = []
+    for item in loc:
+        if isinstance(item, int):
+            if not parts:
+                parts.append(f"[{item}]")
+                continue
+            parts[-1] = f"{parts[-1]}[{item}]"
+            continue
+        parts.append(str(item))
+    return ".".join(parts)
+
+
+def _http_validation_reason(error: dict[str, object]) -> str:
+    error_type = cast(str, error.get("type", ""))
+    if error_type == "value_error":
+        context = error.get("ctx")
+        if isinstance(context, dict):
+            nested_error = cast(dict[str, object], context).get("error")
+            if isinstance(nested_error, ValueError):
+                return str(nested_error)
+    return cast(str, error.get("msg", "is invalid"))
+
+
+def _format_http_validation_error(error: dict[str, object]) -> str:
+    loc = tuple(cast(tuple[object, ...], error.get("loc", ())))
+    error_type = cast(str, error.get("type", ""))
+    path = _http_path_from_loc(loc)
+    if error_type == "extra_forbidden":
+        unknown_keys = ", ".join(str(item) for item in loc if isinstance(item, str))
+        return f"unsupported settings field(s): {unknown_keys}"
+    if error_type in {"model_type", "dict_type"}:
+        if not path:
+            return "request body must be a JSON object"
+        return f"{path} must be an object"
+    reason = _http_validation_reason(error)
+    if not path:
+        return reason
+    if reason.startswith("[") or reason.startswith("."):
+        return f"{path}{reason}"
+    return f"{path} {reason}"
 
 
 @final
@@ -749,41 +918,30 @@ class RuntimeTransportApp:
         return b"".join(body_parts)
 
     def _parse_runtime_request(self, body: bytes) -> RuntimeRequest:
-        try:
-            raw_payload = json.loads(body.decode("utf-8"))
-        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            raise ValueError("request body must be valid JSON") from exc
-
+        raw_payload = _parse_json_body(body)
         if not isinstance(raw_payload, dict):
             raise ValueError("request body must be a JSON object")
-        payload = cast(dict[str, object], raw_payload)
+        try:
+            payload = _RunStreamRequestPayload.model_validate(raw_payload)
+        except ValidationError as exc:
+            error = cast(dict[str, object], exc.errors(include_url=False)[0])
+            raise ValueError(_format_http_validation_error(error)) from exc
 
-        prompt = payload.get("prompt")
-        if not isinstance(prompt, str) or not prompt:
-            raise ValueError("prompt must be a non-empty string")
-
-        session_id = payload.get("session_id")
-        if session_id is not None and not isinstance(session_id, str):
-            raise ValueError("session_id must be a string when provided")
+        session_id = payload.session_id
         if session_id is not None:
             validate_session_id(session_id)
 
-        parent_session_id = payload.get("parent_session_id")
-        if parent_session_id is not None and not isinstance(parent_session_id, str):
-            raise ValueError("parent_session_id must be a string when provided")
+        parent_session_id = payload.parent_session_id
         if parent_session_id is not None:
             validate_session_reference_id(
                 parent_session_id,
                 field_name="parent_session_id",
             )
 
-        metadata = payload.get("metadata", {})
-        if not isinstance(metadata, dict):
-            raise ValueError("metadata must be an object when provided")
-        normalized_metadata = validate_runtime_request_metadata(cast(dict[str, object], metadata))
+        normalized_metadata = validate_runtime_request_metadata(payload.metadata)
 
         return RuntimeRequest(
-            prompt=prompt,
+            prompt=cast(str, payload.prompt),
             session_id=session_id,
             parent_session_id=parent_session_id,
             metadata=normalized_metadata,
@@ -794,98 +952,54 @@ class RuntimeTransportApp:
         self,
         body: bytes,
     ) -> tuple[str, PermissionResolution]:
-        try:
-            raw_payload = json.loads(body.decode("utf-8"))
-        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            raise ValueError("request body must be valid JSON") from exc
-
+        raw_payload = _parse_json_body(body)
         if not isinstance(raw_payload, dict):
             raise ValueError("request body must be a JSON object")
-        payload = cast(dict[str, object], raw_payload)
+        try:
+            payload = _ApprovalResolutionRequestPayload.model_validate(raw_payload)
+        except ValidationError as exc:
+            error = cast(dict[str, object], exc.errors(include_url=False)[0])
+            raise ValueError(_format_http_validation_error(error)) from exc
 
-        request_id = payload.get("request_id")
-        if not isinstance(request_id, str) or not request_id:
-            raise ValueError("request_id must be a non-empty string")
-
-        decision = payload.get("decision")
-        if decision not in ("allow", "deny"):
-            raise ValueError("decision must be 'allow' or 'deny'")
-
-        return request_id, decision
+        return cast(str, payload.request_id), cast(PermissionResolution, payload.decision)
 
     def _parse_settings_request(self, body: bytes) -> dict[str, str | None]:
-        try:
-            raw_payload = json.loads(body.decode("utf-8"))
-        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            raise ValueError("request body must be valid JSON") from exc
-
+        raw_payload = _parse_json_body(body)
         if not isinstance(raw_payload, dict):
             raise ValueError("request body must be a JSON object")
-
-        payload = cast(dict[str, object], raw_payload)
-        allowed_keys = {"provider", "provider_api_key", "model"}
-        unknown_keys = sorted(key for key in payload if key not in allowed_keys)
-        if unknown_keys:
-            raise ValueError(f"unsupported settings field(s): {', '.join(unknown_keys)}")
-
-        def _optional_string(name: str) -> str | None:
-            value = payload.get(name)
-            if value is None:
-                return None
-            if not isinstance(value, str):
-                raise ValueError(f"{name} must be a string when provided")
-            stripped = value.strip()
-            return stripped or None
-
+        try:
+            payload = _SettingsRequestPayload.model_validate(raw_payload)
+        except ValidationError as exc:
+            error = cast(dict[str, object], exc.errors(include_url=False)[0])
+            raise ValueError(_format_http_validation_error(error)) from exc
         return {
-            "provider": _optional_string("provider"),
-            "provider_api_key": _optional_string("provider_api_key"),
-            "model": _optional_string("model"),
+            "provider": payload.provider,
+            "provider_api_key": payload.provider_api_key,
+            "model": payload.model,
         }
 
     def _parse_question_answer_request(
         self,
         body: bytes,
     ) -> tuple[str, tuple[QuestionResponse, ...]]:
-        try:
-            raw_payload = json.loads(body.decode("utf-8"))
-        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            raise ValueError("request body must be valid JSON") from exc
-
+        raw_payload = _parse_json_body(body)
         if not isinstance(raw_payload, dict):
             raise ValueError("request body must be a JSON object")
-        payload = cast(dict[str, object], raw_payload)
+        try:
+            payload = _QuestionAnswerRequestPayload.model_validate(raw_payload)
+        except ValidationError as exc:
+            error = cast(dict[str, object], exc.errors(include_url=False)[0])
+            raise ValueError(_format_http_validation_error(error)) from exc
 
-        request_id = payload.get("request_id")
-        if not isinstance(request_id, str) or not request_id:
-            raise ValueError("request_id must be a non-empty string")
-
-        raw_responses = payload.get("responses")
-        if not isinstance(raw_responses, list) or not raw_responses:
-            raise ValueError("responses must be a non-empty array")
-
-        response_items = cast(list[object], raw_responses)
-        parsed: list[QuestionResponse] = []
-        for index, raw_response in enumerate(response_items):
-            if not isinstance(raw_response, dict):
-                raise ValueError(f"responses[{index}] must be an object")
-            response_payload = cast(dict[str, object], raw_response)
-            header = response_payload.get("header")
-            if not isinstance(header, str) or not header.strip():
-                raise ValueError(f"responses[{index}].header must be a non-empty string")
-            raw_answers = response_payload.get("answers")
-            if not isinstance(raw_answers, list) or not raw_answers:
-                raise ValueError(f"responses[{index}].answers must be a non-empty array")
-            answer_items = cast(list[object], raw_answers)
-            answers: list[str] = []
-            for answer_index, raw_answer in enumerate(answer_items):
-                if not isinstance(raw_answer, str) or not raw_answer.strip():
-                    raise ValueError(
-                        f"responses[{index}].answers[{answer_index}] must be a non-empty string"
-                    )
-                answers.append(raw_answer)
-            parsed.append(QuestionResponse(header=header, answers=tuple(answers)))
-        return request_id, tuple(parsed)
+        responses = payload.responses if payload.responses is not None else ()
+        parsed = tuple(
+            QuestionResponse(
+                header=cast(str, item.header),
+                answers=cast(tuple[str, ...], item.answers),
+            )
+            for item in responses
+        )
+        return cast(str, payload.request_id), parsed
 
     @staticmethod
     def _serialize_runtime_stream_chunk(chunk: RuntimeStreamChunk) -> dict[str, object]:

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -1305,6 +1305,33 @@ def test_transport_rejects_invalid_question_answer_payload(tmp_path: Path) -> No
     assert response.json() == {"error": "responses must be a non-empty array"}
 
 
+def test_transport_rejects_invalid_question_answer_item_payload(tmp_path: Path) -> None:
+    create_runtime_app = _load_transport_app_factory()
+    app = create_runtime_app(workspace=tmp_path)
+
+    response = _run_app(
+        app,
+        method="POST",
+        path="/api/sessions/question-session/question",
+        body=json.dumps(
+            {
+                "request_id": "question-1",
+                "responses": [
+                    {
+                        "header": "Runtime path",
+                        "answers": [""],
+                    }
+                ],
+            }
+        ).encode("utf-8"),
+    )
+
+    assert response.status == 400
+    assert response.json() == {
+        "error": "responses[0].answers[0] must be a non-empty string"
+    }
+
+
 def test_transport_rejects_non_post_method_for_question_route(tmp_path: Path) -> None:
     create_runtime_app = _load_transport_app_factory()
     app = create_runtime_app(workspace=tmp_path)

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -1327,9 +1327,7 @@ def test_transport_rejects_invalid_question_answer_item_payload(tmp_path: Path) 
     )
 
     assert response.status == 400
-    assert response.json() == {
-        "error": "responses[0].answers[0] must be a non-empty string"
-    }
+    assert response.json() == {"error": "responses[0].answers[0] must be a non-empty string"}
 
 
 def test_transport_rejects_non_post_method_for_question_route(tmp_path: Path) -> None:

--- a/tests/unit/provider/test_model_catalog.py
+++ b/tests/unit/provider/test_model_catalog.py
@@ -222,6 +222,44 @@ def test_discover_available_models_marks_fallback_on_fetch_failure() -> None:
     assert result.discovery_mode == "configured_endpoint"
 
 
+def test_discover_available_models_falls_back_on_invalid_openai_discovery_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Response:
+        def __enter__(self) -> _Response:
+            return self
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: TracebackType | None,
+        ) -> bool:
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(["not-an-object"]).encode("utf-8")
+
+    def _fake_urlopen(_request: Request, timeout: float) -> _Response:
+        assert timeout == 10.0
+        return _Response()
+
+    monkeypatch.setattr(model_catalog, "urlopen", _fake_urlopen)
+
+    result = discover_available_models(
+        "openai",
+        LiteLLMProviderConfig(
+            discovery_base_url="https://api.openai.com",
+            model_map={"alias": "gpt-4o"},
+        ),
+    )
+
+    assert result.models == ("alias", "gpt-4o")
+    assert result.source == "fallback"
+    assert result.last_refresh_status == "failed"
+    assert result.last_error == "remote model discovery failed"
+
+
 def test_discover_available_models_custom_provider_builds_url_from_plain_base_url(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/provider/test_provider_config_parser.py
+++ b/tests/unit/provider/test_provider_config_parser.py
@@ -109,6 +109,28 @@ def test_parse_provider_configs_payload_rejects_unknown_provider_block() -> None
         )
 
 
+def test_parse_provider_configs_payload_rejects_invalid_openai_base_url_type() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"runtime config field 'providers\.openai\.base_url' must be a string when provided",
+    ):
+        _ = parse_provider_configs_payload(
+            {"openai": {"base_url": 123}},
+            source="runtime config field 'providers'",
+        )
+
+
+def test_parse_provider_configs_payload_rejects_invalid_litellm_model_map_value() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"runtime config field 'providers\.litellm\.model_map\.demo' must be a string",
+    ):
+        _ = parse_provider_configs_payload(
+            {"litellm": {"model_map": {"demo": 123}}},
+            source="runtime config field 'providers'",
+        )
+
+
 def test_parse_provider_configs_payload_rejects_invalid_custom_provider_name() -> None:
     with pytest.raises(
         ValueError,

--- a/tests/unit/provider/test_snapshot.py
+++ b/tests/unit/provider/test_snapshot.py
@@ -119,6 +119,30 @@ def test_parse_resolved_provider_snapshot_rejects_non_object_snapshot() -> None:
         )
 
 
+def test_parse_resolved_provider_snapshot_rejects_non_object_active_target() -> None:
+    with pytest.raises(
+        ValueError,
+        match=(
+            "invalid provider config: "
+            "persisted runtime_config.resolved_provider.active_target must be an object"
+        ),
+    ):
+        _ = parse_resolved_provider_snapshot(
+            {
+                "active_target": "nope",
+                "targets": [
+                    {
+                        "raw_model": "opencode/gpt-5.4",
+                        "provider": "opencode",
+                        "model": "gpt-5.4",
+                    }
+                ],
+            },
+            source="persisted runtime_config.resolved_provider",
+            registry=ModelProviderRegistry.with_defaults(),
+        )
+
+
 def test_parse_resolved_provider_snapshot_rejects_empty_targets() -> None:
     with pytest.raises(
         ValueError,

--- a/tests/unit/runtime/test_background_task_storage.py
+++ b/tests/unit/runtime/test_background_task_storage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+from contextlib import closing
 from pathlib import Path
 from typing import cast
 
@@ -116,7 +117,7 @@ def test_background_task_storage_persists_delegated_correlation_and_routing_colu
 
     store.create_background_task(workspace=tmp_path, task=task)
 
-    with sqlite3.connect(database_path) as connection:
+    with closing(sqlite3.connect(database_path)) as connection:
         row = connection.execute(
             """
             SELECT requested_child_session_id, routing_mode, routing_category,
@@ -281,7 +282,7 @@ def test_background_task_storage_terminal_states_persist_result_availability_and
         error="operator cancelled",
     )
 
-    with sqlite3.connect(tmp_path / ".voidcode" / "sessions.sqlite3") as connection:
+    with closing(sqlite3.connect(tmp_path / ".voidcode" / "sessions.sqlite3")) as connection:
         rows = connection.execute(
             """
             SELECT task_id, result_available, cancellation_cause
@@ -308,7 +309,7 @@ def test_background_task_storage_cancel_semantics(tmp_path: Path) -> None:
     assert cancelled.status == "cancelled"
     assert cancelled.error == "cancelled before start"
 
-    with sqlite3.connect(tmp_path / ".voidcode" / "sessions.sqlite3") as connection:
+    with closing(sqlite3.connect(tmp_path / ".voidcode" / "sessions.sqlite3")) as connection:
         row = connection.execute(
             "SELECT cancellation_cause, result_available FROM background_tasks WHERE task_id = ?",
             ("task-c",),
@@ -464,7 +465,7 @@ def test_background_task_storage_persists_approval_and_question_request_correlat
     )
     store.save_run(workspace=tmp_path, request=approval_request, response=terminal_response)
 
-    with sqlite3.connect(tmp_path / ".voidcode" / "sessions.sqlite3") as connection:
+    with closing(sqlite3.connect(tmp_path / ".voidcode" / "sessions.sqlite3")) as connection:
         row = connection.execute(
             """
             SELECT requested_child_session_id, session_id, approval_request_id,
@@ -1038,7 +1039,7 @@ def test_background_task_storage_reconciliation_preserves_approval_blocked_child
         message="background task interrupted before completion",
     )
 
-    with sqlite3.connect(tmp_path / ".voidcode" / "sessions.sqlite3") as connection:
+    with closing(sqlite3.connect(tmp_path / ".voidcode" / "sessions.sqlite3")) as connection:
         row = connection.execute(
             """
             SELECT status, approval_request_id, requested_child_session_id,


### PR DESCRIPTION
## Summary
- consolidate provider config boundary parsing onto focused Pydantic payload models while keeping dataclasses as internal truth
- move runtime HTTP JSON body parsing, provider snapshot parsing, and model discovery response parsing onto Pydantic boundary models
- add focused invalid-payload tests for provider config, snapshot, model catalog, and HTTP schema errors

## Testing
- `mise run lint`
- `mise run typecheck`
- `uv run pytest -k "not webfetch_tool"`
- `uv run pytest tests/unit/provider/test_provider_config_parser.py tests/unit/provider/test_snapshot.py tests/unit/provider/test_model_catalog.py tests/integration/test_http_transport.py tests/unit/runtime/test_runtime_service_extensions.py -k "resolved_provider or provider_config or http_transport or invalid_question_answer_item_payload"`

## Notes
- `mise run test` still hits the existing `tests/unit/tools/test_webfetch_tool.py` failures on this machine because `web_fetch` currently blocks `example.com` before the mocked HTTP layer runs. This PR does not touch that tool.

close #184 