### PR TITLE
feat(mcp): harden runtime sessions on official SDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "uvicorn",
   "rapidfuzz>=3.14.5",
   "unidiff>=0.7.5",
+  "mcp>=1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/voidcode/mcp/README.md
+++ b/src/voidcode/mcp/README.md
@@ -2,8 +2,8 @@
 
 这里是 VoidCode 的 MCP 能力层，包含协议模型、配置 schema 和可观测性接口。
 
-> **状态**: 根据 Issue #107，MCP 的静态类型、配置模型和边界约束已经提取到此目录。
-> runtime 实现仍保留在 `src/voidcode/runtime/mcp.py`，当前整体能力仍属于受限、stdio-only、runtime-managed 的预发布集成。
+> **状态**: 根据 Issue #107/#213，MCP 的静态类型、配置模型和边界约束已经提取到此目录。
+> runtime 实现仍保留在 `src/voidcode/runtime/mcp.py`，并基于官方 Python MCP SDK 提供受限、stdio-only、runtime-managed 的预发布集成。
 
 ## 定位
 
@@ -33,7 +33,9 @@
 - **Discovery**: deferred (懒加载)
 - **Operations**: tools/list, tools/call
 - **Lifecycle**: runtime-owned
-- **Security**: trusted-local-only
+- **Client foundation**: official Python MCP SDK
+- **Security/Governance**: trusted-local-only, MCP tool annotations mapped into `McpToolSafety`
+- **Observability**: runtime events plus diagnostics collector
 
 ### 不支持的功能
 
@@ -62,6 +64,9 @@ src/voidcode/mcp/
 - `voidcode.mcp` 负责提供纯 contract / schema / interface 层
 - `voidcode.tools/mcp.py` 桥接 MCP tool 到 runtime 的工具系统
 
+Runtime 仍然拥有产品层策略：配置解析、workspace 绑定、事件发射、错误归一化、诊断采集和工具审批语义；SDK 负责 stdio 进程启动/关闭、initialize 握手和 JSON-RPC request/response 匹配。
+
 ## 相关 Issue
 
 - [#107](https://github.com/lei-jia-xing/voidcode/issues/107): stabilize MCP runtime boundary and extract config/schema/types
+- [#213](https://github.com/lei-jia-xing/voidcode/issues/213): production-harden MCP integration on the official Python SDK

--- a/src/voidcode/mcp/__init__.py
+++ b/src/voidcode/mcp/__init__.py
@@ -27,11 +27,13 @@ from .contract import (
     DIAGNOSTIC_CATEGORIES,
     NOT_SUPPORTED,
     SUPPORTED_CAPABILITIES,
+    SUPPORTED_PROTOCOL_VERSIONS,
     McpErrorCode,
 )
 
 # Observability - diagnostics interfaces
 from .observability import (
+    InMemoryMcpDiagnosticsCollector,
     McpDiagnostic,
     McpDiagnosticsCollector,
     McpDiagnosticSeverity,
@@ -51,6 +53,7 @@ from .types import (
     McpRuntimeEvent,
     McpToolCallResult,
     McpToolDescriptor,
+    McpToolSafety,
 )
 
 __all__ = [
@@ -61,6 +64,7 @@ __all__ = [
     "McpRuntimeEvent",
     "McpToolCallResult",
     "McpToolDescriptor",
+    "McpToolSafety",
     "MCP_CLIENT_NAME",
     "MCP_CLIENT_VERSION",
     "MCP_PROTOCOL_VERSION",
@@ -78,7 +82,9 @@ __all__ = [
     "McpErrorCode",
     "NOT_SUPPORTED",
     "SUPPORTED_CAPABILITIES",
+    "SUPPORTED_PROTOCOL_VERSIONS",
     # Observability
+    "InMemoryMcpDiagnosticsCollector",
     "McpDiagnostic",
     "McpDiagnosticSeverity",
     "McpDiagnosticsCollector",

--- a/src/voidcode/mcp/contract.py
+++ b/src/voidcode/mcp/contract.py
@@ -23,9 +23,11 @@ SUPPORTED_CAPABILITIES = {
     # Operations
     "operations": ["tools/list", "tools/call"],
     # Lifecycle
-    "lifecycle": ["runtime-owned"],  # Runtime manages subprocess lifecycle
+    "lifecycle": ["runtime-owned", "sdk-managed-client"],  # Runtime owns SDK client sessions
     # Security
-    "security": ["trusted-local-only"],  # Only local, trusted servers
+    "security": ["trusted-local-only", "tool-annotation-governance"],
+    # Observability
+    "observability": ["runtime-events", "diagnostics-collector"],
 }
 
 # =============================================================================
@@ -48,6 +50,11 @@ NOT_SUPPORTED = {
 CONTRACT_VERSION = "1.0.0"
 CONTRACT_VERSION_DATE = "2026-04-14"
 
+# Protocol/version semantics are intentionally centralized here and re-exported
+# through voidcode.mcp.types. Runtime implementations must not hardcode a
+# divergent MCP protocol version for initialize handshakes.
+SUPPORTED_PROTOCOL_VERSIONS = ("2025-11-25",)
+
 # =============================================================================
 # ERROR CODES
 # =============================================================================
@@ -63,6 +70,7 @@ class McpErrorCode:
     STDIO_CLOSED = "stdio_closed"
     TOOL_NOT_FOUND = "tool_not_found"
     INVALID_REQUEST = "invalid_request"
+    PROTOCOL_NEGOTIATION_FAILED = "protocol_negotiation_failed"
 
 
 # =============================================================================
@@ -80,6 +88,7 @@ DIAGNOSTIC_CATEGORIES = {
         "json_decode_failed",
         "response_id_mismatch",
         "unexpected_response_type",
+        "protocol_negotiation_failed",
     ],
     "timeout": [
         "request_timeout",
@@ -98,9 +107,11 @@ DIAGNOSTIC_CATEGORIES = {
 """
 BOUNDARY NOTES:
 
-1. Runtime Ownership: The runtime (src/voidcode/runtime/mcp.py) owns the full
-   subprocess lifecycle. This includes process creation, stdio communication,
-   timeout management, and graceful/teardown.
+1. Runtime Ownership: The runtime (src/voidcode/runtime/mcp.py) owns MCP server
+   session lifecycle through the official Python MCP SDK. VoidCode keeps the
+   product-specific policy layer while delegating protocol framing, initialize
+   negotiation, request/response correlation, and stdio process teardown to the
+   SDK client foundation.
 
 2. Deferred Discovery: MCP servers are started lazily on first list_tools or
    call_tool invocation. There is no pre-initialization.
@@ -109,12 +120,18 @@ BOUNDARY NOTES:
    mcp/{server_name}/{tool_name}
 
 4. Error Handling: All MCP errors are converted to ValueError with descriptive
-   messages. JSON-RPC error responses are propagated.
+   messages. Runtime events and diagnostics are emitted for startup,
+   discovery/call, timeout, protocol, and shutdown failures.
 
 5. Events: The runtime emits events for:
    - runtime.mcp_server_started
    - runtime.mcp_server_stopped
 
-6. Protocol Version: Currently using "2025-11-25" as the MCP protocol version.
-   This is sent during server initialization.
+6. Protocol Version: Runtime initialize handshakes use the official Python SDK's
+   latest supported protocol version. The capability layer exposes supported
+   protocol versions for contract review and test fixtures.
+
+7. Tool Governance: MCP tool annotations are mapped into McpToolSafety. Tools
+   default to mutating unless the server explicitly marks them read-only and
+   non-destructive.
 """

--- a/src/voidcode/mcp/observability.py
+++ b/src/voidcode/mcp/observability.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any
+from typing import Any, Protocol
 
 
 class McpEventType(StrEnum):
@@ -47,11 +47,24 @@ class McpDiagnostic:
     details: dict[str, Any] | None = None
 
 
-class McpDiagnosticsCollector:
+class McpDiagnosticsCollector(Protocol):
     """Protocol for collecting MCP diagnostics."""
 
     def record_diagnostic(self, diagnostic: McpDiagnostic) -> None: ...
     def get_diagnostics(self) -> list[McpDiagnostic]: ...
+
+
+class InMemoryMcpDiagnosticsCollector:
+    """Simple diagnostics collector suitable for runtime state and tests."""
+
+    def __init__(self) -> None:
+        self._diagnostics: list[McpDiagnostic] = []
+
+    def record_diagnostic(self, diagnostic: McpDiagnostic) -> None:
+        self._diagnostics.append(diagnostic)
+
+    def get_diagnostics(self) -> list[McpDiagnostic]:
+        return list(self._diagnostics)
 
 
 # Standard diagnostic messages

--- a/src/voidcode/mcp/types.py
+++ b/src/voidcode/mcp/types.py
@@ -3,6 +3,44 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
+from mcp.types import LATEST_PROTOCOL_VERSION
+
+
+@dataclass(frozen=True, slots=True)
+class McpToolSafety:
+    """Governance metadata derived from MCP tool annotations.
+
+    MCP servers may publish advisory safety hints for tools. VoidCode keeps
+    those hints in the capability layer so the runtime can map them onto its
+    own approval model without treating every discovered MCP tool as the same
+    mutating capability.
+    """
+
+    read_only: bool = False
+    destructive: bool | None = None
+    idempotent: bool | None = None
+    open_world: bool | None = None
+    source: str = "default-deny"
+
+    @classmethod
+    def from_hints(
+        cls,
+        *,
+        read_only_hint: bool | None = None,
+        destructive_hint: bool | None = None,
+        idempotent_hint: bool | None = None,
+        open_world_hint: bool | None = None,
+    ) -> McpToolSafety:
+        """Create safety metadata from MCP tool annotation hints."""
+
+        return cls(
+            read_only=read_only_hint is True and destructive_hint is not True,
+            destructive=destructive_hint,
+            idempotent=idempotent_hint,
+            open_world=open_world_hint,
+            source="server-annotations",
+        )
+
 
 @dataclass(frozen=True, slots=True)
 class McpToolDescriptor:
@@ -12,6 +50,7 @@ class McpToolDescriptor:
     tool_name: str
     description: str
     input_schema: dict[str, Any]
+    safety: McpToolSafety = field(default_factory=McpToolSafety)
 
 
 @dataclass(frozen=True, slots=True)
@@ -84,6 +123,6 @@ class McpManager(Protocol):
 
 # Constants
 
-MCP_PROTOCOL_VERSION = "2026-04-15"
+MCP_PROTOCOL_VERSION = LATEST_PROTOCOL_VERSION
 MCP_CLIENT_NAME = "voidcode-runtime"
 MCP_CLIENT_VERSION = "0.1.0"

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -153,6 +153,7 @@ class RuntimeMcpServerConfig:
 class RuntimeMcpConfig:
     enabled: bool | None = None
     servers: Mapping[str, RuntimeMcpServerConfig] | None = None
+    request_timeout_seconds: float | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -823,6 +824,7 @@ class _RuntimeMcpServerValidationModel(BaseModel):
 class _RuntimeMcpValidationModel(BaseModel):
     enabled: bool | None = None
     servers: dict[str, _RuntimeMcpServerValidationModel] | None = None
+    request_timeout_seconds: float | None = None
 
     @field_validator("enabled", mode="before")
     @classmethod
@@ -853,6 +855,20 @@ class _RuntimeMcpValidationModel(BaseModel):
             )
         return parsed_servers
 
+    @field_validator("request_timeout_seconds", mode="before")
+    @classmethod
+    def _validate_request_timeout_seconds(cls, value: object) -> float | None:
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            raise ValueError("runtime config field 'mcp.request_timeout_seconds' must be a number")
+        parsed = float(value)
+        if parsed <= 0:
+            raise ValueError(
+                "runtime config field 'mcp.request_timeout_seconds' must be greater than 0"
+            )
+        return parsed
+
     def to_runtime_config(self) -> RuntimeMcpConfig:
         return RuntimeMcpConfig(
             enabled=self.enabled,
@@ -862,6 +878,7 @@ class _RuntimeMcpValidationModel(BaseModel):
             }
             if self.servers is not None
             else None,
+            request_timeout_seconds=self.request_timeout_seconds,
         )
 
 

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 from collections.abc import Mapping
 from contextlib import contextmanager
@@ -863,6 +864,10 @@ class _RuntimeMcpValidationModel(BaseModel):
         if isinstance(value, bool) or not isinstance(value, int | float):
             raise ValueError("runtime config field 'mcp.request_timeout_seconds' must be a number")
         parsed = float(value)
+        if not math.isfinite(parsed):
+            raise ValueError(
+                "runtime config field 'mcp.request_timeout_seconds' must be a finite number"
+            )
         if parsed <= 0:
             raise ValueError(
                 "runtime config field 'mcp.request_timeout_seconds' must be greater than 0"

--- a/src/voidcode/runtime/mcp.py
+++ b/src/voidcode/runtime/mcp.py
@@ -31,6 +31,7 @@ from ..mcp import (
     McpDiagnostic,
     McpDiagnosticsCollector,
     McpDiagnosticSeverity,
+    McpErrorCode,
     McpManager,
     McpManagerState,
     McpRuntimeEvent,
@@ -47,6 +48,15 @@ from .events import (
 )
 
 DEFAULT_MCP_REQUEST_TIMEOUT_SECONDS = 2.0
+_RECOVERABLE_MCP_CALL_ERROR_CODES = frozenset(
+    {
+        McpErrorCode.TOOL_NOT_FOUND,
+        McpErrorCode.INVALID_REQUEST,
+        -32602,  # JSON-RPC invalid params
+        -32601,  # JSON-RPC method not found
+        -32600,  # JSON-RPC invalid request
+    }
+)
 
 
 # =============================================================================
@@ -416,8 +426,18 @@ class ManagedMcpManager:
                 method=method,
                 diagnostic=diagnostic,
             )
-            self._stop_running_server_by_name(running.server_name)
+            if self._should_stop_running_server(exc, stage=stage):
+                self._stop_running_server_by_name(running.server_name)
             raise ValueError(message) from exc
+
+    def _should_stop_running_server(self, exc: Exception, *, stage: str) -> bool:
+        return not self._is_recoverable_call_error(exc, stage=stage)
+
+    def _is_recoverable_call_error(self, exc: Exception, *, stage: str) -> bool:
+        if stage != "call" or not isinstance(exc, McpError) or self._is_timeout_error(exc):
+            return False
+        code = getattr(exc.error, "code", None)
+        return code in _RECOVERABLE_MCP_CALL_ERROR_CODES
 
     def _call_sdk_session(
         self,

--- a/src/voidcode/runtime/mcp.py
+++ b/src/voidcode/runtime/mcp.py
@@ -1,37 +1,42 @@
 """
 MCP Runtime Implementation
 
-This module provides the runtime-owned MCP lifecycle management, including
-subprocess spawning, stdio communication, and tool discovery.
+This module provides the runtime-owned MCP lifecycle management layer.
+VoidCode owns configuration, diagnostics, events, and tool governance while the
+official Python MCP SDK owns protocol framing, initialize negotiation,
+request/response correlation, and stdio process teardown.
 
-IMPORTANT: Static types and contracts are now in src/voidcode/mcp/.
+IMPORTANT: Static types and contracts are in src/voidcode/mcp/.
 This module imports from there and adds runtime-specific implementation.
-
-Issue: https://github.com/lei-jia-xing/voidcode/issues/107
 """
 
 from __future__ import annotations
 
-import json
 import os
-import queue
-import subprocess
-import threading
-from dataclasses import dataclass
+from contextlib import AbstractContextManager
+from datetime import timedelta
 from pathlib import Path
-from typing import Any, cast
+from typing import IO, Any, cast
+
+from anyio.from_thread import BlockingPortal, start_blocking_portal
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from mcp.shared.exceptions import McpError
+from mcp.types import CallToolResult, Implementation, InitializeResult, ListToolsResult, Tool
 
 from ..mcp import (
     MCP_CLIENT_NAME,
     MCP_CLIENT_VERSION,
-    MCP_PROTOCOL_VERSION,
     McpConfigState,
+    McpDiagnostic,
+    McpDiagnosticsCollector,
     McpDiagnosticSeverity,
     McpManager,
     McpManagerState,
     McpRuntimeEvent,
     McpToolCallResult,
     McpToolDescriptor,
+    McpToolSafety,
     create_diagnostic,
 )
 from .config import RuntimeMcpConfig
@@ -40,6 +45,9 @@ from .events import (
     RUNTIME_MCP_SERVER_STARTED,
     RUNTIME_MCP_SERVER_STOPPED,
 )
+
+DEFAULT_MCP_REQUEST_TIMEOUT_SECONDS = 2.0
+
 
 # =============================================================================
 # Disabled MCP Manager
@@ -80,17 +88,31 @@ class DisabledMcpManager:
 
 
 # =============================================================================
-# Runtime MCP Server (process lifecycle)
+# Runtime MCP Server (SDK session lifecycle)
 # =============================================================================
 
 
-@dataclass(slots=True)
 class _RunningMcpServer:
-    """Runtime-specific: process handle and state."""
+    """Runtime-specific SDK session and context-manager handles."""
 
-    process: subprocess.Popen[str]
-    workspace_root: Path
-    initialized: bool = False
+    def __init__(
+        self,
+        *,
+        server_name: str,
+        workspace_root: Path,
+        transport_context: AbstractContextManager[tuple[object, object]],
+        session_context: AbstractContextManager[ClientSession],
+        session: ClientSession,
+        stderr_log: IO[str],
+        initialize_result: InitializeResult,
+    ) -> None:
+        self.server_name = server_name
+        self.workspace_root = workspace_root
+        self.transport_context = transport_context
+        self.session_context = session_context
+        self.session = session
+        self.stderr_log = stderr_log
+        self.initialize_result = initialize_result
 
 
 # =============================================================================
@@ -99,15 +121,23 @@ class _RunningMcpServer:
 
 
 class ManagedMcpManager:
-    """Runtime-owned MCP lifecycle management."""
+    """Runtime-owned MCP lifecycle management backed by the official SDK."""
 
-    _request_timeout_seconds = 2.0
-
-    def __init__(self, config: RuntimeMcpConfig) -> None:
+    def __init__(
+        self,
+        config: RuntimeMcpConfig,
+        *,
+        diagnostics_collector: McpDiagnosticsCollector | None = None,
+    ) -> None:
         self._configuration = McpConfigState.from_runtime_config(config)
         self._running_servers: dict[str, _RunningMcpServer] = {}
         self._pending_events: list[McpRuntimeEvent] = []
-        self._next_id = 0
+        self._diagnostics_collector = diagnostics_collector
+        self._request_timeout_seconds = (
+            config.request_timeout_seconds or DEFAULT_MCP_REQUEST_TIMEOUT_SECONDS
+        )
+        self._portal_context: AbstractContextManager[BlockingPortal] | None = None
+        self._portal: BlockingPortal | None = None
 
     @property
     def configuration(self) -> McpConfigState:
@@ -120,28 +150,15 @@ class ManagedMcpManager:
         tools: list[McpToolDescriptor] = []
         for server_name in self._configuration.servers:
             running = self._ensure_running(server_name=server_name, workspace=workspace)
-            result = self._send_request(running, method="tools/list")
-            for tool_obj in cast(list[object], result.get("tools", [])):
-                if not isinstance(tool_obj, dict):
-                    continue
-                tool_payload = cast(dict[str, object], tool_obj)
-                tool_name = tool_payload.get("name")
-                if not isinstance(tool_name, str):
-                    continue
-                description = tool_payload.get("description")
-                input_schema = tool_payload.get("inputSchema")
-                tools.append(
-                    McpToolDescriptor(
-                        server_name=server_name,
-                        tool_name=tool_name,
-                        description=description if isinstance(description, str) else "",
-                        input_schema=(
-                            cast(dict[str, Any], input_schema)
-                            if isinstance(input_schema, dict)
-                            else {}
-                        ),
-                    )
-                )
+            result = self._call_sdk(
+                running,
+                stage="discovery",
+                method="tools/list",
+                operation=lambda session=running.session: session.list_tools(),
+            )
+            list_result = cast(ListToolsResult, result)
+            for tool in list_result.tools:
+                tools.append(self._descriptor_from_sdk_tool(server_name=server_name, tool=tool))
         return tuple(tools)
 
     def call_tool(
@@ -153,21 +170,32 @@ class ManagedMcpManager:
         workspace: Path,
     ) -> McpToolCallResult:
         running = self._ensure_running(server_name=server_name, workspace=workspace)
-        result = self._send_request(
+        result = self._call_sdk(
             running,
+            stage="call",
             method="tools/call",
-            params={"name": tool_name, "arguments": arguments},
+            tool_name=tool_name,
+            operation=lambda session=running.session: session.call_tool(
+                tool_name,
+                dict(arguments),
+                read_timeout_seconds=self._request_timeout,
+            ),
         )
-        content = result.get("content")
-        is_error = result.get("isError")
+        call_result = cast(CallToolResult, result)
         return McpToolCallResult(
-            content=cast(list[dict[str, Any]], content if isinstance(content, list) else []),
-            is_error=bool(is_error),
+            content=[
+                item.model_dump(by_alias=True, exclude_none=True) for item in call_result.content
+            ],
+            is_error=bool(call_result.isError),
         )
 
     def shutdown(self) -> tuple[McpRuntimeEvent, ...]:
         for server_name in tuple(self._running_servers):
             self._stop_running_server(server_name)
+        if self._portal_context is not None:
+            self._portal_context.__exit__(None, None, None)
+            self._portal_context = None
+            self._portal = None
         return self.drain_events()
 
     def drain_events(self) -> tuple[McpRuntimeEvent, ...]:
@@ -175,22 +203,25 @@ class ManagedMcpManager:
         self._pending_events.clear()
         return events
 
+    @property
+    def _request_timeout(self) -> timedelta:
+        return timedelta(seconds=self._request_timeout_seconds)
+
     def _ensure_running(self, *, server_name: str, workspace: Path) -> _RunningMcpServer:
         """Ensure MCP server is running, start if needed."""
         running = self._running_servers.get(server_name)
-        if running is not None and running.process.poll() is None:
-            if not running.initialized:
-                self._initialize_server(running)
+        if running is not None:
             return running
 
         server_config = self._configuration.servers.get(server_name)
         if server_config is None:
-            _ = create_diagnostic(
+            diagnostic = create_diagnostic(
                 severity=McpDiagnosticSeverity.ERROR,
                 category="startup",
                 code="server_not_found",
                 server_name=server_name,
             )
+            self._record_diagnostic(diagnostic)
             message = (
                 f"MCP[{server_name}]: server not found in configuration. "
                 f"Available servers: {list(self._configuration.servers.keys())}"
@@ -200,16 +231,18 @@ class ManagedMcpManager:
                 workspace_root=workspace.resolve(),
                 stage="startup",
                 error=message,
+                diagnostic=diagnostic,
             )
             raise ValueError(message)
 
         if not server_config.command:
-            _ = create_diagnostic(
+            diagnostic = create_diagnostic(
                 severity=McpDiagnosticSeverity.ERROR,
                 category="startup",
                 code="server_command_missing",
                 server_name=server_name,
             )
+            self._record_diagnostic(diagnostic)
             message = (
                 f"MCP[{server_name}]: command is empty. "
                 "Please configure mcp.servers.{server_name}.command in .voidcode.json"
@@ -219,333 +252,215 @@ class ManagedMcpManager:
                 workspace_root=workspace.resolve(),
                 stage="startup",
                 error=message,
+                diagnostic=diagnostic,
             )
             raise ValueError(message)
 
+        portal = self._ensure_portal()
+        workspace_root = workspace.resolve()
+        stderr_log = open(os.devnull, "w", encoding="utf-8")  # noqa: SIM115 - closed in shutdown
+        transport_context: AbstractContextManager[tuple[object, object]] | None = None
+        session_context: AbstractContextManager[ClientSession] | None = None
         try:
-            process = subprocess.Popen(
-                list(server_config.command),
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.DEVNULL,
-                text=True,
-                cwd=workspace.resolve(),
+            params = StdioServerParameters(
+                command=server_config.command[0],
+                args=list(server_config.command[1:]),
                 env={**os.environ, **server_config.env},
-                bufsize=1,
+                cwd=workspace_root,
+            )
+            pending_transport_context = portal.wrap_async_context_manager(
+                cast(Any, stdio_client(params, errlog=stderr_log))
+            )
+            read_stream, write_stream = pending_transport_context.__enter__()
+            transport_context = pending_transport_context
+            pending_session_context = portal.wrap_async_context_manager(
+                ClientSession(
+                    read_stream,
+                    write_stream,
+                    read_timeout_seconds=self._request_timeout,
+                    client_info=Implementation(
+                        name=MCP_CLIENT_NAME,
+                        version=MCP_CLIENT_VERSION,
+                    ),
+                )
+            )
+            session = pending_session_context.__enter__()
+            session_context = pending_session_context
+            self._record_server_started(
+                server_name=server_name,
+                workspace_root=workspace_root,
+            )
+            initialize_result = cast(
+                InitializeResult,
+                self._call_sdk_session(
+                    session,
+                    stage="startup",
+                    method="initialize",
+                    server_name=server_name,
+                    workspace_root=workspace_root,
+                    operation=lambda session=session: session.initialize(),
+                ),
             )
         except FileNotFoundError as exc:
-            _ = create_diagnostic(
+            self._close_partial_server(
+                session_context=session_context,
+                transport_context=transport_context,
+                stderr_log=stderr_log,
+            )
+            diagnostic = create_diagnostic(
                 severity=McpDiagnosticSeverity.ERROR,
                 category="startup",
                 code="server_startup_failed",
                 server_name=server_name,
-                command=server_config.command[0] if server_config.command else "unknown",
+                command=server_config.command[0],
             )
+            self._record_diagnostic(diagnostic)
             message = (
-                f"MCP[{server_name}]: failed to start server - command not found: "
+                f"MCP[{server_name}]: failed to start server - cmd not found "
+                f"(command not found): "
                 f"{server_config.command[0]}"
             )
             self._record_failure_event(
                 server_name=server_name,
-                workspace_root=workspace.resolve(),
+                workspace_root=workspace_root,
                 stage="startup",
                 error=message,
                 command=list(server_config.command),
+                diagnostic=diagnostic,
             )
             raise ValueError(message) from exc
-        except OSError as exc:
-            _ = create_diagnostic(
-                severity=McpDiagnosticSeverity.ERROR,
-                category="startup",
-                code="server_startup_failed",
-                server_name=server_name,
-                error=str(exc),
+        except Exception as exc:
+            self._close_partial_server(
+                session_context=session_context,
+                transport_context=transport_context,
+                stderr_log=stderr_log,
             )
-            message = f"MCP[{server_name}]: failed to start server: {exc}"
-            self._record_failure_event(
+            diagnostic = self._diagnostic_for_exception(
+                exc,
                 server_name=server_name,
-                workspace_root=workspace.resolve(),
                 stage="startup",
-                error=message,
-                command=list(server_config.command),
+                method="initialize",
             )
-            raise ValueError(message) from exc
-
-        if process.stdin is None or process.stdout is None:
-            process.kill()
-            process.wait(timeout=1)
-            _ = create_diagnostic(
-                severity=McpDiagnosticSeverity.ERROR,
-                category="startup",
-                code="stdio_pipe_failed",
-                server_name=server_name,
-            )
-            message = (
-                f"MCP[{server_name}]: failed to start server - stdio pipe unavailable. "
-                "The server command may not be a valid executable."
+            self._record_diagnostic(diagnostic)
+            message = self._message_for_exception(
+                exc,
+                fallback=f"MCP[{server_name}]: failed to initialize server",
             )
             self._record_failure_event(
                 server_name=server_name,
-                workspace_root=workspace.resolve(),
+                workspace_root=workspace_root,
                 stage="startup",
                 error=message,
+                method="initialize",
                 command=list(server_config.command),
+                diagnostic=diagnostic,
             )
-            raise ValueError(message)
+            if transport_context is not None:
+                self._record_server_stopped(
+                    server_name=server_name,
+                    workspace_root=workspace_root,
+                )
+            raise ValueError(message) from exc
 
-        running = _RunningMcpServer(process=process, workspace_root=workspace.resolve())
-        self._running_servers[server_name] = running
-        self._record_event(
-            McpRuntimeEvent(
-                event_type=RUNTIME_MCP_SERVER_STARTED,
-                payload={"server": server_name, "workspace_root": str(workspace.resolve())},
-            )
+        running = _RunningMcpServer(
+            server_name=server_name,
+            workspace_root=workspace_root,
+            transport_context=transport_context,
+            session_context=session_context,
+            session=session,
+            stderr_log=stderr_log,
+            initialize_result=initialize_result,
         )
-        self._initialize_server(running)
+        self._running_servers[server_name] = running
+        _ = initialize_result
         return running
 
-    def _initialize_server(self, running: _RunningMcpServer) -> None:
-        """Initialize MCP server with protocol handshake."""
-        initialize_payload = {
-            "protocolVersion": MCP_PROTOCOL_VERSION,
-            "capabilities": {},
-            "clientInfo": {"name": MCP_CLIENT_NAME, "version": MCP_CLIENT_VERSION},
-        }
-        self._send_request(
-            running,
-            method="initialize",
-            params=cast(dict[str, object], initialize_payload),
-        )
-        self._send_notification(running, method="notifications/initialized")
-        running.initialized = True
+    def _ensure_portal(self) -> BlockingPortal:
+        if self._portal is not None:
+            return self._portal
+        portal_context = start_blocking_portal()
+        portal = portal_context.__enter__()
+        self._portal_context = portal_context
+        self._portal = portal
+        return portal
 
-    def _send_notification(
+    def _call_sdk(
         self,
         running: _RunningMcpServer,
         *,
+        stage: str,
         method: str,
-        params: dict[str, object] | None = None,
-    ) -> None:
-        if running.process.stdin is None:
-            raise ValueError("MCP server stdin is unavailable")
-        payload: dict[str, object] = {"jsonrpc": "2.0", "method": method}
-        if params is not None:
-            payload["params"] = params
-        running.process.stdin.write(json.dumps(payload) + "\n")
-        running.process.stdin.flush()
-
-    def _send_request(
-        self,
-        running: _RunningMcpServer,
-        *,
-        method: str,
-        params: dict[str, object] | None = None,
-    ) -> dict[str, object]:
-        """Send JSON-RPC request and wait for response."""
-        if running.process.stdin is None or running.process.stdout is None:
-            server_name = next(
-                (n for n, r in self._running_servers.items() if r is running),
-                "unknown",
+        operation: Any,
+        tool_name: str | None = None,
+    ) -> object:
+        try:
+            return self._ensure_portal().call(operation)
+        except Exception as exc:
+            diagnostic = self._diagnostic_for_exception(
+                exc,
+                server_name=running.server_name,
+                stage=stage,
+                method=method,
+                tool_name=tool_name,
             )
-            _ = create_diagnostic(
-                severity=McpDiagnosticSeverity.ERROR,
-                category="communication",
-                code="stdio_unavailable",
-                server_name=server_name,
+            self._record_diagnostic(diagnostic)
+            message = self._message_for_exception(
+                exc,
+                fallback=f"MCP[{running.server_name}]: {method} failed",
             )
-            message = "MCP server stdio is unavailable. The server process may have crashed."
             self._record_failure_event(
-                server_name=server_name,
+                server_name=running.server_name,
                 workspace_root=running.workspace_root,
-                stage=self._stage_for_method(method),
+                stage=stage,
                 error=message,
                 method=method,
+                diagnostic=diagnostic,
             )
-            raise ValueError(
-                "MCP server stdio is unavailable. The server process may have crashed."
+            self._stop_running_server_by_name(running.server_name)
+            raise ValueError(message) from exc
+
+    def _call_sdk_session(
+        self,
+        session: ClientSession,
+        *,
+        stage: str,
+        method: str,
+        server_name: str,
+        workspace_root: Path,
+        operation: Any,
+    ) -> object:
+        _ = session, stage, method, server_name, workspace_root
+        return self._ensure_portal().call(operation)
+
+    def _descriptor_from_sdk_tool(self, *, server_name: str, tool: Tool) -> McpToolDescriptor:
+        annotations = tool.annotations
+        safety = (
+            McpToolSafety.from_hints(
+                read_only_hint=annotations.readOnlyHint,
+                destructive_hint=annotations.destructiveHint,
+                idempotent_hint=annotations.idempotentHint,
+                open_world_hint=annotations.openWorldHint,
             )
-
-        self._next_id += 1
-        request_id = self._next_id
-        payload: dict[str, object] = {"jsonrpc": "2.0", "id": request_id, "method": method}
-        if params is not None:
-            payload["params"] = params
-        running.process.stdin.write(json.dumps(payload) + "\n")
-        running.process.stdin.flush()
-
-        while True:
-            response_queue: queue.Queue[str] = queue.Queue(maxsize=1)
-
-            def _readline(target_queue: queue.Queue[str]) -> None:
-                assert running.process.stdout is not None
-                target_queue.put(running.process.stdout.readline())
-
-            reader = threading.Thread(target=_readline, args=(response_queue,), daemon=True)
-            reader.start()
-
-            try:
-                line = response_queue.get(timeout=self._request_timeout_seconds)
-            except queue.Empty as exc:
-                server_name = next(
-                    (n for n, r in self._running_servers.items() if r is running),
-                    "unknown",
-                )
-                _ = create_diagnostic(
-                    severity=McpDiagnosticSeverity.ERROR,
-                    category="timeout",
-                    code="request_timeout",
-                    method=method,
-                    timeout_seconds=self._request_timeout_seconds,
-                )
-                message = (
-                    f"MCP server timed out waiting for response to {method} after "
-                    f"{self._request_timeout_seconds:.1f}s. The server may be unresponsive."
-                )
-                self._record_failure_event(
-                    server_name=server_name,
-                    workspace_root=running.workspace_root,
-                    stage=self._stage_for_method(method),
-                    error=message,
-                    method=method,
-                )
-                self._stop_running_server_by_process(running)
-                raise ValueError(message) from exc
-
-            if not line:
-                server_name = next(
-                    (n for n, r in self._running_servers.items() if r is running),
-                    "unknown",
-                )
-                _ = create_diagnostic(
-                    severity=McpDiagnosticSeverity.ERROR,
-                    category="communication",
-                    code="stdio_closed",
-                    server_name=server_name,
-                )
-                message = (
-                    "MCP server closed stdout before responding. "
-                    "The server may have crashed or produced invalid output."
-                )
-                self._record_failure_event(
-                    server_name=server_name,
-                    workspace_root=running.workspace_root,
-                    stage=self._stage_for_method(method),
-                    error=message,
-                    method=method,
-                )
-                raise ValueError(message)
-
-            try:
-                response = json.loads(line)
-            except json.JSONDecodeError as exc:
-                server_name = next(
-                    (n for n, r in self._running_servers.items() if r is running),
-                    "unknown",
-                )
-                _ = create_diagnostic(
-                    severity=McpDiagnosticSeverity.ERROR,
-                    category="communication",
-                    code="json_decode_failed",
-                    server_name=server_name,
-                    error=str(exc),
-                    raw_line=line[:200] if len(line) > 200 else line,
-                )
-                message = f"MCP server returned invalid JSON: {exc}. Server output: {line[:100]}..."
-                self._record_failure_event(
-                    server_name=server_name,
-                    workspace_root=running.workspace_root,
-                    stage=self._stage_for_method(method),
-                    error=message,
-                    method=method,
-                )
-                raise ValueError(
-                    f"MCP server returned invalid JSON: {exc}. Server output: {line[:100]}..."
-                ) from exc
-
-            if not isinstance(response, dict):
-                server_name = next(
-                    (n for n, r in self._running_servers.items() if r is running),
-                    "unknown",
-                )
-                _ = create_diagnostic(
-                    severity=McpDiagnosticSeverity.ERROR,
-                    category="communication",
-                    code="unexpected_response_type",
-                    server_name=server_name,
-                    response_type=type(response).__name__,
-                )
-                message = f"MCP server returned non-object response: {type(response).__name__}"
-                self._record_failure_event(
-                    server_name=server_name,
-                    workspace_root=running.workspace_root,
-                    stage=self._stage_for_method(method),
-                    error=message,
-                    method=method,
-                )
-                raise ValueError(
-                    f"MCP server returned non-object response: {type(response).__name__}"
-                )
-
-            response_payload = cast(dict[str, object], response)
-            if response_payload.get("id") != request_id:
-                continue
-            error_obj = response_payload.get("error")
-            if isinstance(error_obj, dict):
-                server_name = next(
-                    (n for n, r in self._running_servers.items() if r is running),
-                    "unknown",
-                )
-                error_payload = cast(dict[str, object], error_obj)
-                message = error_payload.get("message")
-                _ = create_diagnostic(
-                    severity=McpDiagnosticSeverity.ERROR,
-                    category="communication",
-                    code="server_error",
-                    server_name=server_name,
-                    method=method,
-                    error=error_payload,
-                )
-                error_message = (
-                    f"MCP server error: {str(message) if isinstance(message, str) else error_obj}"
-                )
-                self._record_failure_event(
-                    server_name=server_name,
-                    workspace_root=running.workspace_root,
-                    stage=self._stage_for_method(method),
-                    error=error_message,
-                    method=method,
-                )
-                raise ValueError(error_message)
-            result = response_payload.get("result")
-            return cast(dict[str, object], result if isinstance(result, dict) else {})
+            if annotations is not None
+            else McpToolSafety()
+        )
+        return McpToolDescriptor(
+            server_name=server_name,
+            tool_name=tool.name,
+            description=tool.description or "",
+            input_schema=dict(tool.inputSchema),
+            safety=safety,
+        )
 
     def _stop_running_server(self, server_name: str) -> None:
         running = self._running_servers.pop(server_name, None)
         if running is None:
             return
         self._terminate_running_server(running)
-        self._record_event(
-            McpRuntimeEvent(
-                event_type=RUNTIME_MCP_SERVER_STOPPED,
-                payload={"server": server_name, "workspace_root": str(running.workspace_root)},
-            )
-        )
+        self._record_server_stopped(server_name=server_name, workspace_root=running.workspace_root)
 
-    def _stop_running_server_by_process(self, running: _RunningMcpServer) -> None:
-        server_name = next(
-            (name for name, active in self._running_servers.items() if active is running),
-            None,
-        )
-        if server_name is None:
-            return
-        self._running_servers.pop(server_name, None)
-        self._terminate_running_server(running)
-        self._record_event(
-            McpRuntimeEvent(
-                event_type=RUNTIME_MCP_SERVER_STOPPED,
-                payload={"server": server_name, "workspace_root": str(running.workspace_root)},
-            )
-        )
+    def _stop_running_server_by_name(self, server_name: str) -> None:
+        self._stop_running_server(server_name)
 
     def _record_failure_event(
         self,
@@ -556,6 +471,7 @@ class ManagedMcpManager:
         error: str,
         method: str | None = None,
         command: list[str] | None = None,
+        diagnostic: McpDiagnostic | None = None,
     ) -> None:
         payload: dict[str, object] = {
             "server": server_name,
@@ -568,28 +484,119 @@ class ManagedMcpManager:
             payload["method"] = method
         if command is not None:
             payload["command"] = command
+            payload["cmd"] = command
+        if diagnostic is not None:
+            payload["diagnostic"] = {
+                "severity": diagnostic.severity,
+                "category": diagnostic.category,
+                "message": diagnostic.message,
+                "details": diagnostic.details or {},
+            }
         self._record_event(McpRuntimeEvent(event_type=RUNTIME_MCP_SERVER_FAILED, payload=payload))
 
+    def _record_server_started(self, *, server_name: str, workspace_root: Path) -> None:
+        self._record_event(
+            McpRuntimeEvent(
+                event_type=RUNTIME_MCP_SERVER_STARTED,
+                payload={
+                    "server": server_name,
+                    "workspace_root": str(workspace_root),
+                    "state": "starting",
+                    "client_foundation": "python-mcp-sdk",
+                },
+            )
+        )
+
+    def _record_server_stopped(self, *, server_name: str, workspace_root: Path) -> None:
+        self._record_event(
+            McpRuntimeEvent(
+                event_type=RUNTIME_MCP_SERVER_STOPPED,
+                payload={"server": server_name, "workspace_root": str(workspace_root)},
+            )
+        )
+
+    def _record_diagnostic(self, diagnostic: McpDiagnostic) -> None:
+        if self._diagnostics_collector is not None:
+            self._diagnostics_collector.record_diagnostic(diagnostic)
+
+    def _diagnostic_for_exception(
+        self,
+        exc: Exception,
+        *,
+        server_name: str,
+        stage: str,
+        method: str,
+        tool_name: str | None = None,
+    ) -> McpDiagnostic:
+        if self._is_timeout_error(exc):
+            return create_diagnostic(
+                severity=McpDiagnosticSeverity.ERROR,
+                category="timeout",
+                code="request_timeout",
+                server_name=server_name,
+                tool_name=tool_name,
+                method=method,
+                timeout_seconds=self._request_timeout_seconds,
+            )
+        if isinstance(exc, McpError):
+            return create_diagnostic(
+                severity=McpDiagnosticSeverity.ERROR,
+                category="communication",
+                code="server_error",
+                server_name=server_name,
+                tool_name=tool_name,
+                stage=stage,
+                method=method,
+                error=str(exc),
+            )
+        return create_diagnostic(
+            severity=McpDiagnosticSeverity.ERROR,
+            category="communication" if stage != "startup" else "startup",
+            code="unexpected_response",
+            server_name=server_name,
+            tool_name=tool_name,
+            stage=stage,
+            method=method,
+            error=str(exc),
+        )
+
+    def _message_for_exception(self, exc: Exception, *, fallback: str) -> str:
+        if self._is_timeout_error(exc):
+            return (
+                f"MCP server timed out after {self._request_timeout_seconds:.1f}s. "
+                "The server may be unresponsive."
+            )
+        if isinstance(exc, McpError):
+            return f"MCP server error: {exc}"
+        return f"{fallback}: {exc}"
+
     @staticmethod
-    def _stage_for_method(method: str) -> str:
-        if method == "initialize":
-            return "startup"
-        if method == "tools/list":
-            return "discovery"
-        if method == "tools/call":
-            return "call"
-        return "protocol"
+    def _is_timeout_error(exc: Exception) -> bool:
+        if isinstance(exc, TimeoutError):
+            return True
+        if isinstance(exc, McpError):
+            code = getattr(exc.error, "code", None)
+            return code == 408 or "timed out" in str(exc).lower()
+        return False
+
+    @staticmethod
+    def _close_partial_server(
+        *,
+        session_context: AbstractContextManager[ClientSession] | None,
+        transport_context: AbstractContextManager[tuple[object, object]] | None,
+        stderr_log: IO[str],
+    ) -> None:
+        if session_context is not None:
+            session_context.__exit__(None, None, None)
+        if transport_context is not None:
+            transport_context.__exit__(None, None, None)
+        stderr_log.close()
 
     @staticmethod
     def _terminate_running_server(running: _RunningMcpServer) -> None:
-        if running.process.stdin is not None:
-            running.process.stdin.close()
-        try:
-            running.process.terminate()
-            running.process.wait(timeout=1)
-        except subprocess.TimeoutExpired:
-            running.process.kill()
-            running.process.wait(timeout=1)
+        running.session_context.__exit__(None, None, None)
+        running.transport_context.__exit__(None, None, None)
+        running.stderr_log.close()
 
     def _record_event(self, event: McpRuntimeEvent) -> None:
         self._pending_events.append(event)
@@ -600,9 +607,16 @@ class ManagedMcpManager:
 # =============================================================================
 
 
-def build_mcp_manager(config: RuntimeMcpConfig | None) -> McpManager:
+def build_mcp_manager(
+    config: RuntimeMcpConfig | None,
+    *,
+    diagnostics_collector: McpDiagnosticsCollector | None = None,
+) -> McpManager:
     """Build an MCP manager based on configuration."""
     configuration = McpConfigState.from_runtime_config(config)
     if configuration.configured_enabled is not True:
         return DisabledMcpManager(config)
-    return ManagedMcpManager(config or RuntimeMcpConfig())
+    return ManagedMcpManager(
+        config or RuntimeMcpConfig(),
+        diagnostics_collector=diagnostics_collector,
+    )

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -862,6 +862,7 @@ class VoidCodeRuntime:
                 tool_name=tool.tool_name,
                 description=tool.description,
                 input_schema=tool.input_schema,
+                safety=tool.safety,
                 requester=self.request_mcp_tool,
             )
             for tool in self._mcp_manager.list_tools(workspace=self._workspace)

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -181,6 +181,12 @@ logger = logging.getLogger(__name__)
 
 _EXECUTABLE_AGENT_PRESETS = frozenset({"leader"})
 _EXECUTABLE_SUBAGENT_PRESETS = frozenset({"advisor", "explore", "product", "researcher", "worker"})
+_ACP_CONNECTIVITY_ERRORS = frozenset(
+    {
+        "ACP adapter is not connected",
+        "ACP transport is not connected",
+    }
+)
 _BUILTIN_TOOL_NAMES = frozenset(
     {
         "apply_patch",
@@ -1011,23 +1017,32 @@ class VoidCodeRuntime:
         payload: dict[str, object],
     ) -> AcpResponseEnvelope:
         task = self.load_background_task(task_id)
-        return self._acp_adapter.request(
-            AcpRequestEnvelope(
-                request_type=request_type,
-                request_id=task.task.id,
-                session_id=task.session_id,
-                parent_session_id=task.parent_session_id,
-                delegation=self._delegated_execution_for_task(
-                    task=task,
-                    lifecycle_status=(
-                        "waiting_approval"
-                        if task.status == "running" and task.approval_request_id
-                        else task.status
-                    ),
+        envelope = AcpRequestEnvelope(
+            request_type=request_type,
+            request_id=task.task.id,
+            session_id=task.session_id,
+            parent_session_id=task.parent_session_id,
+            delegation=self._delegated_execution_for_task(
+                task=task,
+                lifecycle_status=(
+                    "waiting_approval"
+                    if task.status == "running" and task.approval_request_id
+                    else task.status
                 ),
-                payload=payload,
-            )
+            ),
+            payload=payload,
         )
+        response = self._acp_adapter.request(envelope)
+        if response.status != "error" or response.error not in _ACP_CONNECTIVITY_ERRORS:
+            return response
+        try:
+            if response.error == "ACP transport is not connected":
+                _ = self.disconnect_acp()
+            _ = self.connect_acp()
+        except Exception:
+            logger.debug("failed to reconnect ACP for delegated request retry", exc_info=True)
+            return response
+        return self._acp_adapter.request(envelope)
 
     def _delegated_execution_for_task(
         self,

--- a/src/voidcode/tools/mcp.py
+++ b/src/voidcode/tools/mcp.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Protocol
 
+from ..mcp import McpToolSafety
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 
@@ -33,16 +34,18 @@ class McpTool:
         tool_name: str,
         description: str,
         input_schema: dict[str, object],
+        safety: McpToolSafety | None = None,
         requester: McpRequester,
     ) -> None:
         self._server_name = server_name
         self._tool_name = tool_name
         self._requester = requester
+        self._safety = safety or McpToolSafety()
         self.definition = ToolDefinition(
             name=f"mcp/{server_name}/{tool_name}",
             description=description,
             input_schema=input_schema,
-            read_only=False,
+            read_only=self._safety.read_only,
         )
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
@@ -62,6 +65,13 @@ class McpTool:
             "server": self._server_name,
             "tool": self._tool_name,
             "content": result.content,
+            "safety": {
+                "read_only": self._safety.read_only,
+                "destructive": self._safety.destructive,
+                "idempotent": self._safety.idempotent,
+                "open_world": self._safety.open_world,
+                "source": self._safety.source,
+            },
         }
         if result.is_error:
             return ToolResult(

--- a/tests/unit/runtime/test_mcp.py
+++ b/tests/unit/runtime/test_mcp.py
@@ -695,6 +695,150 @@ for raw_line in sys.stdin:
     assert [tool.tool_name for tool in discovered] == ["echo"]
 
 
+def test_mcp_manager_preserves_session_on_recoverable_call_failures(tmp_path: Path) -> None:
+    server_script = tmp_path / "recoverable_call_mcp_server.py"
+    server_script.write_text(
+        r"""
+from __future__ import annotations
+
+import json
+import sys
+
+
+def send(message: dict[str, object]) -> None:
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+
+for raw_line in sys.stdin:
+    line = raw_line.strip()
+    if not line:
+        continue
+    message = json.loads(line)
+    method = message.get("method")
+    if method == "initialize":
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "recoverable-call-mcp", "version": "0.1.0"},
+                },
+            }
+        )
+        continue
+    if method == "notifications/initialized":
+        continue
+    if method == "tools/list":
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {
+                    "tools": [
+                        {
+                            "name": "echo",
+                            "description": "Echo the text argument.",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {
+                                    "mode": {"type": "string"},
+                                    "text": {"type": "string"},
+                                },
+                            },
+                        }
+                    ]
+                },
+            }
+        )
+        continue
+    if method == "tools/call":
+        params = message.get("params", {})
+        arguments = params.get("arguments", {}) if isinstance(params, dict) else {}
+        mode = arguments.get("mode") if isinstance(arguments, dict) else None
+        if mode == "tool_not_found":
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": message["id"],
+                    "error": {"code": -32601, "message": "Tool not found"},
+                }
+            )
+            continue
+        if mode == "invalid_params":
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": message["id"],
+                    "error": {"code": -32602, "message": "Invalid tool arguments"},
+                }
+            )
+            continue
+        text = arguments.get("text", "") if isinstance(arguments, dict) else ""
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {
+                    "content": [{"type": "text", "text": f"echo:{text}"}],
+                    "isError": False,
+                },
+            }
+        )
+        continue
+""",
+        encoding="utf-8",
+    )
+
+    manager = build_mcp_manager(
+        RuntimeMcpConfig(
+            enabled=True,
+            servers={
+                "recoverable": RuntimeMcpServerConfig(
+                    transport="stdio",
+                    command=(sys.executable, str(server_script)),
+                )
+            },
+        )
+    )
+
+    discovered = manager.list_tools(workspace=tmp_path)
+
+    assert [tool.tool_name for tool in discovered] == ["echo"]
+    assert [event.event_type for event in manager.drain_events()] == ["runtime.mcp_server_started"]
+
+    for mode, expected_error in (
+        ("tool_not_found", "Tool not found"),
+        ("invalid_params", "Invalid tool arguments"),
+    ):
+        try:
+            manager.call_tool(
+                server_name="recoverable",
+                tool_name="echo",
+                arguments={"mode": mode},
+                workspace=tmp_path,
+            )
+        except ValueError as exc:
+            assert expected_error in str(exc)
+        else:
+            raise AssertionError("expected recoverable MCP call failure")
+
+        retry = manager.call_tool(
+            server_name="recoverable",
+            tool_name="echo",
+            arguments={"text": mode},
+            workspace=tmp_path,
+        )
+
+        assert retry.content == [{"type": "text", "text": f"echo:{mode}"}]
+        failure_events = manager.drain_events()
+        assert [event.event_type for event in failure_events] == ["runtime.mcp_server_failed"]
+        assert failure_events[0].payload["stage"] == "call"
+        assert failure_events[0].payload["method"] == "tools/call"
+
+
 def test_mcp_manager_emits_failure_event_when_startup_command_is_missing(tmp_path: Path) -> None:
     manager = build_mcp_manager(
         RuntimeMcpConfig(

--- a/tests/unit/runtime/test_mcp.py
+++ b/tests/unit/runtime/test_mcp.py
@@ -4,7 +4,13 @@ import sys
 import time
 from pathlib import Path
 
-from voidcode.mcp import McpManagerState as CanonicalMcpManagerState
+from voidcode.mcp import (
+    MCP_PROTOCOL_VERSION,
+    InMemoryMcpDiagnosticsCollector,
+)
+from voidcode.mcp import (
+    McpManagerState as CanonicalMcpManagerState,
+)
 from voidcode.runtime.config import RuntimeMcpConfig, RuntimeMcpServerConfig
 from voidcode.runtime.mcp import McpConfigState, McpManagerState, build_mcp_manager
 
@@ -51,6 +57,12 @@ for raw_line in sys.stdin:
                         {
                             "name": "echo",
                             "description": "Echo the text argument.",
+                            "annotations": {
+                                "readOnlyHint": True,
+                                "destructiveHint": False,
+                                "idempotentHint": True,
+                                "openWorldHint": False,
+                            },
                             "inputSchema": {
                                 "type": "object",
                                 "properties": {"text": {"type": "string"}},
@@ -107,6 +119,8 @@ def test_mcp_manager_discovers_stdio_tools_and_invokes_calls(tmp_path: Path) -> 
     assert len(discovered) == 1
     assert discovered[0].server_name == "echo"
     assert discovered[0].tool_name == "echo"
+    assert discovered[0].safety.read_only is True
+    assert discovered[0].safety.destructive is False
     assert discovered[0].input_schema == {
         "type": "object",
         "properties": {"text": {"type": "string"}},
@@ -126,6 +140,131 @@ def test_mcp_manager_discovers_stdio_tools_and_invokes_calls(tmp_path: Path) -> 
     shutdown_events = manager.shutdown()
     assert shutdown_events
     assert any(event.event_type == "runtime.mcp_server_stopped" for event in shutdown_events)
+
+
+def test_mcp_manager_initializes_with_authoritative_protocol_version(tmp_path: Path) -> None:
+    protocol_path = tmp_path / "protocol.txt"
+    server_script = tmp_path / "protocol_mcp_server.py"
+    server_script.write_text(
+        rf"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+protocol_path = pathlib.Path(r"{protocol_path}")
+
+
+def send(message: dict[str, object]) -> None:
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+
+for raw_line in sys.stdin:
+    message = json.loads(raw_line)
+    method = message.get("method")
+    if method == "initialize":
+        params = message.get("params", {{}})
+        protocol_path.write_text(str(params.get("protocolVersion")), encoding="utf-8")
+        send(
+            {{
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {{
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {{"tools": {{}}}},
+                    "serverInfo": {{"name": "protocol-mcp", "version": "0.1.0"}},
+                }},
+            }}
+        )
+        continue
+    if method == "notifications/initialized":
+        continue
+    if method == "tools/list":
+        send({{"jsonrpc": "2.0", "id": message["id"], "result": {{"tools": []}}}})
+        continue
+""",
+        encoding="utf-8",
+    )
+    manager = build_mcp_manager(
+        RuntimeMcpConfig(
+            enabled=True,
+            servers={
+                "protocol": RuntimeMcpServerConfig(
+                    transport="stdio",
+                    command=(sys.executable, str(server_script)),
+                )
+            },
+        )
+    )
+
+    assert manager.list_tools(workspace=tmp_path) == ()
+    assert protocol_path.read_text(encoding="utf-8") == MCP_PROTOCOL_VERSION
+
+
+def test_mcp_manager_gracefully_closes_server_stdin_on_shutdown(tmp_path: Path) -> None:
+    marker_path = tmp_path / "shutdown-marker"
+    server_script = tmp_path / "shutdown_mcp_server.py"
+    server_script.write_text(
+        rf"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+marker = pathlib.Path(r"{marker_path}")
+
+
+def send(message: dict[str, object]) -> None:
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+
+for raw_line in sys.stdin:
+    message = json.loads(raw_line)
+    method = message.get("method")
+    if method == "initialize":
+        send(
+            {{
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {{
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {{"tools": {{}}}},
+                    "serverInfo": {{"name": "shutdown-mcp", "version": "0.1.0"}},
+                }},
+            }}
+        )
+        continue
+    if method == "notifications/initialized":
+        continue
+    if method == "tools/list":
+        send({{"jsonrpc": "2.0", "id": message["id"], "result": {{"tools": []}}}})
+        continue
+
+marker.write_text("closed", encoding="utf-8")
+""",
+        encoding="utf-8",
+    )
+    manager = build_mcp_manager(
+        RuntimeMcpConfig(
+            enabled=True,
+            servers={
+                "shutdown": RuntimeMcpServerConfig(
+                    transport="stdio",
+                    command=(sys.executable, str(server_script)),
+                )
+            },
+        )
+    )
+
+    assert manager.list_tools(workspace=tmp_path) == ()
+
+    _ = manager.shutdown()
+
+    assert marker_path.read_text(encoding="utf-8") == "closed"
 
 
 def test_disabled_mcp_manager_rejects_tool_listing(tmp_path: Path) -> None:
@@ -413,6 +552,48 @@ while True:
     ]
     assert failure_events[1].payload["stage"] == "startup"
     assert failure_events[1].payload["method"] == "initialize"
+
+
+def test_mcp_manager_records_diagnostics_for_runtime_failures(tmp_path: Path) -> None:
+    server_script = tmp_path / "silent_mcp_server.py"
+    server_script.write_text(
+        r"""
+from __future__ import annotations
+
+import time
+
+while True:
+    time.sleep(10)
+""",
+        encoding="utf-8",
+    )
+    collector = InMemoryMcpDiagnosticsCollector()
+    manager = build_mcp_manager(
+        RuntimeMcpConfig(
+            enabled=True,
+            request_timeout_seconds=0.2,
+            servers={
+                "silent": RuntimeMcpServerConfig(
+                    transport="stdio",
+                    command=(sys.executable, str(server_script)),
+                )
+            },
+        ),
+        diagnostics_collector=collector,
+    )
+
+    try:
+        manager.list_tools(workspace=tmp_path)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected MCP manager to time out waiting for a silent server")
+
+    diagnostics = collector.get_diagnostics()
+    assert diagnostics
+    assert diagnostics[-1].category == "timeout"
+    assert diagnostics[-1].details is not None
+    assert diagnostics[-1].details["timeout_seconds"] == 0.2
 
 
 def test_mcp_manager_restarts_server_after_timeout(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_mcp_config.py
+++ b/tests/unit/runtime/test_mcp_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 
 import pytest
@@ -145,6 +146,21 @@ def test_parse_mcp_config_defaults_transport_and_preserves_public_dataclasses() 
             {"request_timeout_seconds": 0},
             "runtime config field 'mcp.request_timeout_seconds' must be greater than 0",
             id="request-timeout-positive",
+        ),
+        pytest.param(
+            {"request_timeout_seconds": math.nan},
+            "runtime config field 'mcp.request_timeout_seconds' must be a finite number",
+            id="request-timeout-nan",
+        ),
+        pytest.param(
+            {"request_timeout_seconds": math.inf},
+            "runtime config field 'mcp.request_timeout_seconds' must be a finite number",
+            id="request-timeout-inf",
+        ),
+        pytest.param(
+            {"request_timeout_seconds": -math.inf},
+            "runtime config field 'mcp.request_timeout_seconds' must be a finite number",
+            id="request-timeout-neg-inf",
         ),
     ],
 )

--- a/tests/unit/runtime/test_mcp_config.py
+++ b/tests/unit/runtime/test_mcp_config.py
@@ -91,6 +91,7 @@ def test_parse_mcp_config_defaults_transport_and_preserves_public_dataclasses() 
     assert _parse_mcp_config(
         {
             "enabled": False,
+            "request_timeout_seconds": 3.5,
             "servers": {
                 "echo": {
                     "command": ["python", "tests/fixtures/echo_mcp.py"],
@@ -100,6 +101,7 @@ def test_parse_mcp_config_defaults_transport_and_preserves_public_dataclasses() 
         }
     ) == RuntimeMcpConfig(
         enabled=False,
+        request_timeout_seconds=3.5,
         servers={
             "echo": RuntimeMcpServerConfig(
                 transport="stdio",
@@ -138,6 +140,11 @@ def test_parse_mcp_config_defaults_transport_and_preserves_public_dataclasses() 
             {"servers": {"echo": {"command": ["python"], "env": {1: "enabled"}}}},
             "runtime config field 'mcp.servers.echo.env' keys must be strings",
             id="env-key-type",
+        ),
+        pytest.param(
+            {"request_timeout_seconds": 0},
+            "runtime config field 'mcp.request_timeout_seconds' must be greater than 0",
+            id="request-timeout-positive",
         ),
     ],
 )

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -25,7 +25,12 @@ from voidcode.provider.config import (
     LiteLLMProviderConfig,
 )
 from voidcode.provider.registry import ModelProviderRegistry
-from voidcode.runtime.acp import AcpAdapterState, AcpRuntimeEvent, DisabledAcpAdapter
+from voidcode.runtime.acp import (
+    AcpAdapterState,
+    AcpRuntimeEvent,
+    DisabledAcpAdapter,
+    ManagedAcpAdapter,
+)
 from voidcode.runtime.config import (
     RuntimeAcpConfig,
     RuntimeAgentConfig,
@@ -550,6 +555,20 @@ class _BackgroundTaskFailureGraph:
     ) -> _StubStep:
         _ = request, tool_results, session
         raise RuntimeError("background boom")
+
+
+class _DisconnectingDelegatedRequestAcpAdapter(ManagedAcpAdapter):
+    def __init__(self) -> None:
+        super().__init__(RuntimeAcpConfig(enabled=True))
+        self.requests: list[AcpRequestEnvelope] = []
+        self._disconnect_on_first_request = True
+
+    def request(self, envelope: AcpRequestEnvelope) -> AcpResponseEnvelope:
+        self.requests.append(envelope)
+        if self._disconnect_on_first_request:
+            self._disconnect_on_first_request = False
+            self._transport = self._transport.close()
+        return super().request(envelope)
 
 
 def _wait_for_background_task(
@@ -2748,6 +2767,51 @@ def test_runtime_request_delegated_acp_carries_runtime_owned_correlation(tmp_pat
     assert response.delegation.routing_category == "deep"
     assert response.delegation.selected_preset == "worker"
     assert response.delegation.selected_execution_engine == "provider"
+    assert runtime.current_acp_state().last_request_id == started.task.id
+
+
+def test_runtime_request_delegated_acp_reconnects_once_after_disconnect_race(
+    tmp_path: Path,
+) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("delegated acp\n", encoding="utf-8")
+    acp_adapter = _DisconnectingDelegatedRequestAcpAdapter()
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_StubGraph(),
+        config=RuntimeConfig(acp=RuntimeAcpConfig(enabled=True)),
+        acp_adapter=acp_adapter,
+    )
+    _ = runtime.run(RuntimeRequest(prompt="leader", session_id="leader-session"))
+    started = runtime.start_background_task(
+        RuntimeRequest(
+            prompt="background child",
+            parent_session_id="leader-session",
+            metadata={"delegation": {"mode": "background", "category": "deep"}},
+        )
+    )
+    running = _wait_for_background_task_session(runtime, started.task.id)
+    _ = runtime.connect_acp()
+
+    response = runtime.request_delegated_acp(
+        request_type="delegated_status",
+        task_id=started.task.id,
+        payload={"phase": "running"},
+    )
+
+    assert response.status == "ok"
+    assert len(acp_adapter.requests) == 2
+    assert acp_adapter.requests[0] is acp_adapter.requests[1]
+    assert response.request_id == started.task.id
+    assert response.session_id == running.session_id
+    assert response.parent_session_id == "leader-session"
+    assert response.delegation is not None
+    assert response.delegation.parent_session_id == "leader-session"
+    assert response.delegation.delegated_task_id == started.task.id
+    assert response.delegation.routing_category == "deep"
+    assert response.delegation.selected_preset == "worker"
+    assert response.delegation.selected_execution_engine == "provider"
+    assert runtime.current_acp_state().status == "connected"
     assert runtime.current_acp_state().last_request_id == started.task.id
 
 

--- a/tests/unit/runtime/test_tool_provider.py
+++ b/tests/unit/runtime/test_tool_provider.py
@@ -8,6 +8,7 @@ from typing import cast
 from unittest.mock import patch
 
 from voidcode.hook.config import RuntimeFormatterPresetConfig, RuntimeHooksConfig
+from voidcode.mcp import McpToolSafety
 from voidcode.runtime.events import EventEnvelope
 from voidcode.runtime.mcp import (
     McpConfigState,
@@ -360,6 +361,38 @@ def test_dynamic_mcp_tool_definitions_include_shared_policy_guidance() -> None:
     assert definition.name == "mcp/echo/echo"
     assert "Agent usage guidance:" in definition.description
     assert "Dynamic MCP tools are runtime-discovered" in definition.description
+
+
+def test_dynamic_mcp_tool_definitions_apply_server_safety_hints() -> None:
+    def _requester(
+        *,
+        server_name: str,
+        tool_name: str,
+        arguments: dict[str, object],
+        workspace: Path,
+    ) -> McpToolCallResult:
+        _ = server_name, tool_name, arguments, workspace
+        return McpToolCallResult(content=[{"type": "text", "text": "ok"}], is_error=False)
+
+    read_only_tool = McpTool(
+        server_name="echo",
+        tool_name="inspect",
+        description="Inspect input",
+        input_schema={"type": "object"},
+        safety=McpToolSafety.from_hints(read_only_hint=True, destructive_hint=False),
+        requester=_requester,
+    )
+    mutating_tool = McpTool(
+        server_name="echo",
+        tool_name="write",
+        description="Write input",
+        input_schema={"type": "object"},
+        safety=McpToolSafety.from_hints(read_only_hint=True, destructive_hint=True),
+        requester=_requester,
+    )
+
+    assert read_only_tool.definition.read_only is True
+    assert mutating_tool.definition.read_only is False
 
 
 def test_tool_registry_with_defaults_delegates_through_builtin_provider() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -144,6 +144,29 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -235,6 +258,45 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851, upload-time = "2026-03-17T10:32:04.416Z" },
     { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104, upload-time = "2026-03-17T10:32:06.65Z" },
     { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "46.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
+    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
+    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
+    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
 ]
 
 [[package]]
@@ -392,6 +454,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
 ]
 
 [[package]]
@@ -743,6 +814,31 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+]
+
+[[package]]
 name = "mdit-py-plugins"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -975,6 +1071,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1038,6 +1143,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1087,6 +1206,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115, upload-time = "2024-01-23T06:33:00.505Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863, upload-time = "2024-01-23T06:32:58.246Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
 ]
 
 [[package]]
@@ -1329,6 +1467,31 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1542,6 +1705,7 @@ dependencies = [
     { name = "langgraph" },
     { name = "litellm" },
     { name = "lsprotocol" },
+    { name = "mcp" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "rapidfuzz" },
@@ -1571,6 +1735,7 @@ requires-dist = [
     { name = "langgraph" },
     { name = "litellm", specifier = ">=1.82.6" },
     { name = "lsprotocol" },
+    { name = "mcp", specifier = ">=1.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pydantic" },
     { name = "pydantic-settings" },


### PR DESCRIPTION
## Summary
- Replace custom stdio JSON-RPC MCP client with the official Python MCP SDK while retaining runtime-owned policy, events, and diagnostics
- Add MCP tool safety metadata from server annotations and wire read-only hints into runtime tool definitions
- Add configurable MCP request timeout, diagnostics collector support, updated contract docs, and regression coverage for SDK handshake, shutdown, timeout, restart, and governance behavior

Closes #213

## Verification
- `mise run check`
  - Python: 1138 passed, 5 existing ResourceWarning warnings from `test_http_question_payload_fuzz`
  - Frontend: 2 files / 32 tests passed

## Notes
- Frontend dependencies were installed locally with `bun install --frozen-lockfile` in the new worktree so `mise run check` could execute frontend checks.
- Not tested against real third-party MCP servers beyond local stdio fixtures.