### PR TITLE
feat(provider): harden provider resolution and discovery semantics

### DIFF
--- a/src/voidcode/provider/README.md
+++ b/src/voidcode/provider/README.md
@@ -257,3 +257,18 @@ VoidCode 的 Provider 抽象层输出标准化的流式事件包。
 - `registry.py`: 维护已实现的 Provider 实例。
 - `resolution.py`: 负责将原始请求解析为具体的 Provider 配置。
 - `snapshot.py`: 提供安全的快照导出逻辑，确保不泄露机密。
+
+## 模块内约束（production hardening）
+
+- `ResolvedProviderModel` 会显式记录 provider resolution 来源：
+  - `builtin`：内置 provider adapter
+  - `custom`：`providers.custom.<name>` 显式配置的 LiteLLM-compatible provider
+  - `default_litellm`：未声明 provider 时回退到默认 LiteLLM 语义
+- fallback chain 不允许重复 target；即使绕过原始 config parser，`resolution.py` / `snapshot.py`
+  仍会在 provider 模块内拒绝重复链路。
+- model discovery 会显式区分：
+  - `configured_endpoint`：使用 `discovery_base_url`
+  - `configured_base_url`：从 `base_url` 推导探测端点
+  - `disabled`：`discovery_base_url` 被显式置空，表示禁用远端发现
+  - `unavailable`：provider 本身没有可用 discovery endpoint
+- provider error 解析会同时给出 `kind` 与恢复语义（`retryable` / `fallback_allowed`），减少调用侧对启发式字符串的重复判断。

--- a/src/voidcode/provider/__init__.py
+++ b/src/voidcode/provider/__init__.py
@@ -39,6 +39,7 @@ from .minimax import MiniMaxModelProvider
 from .model_catalog import ProviderModelCatalog, discover_available_models
 from .models import (
     ProviderModelSelection,
+    ProviderResolutionMetadata,
     ResolvedProviderChain,
     ResolvedProviderConfig,
     ResolvedProviderModel,
@@ -87,6 +88,7 @@ __all__ = [
     "ProviderExecutionError",
     "ProviderFallbackConfig",
     "ProviderModelSelection",
+    "ProviderResolutionMetadata",
     "ResolvedProviderChain",
     "ResolvedProviderConfig",
     "ResolvedProviderModel",

--- a/src/voidcode/provider/errors.py
+++ b/src/voidcode/provider/errors.py
@@ -46,6 +46,20 @@ class ParsedProviderError:
     kind: Literal["rate_limit", "context_limit", "invalid_model", "transient_failure"]
     message: str
     details: dict[str, object]
+    retryable: bool
+    fallback_allowed: bool
+
+
+def _recovery_policy_for_kind(
+    kind: Literal["rate_limit", "context_limit", "invalid_model", "transient_failure"],
+) -> tuple[bool, bool]:
+    if kind == "context_limit":
+        return False, False
+    if kind == "invalid_model":
+        return False, True
+    if kind == "rate_limit":
+        return True, True
+    return True, True
 
 
 def _extract_error_message(payload: dict[str, Any]) -> str | None:
@@ -135,6 +149,7 @@ def parse_provider_api_error(payload: dict[str, Any]) -> ParsedProviderError:
     status_code = _extract_status_code(payload)
     code = _extract_error_code(payload)
     kind = _classify_api_error_kind(message=message, status_code=status_code, code=code)
+    retryable, fallback_allowed = _recovery_policy_for_kind(kind)
     details: dict[str, object] = dict(payload)
     details.update(
         {
@@ -143,7 +158,13 @@ def parse_provider_api_error(payload: dict[str, Any]) -> ParsedProviderError:
             "error_code": code,
         }
     )
-    return ParsedProviderError(kind=kind, message=message, details=details)
+    return ParsedProviderError(
+        kind=kind,
+        message=message,
+        details=details,
+        retryable=retryable,
+        fallback_allowed=fallback_allowed,
+    )
 
 
 def parse_provider_stream_error(payload: dict[str, Any]) -> ParsedProviderError:
@@ -151,6 +172,7 @@ def parse_provider_stream_error(payload: dict[str, Any]) -> ParsedProviderError:
     status_code = _extract_status_code(payload)
     code = _extract_error_code(payload)
     kind = _classify_api_error_kind(message=message, status_code=status_code, code=code)
+    retryable, fallback_allowed = _recovery_policy_for_kind(kind)
     details: dict[str, object] = dict(payload)
     details.update(
         {
@@ -159,7 +181,13 @@ def parse_provider_stream_error(payload: dict[str, Any]) -> ParsedProviderError:
             "error_code": code,
         }
     )
-    return ParsedProviderError(kind=kind, message=message, details=details)
+    return ParsedProviderError(
+        kind=kind,
+        message=message,
+        details=details,
+        retryable=retryable,
+        fallback_allowed=fallback_allowed,
+    )
 
 
 def provider_execution_error_from_api_payload(
@@ -174,6 +202,7 @@ def provider_execution_error_from_api_payload(
         provider_name=provider_name,
         model_name=model_name,
         message=parsed.message,
+        retryable=parsed.retryable,
         details=parsed.details,
     )
 
@@ -190,6 +219,7 @@ def provider_execution_error_from_stream_payload(
         provider_name=provider_name,
         model_name=model_name,
         message=parsed.message,
+        retryable=parsed.retryable,
         details=parsed.details,
     )
 

--- a/src/voidcode/provider/model_catalog.py
+++ b/src/voidcode/provider/model_catalog.py
@@ -4,7 +4,7 @@ import json
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import cast
+from typing import Literal, cast
 from urllib.error import URLError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
@@ -32,6 +32,12 @@ class ProviderModelCatalog:
     source: str = "remote"
     last_refresh_status: str = "ok"
     last_error: str | None = None
+    discovery_mode: Literal[
+        "configured_endpoint",
+        "configured_base_url",
+        "disabled",
+        "unavailable",
+    ] = "unavailable"
 
 
 @dataclass(frozen=True, slots=True)
@@ -40,6 +46,24 @@ class ModelDiscoveryResult:
     source: str
     last_refresh_status: str
     last_error: str | None
+    discovery_mode: Literal[
+        "configured_endpoint",
+        "configured_base_url",
+        "disabled",
+        "unavailable",
+    ]
+
+
+@dataclass(frozen=True, slots=True)
+class ModelDiscoveryPlan:
+    discovery_mode: Literal[
+        "configured_endpoint",
+        "configured_base_url",
+        "disabled",
+        "unavailable",
+    ]
+    request: DiscoveryRequest | None
+    skip_reason: str | None = None
 
 
 def discover_available_models(
@@ -52,11 +76,11 @@ def discover_available_models(
     error_message: str | None = None
     source = "remote"
     refresh_status = "ok"
-    request = _build_discovery_request(provider_name=provider_name, config=config)
-    if request is not None:
+    discovery_plan = _build_discovery_plan(provider_name=provider_name, config=config)
+    if discovery_plan.request is not None:
         active_fetcher = _fetch_models if fetcher is None else fetcher
         try:
-            discovered = active_fetcher(request)
+            discovered = active_fetcher(discovery_plan.request)
         except (ValueError, OSError, TimeoutError, URLError):
             discovered = ()
             source = "fallback"
@@ -65,7 +89,7 @@ def discover_available_models(
     else:
         source = "fallback"
         refresh_status = "skipped"
-        error_message = "provider has no model discovery endpoint"
+        error_message = discovery_plan.skip_reason
 
     mapped_aliases = tuple(config.model_map.keys()) if config is not None else ()
     mapped_targets = tuple(config.model_map.values()) if config is not None else ()
@@ -85,19 +109,8 @@ def discover_available_models(
         source=source,
         last_refresh_status=refresh_status,
         last_error=error_message,
+        discovery_mode=discovery_plan.discovery_mode,
     )
-
-
-def _base_url_for_discovery(*, config: LiteLLMProviderConfig | None) -> str | None:
-    if config is not None:
-        if config.discovery_base_url is not None:
-            candidate = config.discovery_base_url.strip()
-            if not candidate:
-                return None
-            return candidate.rstrip("/")
-        if config.base_url:
-            return config.base_url.rstrip("/")
-    return None
 
 
 def _timeout_for_discovery(config: LiteLLMProviderConfig | None) -> float:
@@ -117,12 +130,44 @@ def _headers_for_discovery(config: LiteLLMProviderConfig | None) -> dict[str, st
     return {header_name: f"Bearer {config.api_key}"}
 
 
-def _build_discovery_request(
+def _build_discovery_plan(
     *, provider_name: str, config: LiteLLMProviderConfig | None
-) -> DiscoveryRequest | None:
-    base_url = _base_url_for_discovery(config=config)
-    if base_url is None:
-        return None
+) -> ModelDiscoveryPlan:
+    if config is not None and config.discovery_base_url is not None:
+        candidate = config.discovery_base_url.strip()
+        if not candidate:
+            return ModelDiscoveryPlan(
+                discovery_mode="disabled",
+                request=None,
+                skip_reason="provider model discovery disabled by config",
+            )
+        return _discovery_plan_from_base_url(
+            provider_name=provider_name,
+            config=config,
+            base_url=candidate.rstrip("/"),
+            discovery_mode="configured_endpoint",
+        )
+    if config is not None and config.base_url:
+        return _discovery_plan_from_base_url(
+            provider_name=provider_name,
+            config=config,
+            base_url=config.base_url.rstrip("/"),
+            discovery_mode="configured_base_url",
+        )
+    return ModelDiscoveryPlan(
+        discovery_mode="unavailable",
+        request=None,
+        skip_reason="provider has no model discovery endpoint",
+    )
+
+
+def _discovery_plan_from_base_url(
+    *,
+    provider_name: str,
+    config: LiteLLMProviderConfig | None,
+    base_url: str,
+    discovery_mode: Literal["configured_endpoint", "configured_base_url"],
+) -> ModelDiscoveryPlan:
 
     provider = provider_name.strip().lower()
     timeout_seconds = _timeout_for_discovery(config)
@@ -142,12 +187,15 @@ def _build_discovery_request(
             anthropic_headers["x-api-key"] = api_key
         headers = anthropic_headers
 
-    return DiscoveryRequest(
-        provider=provider,
-        base_url=base_url,
-        headers=headers,
-        timeout_seconds=timeout_seconds,
-        api_key=None if config is None else config.api_key,
+    return ModelDiscoveryPlan(
+        discovery_mode=discovery_mode,
+        request=DiscoveryRequest(
+            provider=provider,
+            base_url=base_url,
+            headers=headers,
+            timeout_seconds=timeout_seconds,
+            api_key=None if config is None else config.api_key,
+        ),
     )
 
 

--- a/src/voidcode/provider/models.py
+++ b/src/voidcode/provider/models.py
@@ -1,9 +1,18 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 
 from .config import ProviderFallbackConfig
 from .protocol import ModelTurnProvider
+
+type ProviderResolutionSource = Literal["builtin", "custom", "default_litellm"]
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderResolutionMetadata:
+    source: ProviderResolutionSource | None = None
+    configured: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -17,6 +26,7 @@ class ProviderModelSelection:
 class ResolvedProviderModel:
     selection: ProviderModelSelection = ProviderModelSelection()
     provider: ModelTurnProvider | None = None
+    resolution: ProviderResolutionMetadata = ProviderResolutionMetadata()
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/voidcode/provider/registry.py
+++ b/src/voidcode/provider/registry.py
@@ -18,6 +18,7 @@ from .kimi import KimiModelProvider
 from .litellm import LiteLLMModelProvider
 from .minimax import MiniMaxModelProvider
 from .model_catalog import ProviderModelCatalog, discover_available_models
+from .models import ProviderResolutionSource
 from .openai import OpenAIModelProvider
 from .opencode_go import OpenCodeGoModelProvider
 from .protocol import ModelTurnProvider, StubTurnProvider, TurnProvider
@@ -61,6 +62,14 @@ class StaticModelProvider:
         return StubTurnProvider(name=self.name)
 
 
+@dataclass(frozen=True, slots=True)
+class ProviderResolution:
+    provider_name: str
+    provider: ModelTurnProvider
+    source: ProviderResolutionSource
+    configured: bool
+
+
 @dataclass(slots=True)
 class ModelProviderRegistry:
     providers: dict[str, ModelTurnProvider]
@@ -92,15 +101,33 @@ class ModelProviderRegistry:
             model_catalog={},
         )
 
-    def resolve(self, provider_name: str) -> ModelTurnProvider:
+    def resolve_with_metadata(self, provider_name: str) -> ProviderResolution:
         provider = self.providers.get(provider_name)
         if provider is not None:
-            return provider
+            return ProviderResolution(
+                provider_name=provider_name,
+                provider=provider,
+                source="builtin",
+                configured=True,
+            )
         if self.custom_provider_configs is not None:
             custom_config = self.custom_provider_configs.get(provider_name)
             if custom_config is not None:
-                return LiteLLMModelProvider(name=provider_name, config=custom_config)
-        return LiteLLMModelProvider(name=provider_name, config=self.default_litellm_config)
+                return ProviderResolution(
+                    provider_name=provider_name,
+                    provider=LiteLLMModelProvider(name=provider_name, config=custom_config),
+                    source="custom",
+                    configured=True,
+                )
+        return ProviderResolution(
+            provider_name=provider_name,
+            provider=LiteLLMModelProvider(name=provider_name, config=self.default_litellm_config),
+            source="default_litellm",
+            configured=self.default_litellm_config is not None,
+        )
+
+    def resolve(self, provider_name: str) -> ModelTurnProvider:
+        return self.resolve_with_metadata(provider_name).provider
 
     def provider_config(self, provider_name: str) -> LiteLLMProviderConfig | None:
         if provider_name == "openai":
@@ -251,6 +278,7 @@ class ModelProviderRegistry:
                 source=discovery.source,
                 last_refresh_status=discovery.last_refresh_status,
                 last_error=discovery.last_error,
+                discovery_mode=discovery.discovery_mode,
             )
         return discovery.models
 

--- a/src/voidcode/provider/resolution.py
+++ b/src/voidcode/provider/resolution.py
@@ -4,6 +4,7 @@ from .config import ProviderFallbackConfig
 from .errors import format_invalid_provider_config_error
 from .models import (
     ProviderModelSelection,
+    ProviderResolutionMetadata,
     ResolvedProviderChain,
     ResolvedProviderConfig,
     ResolvedProviderModel,
@@ -20,14 +21,18 @@ def resolve_provider_model(
         return ResolvedProviderModel()
 
     provider_name, model_name = _parse_model_reference(raw_model)
-    provider = registry.resolve(provider_name)
+    provider_resolution = registry.resolve_with_metadata(provider_name)
     return ResolvedProviderModel(
         selection=ProviderModelSelection(
             raw_model=raw_model,
             provider=provider_name,
             model=model_name,
         ),
-        provider=provider,
+        provider=provider_resolution.provider,
+        resolution=ProviderResolutionMetadata(
+            source=provider_resolution.source,
+            configured=provider_resolution.configured,
+        ),
     )
 
 
@@ -39,6 +44,9 @@ def resolve_provider_chain(
     if provider_fallback is None:
         return ResolvedProviderChain()
 
+    _validate_unique_model_references(
+        (provider_fallback.preferred_model, *provider_fallback.fallback_models)
+    )
     preferred = resolve_provider_model(provider_fallback.preferred_model, registry=registry)
     fallbacks = tuple(
         resolve_provider_model(raw_model, registry=registry)
@@ -94,3 +102,8 @@ def _parse_model_reference(raw_model: str) -> tuple[str, str]:
     if separator != "/" or "/" in model_name or not provider_name or not model_name:
         raise ValueError("model must use provider/model format")
     return provider_name, model_name
+
+
+def _validate_unique_model_references(raw_models: tuple[str, ...]) -> None:
+    if len(set(raw_models)) != len(raw_models):
+        raise ValueError("provider fallback chain must not contain duplicate models")

--- a/src/voidcode/provider/snapshot.py
+++ b/src/voidcode/provider/snapshot.py
@@ -88,6 +88,16 @@ def parse_resolved_provider_snapshot(
         raise ValueError(
             format_invalid_provider_config_error(f"{source}.targets", "must not be empty")
         )
+    resolved_target_raw_models = [
+        target.selection.raw_model for target in resolved_targets_list if target.selection.raw_model
+    ]
+    if len(set(resolved_target_raw_models)) != len(resolved_target_raw_models):
+        raise ValueError(
+            format_invalid_provider_config_error(
+                f"{source}.targets",
+                "must not contain duplicate provider targets",
+            )
+        )
     first_target = resolved_targets_list[0]
     resolved_targets: tuple[ResolvedProviderModel, ...] = tuple(resolved_targets_list)
 
@@ -96,12 +106,12 @@ def parse_resolved_provider_snapshot(
         source=f"{source}.active_target",
         registry=registry,
     )
-    resolved_target_raw_models = {
+    resolved_target_raw_model_set = {
         target.selection.raw_model
         for target in resolved_targets
         if target.selection.raw_model is not None
     }
-    if resolved_active_target.selection.raw_model not in resolved_target_raw_models:
+    if resolved_active_target.selection.raw_model not in resolved_target_raw_model_set:
         raise ValueError(
             format_invalid_provider_config_error(
                 f"{source}.active_target",

--- a/tests/unit/provider/test_model_catalog.py
+++ b/tests/unit/provider/test_model_catalog.py
@@ -35,6 +35,7 @@ def test_discover_available_models_combines_alias_discovery_and_targets() -> Non
         "provider/model-b",
     )
     assert models.source in {"remote", "mixed"}
+    assert models.discovery_mode == "configured_endpoint"
 
 
 def test_discover_available_models_for_openai_uses_endpoint_fetcher() -> None:
@@ -56,6 +57,7 @@ def test_discover_available_models_for_openai_uses_endpoint_fetcher() -> None:
     assert captured[0].base_url == "https://api.openai.com"
     assert captured[0].headers == {"Authorization": "Bearer sk-test"}
     assert captured[0].timeout_seconds == 10.0
+    assert models.discovery_mode == "configured_endpoint"
 
 
 def test_discover_available_models_for_anthropic_uses_provider_specific_headers() -> None:
@@ -79,6 +81,7 @@ def test_discover_available_models_for_anthropic_uses_provider_specific_headers(
         "anthropic-version": "2023-06-01",
         "x-api-key": "sk-ant-test",
     }
+    assert models.discovery_mode == "configured_endpoint"
 
 
 def test_discover_available_models_for_google_uses_google_base_url() -> None:
@@ -100,6 +103,7 @@ def test_discover_available_models_for_google_uses_google_base_url() -> None:
     assert captured[0].base_url == "https://generativelanguage.googleapis.com"
     assert captured[0].api_key == "AIza-test"
     assert captured[0].headers == {"x-goog-api-key": "AIza-test"}
+    assert models.discovery_mode == "configured_endpoint"
 
 
 def test_discover_available_models_for_google_with_api_key_header_does_not_append_key_query_param(
@@ -195,6 +199,7 @@ def test_discover_available_models_skips_when_no_discovery_base_url_or_base_url(
     assert result.source == "fallback"
     assert result.last_refresh_status == "skipped"
     assert result.last_error == "provider has no model discovery endpoint"
+    assert result.discovery_mode == "unavailable"
 
 
 def test_discover_available_models_marks_fallback_on_fetch_failure() -> None:
@@ -214,6 +219,7 @@ def test_discover_available_models_marks_fallback_on_fetch_failure() -> None:
     assert result.source == "fallback"
     assert result.last_refresh_status == "failed"
     assert result.last_error == "remote model discovery failed"
+    assert result.discovery_mode == "configured_endpoint"
 
 
 def test_discover_available_models_custom_provider_builds_url_from_plain_base_url(
@@ -254,6 +260,7 @@ def test_discover_available_models_custom_provider_builds_url_from_plain_base_ur
     assert result.models == ("provider/model-a",)
     assert captured["url"] == "https://gateway.example.com/v1/models"
     assert captured["timeout"] == 10.0
+    assert result.discovery_mode == "configured_base_url"
 
 
 def test_discover_available_models_custom_provider_keeps_existing_v1_models_path(
@@ -293,6 +300,7 @@ def test_discover_available_models_custom_provider_keeps_existing_v1_models_path
 
     assert result.models == ("provider/model-b",)
     assert captured["url"] == "https://gateway.example.com/v1/models"
+    assert result.discovery_mode == "configured_base_url"
 
 
 def test_discover_available_models_glm_base_url_uses_v4_models_path(
@@ -329,6 +337,7 @@ def test_discover_available_models_glm_base_url_uses_v4_models_path(
 
     assert result.models == ("glm/glm-4-flash",)
     assert captured["url"] == "https://open.bigmodel.cn/api/paas/v4/models"
+    assert result.discovery_mode == "configured_base_url"
 
 
 def test_discover_available_models_respects_discovery_base_url_when_set(
@@ -369,6 +378,7 @@ def test_discover_available_models_respects_discovery_base_url_when_set(
 
     assert result.models == ("openai/gpt-4o",)
     assert captured["url"] == "https://opencode.ai/zen/v1/models"
+    assert result.discovery_mode == "configured_endpoint"
 
 
 def test_discover_available_models_skips_remote_when_discovery_base_url_is_empty() -> None:
@@ -383,7 +393,8 @@ def test_discover_available_models_skips_remote_when_discovery_base_url_is_empty
     assert result.models == ("alias", "MiniMax-M2.7")
     assert result.source == "fallback"
     assert result.last_refresh_status == "skipped"
-    assert result.last_error == "provider has no model discovery endpoint"
+    assert result.last_error == "provider model discovery disabled by config"
+    assert result.discovery_mode == "disabled"
 
 
 def test_discover_available_models_custom_provider_uses_token_auth_header_without_bearer_prefix(
@@ -432,3 +443,4 @@ def test_discover_available_models_custom_provider_uses_token_auth_header_withou
         str(k).lower(): str(v) for k, v in dict(cast(dict[str, str], captured["headers"])).items()
     }
     assert headers.get("x-api-key") == "token-raw"
+    assert result.discovery_mode == "configured_base_url"

--- a/tests/unit/provider/test_model_model.py
+++ b/tests/unit/provider/test_model_model.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from voidcode.provider.config import LiteLLMProviderConfig, ProviderConfigs
 from voidcode.provider.litellm import LiteLLMModelProvider
 from voidcode.provider.models import ResolvedProviderConfig
 from voidcode.provider.registry import ModelProviderRegistry
@@ -41,6 +42,8 @@ def test_resolve_provider_model_parses_known_provider_reference() -> None:
     assert resolved.selection.model == "gpt-5.4"
     assert resolved.provider is not None
     assert resolved.provider.name == "opencode"
+    assert resolved.resolution.source == "builtin"
+    assert resolved.resolution.configured is True
 
 
 def test_resolve_provider_model_creates_generic_provider_for_unknown_name() -> None:
@@ -54,6 +57,23 @@ def test_resolve_provider_model_creates_generic_provider_for_unknown_name() -> N
     assert resolved.provider is not None
     assert resolved.provider.name == "custom"
     assert isinstance(resolved.provider, LiteLLMModelProvider)
+    assert resolved.resolution.source == "default_litellm"
+    assert resolved.resolution.configured is False
+
+
+def test_resolve_provider_model_marks_custom_configured_provider_resolution() -> None:
+    registry = ModelProviderRegistry.with_defaults(
+        provider_configs=ProviderConfigs(
+            custom={"llama-local": LiteLLMProviderConfig(base_url="http://localhost:11434/v1")}
+        )
+    )
+
+    resolved = resolve_provider_model("llama-local/coder", registry=registry)
+
+    assert resolved.provider is not None
+    assert resolved.provider.name == "llama-local"
+    assert resolved.resolution.source == "custom"
+    assert resolved.resolution.configured is True
 
 
 def test_resolve_provider_chain_preserves_ordered_fallback_targets() -> None:
@@ -121,6 +141,17 @@ def test_resolve_provider_config_rejects_mismatched_model_and_preferred_fallback
             provider_fallback=RuntimeProviderFallbackConfig(
                 preferred_model="custom/demo",
                 fallback_models=("backup/model",),
+            ),
+            registry=ModelProviderRegistry.with_defaults(),
+        )
+
+
+def test_resolve_provider_chain_rejects_duplicate_targets_even_without_parser() -> None:
+    with pytest.raises(ValueError, match="duplicate models"):
+        _ = resolve_provider_chain(
+            RuntimeProviderFallbackConfig(
+                preferred_model="opencode/gpt-5.4",
+                fallback_models=("opencode/gpt-5.4",),
             ),
             registry=ModelProviderRegistry.with_defaults(),
         )

--- a/tests/unit/provider/test_provider_errors.py
+++ b/tests/unit/provider/test_provider_errors.py
@@ -55,12 +55,16 @@ def test_parse_provider_api_error_maps_429_to_rate_limit() -> None:
     assert parsed.kind == "rate_limit"
     assert parsed.message == "Too many requests"
     assert parsed.details["source"] == "api"
+    assert parsed.retryable is True
+    assert parsed.fallback_allowed is True
 
 
 def test_parse_provider_api_error_maps_401_to_invalid_model() -> None:
     parsed = parse_provider_api_error({"status_code": 401, "message": "Unauthorized"})
 
     assert parsed.kind == "invalid_model"
+    assert parsed.retryable is False
+    assert parsed.fallback_allowed is True
 
 
 def test_parse_provider_api_error_maps_context_overflow_patterns() -> None:
@@ -72,6 +76,8 @@ def test_parse_provider_api_error_maps_context_overflow_patterns() -> None:
     )
 
     assert parsed.kind == "context_limit"
+    assert parsed.retryable is False
+    assert parsed.fallback_allowed is False
 
 
 def test_parse_provider_stream_error_maps_context_length_exceeded_code() -> None:
@@ -87,6 +93,8 @@ def test_parse_provider_stream_error_maps_context_length_exceeded_code() -> None
 
     assert parsed.kind == "context_limit"
     assert parsed.details["source"] == "stream"
+    assert parsed.retryable is False
+    assert parsed.fallback_allowed is False
 
 
 def test_provider_execution_error_from_api_payload_preserves_details() -> None:
@@ -97,6 +105,7 @@ def test_provider_execution_error_from_api_payload_preserves_details() -> None:
     )
 
     assert exc.kind == "transient_failure"
+    assert exc.retryable is True
     assert exc.details is not None
     assert exc.details["status_code"] == 503
     assert exc.details["source"] == "api"
@@ -110,6 +119,7 @@ def test_provider_execution_error_from_stream_payload_preserves_details() -> Non
     )
 
     assert exc.kind == "invalid_model"
+    assert exc.retryable is False
     assert exc.details is not None
     assert exc.details["status_code"] == 403
     assert exc.details["source"] == "stream"

--- a/tests/unit/provider/test_registry.py
+++ b/tests/unit/provider/test_registry.py
@@ -73,6 +73,30 @@ def test_registry_unknown_provider_prefers_custom_provider_config() -> None:
     assert resolved.config == custom_config
 
 
+def test_registry_resolve_with_metadata_distinguishes_builtin_custom_and_default_sources() -> None:
+    default_config = LiteLLMProviderConfig(api_key="default")
+    custom_config = LiteLLMProviderConfig(api_key="custom", base_url="http://localhost:11434/v1")
+    registry = ModelProviderRegistry.with_defaults(
+        provider_configs=ProviderConfigs(
+            litellm=default_config,
+            custom={"llama-local": custom_config},
+        )
+    )
+
+    builtin = registry.resolve_with_metadata("openai")
+    custom = registry.resolve_with_metadata("llama-local")
+    fallback = registry.resolve_with_metadata("typo-provider")
+
+    assert builtin.source == "builtin"
+    assert builtin.configured is True
+    assert custom.source == "custom"
+    assert custom.configured is True
+    assert custom.provider.name == "llama-local"
+    assert fallback.source == "default_litellm"
+    assert fallback.configured is True
+    assert fallback.provider.name == "typo-provider"
+
+
 def test_registry_keeps_existing_opencode_static_provider_behavior() -> None:
     registry = ModelProviderRegistry.with_defaults()
 
@@ -104,6 +128,7 @@ def test_registry_refresh_available_models_prefers_model_map_aliases() -> None:
     catalog = registry.provider_catalog("litellm")
     assert catalog is not None
     assert catalog.last_refresh_status in {"ok", "failed", "skipped"}
+    assert catalog.discovery_mode in {"configured_endpoint", "configured_base_url", "disabled"}
 
 
 def test_registry_refresh_custom_provider_uses_custom_config() -> None:
@@ -124,6 +149,7 @@ def test_registry_refresh_custom_provider_uses_custom_config() -> None:
     catalog = registry.provider_catalog("llama-local")
     assert catalog is not None
     assert catalog.provider == "llama-local"
+    assert catalog.discovery_mode == "configured_base_url"
 
 
 def test_registry_google_provider_config_uses_google_api_key_header_for_api_key_auth() -> None:

--- a/tests/unit/provider/test_snapshot.py
+++ b/tests/unit/provider/test_snapshot.py
@@ -139,3 +139,37 @@ def test_parse_resolved_provider_snapshot_rejects_empty_targets() -> None:
             source="persisted runtime_config.resolved_provider",
             registry=ModelProviderRegistry.with_defaults(),
         )
+
+
+def test_parse_resolved_provider_snapshot_rejects_duplicate_targets() -> None:
+    with pytest.raises(
+        ValueError,
+        match=(
+            "invalid provider config: "
+            "persisted runtime_config.resolved_provider.targets "
+            "must not contain duplicate provider targets"
+        ),
+    ):
+        _ = parse_resolved_provider_snapshot(
+            {
+                "active_target": {
+                    "raw_model": "opencode/gpt-5.4",
+                    "provider": "opencode",
+                    "model": "gpt-5.4",
+                },
+                "targets": [
+                    {
+                        "raw_model": "opencode/gpt-5.4",
+                        "provider": "opencode",
+                        "model": "gpt-5.4",
+                    },
+                    {
+                        "raw_model": "opencode/gpt-5.4",
+                        "provider": "opencode",
+                        "model": "gpt-5.4",
+                    },
+                ],
+            },
+            source="persisted runtime_config.resolved_provider",
+            registry=ModelProviderRegistry.with_defaults(),
+        )


### PR DESCRIPTION
## Summary
- add explicit provider resolution metadata so builtin, custom, and default-LiteLLM fallback resolution are visible inside the provider layer
- harden provider fallback and snapshot parsing by rejecting duplicate targets even when callers bypass the raw config parser
- add structured discovery modes plus clearer provider error recovery semantics, then lock the behavior down with provider-focused tests

## Testing
- `mise run lint`
- `mise run typecheck`
- `uv run pytest tests/unit/provider -q`
- `uv run pytest tests/unit/runtime/test_runtime_service_extensions.py -k 'provider_models or provider_fallback_exhaustion or malformed_model_reference' -q`
- `uv run pytest tests/unit/interface/test_cli_smoke.py -k 'provider_models_command_outputs_refreshed_provider_model_list' -q`

Closes #206
