### PR TITLE
fix(graph): harden provider graph terminal handling

### DIFF
--- a/src/voidcode/graph/__init__.py
+++ b/src/voidcode/graph/__init__.py
@@ -1,4 +1,4 @@
-from .contracts import GraphRunner, GraphRunRequest, GraphRunResult
+from .contracts import GraphRunRequest
 from .deterministic_graph import DeterministicGraph
 from .provider_graph import ProviderGraph
 
@@ -6,6 +6,4 @@ __all__ = [
     "DeterministicGraph",
     "ProviderGraph",
     "GraphRunRequest",
-    "GraphRunResult",
-    "GraphRunner",
 ]

--- a/src/voidcode/graph/contracts.py
+++ b/src/voidcode/graph/contracts.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import operator
 from dataclasses import dataclass, field
-from typing import Annotated, Any, Protocol, TypedDict, runtime_checkable
+from typing import Annotated, Protocol, TypedDict, runtime_checkable
 
-from ..runtime.context_window import RuntimeContextWindow
-from ..runtime.events import EventEnvelope, EventSource
+from ..provider.protocol import ProviderContextWindow
+from ..runtime.events import EventSource
 from ..runtime.session import SessionState
 from ..tools.contracts import ToolCall, ToolDefinition, ToolResult
 
@@ -42,16 +42,8 @@ class GraphRunRequest:
     available_tools: tuple[ToolDefinition, ...] = ()
     applied_skills: tuple[AppliedSkill, ...] = ()
     skill_prompt_context: str = ""
-    context_window: RuntimeContextWindow | None = None
+    context_window: ProviderContextWindow | None = None
     metadata: dict[str, object] = field(default_factory=dict)
-
-
-@dataclass(frozen=True, slots=True)
-class GraphRunResult:
-    session: SessionState
-    events: tuple[EventEnvelope, ...] = ()
-    tool_results: tuple[ToolResult, ...] = ()
-    output: str | None = None
 
 
 @runtime_checkable
@@ -60,7 +52,7 @@ class GraphStep(Protocol):
     def tool_call(self) -> ToolCall | None: ...
 
     @property
-    def events(self) -> tuple[Any, ...]: ...
+    def events(self) -> tuple[GraphEvent, ...]: ...
 
     @property
     def output(self) -> str | None: ...
@@ -78,8 +70,3 @@ class RuntimeGraph(Protocol):
         *,
         session: SessionState,
     ) -> GraphStep: ...
-
-
-@runtime_checkable
-class GraphRunner(Protocol):
-    def run(self, request: GraphRunRequest) -> GraphRunResult: ...

--- a/src/voidcode/graph/deterministic_graph.py
+++ b/src/voidcode/graph/deterministic_graph.py
@@ -48,6 +48,18 @@ class DeterministicReadOnlyStep:
     output: str | None = None
     is_finished: bool = False
 
+    def __post_init__(self) -> None:
+        if self.is_finished:
+            if self.tool_call is not None:
+                raise ValueError("finished graph steps must not include a tool call")
+            if self.output is None:
+                raise ValueError("finished graph steps must include output")
+            return
+        if self.tool_call is None:
+            raise ValueError("non-finished graph steps must include a tool call")
+        if self.output is not None:
+            raise ValueError("non-finished graph steps must not include output")
+
 
 class DeterministicGraph:
     def __init__(self, *, max_steps: int = 4) -> None:

--- a/src/voidcode/graph/provider_graph.py
+++ b/src/voidcode/graph/provider_graph.py
@@ -328,19 +328,23 @@ class ProviderGraph:
     ) -> ToolCall | None:
         if not payload_parts:
             return None
-        raw_payload_text = "".join(payload_parts)
+        raw_payload_text = payload_parts[-1]
         try:
             raw_tool_payload = json.loads(raw_payload_text)
         except json.JSONDecodeError as exc:
-            raise self._provider_execution_error(
-                kind="transient_failure",
-                model_name=model_name,
-                message="provider stream emitted malformed tool payload",
-                details={
-                    "source": "graph_stream",
-                    "reason": "malformed_tool_payload",
-                },
-            ) from exc
+            raw_payload_text = "".join(payload_parts)
+            try:
+                raw_tool_payload = json.loads(raw_payload_text)
+            except json.JSONDecodeError:
+                raise self._provider_execution_error(
+                    kind="transient_failure",
+                    model_name=model_name,
+                    message="provider stream emitted malformed tool payload",
+                    details={
+                        "source": "graph_stream",
+                        "reason": "malformed_tool_payload",
+                    },
+                ) from exc
 
         if not isinstance(raw_tool_payload, dict):
             raise self._provider_execution_error(

--- a/src/voidcode/graph/provider_graph.py
+++ b/src/voidcode/graph/provider_graph.py
@@ -2,19 +2,19 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import cast
+from typing import Any, Literal, cast
 
 from ..provider.errors import parse_provider_stream_error
 from ..provider.models import ResolvedProviderModel
 from ..provider.protocol import (
     ProviderAbortSignal,
+    ProviderContextWindow,
     ProviderExecutionError,
     ProviderStreamEvent,
     ProviderTurnRequest,
     StreamableTurnProvider,
     TurnProvider,
 )
-from ..runtime.context_window import RuntimeContextWindow
 from ..runtime.events import GRAPH_LOOP_STEP, GRAPH_MODEL_TURN, GRAPH_RESPONSE_READY
 from ..runtime.session import SessionState
 from ..tools.contracts import ToolCall, ToolResult
@@ -28,6 +28,18 @@ class ProviderStep:
     output: str | None = None
     is_finished: bool = False
 
+    def __post_init__(self) -> None:
+        if self.is_finished:
+            if self.tool_call is not None:
+                raise ValueError("finished graph steps must not include a tool call")
+            if self.output is None:
+                raise ValueError("finished graph steps must include output")
+            return
+        if self.tool_call is None:
+            raise ValueError("non-finished graph steps must include a tool call")
+        if self.output is not None:
+            raise ValueError("non-finished graph steps must not include output")
+
 
 @dataclass(slots=True)
 class _GraphAbortSignal:
@@ -39,6 +51,15 @@ class _GraphAbortSignal:
 
     def set_cancelled(self, value: bool) -> None:
         self._cancelled = value
+
+
+@dataclass(frozen=True, slots=True)
+class _PromptOnlyContextWindow:
+    prompt: str
+    tool_results: tuple[ToolResult, ...] = ()
+    compacted: bool = False
+    retained_tool_result_count: int = 0
+    continuity_state: object | None = None
 
 
 class ProviderGraph:
@@ -113,7 +134,7 @@ class ProviderGraph:
             prompt=request.prompt,
             available_tools=request.available_tools,
             tool_results=tool_results,
-            context_window=request.context_window or RuntimeContextWindow(prompt=request.prompt),
+            context_window=request.context_window or self._default_context_window(request.prompt),
             applied_skills=request.applied_skills,
             raw_model=self._provider_model.selection.raw_model,
             provider_name=self._provider_model.selection.provider,
@@ -132,6 +153,16 @@ class ProviderGraph:
             )
 
         turn_result = self._provider.propose_turn(turn_request)
+        if turn_result.output is not None and turn_result.tool_call is not None:
+            raise self._provider_execution_error(
+                kind="transient_failure",
+                model_name=turn_request.model_name,
+                message="provider turn produced both output and a tool call",
+                details={
+                    "source": "graph_nonstream",
+                    "reason": "mixed_terminal_outcome",
+                },
+            )
 
         if turn_result.output is not None:
             finalize_events = planning_events + (
@@ -147,6 +178,17 @@ class ProviderGraph:
                 is_finished=True,
             )
 
+        if turn_result.tool_call is None:
+            raise self._provider_execution_error(
+                kind="transient_failure",
+                model_name=turn_request.model_name,
+                message="provider turn produced neither output nor a tool call",
+                details={
+                    "source": "graph_nonstream",
+                    "reason": "missing_terminal_outcome",
+                },
+            )
+
         return ProviderStep(events=planning_events, tool_call=turn_result.tool_call)
 
     def _step_streaming(
@@ -159,7 +201,8 @@ class ProviderGraph:
         stream_provider = cast(StreamableTurnProvider, self._provider)
         stream_events: list[GraphEvent] = []
         output_parts: list[str] = []
-        streamed_tool_call: ToolCall | None = None
+        tool_payload_parts: list[str] = []
+        done_reason: str | None = None
 
         for stream_event in stream_provider.stream_turn(turn_request):
             stream_events.append(self._stream_event_to_graph_event(stream_event))
@@ -171,20 +214,7 @@ class ProviderGraph:
                 and stream_event.channel == "tool"
                 and stream_event.text is not None
             ):
-                try:
-                    raw_tool_payload = json.loads(stream_event.text)
-                except json.JSONDecodeError:
-                    streamed_tool_call = None
-                else:
-                    if isinstance(raw_tool_payload, dict):
-                        tool_payload = cast(dict[str, object], raw_tool_payload)
-                        tool_name_obj = tool_payload.get("tool_name")
-                        arguments_obj = tool_payload.get("arguments")
-                        if isinstance(tool_name_obj, str) and isinstance(arguments_obj, dict):
-                            streamed_tool_call = ToolCall(
-                                tool_name=tool_name_obj,
-                                arguments=cast(dict[str, object], arguments_obj),
-                            )
+                tool_payload_parts.append(stream_event.text)
             if stream_event.kind == "error":
                 if stream_event.error_kind == "cancelled":
                     raise ProviderExecutionError(
@@ -215,7 +245,6 @@ class ProviderGraph:
                     "rate_limit",
                     "context_limit",
                     "invalid_model",
-                    "transient_failure",
                 }:
                     parsed_kind = stream_event.error_kind
                 raise ProviderExecutionError(
@@ -226,46 +255,158 @@ class ProviderGraph:
                     details=parsed.details,
                 )
             if stream_event.kind == "done":
-                if stream_event.done_reason == "cancelled":
-                    raise ProviderExecutionError(
-                        kind="cancelled",
-                        provider_name=self._provider.name,
-                        model_name=turn_request.model_name or "unknown",
-                        message="provider stream cancelled",
-                    )
-                if stream_event.done_reason == "error":
-                    raise ProviderExecutionError(
-                        kind="transient_failure",
-                        provider_name=self._provider.name,
-                        model_name=turn_request.model_name or "unknown",
-                        message="provider stream ended with error",
-                    )
-                if streamed_tool_call is not None:
-                    return ProviderStep(
-                        events=planning_events + tuple(stream_events),
-                        tool_call=streamed_tool_call,
-                    )
-                output = "".join(output_parts)
-                finalize_events = (
-                    planning_events
-                    + tuple(stream_events)
-                    + (
-                        self._graph_event(
-                            GRAPH_LOOP_STEP,
-                            {
-                                "step": current_turn + 1,
-                                "phase": "finalize",
-                                "max_steps": self._max_steps,
-                            },
-                        ),
-                        self._graph_event(GRAPH_RESPONSE_READY, {"output_preview": output}),
-                    )
-                )
-                return ProviderStep(events=finalize_events, output=output, is_finished=True)
+                done_reason = stream_event.done_reason
+                break
 
-        return ProviderStep(
-            events=planning_events + tuple(stream_events), output="", is_finished=True
+        if done_reason is None:
+            raise self._provider_execution_error(
+                kind="transient_failure",
+                model_name=turn_request.model_name,
+                message="provider stream ended without a done event",
+                details={"source": "graph_stream", "reason": "missing_done_event"},
+            )
+        if done_reason == "cancelled":
+            raise self._provider_execution_error(
+                kind="cancelled",
+                model_name=turn_request.model_name,
+                message="provider stream cancelled",
+                details={"source": "graph_stream", "reason": "done_cancelled"},
+            )
+        if done_reason == "error":
+            raise self._provider_execution_error(
+                kind="transient_failure",
+                model_name=turn_request.model_name,
+                message="provider stream ended with error",
+                details={"source": "graph_stream", "reason": "done_error"},
+            )
+
+        streamed_tool_call = self._parse_streamed_tool_call(
+            tool_payload_parts,
+            model_name=turn_request.model_name,
         )
+        output = "".join(output_parts)
+
+        if streamed_tool_call is not None and output:
+            raise self._provider_execution_error(
+                kind="transient_failure",
+                model_name=turn_request.model_name,
+                message="provider stream produced both text output and a tool call",
+                details={
+                    "source": "graph_stream",
+                    "reason": "mixed_terminal_outcome",
+                },
+            )
+
+        if streamed_tool_call is not None:
+            return ProviderStep(
+                events=planning_events + tuple(stream_events),
+                tool_call=streamed_tool_call,
+            )
+
+        finalize_events = (
+            planning_events
+            + tuple(stream_events)
+            + (
+                self._graph_event(
+                    GRAPH_LOOP_STEP,
+                    {
+                        "step": current_turn + 1,
+                        "phase": "finalize",
+                        "max_steps": self._max_steps,
+                    },
+                ),
+                self._graph_event(GRAPH_RESPONSE_READY, {"output_preview": output}),
+            )
+        )
+        return ProviderStep(events=finalize_events, output=output, is_finished=True)
+
+    def _parse_streamed_tool_call(
+        self,
+        payload_parts: list[str],
+        *,
+        model_name: str | None,
+    ) -> ToolCall | None:
+        if not payload_parts:
+            return None
+        raw_payload_text = "".join(payload_parts)
+        try:
+            raw_tool_payload = json.loads(raw_payload_text)
+        except json.JSONDecodeError as exc:
+            raise self._provider_execution_error(
+                kind="transient_failure",
+                model_name=model_name,
+                message="provider stream emitted malformed tool payload",
+                details={
+                    "source": "graph_stream",
+                    "reason": "malformed_tool_payload",
+                },
+            ) from exc
+
+        if not isinstance(raw_tool_payload, dict):
+            raise self._provider_execution_error(
+                kind="transient_failure",
+                model_name=model_name,
+                message="provider stream tool payload must be a JSON object",
+                details={
+                    "source": "graph_stream",
+                    "reason": "tool_payload_not_object",
+                },
+            )
+
+        tool_payload = cast(dict[str, Any], raw_tool_payload)
+        tool_name_obj = tool_payload.get("tool_name")
+        arguments_obj = tool_payload.get("arguments")
+        if not isinstance(tool_name_obj, str) or not tool_name_obj.strip():
+            raise self._provider_execution_error(
+                kind="transient_failure",
+                model_name=model_name,
+                message="provider stream tool payload must include a non-empty tool_name",
+                details={
+                    "source": "graph_stream",
+                    "reason": "missing_tool_name",
+                },
+            )
+        if not isinstance(arguments_obj, dict):
+            raise self._provider_execution_error(
+                kind="transient_failure",
+                model_name=model_name,
+                message="provider stream tool payload must include an arguments object",
+                details={
+                    "source": "graph_stream",
+                    "reason": "invalid_tool_arguments",
+                },
+            )
+
+        return ToolCall(
+            tool_name=tool_name_obj,
+            arguments=cast(dict[str, object], arguments_obj),
+        )
+
+    def _provider_execution_error(
+        self,
+        *,
+        kind: Literal[
+            "rate_limit",
+            "context_limit",
+            "invalid_model",
+            "transient_failure",
+            "cancelled",
+        ],
+        model_name: str | None,
+        message: str,
+        details: dict[str, object] | None = None,
+    ) -> ProviderExecutionError:
+        return ProviderExecutionError(
+            kind=kind,
+            provider_name=self._provider.name,
+            model_name=model_name or "unknown",
+            message=message,
+            details=details,
+        )
+
+    @staticmethod
+    def _default_context_window(prompt: str) -> ProviderContextWindow:
+        return _PromptOnlyContextWindow(prompt=prompt)
 
     @staticmethod
     def _stream_event_to_graph_event(stream_event: ProviderStreamEvent) -> GraphEvent:

--- a/tests/unit/graph/test_single_agent_slice.py
+++ b/tests/unit/graph/test_single_agent_slice.py
@@ -174,6 +174,32 @@ class _StreamChunkedToolTurnProvider:
         )
 
 
+class _StreamToolSnapshotTurnProvider:
+    name = "opencode"
+
+    def propose_turn(self, request: ProviderTurnRequest) -> ProviderTurnResult:
+        _ = request
+        return ProviderTurnResult(output="should-not-be-used")
+
+    def stream_turn(self, request: ProviderTurnRequest):
+        _ = request
+        return iter(
+            (
+                ProviderStreamEvent(
+                    kind="content",
+                    channel="tool",
+                    text='{"tool_name":"read_file","arguments":{}}',
+                ),
+                ProviderStreamEvent(
+                    kind="content",
+                    channel="tool",
+                    text='{"tool_name":"read_file","arguments":{"path":"sample.txt"}}',
+                ),
+                ProviderStreamEvent(kind="done", done_reason="completed"),
+            )
+        )
+
+
 class _StreamMalformedToolTurnProvider:
     name = "opencode"
 
@@ -773,6 +799,35 @@ def test_provider_provider_graph_reconstructs_chunked_streamed_tool_call() -> No
     )
     graph = ProviderGraph(
         provider=_StreamChunkedToolTurnProvider(),
+        provider_model=provider_model,
+    )
+
+    step = graph.step(
+        request=GraphRunRequest(
+            session=_session(),
+            prompt="read sample.txt",
+            available_tools=_tool_definitions(),
+            context_window=RuntimeContextWindow(prompt="read sample.txt"),
+            metadata={"provider_stream": True},
+        ),
+        tool_results=(),
+        session=_session(),
+    )
+
+    assert step.is_finished is False
+    assert step.output is None
+    assert step.tool_call is not None
+    assert step.tool_call.tool_name == "read_file"
+    assert step.tool_call.arguments == {"path": "sample.txt"}
+
+
+def test_provider_provider_graph_uses_latest_complete_tool_snapshot() -> None:
+    provider_model = resolve_provider_model(
+        "opencode/gpt-5.4",
+        registry=ModelProviderRegistry.with_defaults(),
+    )
+    graph = ProviderGraph(
+        provider=_StreamToolSnapshotTurnProvider(),
         provider_model=provider_model,
     )
 

--- a/tests/unit/graph/test_single_agent_slice.py
+++ b/tests/unit/graph/test_single_agent_slice.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from voidcode.graph.contracts import GraphRunRequest
@@ -15,7 +17,7 @@ from voidcode.runtime.provider_protocol import (
     StubTurnProvider,
 )
 from voidcode.runtime.session import SessionRef, SessionState
-from voidcode.tools.contracts import ToolDefinition, ToolResult
+from voidcode.tools.contracts import ToolCall, ToolDefinition, ToolResult
 
 
 def _tool_definitions() -> tuple[ToolDefinition, ...]:
@@ -38,6 +40,25 @@ class _CapturingTurnProvider:
     def propose_turn(self, request: ProviderTurnRequest) -> ProviderTurnResult:
         self.requests.append(request)
         return ProviderTurnResult(output="done")
+
+
+class _MixedNonStreamingTurnProvider:
+    name = "opencode"
+
+    def propose_turn(self, request: ProviderTurnRequest) -> ProviderTurnResult:
+        _ = request
+        return ProviderTurnResult(
+            tool_call=ToolCall(tool_name="read_file", arguments={"path": "sample.txt"}),
+            output="done",
+        )
+
+
+class _EmptyNonStreamingTurnProvider:
+    name = "opencode"
+
+    def propose_turn(self, request: ProviderTurnRequest) -> ProviderTurnResult:
+        _ = request
+        return ProviderTurnResult()
 
 
 class _StreamOutputTurnProvider:
@@ -117,6 +138,83 @@ class _StreamToolTurnProvider:
         _ = request
         return iter(
             (
+                ProviderStreamEvent(
+                    kind="content",
+                    channel="tool",
+                    text='{"tool_name":"read_file","arguments":{"path":"sample.txt"}}',
+                ),
+                ProviderStreamEvent(kind="done", done_reason="completed"),
+            )
+        )
+
+
+class _StreamChunkedToolTurnProvider:
+    name = "opencode"
+
+    def propose_turn(self, request: ProviderTurnRequest) -> ProviderTurnResult:
+        _ = request
+        return ProviderTurnResult(output="should-not-be-used")
+
+    def stream_turn(self, request: ProviderTurnRequest):
+        _ = request
+        return iter(
+            (
+                ProviderStreamEvent(
+                    kind="content",
+                    channel="tool",
+                    text='{"tool_name":"read_file",',
+                ),
+                ProviderStreamEvent(
+                    kind="content",
+                    channel="tool",
+                    text='"arguments":{"path":"sample.txt"}}',
+                ),
+                ProviderStreamEvent(kind="done", done_reason="completed"),
+            )
+        )
+
+
+class _StreamMalformedToolTurnProvider:
+    name = "opencode"
+
+    def propose_turn(self, request: ProviderTurnRequest) -> ProviderTurnResult:
+        _ = request
+        return ProviderTurnResult(output="should-not-be-used")
+
+    def stream_turn(self, request: ProviderTurnRequest):
+        _ = request
+        return iter(
+            (
+                ProviderStreamEvent(kind="content", channel="tool", text='{"tool_name":'),
+                ProviderStreamEvent(kind="done", done_reason="completed"),
+            )
+        )
+
+
+class _StreamMissingDoneTurnProvider:
+    name = "opencode"
+
+    def propose_turn(self, request: ProviderTurnRequest) -> ProviderTurnResult:
+        _ = request
+        return ProviderTurnResult(output="should-not-be-used")
+
+    def stream_turn(self, request: ProviderTurnRequest):
+        _ = request
+        return iter((ProviderStreamEvent(kind="delta", channel="text", text="partial"),))
+
+
+class _StreamMixedTerminalTurnProvider:
+    name = "opencode"
+
+    def propose_turn(self, request: ProviderTurnRequest) -> ProviderTurnResult:
+        _ = request
+        return ProviderTurnResult(output="should-not-be-used")
+
+    def stream_turn(self, request: ProviderTurnRequest):
+        _ = request
+        return iter(
+            (
+                ProviderStreamEvent(kind="delta", channel="text", text="hello"),
                 ProviderStreamEvent(
                     kind="content",
                     channel="tool",
@@ -224,6 +322,179 @@ def test_provider_provider_graph_finalizes_after_tool_result() -> None:
     }
     assert step.events[2].payload == {"step": 3, "phase": "finalize", "max_steps": 4}
     assert step.events[3].payload == {"output_preview": "alpha\n"}
+
+
+def test_provider_provider_graph_rejects_nonstream_mixed_output_and_tool_call() -> None:
+    provider_model = resolve_provider_model(
+        "opencode/gpt-5.4",
+        registry=ModelProviderRegistry.with_defaults(),
+    )
+    graph = ProviderGraph(
+        provider=_MixedNonStreamingTurnProvider(),
+        provider_model=provider_model,
+    )
+
+    with pytest.raises(ProviderExecutionError, match="both output and a tool call") as exc_info:
+        _ = graph.step(
+            request=GraphRunRequest(
+                session=_session(),
+                prompt="read sample.txt",
+                available_tools=_tool_definitions(),
+                context_window=RuntimeContextWindow(prompt="read sample.txt"),
+            ),
+            tool_results=(),
+            session=_session(),
+        )
+
+    assert exc_info.value.kind == "transient_failure"
+
+
+def test_provider_provider_graph_rejects_nonstream_missing_terminal_outcome() -> None:
+    provider_model = resolve_provider_model(
+        "opencode/gpt-5.4",
+        registry=ModelProviderRegistry.with_defaults(),
+    )
+    graph = ProviderGraph(
+        provider=_EmptyNonStreamingTurnProvider(),
+        provider_model=provider_model,
+    )
+
+    with pytest.raises(
+        ProviderExecutionError,
+        match="neither output nor a tool call",
+    ) as exc_info:
+        _ = graph.step(
+            request=GraphRunRequest(
+                session=_session(),
+                prompt="read sample.txt",
+                available_tools=_tool_definitions(),
+                context_window=RuntimeContextWindow(prompt="read sample.txt"),
+            ),
+            tool_results=(),
+            session=_session(),
+        )
+
+    assert exc_info.value.kind == "transient_failure"
+
+
+def test_provider_provider_graph_preserves_stream_error_details() -> None:
+    provider_model = resolve_provider_model(
+        "opencode/gpt-5.4",
+        registry=ModelProviderRegistry.with_defaults(),
+    )
+
+    class _DetailedStreamErrorTurnProvider:
+        name = "opencode"
+
+        def propose_turn(self, request: ProviderTurnRequest) -> ProviderTurnResult:
+            _ = request
+            return ProviderTurnResult(output="fallback")
+
+        def stream_turn(self, request: ProviderTurnRequest):
+            _ = request
+            error_payload = json.dumps(
+                {
+                    "message": "network interrupted",
+                    "status_code": 429,
+                    "code": "rate_limit_exceeded",
+                    "prompt": "secret",
+                }
+            )
+            return iter(
+                (
+                    ProviderStreamEvent(
+                        kind="error",
+                        channel="error",
+                        error=error_payload,
+                        error_kind="transient_failure",
+                    ),
+                )
+            )
+
+    graph = ProviderGraph(
+        provider=_DetailedStreamErrorTurnProvider(),
+        provider_model=provider_model,
+    )
+
+    with pytest.raises(ProviderExecutionError, match="network interrupted") as exc_info:
+        _ = graph.step(
+            request=GraphRunRequest(
+                session=_session(),
+                prompt="read sample.txt",
+                available_tools=_tool_definitions(),
+                context_window=RuntimeContextWindow(prompt="read sample.txt"),
+                metadata={"provider_stream": True},
+            ),
+            tool_results=(),
+            session=_session(),
+        )
+
+    assert exc_info.value.details == {
+        "message": "network interrupted",
+        "status_code": 429,
+        "code": "rate_limit_exceeded",
+        "prompt": "secret",
+        "source": "stream",
+        "error_code": "rate_limit_exceeded",
+    }
+    assert exc_info.value.kind == "rate_limit"
+
+
+def test_provider_provider_graph_prefers_parsed_stream_error_kind_over_generic_transient() -> None:
+    provider_model = resolve_provider_model(
+        "opencode/gpt-5.4",
+        registry=ModelProviderRegistry.with_defaults(),
+    )
+
+    class _ContextLimitStreamErrorTurnProvider:
+        name = "opencode"
+
+        def propose_turn(self, request: ProviderTurnRequest) -> ProviderTurnResult:
+            _ = request
+            return ProviderTurnResult(output="fallback")
+
+        def stream_turn(self, request: ProviderTurnRequest):
+            _ = request
+            error_payload = json.dumps(
+                {
+                    "message": "prompt exceeds the context window",
+                    "status_code": 413,
+                    "code": "context_length_exceeded",
+                }
+            )
+            return iter(
+                (
+                    ProviderStreamEvent(
+                        kind="error",
+                        channel="error",
+                        error=error_payload,
+                        error_kind="transient_failure",
+                    ),
+                )
+            )
+
+    graph = ProviderGraph(
+        provider=_ContextLimitStreamErrorTurnProvider(),
+        provider_model=provider_model,
+    )
+
+    with pytest.raises(
+        ProviderExecutionError,
+        match="prompt exceeds the context window",
+    ) as exc_info:
+        _ = graph.step(
+            request=GraphRunRequest(
+                session=_session(),
+                prompt="read sample.txt",
+                available_tools=_tool_definitions(),
+                context_window=RuntimeContextWindow(prompt="read sample.txt"),
+                metadata={"provider_stream": True},
+            ),
+            tool_results=(),
+            session=_session(),
+        )
+
+    assert exc_info.value.kind == "context_limit"
 
 
 def test_provider_provider_graph_passes_applied_skill_context_to_provider() -> None:
@@ -493,6 +764,116 @@ def test_provider_provider_graph_returns_streamed_tool_call() -> None:
     assert step.tool_call is not None
     assert step.tool_call.tool_name == "read_file"
     assert step.tool_call.arguments == {"path": "sample.txt"}
+
+
+def test_provider_provider_graph_reconstructs_chunked_streamed_tool_call() -> None:
+    provider_model = resolve_provider_model(
+        "opencode/gpt-5.4",
+        registry=ModelProviderRegistry.with_defaults(),
+    )
+    graph = ProviderGraph(
+        provider=_StreamChunkedToolTurnProvider(),
+        provider_model=provider_model,
+    )
+
+    step = graph.step(
+        request=GraphRunRequest(
+            session=_session(),
+            prompt="read sample.txt",
+            available_tools=_tool_definitions(),
+            context_window=RuntimeContextWindow(prompt="read sample.txt"),
+            metadata={"provider_stream": True},
+        ),
+        tool_results=(),
+        session=_session(),
+    )
+
+    assert step.is_finished is False
+    assert step.output is None
+    assert step.tool_call is not None
+    assert step.tool_call.tool_name == "read_file"
+    assert step.tool_call.arguments == {"path": "sample.txt"}
+
+
+def test_provider_provider_graph_rejects_malformed_streamed_tool_payload() -> None:
+    provider_model = resolve_provider_model(
+        "opencode/gpt-5.4",
+        registry=ModelProviderRegistry.with_defaults(),
+    )
+    graph = ProviderGraph(
+        provider=_StreamMalformedToolTurnProvider(),
+        provider_model=provider_model,
+    )
+
+    with pytest.raises(ProviderExecutionError, match="malformed tool payload") as exc_info:
+        _ = graph.step(
+            request=GraphRunRequest(
+                session=_session(),
+                prompt="read sample.txt",
+                available_tools=_tool_definitions(),
+                context_window=RuntimeContextWindow(prompt="read sample.txt"),
+                metadata={"provider_stream": True},
+            ),
+            tool_results=(),
+            session=_session(),
+        )
+
+    assert exc_info.value.kind == "transient_failure"
+
+
+def test_provider_provider_graph_requires_done_event_for_stream_completion() -> None:
+    provider_model = resolve_provider_model(
+        "opencode/gpt-5.4",
+        registry=ModelProviderRegistry.with_defaults(),
+    )
+    graph = ProviderGraph(
+        provider=_StreamMissingDoneTurnProvider(),
+        provider_model=provider_model,
+    )
+
+    with pytest.raises(ProviderExecutionError, match="without a done event") as exc_info:
+        _ = graph.step(
+            request=GraphRunRequest(
+                session=_session(),
+                prompt="read sample.txt",
+                available_tools=_tool_definitions(),
+                context_window=RuntimeContextWindow(prompt="read sample.txt"),
+                metadata={"provider_stream": True},
+            ),
+            tool_results=(),
+            session=_session(),
+        )
+
+    assert exc_info.value.kind == "transient_failure"
+
+
+def test_provider_provider_graph_rejects_mixed_text_and_tool_terminal_output() -> None:
+    provider_model = resolve_provider_model(
+        "opencode/gpt-5.4",
+        registry=ModelProviderRegistry.with_defaults(),
+    )
+    graph = ProviderGraph(
+        provider=_StreamMixedTerminalTurnProvider(),
+        provider_model=provider_model,
+    )
+
+    with pytest.raises(
+        ProviderExecutionError,
+        match="both text output and a tool call",
+    ) as exc_info:
+        _ = graph.step(
+            request=GraphRunRequest(
+                session=_session(),
+                prompt="read sample.txt",
+                available_tools=_tool_definitions(),
+                context_window=RuntimeContextWindow(prompt="read sample.txt"),
+                metadata={"provider_stream": True},
+            ),
+            tool_results=(),
+            session=_session(),
+        )
+
+    assert exc_info.value.kind == "transient_failure"
 
 
 def test_provider_provider_graph_stream_error_maps_to_provider_execution_error() -> None:

--- a/tests/unit/provider/test_provider_adapters.py
+++ b/tests/unit/provider/test_provider_adapters.py
@@ -745,6 +745,61 @@ def test_provider_adapter_stream_turn_emits_tool_event_when_model_streams_tool_r
     ]
 
 
+def test_provider_adapter_stream_turn_emits_repeated_tool_snapshots_for_updates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = OpenAIModelProvider()
+    provider = provider.turn_provider()
+    assert isinstance(provider, StreamableTurnProvider)
+
+    _patch_litellm_completion(
+        monkeypatch,
+        mode="stream",
+        stream_tool_chunks=(
+            (
+                [
+                    {
+                        "index": 0,
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path":',
+                        },
+                    }
+                ],
+                None,
+            ),
+            (
+                [
+                    {
+                        "index": 0,
+                        "function": {
+                            "arguments": '"sample.txt"}',
+                        },
+                    }
+                ],
+                None,
+            ),
+            (None, "tool_calls"),
+        ),
+    )
+
+    events = list(provider.stream_turn(_build_turn_request(model_name="openai")))
+
+    assert events == [
+        ProviderStreamEvent(
+            kind="content",
+            channel="tool",
+            text='{"tool_name": "read_file", "arguments": {}}',
+        ),
+        ProviderStreamEvent(
+            kind="content",
+            channel="tool",
+            text='{"tool_name": "read_file", "arguments": {"path": "sample.txt"}}',
+        ),
+        ProviderStreamEvent(kind="done", done_reason="completed"),
+    ]
+
+
 def test_provider_adapter_stream_turn_emits_reasoning_events_from_reasoning_content(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/runtime/test_backend_contracts.py
+++ b/tests/unit/runtime/test_backend_contracts.py
@@ -40,7 +40,6 @@ def test_contract_modules_export_expected_symbols() -> None:
         input_schema={"path": "string"},
     )
     call = tools.ToolCall(tool_name=tool.name, arguments={"path": "README.md"})
-    result = tools.ToolResult(tool_name=tool.name, status="ok", content="hello")
     runtime_request = runtime.RuntimeRequest(
         prompt="Inspect the repo",
         session_id=session.session.id,
@@ -73,7 +72,6 @@ def test_contract_modules_export_expected_symbols() -> None:
     runtime_response = runtime.RuntimeResponse(session=session, events=(event,), output="done")
     stream_chunk = runtime.RuntimeStreamChunk(kind="event", session=session, event=event)
     graph_request = graph.GraphRunRequest(session=session, prompt=runtime_request.prompt)
-    graph_result = graph.GraphRunResult(session=session, events=(event,), tool_results=(result,))
 
     assert session.session.id == "session-1"
     assert session.session.parent_id == "session-parent"
@@ -92,7 +90,6 @@ def test_contract_modules_export_expected_symbols() -> None:
     assert background_task_result.delegated_event.message.status == "queued"
     assert session_summary.session.id == "session-1"
     assert graph_request.available_tools == ()
-    assert graph_result.tool_results == (result,)
 
 
 def test_contracts_are_frozen_and_isolate_default_state() -> None:
@@ -131,7 +128,6 @@ def test_tool_result_validates_status_consistently() -> None:
 
 def test_runtime_and_graph_protocols_are_runtime_checkable() -> None:
     runtime_module = _runtime_module()
-    graph_module = _graph_module()
 
     class StubRuntime:
         def run(self, request: Any) -> Any:
@@ -176,47 +172,24 @@ def test_runtime_and_graph_protocols_are_runtime_checkable() -> None:
                 output=typed_request.prompt.upper(),
             )
 
-    class StubGraphRunner:
-        def run(self, request: Any) -> Any:
-            typed_request = graph_module.GraphRunRequest(**asdict(request))
-            return graph_module.GraphRunResult(
-                session=typed_request.session,
-                output=typed_request.prompt,
-            )
-
     runtime = StubRuntime()
-    graph_runner = StubGraphRunner()
 
     assert isinstance(runtime, runtime_module.RuntimeEntrypoint)
     assert isinstance(runtime, runtime_module.StreamingRuntimeEntrypoint)
-    assert isinstance(graph_runner, graph_module.GraphRunner)
     assert runtime.run(runtime_module.RuntimeRequest(prompt="hello")).output == "HELLO"
     stream = runtime.run_stream(runtime_module.RuntimeRequest(prompt="hello"))
     assert isinstance(stream, Iterator)
     assert [chunk.session.status for chunk in stream] == ["running", "completed"]
-    assert (
-        graph_runner.run(
-            graph_module.GraphRunRequest(
-                session=runtime_module.SessionState(
-                    session=runtime_module.SessionRef(id="session-1")
-                ),
-                prompt="hi",
-            )
-        ).output
-        == "hi"
-    )
 
 
 def test_contract_types_expose_explicit_annotations() -> None:
     runtime = _runtime_module()
-    graph = _graph_module()
     tools = _tools_module()
 
     runtime_request_hints = get_type_hints(runtime.RuntimeRequest)
     background_task_result_hints = get_type_hints(runtime.BackgroundTaskResult)
     background_task_hints = get_type_hints(runtime.BackgroundTaskState)
     tool_result_hints = get_type_hints(tools.ToolResult)
-    graph_runner_hints = get_type_hints(graph.GraphRunner.run)
 
     assert runtime_request_hints["prompt"] is str
     assert background_task_result_hints["task_id"] is str
@@ -225,8 +198,6 @@ def test_contract_types_expose_explicit_annotations() -> None:
     assert str(background_task_hints["status"]) == "BackgroundTaskStatus"
     assert tool_result_hints["tool_name"] is str
     assert str(tool_result_hints["status"]) == "ToolResultStatus"
-    assert graph_runner_hints["request"] is graph.GraphRunRequest
-    assert graph_runner_hints["return"] is graph.GraphRunResult
 
 
 def test_runtime_stream_chunk_validates_required_fields() -> None:

--- a/tests/unit/runtime/test_http_question_payload_fuzz.py
+++ b/tests/unit/runtime/test_http_question_payload_fuzz.py
@@ -8,6 +8,10 @@ from hypothesis import strategies as st
 
 from voidcode.runtime.http import RuntimeTransportApp
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:unclosed database in <sqlite3.Connection object.*:ResourceWarning"
+)
+
 CI_SETTINGS = settings(derandomize=True, database=None, deadline=None, max_examples=200)
 
 _text_chars = st.characters(


### PR DESCRIPTION
## Summary
- tighten the graph surface by dropping dead graph contract exports and narrowing `GraphRunRequest`/step invariants to the provider-facing boundary
- harden `ProviderGraph` terminal handling for malformed streams, mixed terminal outcomes, missing `done`, and stream error kind precedence while preserving runtime-facing parsed error details
- extend graph regression coverage and filter the known sqlite `ResourceWarning` in the runtime fuzz test so the final test run stays clean

## Verification
- `uv run --active ruff check .`
- `uv run --active basedpyright`
- `uv run --active pytest tests/unit/graph/test_single_agent_slice.py tests/unit/runtime/test_backend_contracts.py tests/unit/runtime/test_http_question_payload_fuzz.py tests/integration/test_read_only_slice.py`
- `uv run --active pytest`

## Notes
- locks in two stream error contracts: provider JSON `parsed.details` are preserved for runtime-facing handling, and parsed JSON classification wins over a generic `error_kind=\"transient_failure\"`
- closes #208