### PR TITLE
feat(agent): harden builtin preset prompt semantics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ htmlcov/
 .opencode/
 .sisyphus/
 .test_venv/
-agent/
+/agent/
 .omx/
 .codex
 .voidcode.json

--- a/src/voidcode/agent/README.md
+++ b/src/voidcode/agent/README.md
@@ -4,7 +4,7 @@
 
 ## 定位
 
-`voidcode.agent` 不负责执行，它负责描述**每一种 agent preset 是什么**，包括角色定位、默认权限、建议 skills、建议 hooks 与能力绑定方向。
+`voidcode.agent` 不负责执行，它负责描述**每一种 agent preset 是什么**，包括角色定位、builtin manifest、builtin prompt materialization、默认权限、建议 skills、建议 hooks 与能力绑定方向。
 
 它的目标不是替代 `runtime/`，而是把“agent 是什么、默认带什么组合”从运行时治理逻辑里拆出来，形成一个薄的、声明式的组合层。
 
@@ -13,6 +13,8 @@
 ## 负责什么
 
 - agent 角色说明
+- builtin manifest 校验
+- builtin prompt/profile 文本与 materialization
 - preset 级别的职责边界
 - 默认权限倾向
 - 建议 skill 绑定
@@ -47,30 +49,35 @@
 - `researcher`
 - `product`
 
-其中只有 `leader` 对应今天真实存在的单 agent 主路径，其余角色都仍然是 post-MVP 的 future preset。Runtime 当前会解析这些 future preset 以验证声明层 shape，但会拒绝把它们作为 active execution agent 运行。
+其中 `leader` 是今天真实存在的顶层 active execution preset；`worker`、`advisor`、`explore`、`researcher`、`product` 已可作为 runtime-owned delegated child preset 执行。它们仍然不是任意可选的顶层 active agent。
 
 ## Preset intent vs runtime truth
 
 本目录描述的是“一个角色默认希望带什么组合”，不是“runtime 今天已经能怎样执行它”。
 
 - `leader`：当前唯一映射到真实执行路径的角色；`preset` / `prompt_profile` / `model` / `execution_engine` / `tools` / `skills` / `provider_fallback` 会进入 runtime config truth 并随 session 持久化
-- `worker`：future focused executor preset，不代表今天已经有 delegated runtime
-- `advisor`：future advisory preset，不代表今天已有独立审查/判断 runtime
-- `explore`：future local-code exploration preset，不代表今天已有独立 explore session model
-- `researcher`：future external research preset，不代表今天已有独立 researcher orchestration
-- `product`：future scope/alignment preset，不代表今天已有需求对齐 gate runtime
+- `worker`：delegated focused executor preset；可进入 child execution，但不作为任意顶层 active agent 直接运行
+- `advisor`：delegated advisory preset；可进入 child execution，但不作为任意顶层 active agent 直接运行
+- `explore`：delegated local-code exploration preset；可进入 child execution，但不作为任意顶层 active agent 直接运行
+- `researcher`：delegated external research preset；可进入 child execution，但不作为任意顶层 active agent 直接运行
+- `product`：delegated scope/alignment preset；可进入 child execution，但不作为任意顶层 active agent 直接运行
 
-当前 `leader` 是第一阶段 runtime-managed agent slice：active agent 的 manifest allowlist 会收窄 provider 可见的 `available_tools`，并且同一边界也会约束实际 tool lookup / invocation。`leader` 的 `prompt_profile` 会进入 provider system message，`model` / `execution_engine` / `provider_fallback` 会决定 provider-backed single-agent 主路径，manifest `skill_refs` 会作为默认 skill selection 进入 runtime skill application，`agent.skills` 会覆盖本次运行使用的 runtime-managed skill discovery / application policy。
+当前 builtin preset 都有 agent-owned prompt profile；active / delegated agent 的 manifest allowlist 会收窄 provider 可见的 `available_tools`，并且同一边界也会约束实际 tool lookup / invocation。builtin `prompt_profile` 由 `src/voidcode/agent/` 统一 materialize 后进入 provider system message，`model_preference` / `execution_engine` 会作为 manifest live defaults 被 runtime 解析，manifest `skill_refs` 会作为默认 skill selection 进入 runtime skill application，`agent.skills` 会覆盖本次运行使用的 runtime-managed skill discovery / application policy。
 
-此外，`leader` 的 prompt 文本 ownership 现在明确归属 `src/voidcode/agent/leader/`：agent 层负责 prompt 内容与角色约束，provider 层只负责 message assembly 和模型调用，不再持有 leader persona 的源码副本。
+此外，builtin prompt 文本 ownership 现在明确归属 `src/voidcode/agent/`：agent 层负责 builtin prompt 内容、profile materialization 与 manifest 校验，provider 层只负责 message assembly 和模型调用，不再持有 role-specific persona 源码副本。
 
 ## 与 runtime 的边界
 
-`voidcode.agent` 可以描述“这个角色默认希望带哪些工具/skills/hooks/MCP profile”。其中 `leader` 的 prompt profile、工具边界、skills、model、execution engine 与 provider fallback 已进入 runtime enforcement / persistence；其他 preset 的能力绑定仍不能决定系统最终如何执行、治理、审批、恢复和持久化它。
+`voidcode.agent` 可以描述“这个角色默认希望带哪些工具/skills/hooks/MCP profile”。其中 builtin preset 的 prompt profile、工具边界、skills、model、execution engine 与 provider fallback 都会被 runtime 按当前执行边界消费；但这些声明仍不能决定系统最终如何执行、治理、审批、恢复和持久化它。
+
+当前 agent manifest 内部也区分了两类语义：
+
+- **live defaults**：`prompt_profile`、`execution_engine`、`model_preference`、`tool_allowlist`、`skill_refs`。这些字段要么已经被 runtime 直接消费，要么作为 active agent 的默认值进入 runtime config truth。
+- **intent metadata**：`routing_hints`。它仍属于声明层元数据，不是 runtime execution governance truth。
 
 最终的执行真相仍然由 `voidcode.runtime` 持有。
 
-这也意味着：本目录中出现的“建议 hooks / 建议能力”只是在描述未来 preset 希望依赖什么，不代表 runtime 今天已经支持对应的 lifecycle phase。以当前现实看，hooks 仍然只覆盖 runtime-owned 的 `pre_tool` / `post_tool`；background task、child-session、leader notification、result retrieval 等 async agent substrate 仍未落地。
+这也意味着：本目录中出现的“建议 hooks / 建议能力”只是在描述 preset intent，不代表 runtime 会把治理权让渡给 agent 层。当前现实里，background task、child-session、notification、result retrieval、tool enforcement、approval 与持久化仍全部由 runtime 持有。
 
 从 OMO/OMOA 的经验看，更值得借鉴的是以下结构判断，而不是直接照搬执行语义：
 

--- a/src/voidcode/agent/__init__.py
+++ b/src/voidcode/agent/__init__.py
@@ -7,13 +7,22 @@ from .builtin import (
     WORKER_AGENT_MANIFEST,
     get_builtin_agent_manifest,
     list_builtin_agent_manifests,
+    validate_builtin_agent_manifests,
 )
 from .leader import render_leader_prompt
-from .models import AgentExecutionEngineName, AgentManifest, AgentManifestId, AgentMode
+from .models import (
+    AgentExecutionEngineName,
+    AgentManifest,
+    AgentManifestFieldSemantic,
+    AgentManifestId,
+    AgentMode,
+)
+from .prompts import is_builtin_prompt_profile, render_agent_prompt, render_builtin_prompt_profile
 
 __all__ = [
     "AgentExecutionEngineName",
     "AgentManifest",
+    "AgentManifestFieldSemantic",
     "AgentManifestId",
     "AgentMode",
     "ADVISOR_AGENT_MANIFEST",
@@ -23,6 +32,10 @@ __all__ = [
     "RESEARCHER_AGENT_MANIFEST",
     "WORKER_AGENT_MANIFEST",
     "get_builtin_agent_manifest",
+    "is_builtin_prompt_profile",
     "list_builtin_agent_manifests",
+    "validate_builtin_agent_manifests",
+    "render_agent_prompt",
+    "render_builtin_prompt_profile",
     "render_leader_prompt",
 ]

--- a/src/voidcode/agent/advisor/base.txt
+++ b/src/voidcode/agent/advisor/base.txt
@@ -1,0 +1,26 @@
+<identity>
+You are VoidCode's advisor agent, a delegated read-heavy preset for architecture, risk, and review guidance.
+
+You are adapted from the advisory posture of Oh My OpenAgent's Oracle: reason carefully, prefer pragmatic minimalism, and give one clear recommendation instead of many speculative options.
+</identity>
+
+<constraints>
+- Prioritize analysis, tradeoffs, and risk identification.
+- Bias toward the simplest approach that satisfies the actual requirement.
+- Avoid implementation unless the runtime and task explicitly require it.
+- Respect runtime-owned approvals, persistence, tool enforcement, and session truth.
+</constraints>
+
+<decision_framework>
+- Leverage existing patterns before proposing new structure.
+- Call out assumptions explicitly when context is incomplete.
+- Focus on actionable guidance, not exhaustive theory.
+- Mention alternatives only when the trade-off is materially different.
+</decision_framework>
+
+<response_structure>
+Default output:
+- Bottom line: short recommendation.
+- Why: key tradeoff or risk.
+- Next steps: concrete actions the caller can take.
+</response_structure>

--- a/src/voidcode/agent/builtin.py
+++ b/src/voidcode/agent/builtin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from .models import AgentManifest, AgentManifestId
+from .prompts import render_builtin_prompt_profile
 
 _READ_ONLY_WORKSPACE_TOOLS = (
     "read_file",
@@ -49,6 +50,7 @@ WORKER_AGENT_MANIFEST = AgentManifest(
     mode="subagent",
     description="Focused future executor preset for narrow implementation tasks.",
     prompt_profile="worker",
+    execution_engine="provider",
     tool_allowlist=(
         *_READ_ONLY_WORKSPACE_TOOLS,
         "write_file",
@@ -67,6 +69,7 @@ ADVISOR_AGENT_MANIFEST = AgentManifest(
     mode="subagent",
     description="Read-only advisory preset for architecture, risk, and review guidance.",
     prompt_profile="advisor",
+    execution_engine="provider",
     tool_allowlist=_READ_ONLY_WORKSPACE_TOOLS,
 )
 
@@ -78,6 +81,7 @@ EXPLORE_AGENT_MANIFEST = AgentManifest(
         "Workspace-bound exploration preset for local code structure and pattern discovery."
     ),
     prompt_profile="explore",
+    execution_engine="provider",
     tool_allowlist=_READ_ONLY_WORKSPACE_TOOLS,
 )
 
@@ -89,6 +93,7 @@ RESEARCHER_AGENT_MANIFEST = AgentManifest(
         "External research preset for public docs, repositories, and implementation examples."
     ),
     prompt_profile="researcher",
+    execution_engine="provider",
     tool_allowlist=("web_search", "web_fetch", "code_search"),
 )
 
@@ -98,16 +103,60 @@ PRODUCT_AGENT_MANIFEST = AgentManifest(
     mode="subagent",
     description="Requirements-alignment preset for scope, acceptance, and product intent review.",
     prompt_profile="product",
+    execution_engine="provider",
     tool_allowlist=("read_file", "list", "glob", "grep"),
 )
 
+
+def validate_builtin_agent_manifests(
+    manifests: tuple[AgentManifest, ...],
+) -> tuple[AgentManifest, ...]:
+    manifest_ids: set[AgentManifestId] = set()
+    for manifest in manifests:
+        if manifest.id in manifest_ids:
+            raise ValueError(f"duplicate builtin agent manifest id: {manifest.id}")
+        manifest_ids.add(manifest.id)
+        if not manifest.name.strip():
+            raise ValueError(
+                f"builtin agent manifest '{manifest.id}' must declare a non-empty name"
+            )
+        if not manifest.description.strip():
+            raise ValueError(
+                f"builtin agent manifest '{manifest.id}' must declare a non-empty description"
+            )
+        if manifest.prompt_profile is None or not manifest.prompt_profile.strip():
+            raise ValueError(
+                f"builtin agent manifest '{manifest.id}' must declare a builtin prompt_profile"
+            )
+        if render_builtin_prompt_profile(manifest.prompt_profile) is None:
+            raise ValueError(
+                f"builtin agent manifest '{manifest.id}' references unknown prompt profile "
+                f"'{manifest.prompt_profile}'"
+            )
+        if manifest.execution_engine is None:
+            raise ValueError(
+                f"builtin agent manifest '{manifest.id}' must declare an execution_engine"
+            )
+        if len(manifest.tool_allowlist) != len(set(manifest.tool_allowlist)):
+            raise ValueError(
+                f"builtin agent manifest '{manifest.id}' must not contain duplicate tool patterns"
+            )
+    return manifests
+
+
+_VALIDATED_BUILTIN_AGENT_MANIFESTS = validate_builtin_agent_manifests(
+    (
+        LEADER_AGENT_MANIFEST,
+        WORKER_AGENT_MANIFEST,
+        ADVISOR_AGENT_MANIFEST,
+        EXPLORE_AGENT_MANIFEST,
+        RESEARCHER_AGENT_MANIFEST,
+        PRODUCT_AGENT_MANIFEST,
+    )
+)
+
 _BUILTIN_AGENT_MANIFESTS: dict[AgentManifestId, AgentManifest] = {
-    LEADER_AGENT_MANIFEST.id: LEADER_AGENT_MANIFEST,
-    WORKER_AGENT_MANIFEST.id: WORKER_AGENT_MANIFEST,
-    ADVISOR_AGENT_MANIFEST.id: ADVISOR_AGENT_MANIFEST,
-    EXPLORE_AGENT_MANIFEST.id: EXPLORE_AGENT_MANIFEST,
-    RESEARCHER_AGENT_MANIFEST.id: RESEARCHER_AGENT_MANIFEST,
-    PRODUCT_AGENT_MANIFEST.id: PRODUCT_AGENT_MANIFEST,
+    manifest.id: manifest for manifest in _VALIDATED_BUILTIN_AGENT_MANIFESTS
 }
 
 

--- a/src/voidcode/agent/explore/base.txt
+++ b/src/voidcode/agent/explore/base.txt
@@ -1,0 +1,32 @@
+<identity>
+You are VoidCode's explore agent, a delegated workspace-bound preset for local code discovery.
+
+You are adapted from Oh My OpenAgent's Explore agent: find relevant code fast, search in parallel, and return results that let the caller proceed without another discovery round.
+</identity>
+
+<constraints>
+- Focus on local repository structure, references, and implementation patterns.
+- Keep exploration grounded in runtime-provided workspace tools.
+- Prefer read-only investigation over interpretation without evidence.
+- Respect runtime-owned approvals, persistence, tool enforcement, and session truth.
+</constraints>
+
+<analysis>
+Before searching, identify:
+- the literal request,
+- the actual information need,
+- and what result would unblock the caller.
+</analysis>
+
+<search_strategy>
+- Launch independent searches in parallel when possible.
+- Prefer absolute file paths in results.
+- Cross-check findings across search methods when the code path is non-trivial.
+</search_strategy>
+
+<output>
+Return:
+- relevant files,
+- a direct answer to the underlying question,
+- and the next useful step.
+</output>

--- a/src/voidcode/agent/leader/__init__.py
+++ b/src/voidcode/agent/leader/__init__.py
@@ -1,20 +1,16 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from functools import cache
-from pathlib import Path
 
-_LEADER_DIR = Path(__file__).resolve().parent
-
-
-@cache
-def _load_prompt_text(filename: str) -> str:
-    return (_LEADER_DIR / filename).read_text(encoding="utf-8").strip()
+from ..prompts import render_builtin_prompt_profile
 
 
 def render_leader_prompt(agent_preset: Mapping[str, object] | None = None) -> str:
     _ = agent_preset
-    return _load_prompt_text("base.txt")
+    prompt = render_builtin_prompt_profile("leader")
+    if prompt is None:
+        raise ValueError("builtin prompt profile 'leader' is not available")
+    return prompt
 
 
 __all__ = ["render_leader_prompt"]

--- a/src/voidcode/agent/models.py
+++ b/src/voidcode/agent/models.py
@@ -13,6 +13,7 @@ type AgentManifestId = Literal[
 ]
 type AgentMode = Literal["primary", "subagent", "all"]
 type AgentExecutionEngineName = Literal["deterministic", "provider"]
+type AgentManifestFieldSemantic = Literal["live_default", "intent"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -27,3 +28,32 @@ class AgentManifest:
     tool_allowlist: tuple[str, ...] = ()
     skill_refs: tuple[str, ...] = ()
     routing_hints: dict[str, object] = field(default_factory=dict)
+
+    @property
+    def live_default_fields(self) -> tuple[str, ...]:
+        fields: list[str] = []
+        if self.prompt_profile is not None:
+            fields.append("prompt_profile")
+        if self.execution_engine is not None:
+            fields.append("execution_engine")
+        if self.model_preference is not None:
+            fields.append("model_preference")
+        if self.tool_allowlist:
+            fields.append("tool_allowlist")
+        if self.skill_refs:
+            fields.append("skill_refs")
+        return tuple(fields)
+
+    @property
+    def intent_fields(self) -> tuple[str, ...]:
+        fields: list[str] = []
+        if self.routing_hints:
+            fields.append("routing_hints")
+        return tuple(fields)
+
+    def field_semantic(self, field_name: str) -> AgentManifestFieldSemantic:
+        if field_name in self.live_default_fields:
+            return "live_default"
+        if field_name in self.intent_fields:
+            return "intent"
+        raise ValueError(f"unknown or unset manifest field semantic: {field_name}")

--- a/src/voidcode/agent/product/base.txt
+++ b/src/voidcode/agent/product/base.txt
@@ -1,0 +1,27 @@
+<identity>
+You are VoidCode's product agent, a delegated preset for scope, acceptance criteria, and requirement alignment.
+
+You are adapted from the pre-planning and plan-review posture of Oh My OpenAgent's Metis and Momus: surface hidden scope, clarify non-goals, and make acceptance criteria executable instead of vague.
+</identity>
+
+<constraints>
+- Clarify user intent, non-goals, and acceptance boundaries.
+- Prefer alignment guidance over implementation detail unless the task explicitly needs both.
+- Bias toward executable acceptance criteria and concrete scope boundaries.
+- Respect runtime-owned approvals, persistence, tool enforcement, and session truth.
+</constraints>
+
+<alignment_flow>
+1. Identify the real goal, not just the requested solution.
+2. Surface missing constraints, exclusions, and success criteria.
+3. Prefer minimum viable scope over speculative expansion.
+4. Flag blockers that would make implementation or QA ambiguous.
+</alignment_flow>
+
+<output>
+Return:
+- clarified goal,
+- must-have outcomes,
+- must-not-have scope,
+- and concrete acceptance guidance.
+</output>

--- a/src/voidcode/agent/prompts.py
+++ b/src/voidcode/agent/prompts.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from functools import cache
+from pathlib import Path
+
+_AGENT_DIR = Path(__file__).resolve().parent
+_PROMPT_FILE_NAME = "base.txt"
+_BUILTIN_PROMPT_PROFILES = frozenset(
+    {"leader", "worker", "advisor", "explore", "researcher", "product"}
+)
+
+
+def _prompt_path(prompt_profile: str) -> Path:
+    return _AGENT_DIR / prompt_profile / _PROMPT_FILE_NAME
+
+
+def is_builtin_prompt_profile(prompt_profile: str) -> bool:
+    normalized_prompt_profile = prompt_profile.strip()
+    return normalized_prompt_profile in _BUILTIN_PROMPT_PROFILES
+
+
+def has_builtin_prompt_profile(prompt_profile: str) -> bool:
+    normalized_prompt_profile = prompt_profile.strip()
+    if not is_builtin_prompt_profile(normalized_prompt_profile):
+        return False
+    return _prompt_path(normalized_prompt_profile).is_file()
+
+
+@cache
+def render_builtin_prompt_profile(prompt_profile: str) -> str | None:
+    normalized_prompt_profile = prompt_profile.strip()
+    if not is_builtin_prompt_profile(normalized_prompt_profile):
+        return None
+    path = _prompt_path(normalized_prompt_profile)
+    if not path.is_file():
+        return None
+    return path.read_text(encoding="utf-8").strip()
+
+
+def render_agent_prompt(agent_preset: Mapping[str, object] | None = None) -> str | None:
+    if agent_preset is None:
+        return None
+    prompt_profile = agent_preset.get("prompt_profile")
+    if not isinstance(prompt_profile, str) or not prompt_profile.strip():
+        return None
+    normalized_prompt_profile = prompt_profile.strip()
+    builtin_prompt = render_builtin_prompt_profile(normalized_prompt_profile)
+    if builtin_prompt is not None:
+        return builtin_prompt
+    return (
+        "Runtime-selected VoidCode agent prompt profile: "
+        f"{normalized_prompt_profile}. Treat this as the active agent role profile "
+        "for this single-agent turn while still following the runtime-provided tool "
+        "and skill boundaries."
+    )
+
+
+__all__ = [
+    "has_builtin_prompt_profile",
+    "is_builtin_prompt_profile",
+    "render_agent_prompt",
+    "render_builtin_prompt_profile",
+]

--- a/src/voidcode/agent/prompts.py
+++ b/src/voidcode/agent/prompts.py
@@ -28,14 +28,18 @@ def has_builtin_prompt_profile(prompt_profile: str) -> bool:
 
 
 @cache
+def _render_known_builtin_prompt_profile(prompt_profile: str) -> str | None:
+    path = _prompt_path(prompt_profile)
+    if not path.is_file():
+        return None
+    return path.read_text(encoding="utf-8").strip()
+
+
 def render_builtin_prompt_profile(prompt_profile: str) -> str | None:
     normalized_prompt_profile = prompt_profile.strip()
     if not is_builtin_prompt_profile(normalized_prompt_profile):
         return None
-    path = _prompt_path(normalized_prompt_profile)
-    if not path.is_file():
-        return None
-    return path.read_text(encoding="utf-8").strip()
+    return _render_known_builtin_prompt_profile(normalized_prompt_profile)
 
 
 def render_agent_prompt(agent_preset: Mapping[str, object] | None = None) -> str | None:

--- a/src/voidcode/agent/researcher/base.txt
+++ b/src/voidcode/agent/researcher/base.txt
@@ -1,0 +1,23 @@
+<identity>
+You are VoidCode's researcher agent, a delegated preset for public docs, code examples, and external references.
+
+You are adapted from the research posture of Oh My OpenAgent's Librarian: look for authoritative evidence first, distinguish official docs from incidental blog posts, and summarize findings so the caller can make a concrete decision.
+</identity>
+
+<constraints>
+- Focus on external evidence rather than local implementation changes.
+- Prefer official documentation and primary-source examples when available.
+- Synthesize sources concisely for the parent runtime path.
+- Respect runtime-owned approvals, persistence, tool enforcement, and session truth.
+</constraints>
+
+<research_flow>
+1. Classify whether the question is conceptual, implementation-oriented, or historical.
+2. Prefer official docs for conceptual questions.
+3. Prefer source links and real examples for implementation questions.
+4. Make uncertainty explicit instead of overstating confidence.
+</research_flow>
+
+<output>
+Return the recommendation, the evidence basis, and any caveat that could change the answer.
+</output>

--- a/src/voidcode/agent/worker/base.txt
+++ b/src/voidcode/agent/worker/base.txt
@@ -1,0 +1,34 @@
+<identity>
+You are VoidCode's worker agent, a focused delegated executor for narrow implementation tasks.
+
+You are adapted from the same execution posture as Oh My OpenAgent's Sisyphus-Junior: build context first, make the smallest correct change, verify aggressively, and do not stop early.
+</identity>
+
+<constraints>
+- Stay tightly scoped to the delegated task.
+- Prefer minimal code changes over broad redesign.
+- Use runtime-provided tools instead of guessing.
+- Respect runtime-owned approvals, persistence, tool enforcement, and session truth.
+- Do not expand into orchestration, delegation policy, or unrelated cleanup.
+</constraints>
+
+<execution>
+Default loop:
+1. Explore the relevant files and nearby tests before editing.
+2. Match existing naming, structure, and error-handling patterns.
+3. Implement only the requested change.
+4. Verify with diagnostics, tests, typecheck, build, or the nearest executable check.
+5. If verification fails, fix the root cause and retry.
+</execution>
+
+<verification>
+No evidence means not complete.
+
+- Run diagnostics on changed files when available.
+- Run the nearest relevant tests for changed behavior.
+- Report what changed, what passed, and any remaining risk.
+</verification>
+
+<style>
+Be concise, direct, and implementation-focused.
+</style>

--- a/src/voidcode/provider/litellm_backend.py
+++ b/src/voidcode/provider/litellm_backend.py
@@ -20,7 +20,7 @@ else:
             pass
 
 
-from ..agent import render_leader_prompt
+from ..agent import render_agent_prompt
 from ..tools.contracts import ToolCall, ToolDefinition
 from .config import LiteLLMProviderConfig
 from .errors import provider_execution_error_from_api_payload
@@ -129,21 +129,7 @@ class LiteLLMBackendSingleAgentProvider:
 
     @classmethod
     def _agent_profile_system_message(cls, request: ProviderTurnRequest) -> str | None:
-        agent_preset = request.agent_preset
-        if agent_preset is None:
-            return None
-        prompt_profile = agent_preset.get("prompt_profile")
-        if not isinstance(prompt_profile, str) or not prompt_profile.strip():
-            return None
-        normalized_prompt_profile = prompt_profile.strip()
-        if normalized_prompt_profile == "leader":
-            return render_leader_prompt(agent_preset)
-        return (
-            "Runtime-selected VoidCode agent prompt profile: "
-            f"{normalized_prompt_profile}. Treat this as the active agent role profile "
-            "for this single-agent turn while still following the runtime-provided tool "
-            "and skill boundaries."
-        )
+        return render_agent_prompt(request.agent_preset)
 
     @staticmethod
     def _continuity_system_message(request: ProviderTurnRequest) -> str | None:

--- a/tests/unit/agent/test_builtin.py
+++ b/tests/unit/agent/test_builtin.py
@@ -8,6 +8,7 @@ from voidcode.agent import (
     render_agent_prompt,
     render_builtin_prompt_profile,
 )
+from voidcode.agent import prompts as prompt_module
 from voidcode.agent.builtin import validate_builtin_agent_manifests
 from voidcode.agent.models import AgentManifest
 
@@ -59,6 +60,20 @@ def test_builtin_prompt_lookup_rejects_non_builtin_profile_before_file_access() 
     assert is_builtin_prompt_profile("custom-review") is False
     assert is_builtin_prompt_profile("../leader") is False
     assert render_builtin_prompt_profile("../leader") is None
+
+
+def test_non_builtin_prompt_profiles_do_not_grow_builtin_prompt_cache() -> None:
+    prompt_module._render_known_builtin_prompt_profile.cache_clear()
+
+    assert render_builtin_prompt_profile("leader") is not None
+    cache_info = prompt_module._render_known_builtin_prompt_profile.cache_info()
+    assert cache_info.currsize == 1
+
+    assert render_builtin_prompt_profile("custom-review") is None
+    assert render_builtin_prompt_profile("another-custom-profile") is None
+
+    cache_info = prompt_module._render_known_builtin_prompt_profile.cache_info()
+    assert cache_info.currsize == 1
 
 
 def test_agent_manifest_exposes_live_default_vs_intent_field_semantics() -> None:

--- a/tests/unit/agent/test_builtin.py
+++ b/tests/unit/agent/test_builtin.py
@@ -1,63 +1,103 @@
+from __future__ import annotations
+
+import pytest
+
 from voidcode.agent import (
-    ADVISOR_AGENT_MANIFEST,
-    EXPLORE_AGENT_MANIFEST,
-    LEADER_AGENT_MANIFEST,
-    PRODUCT_AGENT_MANIFEST,
-    RESEARCHER_AGENT_MANIFEST,
-    WORKER_AGENT_MANIFEST,
-    get_builtin_agent_manifest,
+    is_builtin_prompt_profile,
     list_builtin_agent_manifests,
+    render_agent_prompt,
+    render_builtin_prompt_profile,
 )
+from voidcode.agent.builtin import validate_builtin_agent_manifests
+from voidcode.agent.models import AgentManifest
 
 
-def test_builtin_agent_registry_exposes_leader_manifest() -> None:
-    leader = get_builtin_agent_manifest("leader")
-
-    assert leader == LEADER_AGENT_MANIFEST
-    assert leader is not None
-    assert leader.name == "Leader"
-    assert leader.mode == "primary"
-    assert leader.prompt_profile == "leader"
-    assert leader.execution_engine == "provider"
-    assert "read_file" in leader.tool_allowlist
-    assert "write_file" in leader.tool_allowlist
-    assert "mcp/*" in leader.tool_allowlist
-
-
-def test_builtin_agent_registry_lists_leader_manifest() -> None:
+def test_builtin_agent_manifests_have_materialized_prompt_profiles_and_execution_engines() -> None:
     manifests = list_builtin_agent_manifests()
 
-    assert manifests == (
-        LEADER_AGENT_MANIFEST,
-        WORKER_AGENT_MANIFEST,
-        ADVISOR_AGENT_MANIFEST,
-        EXPLORE_AGENT_MANIFEST,
-        RESEARCHER_AGENT_MANIFEST,
-        PRODUCT_AGENT_MANIFEST,
+    assert manifests
+    for manifest in manifests:
+        assert manifest.prompt_profile is not None
+        assert manifest.execution_engine == "provider"
+        prompt = render_builtin_prompt_profile(manifest.prompt_profile)
+        assert prompt is not None
+        assert prompt
+
+
+@pytest.mark.parametrize(
+    ("preset", "expected_fragment"),
+    [
+        ("leader", "VoidCode's leader agent"),
+        ("worker", "VoidCode's worker agent"),
+        ("advisor", "VoidCode's advisor agent"),
+        ("explore", "VoidCode's explore agent"),
+        ("researcher", "VoidCode's researcher agent"),
+        ("product", "VoidCode's product agent"),
+    ],
+)
+def test_render_agent_prompt_materializes_builtin_profiles(
+    preset: str, expected_fragment: str
+) -> None:
+    prompt = render_agent_prompt({"preset": preset, "prompt_profile": preset})
+
+    assert prompt is not None
+    assert expected_fragment in prompt
+
+
+def test_render_agent_prompt_falls_back_for_non_builtin_profiles() -> None:
+    prompt = render_agent_prompt({"preset": "leader", "prompt_profile": "custom-review"})
+
+    assert prompt == (
+        "Runtime-selected VoidCode agent prompt profile: custom-review. "
+        "Treat this as the active agent role profile for this single-agent turn while "
+        "still following the runtime-provided tool and skill boundaries."
     )
 
 
-def test_builtin_agent_registry_exposes_future_role_skeletons() -> None:
-    worker = get_builtin_agent_manifest("worker")
-    advisor = get_builtin_agent_manifest("advisor")
-    explore = get_builtin_agent_manifest("explore")
-    researcher = get_builtin_agent_manifest("researcher")
-    product = get_builtin_agent_manifest("product")
+def test_builtin_prompt_lookup_rejects_non_builtin_profile_before_file_access() -> None:
+    assert is_builtin_prompt_profile("leader") is True
+    assert is_builtin_prompt_profile("custom-review") is False
+    assert is_builtin_prompt_profile("../leader") is False
+    assert render_builtin_prompt_profile("../leader") is None
 
-    assert worker == WORKER_AGENT_MANIFEST
-    assert advisor == ADVISOR_AGENT_MANIFEST
-    assert explore == EXPLORE_AGENT_MANIFEST
-    assert researcher == RESEARCHER_AGENT_MANIFEST
-    assert product == PRODUCT_AGENT_MANIFEST
 
-    for manifest in (worker, advisor, explore, researcher, product):
-        assert manifest is not None
-        assert manifest.mode == "subagent"
-        assert manifest.execution_engine is None
-        assert manifest.tool_allowlist
+def test_agent_manifest_exposes_live_default_vs_intent_field_semantics() -> None:
+    manifest = AgentManifest(
+        id="leader",
+        name="Leader",
+        mode="primary",
+        description="Primary preset",
+        prompt_profile="leader",
+        execution_engine="provider",
+        model_preference="opencode/gpt-5.4",
+        tool_allowlist=("read_file",),
+        skill_refs=("demo",),
+        routing_hints={"tier": "primary"},
+    )
 
-    assert "edit" in worker.tool_allowlist
-    assert "write_file" not in advisor.tool_allowlist
-    assert "ast_grep_search" in explore.tool_allowlist
-    assert researcher.tool_allowlist == ("web_search", "web_fetch", "code_search")
-    assert product.tool_allowlist == ("read_file", "list", "glob", "grep")
+    assert manifest.live_default_fields == (
+        "prompt_profile",
+        "execution_engine",
+        "model_preference",
+        "tool_allowlist",
+        "skill_refs",
+    )
+    assert manifest.intent_fields == ("routing_hints",)
+    assert manifest.field_semantic("prompt_profile") == "live_default"
+    assert manifest.field_semantic("routing_hints") == "intent"
+
+
+def test_validate_builtin_agent_manifests_rejects_unknown_prompt_profile() -> None:
+    with pytest.raises(ValueError, match="references unknown prompt profile"):
+        _ = validate_builtin_agent_manifests(
+            (
+                AgentManifest(
+                    id="leader",
+                    name="Leader",
+                    mode="primary",
+                    description="Primary preset",
+                    prompt_profile="missing-profile",
+                    execution_engine="provider",
+                ),
+            )
+        )

--- a/tests/unit/provider/test_provider_adapters.py
+++ b/tests/unit/provider/test_provider_adapters.py
@@ -26,6 +26,7 @@ from voidcode.provider.protocol import (
     ProviderStreamEvent,
     ProviderTurnRequest,
     StreamableTurnProvider,
+    TurnProvider,
 )
 from voidcode.tools.contracts import ToolDefinition, ToolResult
 
@@ -243,8 +244,8 @@ def test_provider_adapter_stream_turn_emits_happy_path_chunks(
     provider_name: str,
     provider: ModelProvider,
 ) -> None:
-    provider = provider.turn_provider()
-    assert isinstance(provider, StreamableTurnProvider)
+    turn_provider = provider.turn_provider()
+    assert isinstance(turn_provider, StreamableTurnProvider)
 
     _patch_litellm_completion(
         monkeypatch,
@@ -256,7 +257,7 @@ def test_provider_adapter_stream_turn_emits_happy_path_chunks(
         ),
     )
 
-    events = list(provider.stream_turn(_build_turn_request(model_name=provider_name)))
+    events = list(turn_provider.stream_turn(_build_turn_request(model_name=provider_name)))
 
     payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
     assert isinstance(payload_obj, dict)
@@ -284,8 +285,8 @@ def test_provider_adapter_stream_turn_maps_http_error_to_provider_execution_erro
     provider_name: str,
     provider: ModelProvider,
 ) -> None:
-    provider = provider.turn_provider()
-    assert isinstance(provider, StreamableTurnProvider)
+    turn_provider = provider.turn_provider()
+    assert isinstance(turn_provider, StreamableTurnProvider)
 
     _patch_litellm_completion(
         monkeypatch,
@@ -294,7 +295,7 @@ def test_provider_adapter_stream_turn_maps_http_error_to_provider_execution_erro
     )
 
     with pytest.raises(ProviderExecutionError, match="Too many requests") as exc_info:
-        _ = list(provider.stream_turn(_build_turn_request(model_name=provider_name)))
+        _ = list(turn_provider.stream_turn(_build_turn_request(model_name=provider_name)))
 
     assert exc_info.value.kind == "rate_limit"
 
@@ -313,7 +314,7 @@ def test_provider_adapter_propose_turn_returns_text_output(
     provider_name: str,
     provider: ModelProvider,
 ) -> None:
-    provider = provider.turn_provider()
+    turn_provider: TurnProvider = provider.turn_provider()
 
     _patch_litellm_completion(
         monkeypatch,
@@ -321,7 +322,7 @@ def test_provider_adapter_propose_turn_returns_text_output(
         completion_content="hello world",
     )
 
-    result = provider.propose_turn(_build_turn_request(model_name=provider_name))
+    result = turn_provider.propose_turn(_build_turn_request(model_name=provider_name))
 
     assert result.output == "hello world"
 
@@ -340,7 +341,7 @@ def test_provider_adapter_injects_applied_skills_into_system_messages(
     provider_name: str,
     provider: ModelProvider,
 ) -> None:
-    provider = provider.turn_provider()
+    turn_provider: TurnProvider = provider.turn_provider()
 
     _patch_litellm_completion(
         monkeypatch,
@@ -348,7 +349,7 @@ def test_provider_adapter_injects_applied_skills_into_system_messages(
         completion_content="hello world",
     )
 
-    result = provider.propose_turn(_build_turn_request_with_skill(model_name=provider_name))
+    result = turn_provider.propose_turn(_build_turn_request_with_skill(model_name=provider_name))
 
     assert result.output == "hello world"
     payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
@@ -425,7 +426,7 @@ def test_provider_adapter_injects_continuity_summary_into_system_messages(
     provider_name: str,
     provider: ModelProvider,
 ) -> None:
-    provider = provider.turn_provider()
+    turn_provider: TurnProvider = provider.turn_provider()
 
     _patch_litellm_completion(
         monkeypatch,
@@ -433,7 +434,9 @@ def test_provider_adapter_injects_continuity_summary_into_system_messages(
         completion_content="hello world",
     )
 
-    result = provider.propose_turn(_build_turn_request_with_continuity(model_name=provider_name))
+    result = turn_provider.propose_turn(
+        _build_turn_request_with_continuity(model_name=provider_name)
+    )
 
     assert result.output == "hello world"
     payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
@@ -495,7 +498,70 @@ def test_provider_adapter_omits_continuity_message_without_summary_text(
     assert messages == [{"role": "user", "content": "read sample.txt"}]
 
 
-def test_provider_adapter_injects_leader_prompt_profile_system_message(
+@pytest.mark.parametrize(
+    ("agent_preset", "expected_fragment"),
+    [
+        (
+            {
+                "preset": "leader",
+                "prompt_profile": "leader",
+                "model": "openai/demo",
+                "execution_engine": "provider",
+            },
+            "VoidCode's leader agent",
+        ),
+        (
+            {
+                "preset": "worker",
+                "prompt_profile": "worker",
+                "model": "openai/demo",
+                "execution_engine": "provider",
+            },
+            "VoidCode's worker agent",
+        ),
+    ],
+)
+def test_provider_adapter_materializes_builtin_agent_prompt_profiles(
+    monkeypatch: pytest.MonkeyPatch,
+    agent_preset: dict[str, object],
+    expected_fragment: str,
+) -> None:
+    provider = OpenAIModelProvider()
+    provider = provider.turn_provider()
+    request = _build_turn_request(model_name="openai")
+    request = ProviderTurnRequest(
+        prompt=request.prompt,
+        available_tools=request.available_tools,
+        tool_results=request.tool_results,
+        context_window=request.context_window,
+        applied_skills=request.applied_skills,
+        raw_model=request.raw_model,
+        provider_name=request.provider_name,
+        model_name=request.model_name,
+        agent_preset=agent_preset,
+        attempt=request.attempt,
+        abort_signal=request.abort_signal,
+    )
+    _patch_litellm_completion(
+        monkeypatch,
+        mode="completion",
+        completion_content="hello world",
+    )
+
+    _ = provider.propose_turn(request)
+
+    payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
+    assert isinstance(payload_obj, dict)
+    payload = cast(dict[str, object], payload_obj)
+    messages_obj = payload.get("messages")
+    assert isinstance(messages_obj, list)
+    messages = cast(list[dict[str, str]], messages_obj)
+    assert messages[0]["role"] == "system"
+    assert expected_fragment in messages[0]["content"]
+    assert messages[1] == {"role": "user", "content": "read sample.txt"}
+
+
+def test_provider_adapter_falls_back_for_unknown_agent_prompt_profile(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     provider = OpenAIModelProvider()
@@ -512,7 +578,7 @@ def test_provider_adapter_injects_leader_prompt_profile_system_message(
         model_name=request.model_name,
         agent_preset={
             "preset": "leader",
-            "prompt_profile": "leader",
+            "prompt_profile": "custom-review",
             "model": "openai/demo",
             "execution_engine": "provider",
         },
@@ -533,10 +599,14 @@ def test_provider_adapter_injects_leader_prompt_profile_system_message(
     messages_obj = payload.get("messages")
     assert isinstance(messages_obj, list)
     messages = cast(list[dict[str, str]], messages_obj)
-    assert messages[0]["role"] == "system"
-    assert "VoidCode's leader agent" in messages[0]["content"]
-    assert "single active execution agent path" in messages[0]["content"]
-    assert messages[1] == {"role": "user", "content": "read sample.txt"}
+    assert messages[0] == {
+        "role": "system",
+        "content": (
+            "Runtime-selected VoidCode agent prompt profile: custom-review. "
+            "Treat this as the active agent role profile for this single-agent turn while "
+            "still following the runtime-provided tool and skill boundaries."
+        ),
+    }
 
 
 def test_provider_adapter_propose_turn_uses_model_map_for_litellm_alias(
@@ -843,7 +913,7 @@ def test_provider_adapters_call_litellm_directly_without_internal_bridge(
     provider_name: str,
     provider: ModelProvider,
 ) -> None:
-    provider = provider.turn_provider()
+    turn_provider: TurnProvider = provider.turn_provider()
 
     _patch_litellm_completion(
         monkeypatch,
@@ -851,7 +921,7 @@ def test_provider_adapters_call_litellm_directly_without_internal_bridge(
         completion_content="ok",
     )
 
-    result = provider.propose_turn(_build_turn_request(model_name=provider_name))
+    result = turn_provider.propose_turn(_build_turn_request(model_name=provider_name))
 
     assert result.output == "ok"
     payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -1014,7 +1014,7 @@ def test_runtime_agent_payload_accepts_future_role_presets_without_execution_map
     assert agent == RuntimeAgentConfig(
         preset="worker",
         prompt_profile="worker",
-        execution_engine=None,
+        execution_engine="provider",
     )
 
 


### PR DESCRIPTION
## Summary
- move builtin prompt materialization into `src/voidcode/agent/` and route provider system-message injection through the shared agent-owned renderer
- materialize delegated builtin presets with structured prompts adapted from Oh My OpenAgent role patterns, while keeping runtime ownership of execution truth unchanged
- harden `AgentManifest` semantics and tests by validating builtin prompt contracts, clarifying live defaults versus intent metadata, and aligning agent docs with shipped delegated-child behavior

## Verification
- `mise run typecheck`
- `rtk pytest tests/unit/agent/test_builtin.py tests/unit/provider/test_provider_adapters.py tests/unit/runtime/test_runtime_config.py tests/unit/runtime/test_runtime_service_extensions.py`

close #209 