### PR TITLE
feat(skills): harden local skill subsystem contracts

### DIFF
--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -4085,6 +4085,19 @@ class VoidCodeRuntime:
     def _loaded_skill_names(skill_registry: SkillRegistry) -> list[str]:
         return sorted(skill_registry.skills)
 
+    @staticmethod
+    def _validated_runtime_context_from_payload(payload: dict[str, str]) -> SkillRuntimeContext:
+        try:
+            return runtime_context_from_payload(payload)
+        except ValueError as exc:
+            source_path = payload.get("source_path", "")
+            prefix = (
+                f"persisted skill payload {source_path}"
+                if source_path
+                else "persisted skill payload"
+            )
+            raise ValueError(f"{prefix}: {exc}") from exc
+
     def _applied_skill_contexts(
         self,
         skill_registry: SkillRegistry,
@@ -4217,7 +4230,8 @@ class VoidCodeRuntime:
         persisted_payloads = self._persisted_applied_skill_payloads(metadata)
         if persisted_payloads is not None:
             contexts = tuple(
-                runtime_context_from_payload(payload) for payload in persisted_payloads
+                self._validated_runtime_context_from_payload(payload)
+                for payload in persisted_payloads
             )
             selected_names = self._persisted_selected_skill_names(metadata)
             return build_skill_execution_snapshot(
@@ -4317,17 +4331,27 @@ class VoidCodeRuntime:
                 or not isinstance(content, str)
             ):
                 raise ValueError("persisted applied skill payloads must include string fields")
+            if not name.strip() or not description.strip() or not content.strip():
+                raise ValueError("persisted applied skill payload string fields must not be empty")
             normalized_payload = {"name": name, "description": description, "content": content}
             if prompt_context is not None:
                 if not isinstance(prompt_context, str):
                     raise ValueError(
                         "persisted applied skill payload prompt_context must be a string"
                     )
+                if not prompt_context.strip():
+                    raise ValueError(
+                        "persisted applied skill payload prompt_context must not be empty"
+                    )
                 normalized_payload["prompt_context"] = prompt_context
             if execution_notes is not None:
                 if not isinstance(execution_notes, str):
                     raise ValueError(
                         "persisted applied skill payload execution_notes must be a string"
+                    )
+                if not execution_notes.strip():
+                    raise ValueError(
+                        "persisted applied skill payload execution_notes must not be empty"
                     )
                 normalized_payload["execution_notes"] = execution_notes
             if source_path is not None:

--- a/src/voidcode/runtime/skills.py
+++ b/src/voidcode/runtime/skills.py
@@ -33,6 +33,7 @@ class SkillExecutionSnapshot:
 
 
 _WHITESPACE_PATTERN = re.compile(r"[ \t]+")
+_REQUIRED_SKILL_PAYLOAD_FIELDS = ("name", "description", "content")
 
 
 def _normalize_text(value: str) -> str:
@@ -84,11 +85,26 @@ def build_skill_prompt_context(contexts: Iterable[SkillRuntimeContext]) -> str:
 
 
 def runtime_context_from_payload(payload: dict[str, str]) -> SkillRuntimeContext:
-    name = payload["name"]
-    description = payload["description"]
-    content = payload["content"]
+    missing_fields = [
+        field_name for field_name in _REQUIRED_SKILL_PAYLOAD_FIELDS if field_name not in payload
+    ]
+    if missing_fields:
+        raise ValueError(
+            "persisted skill payload missing required fields: " + ", ".join(missing_fields)
+        )
+    name = payload["name"].strip()
+    description = payload["description"].strip()
+    content = payload["content"].strip()
+    if not name:
+        raise ValueError("persisted skill payload field 'name' must be a non-empty string")
+    if not description:
+        raise ValueError("persisted skill payload field 'description' must be a non-empty string")
+    if not content:
+        raise ValueError("persisted skill payload field 'content' must be a non-empty string")
     prompt_context = payload.get("prompt_context")
-    execution_notes = payload.get("execution_notes", content)
+    execution_notes = payload.get("execution_notes", content).strip()
+    if not execution_notes:
+        execution_notes = content
     if prompt_context is None:
         prompt_parts = [f"Skill: {name}"]
         if description:
@@ -96,13 +112,17 @@ def runtime_context_from_payload(payload: dict[str, str]) -> SkillRuntimeContext
         if execution_notes:
             prompt_parts.append(f"Instructions:\n{execution_notes}")
         prompt_context = "\n".join(prompt_parts).strip()
+    else:
+        prompt_context = prompt_context.strip()
+        if not prompt_context:
+            raise ValueError("persisted skill payload field 'prompt_context' must not be empty")
     return SkillRuntimeContext(
         name=name,
         description=description,
         content=content,
         prompt_context=prompt_context,
         execution_notes=execution_notes,
-        source_path=payload.get("source_path", ""),
+        source_path=payload.get("source_path", "").strip(),
     )
 
 
@@ -201,6 +221,7 @@ def snapshot_from_payload(payload: dict[str, object]) -> SkillExecutionSnapshot:
             if not isinstance(value, str):
                 raise ValueError("persisted skill snapshot payload values must be strings")
             normalized[key] = value
+        _ = runtime_context_from_payload(normalized)
         applied_payloads.append(normalized)
     source = payload.get("source", "legacy")
     if source not in {"run", "resume", "replay", "legacy"}:

--- a/src/voidcode/skills/__init__.py
+++ b/src/voidcode/skills/__init__.py
@@ -2,15 +2,18 @@ from .discovery import (
     DEFAULT_SKILL_SEARCH_PATHS,
     SKILL_ENTRY_FILE_NAME,
     LocalSkillMetadataLoader,
+    SkillLoadError,
     resolve_workspace_relative_path,
 )
 from .manifest import (
     FRONTMATTER_DELIMITER,
     SUPPORTED_FRONTMATTER_KEYS,
+    SkillManifestParseError,
     parse_skill_body,
     parse_skill_frontmatter,
+    parse_skill_manifest,
 )
-from .models import SkillMetadata
+from .models import SkillManifest, SkillManifestFrontmatter, SkillMetadata
 from .registry import SkillRegistry
 
 __all__ = [
@@ -18,10 +21,15 @@ __all__ = [
     "FRONTMATTER_DELIMITER",
     "LocalSkillMetadataLoader",
     "SKILL_ENTRY_FILE_NAME",
+    "SkillLoadError",
+    "SkillManifest",
+    "SkillManifestFrontmatter",
+    "SkillManifestParseError",
     "SUPPORTED_FRONTMATTER_KEYS",
     "SkillMetadata",
     "SkillRegistry",
     "parse_skill_body",
     "parse_skill_frontmatter",
+    "parse_skill_manifest",
     "resolve_workspace_relative_path",
 ]

--- a/src/voidcode/skills/discovery.py
+++ b/src/voidcode/skills/discovery.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 from collections.abc import Iterable
 from pathlib import Path
 
-from .manifest import parse_skill_body, parse_skill_frontmatter
+from .manifest import SkillManifestParseError, parse_skill_manifest
 from .models import SkillMetadata
 
 SKILL_ENTRY_FILE_NAME = "SKILL.md"
 DEFAULT_SKILL_SEARCH_PATHS = (".voidcode/skills",)
+
+
+class SkillLoadError(ValueError):
+    pass
 
 
 class LocalSkillMetadataLoader:
@@ -26,9 +30,8 @@ class LocalSkillMetadataLoader:
             )
             if not skill_root.exists() or not skill_root.is_dir():
                 continue
-            for skill_dir in sorted(path for path in skill_root.iterdir() if path.is_dir()):
-                entry_path = skill_dir / SKILL_ENTRY_FILE_NAME
-                if not entry_path.exists() or not entry_path.is_file():
+            for entry_path in sorted(skill_root.glob(f"**/{SKILL_ENTRY_FILE_NAME}")):
+                if not entry_path.is_file():
                     continue
                 discovered.append(self.load(entry_path))
 
@@ -36,15 +39,23 @@ class LocalSkillMetadataLoader:
 
     def load(self, entry_path: Path) -> SkillMetadata:
         resolved_entry_path = entry_path.resolve()
-        contents = resolved_entry_path.read_text(encoding="utf-8")
-        metadata = parse_skill_frontmatter(contents)
-        return SkillMetadata(
-            name=metadata["name"],
-            description=metadata["description"],
-            directory=resolved_entry_path.parent,
-            entry_path=resolved_entry_path,
-            content=parse_skill_body(contents),
-        )
+        try:
+            contents = resolved_entry_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise SkillLoadError(f"failed to read skill file {resolved_entry_path}: {exc}") from exc
+        try:
+            manifest = parse_skill_manifest(contents, path=str(resolved_entry_path))
+            return SkillMetadata(
+                name=manifest.name,
+                description=manifest.description,
+                directory=resolved_entry_path.parent,
+                entry_path=resolved_entry_path,
+                content=manifest.content,
+            )
+        except SkillManifestParseError as exc:
+            raise SkillLoadError(str(exc)) from exc
+        except ValueError as exc:
+            raise SkillLoadError(f"{resolved_entry_path}: {exc}") from exc
 
 
 def resolve_workspace_relative_path(*, workspace: Path, configured_path: str) -> Path:

--- a/src/voidcode/skills/manifest.py
+++ b/src/voidcode/skills/manifest.py
@@ -1,13 +1,28 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+from .models import SkillManifest, SkillManifestFrontmatter
+
 FRONTMATTER_DELIMITER = "---"
 SUPPORTED_FRONTMATTER_KEYS = frozenset({"name", "description"})
 
 
-def parse_skill_frontmatter(contents: str) -> dict[str, str]:
+@dataclass(frozen=True, slots=True)
+class SkillManifestParseError(ValueError):
+    message: str
+    path: str | None = None
+
+    def __str__(self) -> str:
+        if self.path:
+            return f"{self.path}: {self.message}"
+        return self.message
+
+
+def _parse_skill_frontmatter_fields(contents: str) -> dict[str, str]:
     lines = contents.splitlines()
     if not lines or lines[0].strip() != FRONTMATTER_DELIMITER:
-        raise ValueError("skill file must begin with a simplified frontmatter block")
+        raise SkillManifestParseError("skill file must begin with a simplified frontmatter block")
 
     parsed: dict[str, str] = {}
     for index, raw_line in enumerate(lines[1:], start=2):
@@ -18,31 +33,73 @@ def parse_skill_frontmatter(contents: str) -> dict[str, str]:
             continue
         key, separator, value = raw_line.partition(":")
         if separator != ":":
-            raise ValueError(f"skill frontmatter line {index} must use 'key: value' syntax")
+            raise SkillManifestParseError(
+                f"skill frontmatter line {index} must use 'key: value' syntax"
+            )
         normalized_key = key.strip()
         if normalized_key not in SUPPORTED_FRONTMATTER_KEYS:
-            raise ValueError(f"unsupported skill frontmatter key: {normalized_key}")
+            raise SkillManifestParseError(f"unsupported skill frontmatter key: {normalized_key}")
         normalized_value = value.strip()
         if not normalized_value:
-            raise ValueError(f"skill frontmatter field '{normalized_key}' must not be empty")
+            raise SkillManifestParseError(
+                f"skill frontmatter field '{normalized_key}' must not be empty"
+            )
         parsed[normalized_key] = normalized_value
     else:
-        raise ValueError("skill frontmatter must terminate with a closing '---' line")
+        raise SkillManifestParseError("skill frontmatter must terminate with a closing '---' line")
 
     missing_keys = SUPPORTED_FRONTMATTER_KEYS.difference(parsed)
     if missing_keys:
         missing = ", ".join(sorted(missing_keys))
-        raise ValueError(f"skill frontmatter missing required fields: {missing}")
+        raise SkillManifestParseError(f"skill frontmatter missing required fields: {missing}")
     return parsed
 
 
-def parse_skill_body(contents: str) -> str:
+def parse_skill_frontmatter(
+    contents: str,
+    *,
+    path: str | None = None,
+) -> SkillManifestFrontmatter:
+    try:
+        parsed = _parse_skill_frontmatter_fields(contents)
+        return SkillManifestFrontmatter(
+            name=parsed["name"],
+            description=parsed["description"],
+        )
+    except ValueError as exc:
+        if isinstance(exc, SkillManifestParseError):
+            raise SkillManifestParseError(exc.message, path=path) from exc
+        raise SkillManifestParseError(str(exc), path=path) from exc
+
+
+def parse_skill_body(contents: str, *, path: str | None = None) -> str:
     lines = contents.splitlines()
     if not lines or lines[0].strip() != FRONTMATTER_DELIMITER:
-        raise ValueError("skill file must begin with a simplified frontmatter block")
+        raise SkillManifestParseError(
+            "skill file must begin with a simplified frontmatter block",
+            path=path,
+        )
 
     for index, raw_line in enumerate(lines[1:], start=2):
         if raw_line.strip() == FRONTMATTER_DELIMITER:
             return "\n".join(lines[index:]).strip()
 
-    raise ValueError("skill frontmatter must terminate with a closing '---' line")
+    raise SkillManifestParseError(
+        "skill frontmatter must terminate with a closing '---' line",
+        path=path,
+    )
+
+
+def parse_skill_manifest(contents: str, *, path: str | None = None) -> SkillManifest:
+    frontmatter = parse_skill_frontmatter(contents, path=path)
+    body = parse_skill_body(contents, path=path)
+    try:
+        if not body.strip():
+            raise ValueError("content must be a non-empty string")
+        return SkillManifest(
+            name=frontmatter.name,
+            description=frontmatter.description,
+            content=body,
+        )
+    except ValueError as exc:
+        raise SkillManifestParseError(str(exc), path=path) from exc

--- a/src/voidcode/skills/models.py
+++ b/src/voidcode/skills/models.py
@@ -4,10 +4,64 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
+def _validated_non_empty_string(value: object, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return normalized
+
+
+def _validated_string(value: object, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    return value
+
+
+def _validated_path(value: object, *, field_name: str) -> Path:
+    if not isinstance(value, Path):
+        raise ValueError(f"{field_name} must be a pathlib.Path")
+    return value
+
+
 @dataclass(frozen=True, slots=True)
-class SkillMetadata:
+class SkillManifestFrontmatter:
     name: str
     description: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "name", _validated_non_empty_string(self.name, field_name="name"))
+        object.__setattr__(
+            self,
+            "description",
+            _validated_non_empty_string(self.description, field_name="description"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SkillManifest(SkillManifestFrontmatter):
+    content: str
+
+    def __post_init__(self) -> None:
+        SkillManifestFrontmatter.__post_init__(self)
+        object.__setattr__(
+            self,
+            "content",
+            _validated_string(self.content, field_name="content"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SkillMetadata(SkillManifest):
     directory: Path
     entry_path: Path
-    content: str
+
+    def __post_init__(self) -> None:
+        SkillManifest.__post_init__(self)
+        directory = _validated_path(self.directory, field_name="directory")
+        entry_path = _validated_path(self.entry_path, field_name="entry_path")
+        object.__setattr__(self, "directory", directory)
+        object.__setattr__(self, "entry_path", entry_path)
+        if entry_path.parent != directory:
+            raise ValueError("entry_path must live inside directory")

--- a/src/voidcode/skills/registry.py
+++ b/src/voidcode/skills/registry.py
@@ -14,7 +14,16 @@ class SkillRegistry:
 
     @classmethod
     def from_skills(cls, skills: Iterable[SkillMetadata]) -> SkillRegistry:
-        return cls(skills={skill.name: skill for skill in skills})
+        resolved: dict[str, SkillMetadata] = {}
+        for skill in skills:
+            existing = resolved.get(skill.name)
+            if existing is not None:
+                raise ValueError(
+                    "duplicate skill name "
+                    f"'{skill.name}' discovered at {existing.entry_path} and {skill.entry_path}"
+                )
+            resolved[skill.name] = skill
+        return cls(skills=resolved)
 
     @classmethod
     def discover(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -2560,7 +2560,7 @@ def test_runtime_initializes_extension_state_from_config_when_enabled(tmp_path: 
     skill_dir = tmp_path / ".voidcode" / "skills" / "demo"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
-        "---\nname: demo\ndescription: Demo skill\n---\n",
+        "---\nname: demo\ndescription: Demo skill\n---\n# Demo\nUse the demo skill.\n",
         encoding="utf-8",
     )
 
@@ -2607,13 +2607,34 @@ def test_runtime_initializes_extension_state_from_config_when_enabled(tmp_path: 
     assert acp_state.available is False
 
 
+def test_runtime_rejects_duplicate_discovered_skill_names(tmp_path: Path) -> None:
+    first = tmp_path / ".voidcode" / "skills" / "first"
+    second = tmp_path / ".voidcode" / "skills" / "nested" / "second"
+    first.mkdir(parents=True)
+    second.mkdir(parents=True)
+    (first / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: First demo skill\n---\n# First\n",
+        encoding="utf-8",
+    )
+    (second / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: Second demo skill\n---\n# Second\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate skill name 'demo' discovered"):
+        _ = VoidCodeRuntime(
+            workspace=tmp_path,
+            config=RuntimeConfig(skills=RuntimeSkillsConfig(enabled=True)),
+        )
+
+
 def test_runtime_keeps_skill_registry_empty_when_skills_not_explicitly_enabled(
     tmp_path: Path,
 ) -> None:
     skill_dir = tmp_path / "custom-skills" / "demo"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
-        "---\nname: demo\ndescription: Demo skill\n---\n",
+        "---\nname: demo\ndescription: Demo skill\n---\n# Demo\nUse the demo skill.\n",
         encoding="utf-8",
     )
 
@@ -3319,11 +3340,11 @@ def test_runtime_default_extension_construction_preserves_public_run_path(
     alpha_skill_dir.mkdir(parents=True)
     zeta_skill_dir.mkdir(parents=True)
     (alpha_skill_dir / "SKILL.md").write_text(
-        "---\nname: alpha\ndescription: Alpha skill\n---\n",
+        "---\nname: alpha\ndescription: Alpha skill\n---\n# Alpha\nUse alpha.\n",
         encoding="utf-8",
     )
     (zeta_skill_dir / "SKILL.md").write_text(
-        "---\nname: zeta\ndescription: Zeta skill\n---\n",
+        "---\nname: zeta\ndescription: Zeta skill\n---\n# Zeta\nUse zeta.\n",
         encoding="utf-8",
     )
 
@@ -4088,6 +4109,68 @@ def test_runtime_resume_reuses_frozen_skill_payloads_for_execution_semantics(
     )
 
 
+def test_runtime_resume_rejects_invalid_persisted_skill_payload_with_source_path(
+    tmp_path: Path,
+) -> None:
+    skill_dir = tmp_path / ".voidcode" / "skills" / "demo"
+    _write_demo_skill(
+        skill_dir,
+        content="# Demo\nUse concise bullet points.",
+    )
+
+    initial_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(skills=RuntimeSkillsConfig(enabled=True), approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    waiting = initial_runtime.run(RuntimeRequest(prompt="go", session_id="invalid-skill-payload"))
+    approval_request_id = str(waiting.events[-1].payload["request_id"])
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        row = connection.execute(
+            "SELECT metadata_json FROM sessions WHERE session_id = ?",
+            ("invalid-skill-payload",),
+        ).fetchone()
+        assert row is not None
+        metadata = json.loads(str(row[0]))
+        assert isinstance(metadata, dict)
+        metadata_dict = cast(dict[str, object], metadata)
+        applied_payloads = cast(list[dict[str, object]], metadata_dict["applied_skill_payloads"])
+        applied_payloads[0]["content"] = "   "
+        metadata_dict["skill_snapshot"] = {
+            **cast(dict[str, object], metadata_dict["skill_snapshot"]),
+            "applied_skill_payloads": applied_payloads,
+        }
+        _ = connection.execute(
+            "UPDATE sessions SET metadata_json = ? WHERE session_id = ?",
+            (json.dumps(metadata_dict, sort_keys=True), "invalid-skill-payload"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(skills=RuntimeSkillsConfig(enabled=True), approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"persisted skill payload field 'content' must be a non-empty string",
+    ):
+        _ = resumed_runtime.resume(
+            session_id="invalid-skill-payload",
+            approval_request_id=approval_request_id,
+            approval_decision="allow",
+        )
+
+
 class _MultiStepStubGraph:
     def step(
         self,
@@ -4331,6 +4414,66 @@ def test_runtime_resume_preserves_legacy_name_only_empty_applied_skills_snapshot
     assert resumed.session.status == "completed"
     assert _ApprovalThenCaptureSkillGraph.last_request is not None
     assert _ApprovalThenCaptureSkillGraph.last_request.applied_skills == ()
+
+
+def test_runtime_resume_rejects_invalid_legacy_persisted_skill_payload_with_source_path(
+    tmp_path: Path,
+) -> None:
+    skill_dir = tmp_path / ".voidcode" / "skills" / "demo"
+    _write_demo_skill(
+        skill_dir,
+        description="Demo skill",
+        content="# Demo\nOriginal instructions.",
+    )
+
+    initial_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(skills=RuntimeSkillsConfig(enabled=True), approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    waiting = initial_runtime.run(RuntimeRequest(prompt="go", session_id="legacy-invalid-skill"))
+    approval_request_id = str(waiting.events[-1].payload["request_id"])
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        row = connection.execute(
+            "SELECT metadata_json FROM sessions WHERE session_id = ?",
+            ("legacy-invalid-skill",),
+        ).fetchone()
+        assert row is not None
+        metadata = json.loads(str(row[0]))
+        assert isinstance(metadata, dict)
+        metadata_dict = cast(dict[str, object], metadata)
+        metadata_dict.pop("skill_snapshot", None)
+        applied_payloads = cast(list[dict[str, object]], metadata_dict["applied_skill_payloads"])
+        applied_payloads[0]["execution_notes"] = "   "
+        _ = connection.execute(
+            "UPDATE sessions SET metadata_json = ? WHERE session_id = ?",
+            (json.dumps(metadata_dict, sort_keys=True), "legacy-invalid-skill"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(skills=RuntimeSkillsConfig(enabled=True), approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"persisted applied skill payload execution_notes must not be empty",
+    ):
+        _ = resumed_runtime.resume(
+            session_id="legacy-invalid-skill",
+            approval_request_id=approval_request_id,
+            approval_decision="allow",
+        )
 
 
 def test_runtime_resume_reconstructs_legacy_applied_skill_names_from_live_registry(

--- a/tests/unit/runtime/test_skills.py
+++ b/tests/unit/runtime/test_skills.py
@@ -9,12 +9,15 @@ from voidcode.runtime.skills import (
     build_runtime_contexts,
     build_skill_execution_snapshot,
     build_skill_prompt_context,
+    runtime_context_from_payload,
     snapshot_from_payload,
     snapshot_payload,
 )
 from voidcode.skills import (
     DEFAULT_SKILL_SEARCH_PATHS,
     LocalSkillMetadataLoader,
+    SkillManifestFrontmatter,
+    SkillManifestParseError,
     SkillRegistry,
     parse_skill_frontmatter,
 )
@@ -25,14 +28,14 @@ def test_parse_skill_frontmatter_returns_required_metadata() -> None:
         "---\nname: summarize\ndescription: Summarize selected files.\n---\n# Summarize\n"
     )
 
-    assert metadata == {
-        "name": "summarize",
-        "description": "Summarize selected files.",
-    }
+    assert metadata == SkillManifestFrontmatter(
+        name="summarize",
+        description="Summarize selected files.",
+    )
 
 
 def test_parse_skill_frontmatter_rejects_missing_required_fields() -> None:
-    with pytest.raises(ValueError, match="missing required fields: description"):
+    with pytest.raises(SkillManifestParseError, match="missing required fields: description"):
         _ = parse_skill_frontmatter("---\nname: summarize\n---\n")
 
 
@@ -146,6 +149,17 @@ def test_skill_runtime_context_builds_execution_prompt_context(tmp_path: Path) -
 def test_skill_loader_rejects_workspace_escape_search_paths(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="escapes workspace"):
         _ = LocalSkillMetadataLoader().discover(workspace=tmp_path, search_paths=("../skills",))
+
+
+def test_runtime_context_from_payload_rejects_empty_required_fields() -> None:
+    with pytest.raises(ValueError, match="field 'content' must be a non-empty string"):
+        _ = runtime_context_from_payload(
+            {
+                "name": "demo",
+                "description": "Demo",
+                "content": "   ",
+            }
+        )
 
 
 def test_build_skill_execution_snapshot_stable_payload() -> None:

--- a/tests/unit/skills/test_skills.py
+++ b/tests/unit/skills/test_skills.py
@@ -8,8 +8,11 @@ from voidcode.runtime.skills import SkillRuntimeContext, build_runtime_contexts
 from voidcode.skills import (
     DEFAULT_SKILL_SEARCH_PATHS,
     LocalSkillMetadataLoader,
+    SkillManifestFrontmatter,
+    SkillManifestParseError,
     SkillRegistry,
     parse_skill_frontmatter,
+    parse_skill_manifest,
 )
 
 
@@ -18,15 +21,20 @@ def test_parse_skill_frontmatter_returns_required_metadata() -> None:
         "---\nname: summarize\ndescription: Summarize selected files.\n---\n# Summarize\n"
     )
 
-    assert metadata == {
-        "name": "summarize",
-        "description": "Summarize selected files.",
-    }
+    assert metadata == SkillManifestFrontmatter(
+        name="summarize",
+        description="Summarize selected files.",
+    )
 
 
 def test_parse_skill_frontmatter_rejects_missing_required_fields() -> None:
-    with pytest.raises(ValueError, match="missing required fields: description"):
+    with pytest.raises(SkillManifestParseError, match="missing required fields: description"):
         _ = parse_skill_frontmatter("---\nname: summarize\n---\n")
+
+
+def test_parse_skill_manifest_rejects_empty_body() -> None:
+    with pytest.raises(SkillManifestParseError, match="content must be a non-empty string"):
+        _ = parse_skill_manifest("---\nname: summarize\ndescription: Demo\n---\n")
 
 
 def test_skill_loader_discovers_local_skills_from_default_workspace_path(tmp_path: Path) -> None:
@@ -56,6 +64,48 @@ def test_skill_loader_discovers_local_skills_from_default_workspace_path(tmp_pat
         summarize_dir.resolve(),
     )
     assert tuple(skill.entry_path.name for skill in skills) == ("SKILL.md", "SKILL.md")
+
+
+def test_skill_loader_discovers_nested_skill_directories(tmp_path: Path) -> None:
+    skill_dir = tmp_path / ".voidcode" / "skills" / "python" / "summarize"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: summarize\ndescription: Summarize selected files.\n---\n# Summarize\n",
+        encoding="utf-8",
+    )
+
+    skills = LocalSkillMetadataLoader().discover(workspace=tmp_path)
+
+    assert [skill.name for skill in skills] == ["summarize"]
+    assert skills[0].directory == skill_dir.resolve()
+
+
+def test_skill_loader_reports_entry_path_in_parse_errors(tmp_path: Path) -> None:
+    skill_dir = tmp_path / ".voidcode" / "skills" / "broken"
+    skill_dir.mkdir(parents=True)
+    entry_path = skill_dir / "SKILL.md"
+    entry_path.write_text("---\nname: broken\n---\n# Missing description\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=str(entry_path.resolve()).replace(".", r"\.")):
+        _ = LocalSkillMetadataLoader().load(entry_path)
+
+
+def test_skill_registry_rejects_duplicate_skill_names(tmp_path: Path) -> None:
+    alpha = tmp_path / ".voidcode" / "skills" / "alpha"
+    beta = tmp_path / ".voidcode" / "skills" / "nested" / "beta"
+    alpha.mkdir(parents=True)
+    beta.mkdir(parents=True)
+    (alpha / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: Alpha demo.\n---\n# Alpha\n",
+        encoding="utf-8",
+    )
+    (beta / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: Beta demo.\n---\n# Beta\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate skill name 'demo' discovered"):
+        _ = SkillRegistry.discover(workspace=tmp_path)
 
 
 def test_skill_registry_discovers_and_resolves_skills(tmp_path: Path) -> None:

--- a/tests/unit/tools/test_skill_tool.py
+++ b/tests/unit/tools/test_skill_tool.py
@@ -38,6 +38,24 @@ def test_skill_tool_returns_skill_body_and_metadata(tmp_path: Path) -> None:
     }
 
 
+def test_skill_tool_definition_includes_nested_skill_locations(tmp_path: Path) -> None:
+    skill_dir = tmp_path / ".voidcode" / "skills" / "python" / "demo"
+    skill_dir.mkdir(parents=True)
+    entry = skill_dir / "SKILL.md"
+    entry.write_text("# Demo\nUse it.\n", encoding="utf-8")
+    skill = SkillMetadata(
+        name="demo",
+        description="Demo skill",
+        directory=skill_dir,
+        entry_path=entry,
+        content="# Demo\nUse it.",
+    )
+
+    tool = SkillTool(list_skills=lambda: (skill,), resolve_skill=lambda name: skill)
+
+    assert entry.as_uri() in tool.definition.description
+
+
 def test_skill_tool_rejects_missing_name(tmp_path: Path) -> None:
     tool = SkillTool(
         list_skills=lambda: (), resolve_skill=lambda name: (_ for _ in ()).throw(ValueError(name))


### PR DESCRIPTION
## Summary
- tighten the local `skills` capability layer with typed manifest parsing, path-aware load errors, recursive local discovery, and fail-fast duplicate skill-name handling
- validate persisted skill payloads before rebuilding runtime contexts so resume and legacy snapshot paths reject malformed skill state with clearer errors
- extend pure skills, runtime, and tool coverage so the hardened skills contract stays stable across discovery, run, and resume flows

## Testing
- mise run typecheck
- rtk pytest tests/unit/skills/test_skills.py tests/unit/runtime/test_skills.py tests/unit/runtime/test_runtime_service_extensions.py tests/unit/tools/test_skill_tool.py

close #211 