### PR TITLE
fix(lsp): harden request handling and failure bounds

### DIFF
--- a/src/voidcode/runtime/background_tasks.py
+++ b/src/voidcode/runtime/background_tasks.py
@@ -1,0 +1,659 @@
+# pyright: reportPrivateUsage=false
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import TYPE_CHECKING, Any, cast
+from uuid import uuid4
+
+from ..hook.config import RuntimeHookSurface
+from ..hook.executor import LifecycleHookExecutionRequest, run_lifecycle_hooks
+from .contracts import (
+    BackgroundTaskResult,
+    InternalRuntimeRequestMetadata,
+    RuntimeRequest,
+    RuntimeRequestMetadataPayload,
+    RuntimeResponse,
+    RuntimeSessionResult,
+    UnknownSessionError,
+)
+from .events import (
+    RUNTIME_BACKGROUND_TASK_CANCELLED,
+    RUNTIME_BACKGROUND_TASK_COMPLETED,
+    RUNTIME_BACKGROUND_TASK_FAILED,
+    RUNTIME_BACKGROUND_TASK_WAITING_APPROVAL,
+    RUNTIME_FAILED,
+    EventEnvelope,
+)
+from .session import SessionState
+from .storage import SessionEventAppender
+from .task import (
+    BackgroundTaskRef,
+    BackgroundTaskRequestSnapshot,
+    BackgroundTaskState,
+    BackgroundTaskStatus,
+    is_background_task_terminal,
+    validate_background_task_id,
+)
+
+if TYPE_CHECKING:
+    from .service import VoidCodeRuntime
+
+logger = logging.getLogger(__name__)
+
+
+class RuntimeBackgroundTaskSupervisor:
+    def __init__(self, runtime: VoidCodeRuntime) -> None:
+        self._runtime = runtime
+
+    def start_background_task(self, request: RuntimeRequest) -> BackgroundTaskState:
+        runtime = self._runtime
+        self.reconcile_background_tasks_if_needed()
+        validated_request = runtime._validated_request(request)
+        task_id = f"task-{uuid4().hex}"
+        initial_state = BackgroundTaskState(
+            task=BackgroundTaskRef(id=task_id),
+            status="queued",
+            request=BackgroundTaskRequestSnapshot(
+                prompt=validated_request.prompt,
+                session_id=validated_request.session_id,
+                parent_session_id=validated_request.parent_session_id,
+                metadata=dict(validated_request.metadata),
+                allocate_session_id=validated_request.allocate_session_id,
+            ),
+        )
+        runtime._session_store.create_background_task(
+            workspace=runtime._workspace, task=initial_state
+        )
+        worker = threading.Thread(
+            target=runtime._run_background_task_worker,
+            args=(task_id,),
+            name=f"voidcode-background-task-{task_id}",
+            daemon=True,
+        )
+        runtime._background_task_threads[task_id] = worker
+        worker.start()
+        return runtime.load_background_task(task_id)
+
+    def load_background_task_result(self, task_id: str) -> BackgroundTaskResult:
+        task = self._runtime.load_background_task(task_id)
+        self.backfill_parent_background_task_event(task=task)
+        return self.background_task_result(task=task)
+
+    def cancel_background_task(self, task_id: str) -> BackgroundTaskState:
+        runtime = self._runtime
+        validate_background_task_id(task_id)
+        previous_task = runtime._session_store.load_background_task(
+            workspace=runtime._workspace,
+            task_id=task_id,
+        )
+        task = runtime._session_store.request_background_task_cancel(
+            workspace=runtime._workspace,
+            task_id=task_id,
+        )
+        if task.status == "running" and task.session_id is not None:
+            child_response = self.load_background_task_child_response(task=task)
+            if child_response is not None and child_response.session.status == "waiting":
+                runtime._session_store.clear_pending_approval(
+                    workspace=runtime._workspace,
+                    session_id=task.session_id,
+                )
+                runtime._session_store.clear_pending_question(
+                    workspace=runtime._workspace,
+                    session_id=task.session_id,
+                )
+                cancelled_metadata = dict(child_response.session.metadata)
+                cancelled_metadata["abort_requested"] = True
+                cancelled_response = RuntimeResponse(
+                    session=SessionState(
+                        session=child_response.session.session,
+                        status="failed",
+                        turn=child_response.session.turn,
+                        metadata=cancelled_metadata,
+                    ),
+                    events=child_response.events
+                    + (
+                        EventEnvelope(
+                            session_id=task.session_id,
+                            sequence=(
+                                child_response.events[-1].sequence if child_response.events else 0
+                            )
+                            + 1,
+                            event_type=RUNTIME_FAILED,
+                            source="runtime",
+                            payload={
+                                "error": "cancelled by parent while child session was waiting",
+                                "cancelled": True,
+                                "delegated_task_id": task.task.id,
+                            },
+                        ),
+                    ),
+                    output=child_response.output,
+                )
+                runtime._session_store.save_run(
+                    workspace=runtime._workspace,
+                    request=RuntimeRequest(
+                        prompt=runtime._prompt_from_events(child_response.events),
+                        session_id=task.session_id,
+                        parent_session_id=task.parent_session_id,
+                        metadata=cast(RuntimeRequestMetadataPayload, cancelled_metadata),
+                    ),
+                    response=cancelled_response,
+                )
+                task = runtime._session_store.mark_background_task_terminal(
+                    workspace=runtime._workspace,
+                    task_id=task_id,
+                    status="cancelled",
+                    error="cancelled by parent while child session was waiting",
+                )
+        if previous_task.status != "cancelled" and task.status == "cancelled":
+            self.run_background_task_lifecycle_hook(task)
+        return task
+
+    def load_background_task_child_response(
+        self,
+        *,
+        task: BackgroundTaskState,
+    ) -> RuntimeResponse | None:
+        runtime = self._runtime
+        child_session_id = task.session_id
+        if child_session_id is None:
+            return None
+        try:
+            response = runtime._session_store.load_session(
+                workspace=runtime._workspace,
+                session_id=child_session_id,
+            )
+        except UnknownSessionError:
+            return None
+        runtime._validate_session_workspace(response.session, session_id=child_session_id)
+        return response
+
+    def load_background_task_child_result(
+        self,
+        *,
+        task: BackgroundTaskState,
+    ) -> RuntimeSessionResult | None:
+        runtime = self._runtime
+        child_session_id = task.session_id
+        if child_session_id is None:
+            return None
+        try:
+            result = runtime._session_store.load_session_result(
+                workspace=runtime._workspace,
+                session_id=child_session_id,
+            )
+        except UnknownSessionError:
+            return None
+        runtime._validate_session_workspace(result.session, session_id=child_session_id)
+        return result
+
+    def background_task_result(self, *, task: BackgroundTaskState) -> BackgroundTaskResult:
+        child_result = self.load_background_task_child_result(task=task)
+        approval_blocked = child_result is not None and child_result.status == "waiting"
+        summary_output = child_result.summary if child_result is not None else None
+        error = (
+            child_result.error if child_result is not None and child_result.error else task.error
+        )
+        result_available = task.result_available
+        if not result_available and task.status != "cancelled" and child_result is not None:
+            result_available = True
+        return BackgroundTaskResult(
+            task_id=task.task.id,
+            parent_session_id=task.parent_session_id,
+            child_session_id=task.session_id,
+            status=task.status,
+            requested_child_session_id=task.request.session_id or task.session_id,
+            routing=task.routing_identity,
+            approval_request_id=task.approval_request_id,
+            question_request_id=task.question_request_id,
+            approval_blocked=approval_blocked,
+            summary_output=summary_output,
+            error=error,
+            result_available=result_available,
+            cancellation_cause=task.cancellation_cause,
+        )
+
+    def emit_background_task_parent_terminal_event(self, *, task: BackgroundTaskState) -> None:
+        runtime = self._runtime
+        parent_session_id = task.parent_session_id
+        if parent_session_id is None or task.status not in ("completed", "failed", "cancelled"):
+            return
+        session_event_appender = runtime._session_store
+        if not isinstance(session_event_appender, SessionEventAppender):
+            logger.debug(
+                "skipping background terminal parent event for session store without append support"
+            )
+            return
+        result = self.background_task_result(task=task)
+        event_type_by_status: dict[BackgroundTaskStatus, str] = {
+            "completed": RUNTIME_BACKGROUND_TASK_COMPLETED,
+            "failed": RUNTIME_BACKGROUND_TASK_FAILED,
+            "cancelled": RUNTIME_BACKGROUND_TASK_CANCELLED,
+        }
+        event_type = event_type_by_status[task.status]
+        payload: dict[str, object] = {
+            "task_id": task.task.id,
+            "parent_session_id": parent_session_id,
+            "status": task.status,
+            "result_available": result.result_available,
+            "delegation": result.delegated_execution.as_payload(),
+            "message": result.delegated_message.as_payload(),
+        }
+        if result.child_session_id is not None:
+            payload["child_session_id"] = result.child_session_id
+        if task.status == "completed" and result.summary_output is not None:
+            payload["summary_output"] = result.summary_output
+        if task.status in ("failed", "cancelled") and result.error is not None:
+            payload["error"] = result.error
+        if task.approval_request_id is not None:
+            payload["approval_request_id"] = task.approval_request_id
+        if task.question_request_id is not None:
+            payload["question_request_id"] = task.question_request_id
+        try:
+            _ = session_event_appender.append_session_event(
+                workspace=runtime._workspace,
+                session_id=parent_session_id,
+                event_type=event_type,
+                source="runtime",
+                payload=payload,
+                dedupe_key=f"{event_type}:{task.task.id}",
+            )
+            runtime._append_parent_acp_delegated_lifecycle_event(
+                task=task,
+                lifecycle_status=task.status,
+                result_available=result.result_available,
+                payload=payload,
+            )
+            runtime._publish_delegated_acp_event(
+                task=task,
+                lifecycle_status=task.status,
+                result_available=result.result_available,
+                payload=payload,
+            )
+        except UnknownSessionError:
+            logger.debug(
+                "skipping background terminal event for unavailable parent session: %s",
+                parent_session_id,
+            )
+
+    def backfill_parent_background_task_event(self, *, task: BackgroundTaskState) -> None:
+        if task.parent_session_id is None:
+            return
+        if task.status in ("completed", "failed", "cancelled"):
+            self.emit_background_task_parent_terminal_event(task=task)
+            return
+        if task.status != "running":
+            return
+        child_response = self.load_background_task_child_response(task=task)
+        if child_response is None or child_response.session.status != "waiting":
+            return
+        self.emit_background_task_waiting_approval(
+            task=task,
+            child_response=child_response,
+        )
+
+    def reconcile_parent_background_task_events_for_session(
+        self,
+        *,
+        parent_session_id: str,
+    ) -> None:
+        runtime = self._runtime
+        task_summaries = runtime._session_store.list_background_tasks_by_parent_session(
+            workspace=runtime._workspace,
+            parent_session_id=parent_session_id,
+        )
+        for task_summary in task_summaries:
+            task = runtime._session_store.load_background_task(
+                workspace=runtime._workspace,
+                task_id=task_summary.task.id,
+            )
+            if task.status == "running" and task.session_id is not None:
+                child_response = self.load_background_task_child_response(task=task)
+                if child_response is not None and child_response.session.status in (
+                    "waiting",
+                    "completed",
+                    "failed",
+                ):
+                    self.finalize_background_task_from_session_response(
+                        session_response=child_response
+                    )
+                    continue
+            self.backfill_parent_background_task_event(task=task)
+
+    def emit_background_task_waiting_approval(
+        self,
+        *,
+        task: BackgroundTaskState,
+        child_response: RuntimeResponse,
+    ) -> None:
+        runtime = self._runtime
+        parent_session_id = task.parent_session_id
+        child_session_id = task.session_id
+        if parent_session_id is None or child_session_id is None:
+            return
+        approval_request_id = runtime._approval_request_id_from_waiting_response(child_response)
+        dedupe_key = (
+            f"background_task_waiting_approval:{task.task.id}:{approval_request_id}"
+            if approval_request_id is not None
+            else f"background_task_waiting_approval:{task.task.id}:{child_session_id}"
+        )
+        session_event_appender = runtime._session_store
+        if not isinstance(session_event_appender, SessionEventAppender):
+            logger.debug(
+                "skipping background waiting event for session store without append support"
+            )
+            return
+        result = self.background_task_result(task=task)
+        try:
+            _ = session_event_appender.append_session_event(
+                workspace=runtime._workspace,
+                session_id=parent_session_id,
+                event_type=RUNTIME_BACKGROUND_TASK_WAITING_APPROVAL,
+                source="runtime",
+                payload={
+                    "task_id": task.task.id,
+                    "parent_session_id": parent_session_id,
+                    "child_session_id": child_session_id,
+                    "status": "running",
+                    "approval_blocked": True,
+                    "delegation": result.delegated_execution.as_payload(),
+                    "message": result.delegated_message.as_payload(),
+                    **(
+                        {"approval_request_id": approval_request_id}
+                        if approval_request_id is not None
+                        else {}
+                    ),
+                },
+                dedupe_key=dedupe_key,
+            )
+            acp_payload: dict[str, object] = {
+                "task_id": task.task.id,
+                "parent_session_id": parent_session_id,
+                "child_session_id": child_session_id,
+                "approval_request_id": approval_request_id,
+                "status": "running",
+                "approval_blocked": True,
+            }
+            runtime._append_parent_acp_delegated_lifecycle_event(
+                task=task,
+                lifecycle_status="waiting_approval",
+                approval_blocked=True,
+                payload=acp_payload,
+            )
+            runtime._publish_delegated_acp_event(
+                task=task,
+                lifecycle_status="waiting_approval",
+                approval_blocked=True,
+                payload=acp_payload,
+            )
+        except UnknownSessionError:
+            logger.debug(
+                "skipping background waiting event for unavailable parent session: %s",
+                parent_session_id,
+            )
+
+    def finalize_background_task_from_session_response(
+        self,
+        *,
+        session_response: RuntimeResponse,
+    ) -> None:
+        runtime = self._runtime
+        metadata = session_response.session.metadata
+        background_task_id = metadata.get("background_task_id")
+        background_run = metadata.get("background_run")
+        if not isinstance(background_task_id, str) or background_run is not True:
+            return
+        current_task = runtime._session_store.load_background_task(
+            workspace=runtime._workspace,
+            task_id=background_task_id,
+        )
+        if is_background_task_terminal(current_task.status):
+            return
+        if session_response.session.status == "waiting":
+            self.emit_background_task_waiting_approval(
+                task=current_task,
+                child_response=session_response,
+            )
+            return
+        terminal_status: BackgroundTaskStatus = (
+            "completed" if session_response.session.status == "completed" else "failed"
+        )
+        if current_task.status == terminal_status:
+            return
+        error: str | None = None
+        if terminal_status == "failed":
+            for event in reversed(session_response.events):
+                if event.event_type == RUNTIME_FAILED:
+                    event_error = event.payload.get("error")
+                    error = str(event_error) if event_error is not None else None
+                    break
+        terminal_task = runtime._session_store.mark_background_task_terminal(
+            workspace=runtime._workspace,
+            task_id=background_task_id,
+            status=terminal_status,
+            error=error,
+        )
+        self.run_background_task_lifecycle_hook(terminal_task)
+
+    def run_background_task_lifecycle_hook(self, task: BackgroundTaskState) -> None:
+        surface_by_status: dict[BackgroundTaskStatus, RuntimeHookSurface] = {
+            "completed": "background_task_completed",
+            "failed": "background_task_failed",
+            "cancelled": "background_task_cancelled",
+        }
+        surface = surface_by_status.get(task.status)
+        if surface is None:
+            return
+        self.run_background_task_lifecycle_surface(
+            task=task,
+            surface=surface,
+            session_id=task.session_id or task.request.session_id or "runtime",
+        )
+        self.emit_background_task_parent_terminal_event(task=task)
+        if task.status == "completed" and task.parent_session_id is not None:
+            self.run_background_task_lifecycle_surface(
+                task=task,
+                surface="delegated_result_available",
+                session_id=task.parent_session_id,
+                extra_payload={
+                    "delegated_session_id": task.session_id or "",
+                    "parent_session_id": task.parent_session_id,
+                },
+            )
+
+    def run_background_task_lifecycle_surface(
+        self,
+        *,
+        task: BackgroundTaskState,
+        surface: RuntimeHookSurface,
+        session_id: str,
+        extra_payload: dict[str, object] | None = None,
+    ) -> None:
+        runtime = self._runtime
+        outcome = run_lifecycle_hooks(
+            LifecycleHookExecutionRequest(
+                hooks=runtime._config.hooks,
+                workspace=runtime._workspace,
+                session_id=session_id,
+                surface=surface,
+                recursion_env_var=runtime._hook_recursion_env_var,
+                environment=os.environ,
+                sequence_start=0,
+                payload={
+                    "background_task_id": task.task.id,
+                    "background_task_status": task.status,
+                    **({"background_task_error": task.error} if task.error is not None else {}),
+                    **(extra_payload or {}),
+                },
+            )
+        )
+        if outcome.failed_error is not None:
+            logger.warning("background task lifecycle hook failed: %s", outcome.failed_error)
+
+    def reconcile_background_tasks_if_needed(self) -> None:
+        runtime = self._runtime
+        if runtime._background_tasks_reconciled:
+            return
+        task_summaries = runtime._session_store.list_background_tasks(workspace=runtime._workspace)
+        for task_summary in task_summaries:
+            if task_summary.status != "running" or task_summary.session_id is None:
+                continue
+            task = runtime._session_store.load_background_task(
+                workspace=runtime._workspace,
+                task_id=task_summary.task.id,
+            )
+            child_response = self.load_background_task_child_response(task=task)
+            if child_response is None:
+                continue
+            if child_response.session.status in ("waiting", "completed", "failed"):
+                self.finalize_background_task_from_session_response(session_response=child_response)
+        fail_incomplete = getattr(runtime._session_store, "fail_incomplete_background_tasks", None)
+        if callable(fail_incomplete):
+            failed_tasks = cast(
+                tuple[BackgroundTaskState, ...],
+                fail_incomplete(
+                    workspace=runtime._workspace,
+                    message="background task interrupted before completion",
+                ),
+            )
+            for failed_task in failed_tasks:
+                self.run_background_task_lifecycle_hook(failed_task)
+        task_summaries = runtime._session_store.list_background_tasks(workspace=runtime._workspace)
+        for task_summary in task_summaries:
+            task = runtime._session_store.load_background_task(
+                workspace=runtime._workspace,
+                task_id=task_summary.task.id,
+            )
+            self.backfill_parent_background_task_event(task=task)
+        runtime._background_tasks_reconciled = True
+
+    def run_background_task_worker(self, task_id: str) -> None:
+        runtime = self._runtime
+        try:
+            task = runtime.load_background_task(task_id)
+            if task.status == "cancelled":
+                return
+            request = RuntimeRequest(
+                prompt=task.request.prompt,
+                session_id=task.request.session_id,
+                parent_session_id=task.request.parent_session_id,
+                metadata=cast(RuntimeRequestMetadataPayload, task.request.metadata),
+                allocate_session_id=task.request.allocate_session_id,
+            )
+            routing = runtime._session_routing_for_request(request)
+            session_id = routing.session_id
+            running_task = runtime._session_store.mark_background_task_running(
+                workspace=runtime._workspace,
+                task_id=task_id,
+                session_id=session_id,
+            )
+            if running_task.status != "running":
+                return
+            dispatch_task = runtime.load_background_task(task_id)
+            if dispatch_task.status != "running":
+                return
+            if dispatch_task.cancel_requested_at is not None:
+                terminal_task = runtime._session_store.mark_background_task_terminal(
+                    workspace=runtime._workspace,
+                    task_id=task_id,
+                    status="cancelled",
+                    error="cancelled before dispatch",
+                )
+                self.run_background_task_lifecycle_hook(terminal_task)
+                return
+            events: list[EventEnvelope] = []
+            output: str | None = None
+            final_session: Any | None = None
+            internal_request = RuntimeRequest(
+                prompt=dispatch_task.request.prompt,
+                session_id=session_id,
+                parent_session_id=dispatch_task.request.parent_session_id,
+                metadata=cast(
+                    InternalRuntimeRequestMetadata,
+                    {
+                        **dispatch_task.request.metadata,
+                        "background_task_id": task_id,
+                        "background_run": True,
+                    },
+                ),
+                allocate_session_id=False,
+            )
+            for chunk in runtime._run_with_persistence(
+                internal_request,
+                allow_internal_metadata=True,
+            ):
+                final_session = chunk.session
+                if chunk.event is not None:
+                    events.append(chunk.event)
+                if chunk.kind == "output":
+                    output = chunk.output
+                current_task_state = runtime._session_store.load_background_task(
+                    workspace=runtime._workspace,
+                    task_id=task_id,
+                )
+                if current_task_state.cancel_requested_at is not None:
+                    if final_session is None:
+                        raise ValueError("runtime stream emitted no chunks")
+                    cancel_metadata = dict(final_session.metadata)
+                    cancel_metadata["abort_requested"] = True
+                    cancelled_response = RuntimeResponse(
+                        session=SessionState(
+                            session=final_session.session,
+                            status="failed",
+                            turn=final_session.turn,
+                            metadata=cancel_metadata,
+                        ),
+                        events=tuple(events)
+                        + (
+                            EventEnvelope(
+                                session_id=session_id,
+                                sequence=(events[-1].sequence if events else 0) + 1,
+                                event_type=RUNTIME_FAILED,
+                                source="runtime",
+                                payload={
+                                    "error": "cancelled by parent during delegated execution",
+                                    "cancelled": True,
+                                    "delegated_task_id": task_id,
+                                },
+                            ),
+                        ),
+                        output=output,
+                    )
+                    runtime._session_store.save_run(
+                        workspace=runtime._workspace,
+                        request=internal_request,
+                        response=cancelled_response,
+                    )
+                    terminal_task = runtime._session_store.mark_background_task_terminal(
+                        workspace=runtime._workspace,
+                        task_id=task_id,
+                        status="cancelled",
+                        error="cancelled by parent during delegated execution",
+                    )
+                    self.run_background_task_lifecycle_hook(terminal_task)
+                    return
+            if final_session is None:
+                raise ValueError("runtime stream emitted no chunks")
+            if final_session.status == "waiting":
+                final_session = runtime._reload_persisted_session(
+                    session_id=final_session.session.id
+                )
+            response = RuntimeResponse(
+                session=final_session,
+                events=tuple(events),
+                output=output,
+            )
+            self.finalize_background_task_from_session_response(session_response=response)
+        except Exception as exc:
+            logger.exception("background task failed: %s", task_id)
+            terminal_task = runtime._session_store.mark_background_task_terminal(
+                workspace=runtime._workspace,
+                task_id=task_id,
+                status="failed",
+                error=str(exc),
+            )
+            self.run_background_task_lifecycle_hook(terminal_task)
+        finally:
+            runtime._background_task_threads.pop(task_id, None)

--- a/src/voidcode/runtime/lsp.py
+++ b/src/voidcode/runtime/lsp.py
@@ -27,6 +27,21 @@ from .config import RuntimeLspConfig
 
 logger = logging.getLogger(__name__)
 
+MAX_LSP_HEADER_BYTES = 8192
+MAX_LSP_MESSAGE_BYTES = 1024 * 1024
+
+
+class LspRuntimeError(ValueError):
+    """Base class for runtime-managed LSP failures."""
+
+
+class LspProtocolError(LspRuntimeError):
+    """Raised when an LSP server violates JSON-RPC/LSP framing or payload rules."""
+
+
+class LspMessageBoundsError(LspRuntimeError):
+    """Raised when an LSP message exceeds configured runtime bounds."""
+
 
 @dataclass(frozen=True, slots=True)
 class LspConfigState:
@@ -140,6 +155,8 @@ class _RunningLspServer:
     process: subprocess.Popen[bytes]
     workspace_root: Path
     initialized: bool = False
+    next_request_id: int = 1
+    request_lock: threading.Lock = field(default_factory=threading.Lock)
 
 
 @dataclass(slots=True)
@@ -675,13 +692,16 @@ class ManagedLspManager:
         server_name: str,
     ) -> dict[str, object]:
         process = running_server.process
-        self._write_message(
-            process=process,
-            message={"jsonrpc": "2.0", "id": 1, "method": method, "params": params},
-        )
-        response = self._read_message(process=process)
-        while response is not None and response.get("id") != 1:
+        with running_server.request_lock:
+            request_id = running_server.next_request_id
+            running_server.next_request_id += 1
+            self._write_message(
+                process=process,
+                message={"jsonrpc": "2.0", "id": request_id, "method": method, "params": params},
+            )
             response = self._read_message(process=process)
+            while response is not None and response.get("id") != request_id:
+                response = self._read_message(process=process)
         if response is None:
             raise ValueError(f"No response from LSP server {server_name} for {method}")
         return response
@@ -739,15 +759,29 @@ class ManagedLspManager:
             if not chunk:
                 return None
             header += chunk
+            if len(header) > MAX_LSP_HEADER_BYTES:
+                raise LspMessageBoundsError(f"LSP header exceeded {MAX_LSP_HEADER_BYTES} bytes")
 
         header_text = header.decode("ascii", errors="ignore")
         content_length = None
         for line in header_text.split("\r\n"):
             if line.lower().startswith("content-length:"):
-                content_length = int(line.split(":", 1)[1].strip())
+                raw_length = line.split(":", 1)[1].strip()
+                try:
+                    content_length = int(raw_length)
+                except ValueError as exc:
+                    raise LspProtocolError(
+                        f"invalid Content-Length from LSP server: {raw_length}"
+                    ) from exc
                 break
         if content_length is None:
-            return None
+            raise LspProtocolError("missing Content-Length in LSP response header")
+        if content_length < 0:
+            raise LspProtocolError("invalid negative Content-Length from LSP server")
+        if content_length > MAX_LSP_MESSAGE_BYTES:
+            raise LspMessageBoundsError(
+                f"LSP Content-Length {content_length} exceeds {MAX_LSP_MESSAGE_BYTES} bytes"
+            )
 
         body = b""
         while len(body) < content_length:
@@ -756,7 +790,17 @@ class ManagedLspManager:
             if not chunk:
                 return None
             body += chunk
-        return cast(dict[str, object], json.loads(body.decode("utf-8")))
+        try:
+            decoded_body = body.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise LspProtocolError("invalid UTF-8 payload from LSP server") from exc
+        try:
+            payload = json.loads(decoded_body)
+        except json.JSONDecodeError as exc:
+            raise LspProtocolError("invalid JSON payload from LSP server") from exc
+        if not isinstance(payload, dict):
+            raise LspProtocolError("expected JSON-RPC object payload from LSP server")
+        return cast(dict[str, object], payload)
 
     @staticmethod
     def _wait_for_windows_pipe(*, fd: int, timeout: float) -> bool:

--- a/src/voidcode/runtime/permission.py
+++ b/src/voidcode/runtime/permission.py
@@ -39,6 +39,7 @@ class PendingApproval:
     target_summary: str = ""
     reason: str = ""
     policy_mode: PermissionDecision = "ask"
+    request_event_sequence: int | None = None
     owner_session_id: str | None = None
     owner_parent_session_id: str | None = None
     delegated_task_id: str | None = None

--- a/src/voidcode/runtime/resume.py
+++ b/src/voidcode/runtime/resume.py
@@ -1,0 +1,996 @@
+# pyright: reportPrivateUsage=false
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+from ..graph.contracts import GraphRunRequest
+from ..tools.contracts import ToolResult, ToolResultStatus
+from ..tools.question import QuestionTool
+from .config import serialize_runtime_agent_config
+from .contracts import NoPendingQuestionError, RuntimeRequest, RuntimeResponse, RuntimeStreamChunk
+from .events import RUNTIME_QUESTION_ANSWERED, RUNTIME_SKILLS_BINDING_MISMATCH, EventEnvelope
+from .permission import PendingApproval, PermissionResolution
+from .question import PendingQuestion, QuestionResponse
+from .session import SessionState
+
+if TYPE_CHECKING:
+    from .service import VoidCodeRuntime
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalResumeCheckpointState:
+    prompt: str
+    session_metadata: dict[str, object]
+    tool_results: tuple[ToolResult, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PersistedResumeCheckpointEnvelope:
+    kind: str
+    version: int
+    payload: dict[str, object]
+
+
+class RuntimeResumeCoordinator:
+    def __init__(self, runtime: VoidCodeRuntime) -> None:
+        self._runtime = runtime
+
+    def resume_pending_approval_stream(
+        self,
+        *,
+        session_id: str,
+        approval_request_id: str,
+        approval_decision: PermissionResolution,
+        finalize_background_task: bool = False,
+    ) -> Iterator[RuntimeStreamChunk]:
+        stored_response, pending, checkpoint = self._load_pending_approval_context(
+            session_id=session_id,
+            approval_request_id=approval_request_id,
+        )
+        streamed_events: list[EventEnvelope] = []
+        output: str | None = None
+        final_session: Any | None = None
+        for chunk in self.resume_pending_approval_impl(
+            stored=stored_response,
+            pending=pending,
+            approval_decision=approval_decision,
+            checkpoint=checkpoint,
+        ):
+            final_session = chunk.session
+            if chunk.event is not None:
+                streamed_events.append(chunk.event)
+            if chunk.kind == "output":
+                output = chunk.output
+            yield chunk
+        if finalize_background_task:
+            response = self.response_from_resumed_chunks(
+                stored_response=stored_response,
+                streamed_events=streamed_events,
+                output=output,
+                final_session=final_session,
+            )
+            self._runtime._finalize_background_task_from_session_response(session_response=response)
+
+    def resume_pending_approval_response(
+        self,
+        *,
+        session_id: str,
+        approval_request_id: str,
+        approval_decision: PermissionResolution,
+    ) -> tuple[tuple[EventEnvelope, ...], RuntimeResponse]:
+        stored_response, pending, checkpoint = self._load_pending_approval_context(
+            session_id=session_id,
+            approval_request_id=approval_request_id,
+        )
+        streamed_events: list[EventEnvelope] = []
+        output: str | None = None
+        final_session: Any | None = None
+        for chunk in self.resume_pending_approval_impl(
+            stored=stored_response,
+            pending=pending,
+            approval_decision=approval_decision,
+            checkpoint=checkpoint,
+        ):
+            final_session = chunk.session
+            if chunk.event is not None:
+                streamed_events.append(chunk.event)
+            if chunk.kind == "output":
+                output = chunk.output
+        response = self.response_from_resumed_chunks(
+            stored_response=stored_response,
+            streamed_events=streamed_events,
+            output=output,
+            final_session=final_session,
+        )
+        return stored_response.events, response
+
+    def answer_pending_question_stream(
+        self,
+        *,
+        session_id: str,
+        question_request_id: str,
+        responses: tuple[QuestionResponse, ...],
+        finalize_background_task: bool = False,
+    ) -> Iterator[RuntimeStreamChunk]:
+        stored_response, pending, checkpoint, normalized_responses = (
+            self._load_pending_question_context(
+                session_id=session_id,
+                question_request_id=question_request_id,
+                responses=responses,
+            )
+        )
+        streamed_events: list[EventEnvelope] = []
+        output: str | None = None
+        final_session: Any | None = None
+        for chunk in self.answer_pending_question_impl(
+            stored=stored_response,
+            pending=pending,
+            responses=normalized_responses,
+            checkpoint=checkpoint,
+        ):
+            final_session = chunk.session
+            if chunk.event is not None:
+                streamed_events.append(chunk.event)
+            if chunk.kind == "output":
+                output = chunk.output
+            yield chunk
+        if finalize_background_task:
+            response = self.response_from_resumed_chunks(
+                stored_response=stored_response,
+                streamed_events=streamed_events,
+                output=output,
+                final_session=final_session,
+            )
+            self._runtime._finalize_background_task_from_session_response(session_response=response)
+
+    def answer_pending_question_response(
+        self,
+        *,
+        session_id: str,
+        question_request_id: str,
+        responses: tuple[QuestionResponse, ...],
+    ) -> tuple[tuple[EventEnvelope, ...], RuntimeResponse]:
+        stored_response, pending, checkpoint, normalized_responses = (
+            self._load_pending_question_context(
+                session_id=session_id,
+                question_request_id=question_request_id,
+                responses=responses,
+            )
+        )
+        streamed_events: list[EventEnvelope] = []
+        output: str | None = None
+        final_session: Any | None = None
+        for chunk in self.answer_pending_question_impl(
+            stored=stored_response,
+            pending=pending,
+            responses=normalized_responses,
+            checkpoint=checkpoint,
+        ):
+            final_session = chunk.session
+            if chunk.event is not None:
+                streamed_events.append(chunk.event)
+            if chunk.kind == "output":
+                output = chunk.output
+        response = self.response_from_resumed_chunks(
+            stored_response=stored_response,
+            streamed_events=streamed_events,
+            output=output,
+            final_session=final_session,
+        )
+        return stored_response.events, response
+
+    def answer_pending_question_impl(
+        self,
+        *,
+        stored: Any,
+        pending: PendingQuestion,
+        responses: tuple[QuestionResponse, ...],
+        checkpoint: dict[str, object] | None,
+    ) -> Iterator[RuntimeStreamChunk]:
+        runtime = self._runtime
+        session = SessionState(
+            session=stored.session.session,
+            status="running",
+            turn=stored.session.turn,
+            metadata=stored.session.metadata,
+        )
+        max_stored_sequence = stored.events[-1].sequence if stored.events else 0
+        question_answer_result = QuestionTool.answer_tool_result(responses)
+
+        checkpoint_state = self.question_resume_state_from_checkpoint(
+            checkpoint=checkpoint,
+            pending=pending,
+            stored_metadata=stored.session.metadata,
+        )
+        if checkpoint_state is not None:
+            prompt = checkpoint_state.prompt
+            session = SessionState(
+                session=stored.session.session,
+                status="running",
+                turn=stored.session.turn,
+                metadata=checkpoint_state.session_metadata,
+            )
+            tool_results: list[ToolResult] = list(checkpoint_state.tool_results)
+        else:
+            prompt, tool_results = self._resume_prompt_and_tool_results_from_stored_events(
+                stored.events
+            )
+        runtime._validate_session_workspace(session, session_id=stored.session.session.id)
+        tool_results.append(question_answer_result)
+
+        sequence = max_stored_sequence + 1
+        answered_event = EventEnvelope(
+            session_id=session.session.id,
+            sequence=sequence,
+            event_type=RUNTIME_QUESTION_ANSWERED,
+            source="runtime",
+            payload={
+                "request_id": pending.request_id,
+                "responses": [
+                    {"header": response.header, "answers": list(response.answers)}
+                    for response in responses
+                ],
+            },
+        )
+        yield RuntimeStreamChunk(kind="event", session=session, event=answered_event)
+        sequence += 1
+        loop_events = [answered_event]
+        tool_completed_event = EventEnvelope(
+            session_id=session.session.id,
+            sequence=sequence,
+            event_type="runtime.tool_completed",
+            source="tool",
+            payload={
+                "tool": question_answer_result.tool_name,
+                "status": question_answer_result.status,
+                "content": question_answer_result.content,
+                "error": question_answer_result.error,
+                **question_answer_result.data,
+            },
+        )
+        yield RuntimeStreamChunk(kind="event", session=session, event=tool_completed_event)
+        loop_events.append(tool_completed_event)
+
+        effective_config = runtime._effective_runtime_config_from_metadata(session.metadata)
+        tool_registry = runtime._tool_registry_for_effective_config(effective_config)
+        skill_registry = runtime._skill_registry_for_effective_config(effective_config)
+        resumed_skill_snapshot = runtime._build_skill_snapshot(
+            skill_registry,
+            metadata=session.metadata,
+            agent=effective_config.agent,
+            source="resume",
+        )
+        graph_request = GraphRunRequest(
+            session=session,
+            prompt=prompt,
+            available_tools=tool_registry.definitions(),
+            applied_skills=resumed_skill_snapshot.applied_skill_payloads,
+            skill_prompt_context=resumed_skill_snapshot.skill_prompt_context,
+            context_window=runtime._prepare_provider_context_window(
+                prompt=prompt,
+                tool_results=tuple(tool_results),
+                session_metadata=session.metadata,
+            ),
+            metadata={
+                **session.metadata,
+                "agent_preset": serialize_runtime_agent_config(effective_config.agent),
+                "provider_attempt": (
+                    session.metadata.get("provider_attempt", 0)
+                    if isinstance(session.metadata.get("provider_attempt", 0), int)
+                    else 0
+                ),
+            },
+        )
+        graph = runtime._graph_for_session_metadata(session.metadata)
+        output: str | None = None
+        final_session = session
+        try:
+            for chunk in runtime._execute_graph_loop(
+                graph=graph,
+                tool_registry=tool_registry,
+                session=session,
+                sequence=sequence,
+                graph_request=graph_request,
+                tool_results=tool_results,
+                permission_policy=runtime._permission_policy_for_session(session.metadata),
+                preserved_continuity_state=runtime._continuity_state_from_session_metadata(
+                    session.metadata
+                ),
+            ):
+                final_session = chunk.session
+                if chunk.event is not None:
+                    loop_events.append(chunk.event)
+                if chunk.kind == "output":
+                    output = chunk.output
+                yield chunk
+        except Exception:
+            if final_session.status == "failed":
+                response = RuntimeResponse(
+                    session=final_session,
+                    events=stored.events + tuple(loop_events),
+                    output=output,
+                )
+                request = RuntimeRequest(
+                    prompt=prompt,
+                    session_id=stored.session.session.id,
+                    parent_session_id=stored.session.session.parent_id,
+                )
+                runtime._persist_response(request=request, response=response)
+                return
+            raise
+
+        response = RuntimeResponse(
+            session=final_session,
+            events=stored.events + tuple(loop_events),
+            output=output,
+        )
+        request = RuntimeRequest(
+            prompt=prompt,
+            session_id=stored.session.session.id,
+            parent_session_id=stored.session.session.parent_id,
+        )
+        runtime._persist_response(request=request, response=response)
+
+    def response_from_resumed_chunks(
+        self,
+        *,
+        stored_response: Any,
+        streamed_events: list[EventEnvelope],
+        output: str | None,
+        final_session: Any | None,
+    ) -> RuntimeResponse:
+        if final_session is None:
+            raise ValueError("runtime stream emitted no chunks")
+        if final_session.status == "waiting":
+            final_session = self._runtime._reload_persisted_session(
+                session_id=final_session.session.id
+            )
+        resolved_session = cast(SessionState, final_session)
+        return RuntimeResponse(
+            session=resolved_session,
+            events=stored_response.events + tuple(streamed_events),
+            output=output,
+        )
+
+    def resume_pending_approval_impl(
+        self,
+        *,
+        stored: Any,
+        pending: PendingApproval,
+        approval_decision: PermissionResolution,
+        checkpoint: dict[str, object] | None,
+    ) -> Iterator[RuntimeStreamChunk]:
+        runtime = self._runtime
+        session = SessionState(
+            session=stored.session.session,
+            status="running",
+            turn=stored.session.turn,
+            metadata=stored.session.metadata,
+        )
+        max_stored_sequence = stored.events[-1].sequence if stored.events else 0
+        loop_events: list[EventEnvelope] = []
+        output: str | None = None
+
+        checkpoint_state = self.approval_resume_state_from_checkpoint(
+            checkpoint=checkpoint,
+            pending=pending,
+            stored_metadata=stored.session.metadata,
+        )
+        binding_mismatch_payload: dict[str, object] | None = None
+        if checkpoint is not None:
+            checkpoint_binding = checkpoint.get("skill_binding_snapshot")
+            checkpoint_binding_payload = (
+                cast(dict[str, object], checkpoint_binding)
+                if isinstance(checkpoint_binding, dict)
+                else None
+            )
+            if checkpoint_binding_payload is not None:
+                stored_snapshot_payload = cast(
+                    dict[str, object] | None,
+                    stored.session.metadata.get("skill_snapshot"),
+                )
+                stored_binding_payload = (
+                    cast(dict[str, object], stored_snapshot_payload.get("binding_snapshot"))
+                    if isinstance(stored_snapshot_payload, dict)
+                    and isinstance(stored_snapshot_payload.get("binding_snapshot"), dict)
+                    else None
+                )
+                mismatch_payload = runtime._skill_binding_mismatch_payload(
+                    checkpoint_binding_payload,
+                    stored_binding_payload,
+                )
+                if cast(bool, mismatch_payload["mismatch"]):
+                    binding_mismatch_payload = mismatch_payload
+        if checkpoint_state is not None:
+            prompt = checkpoint_state.prompt
+            session = SessionState(
+                session=stored.session.session,
+                status="running",
+                turn=stored.session.turn,
+                metadata=checkpoint_state.session_metadata,
+            )
+            tool_results: list[ToolResult] = list(checkpoint_state.tool_results)
+        else:
+            prompt, tool_results = self._resume_prompt_and_tool_results_from_stored_events(
+                stored.events
+            )
+
+        runtime._validate_session_workspace(session, session_id=stored.session.session.id)
+        session = runtime._session_with_current_acp_metadata(session)
+        preserved_continuity_state = runtime._continuity_state_from_session_metadata(
+            session.metadata
+        )
+        mcp_startup_chunks, session, _, mcp_failed_chunk = runtime._refresh_mcp_tools_for_session(
+            session=session,
+            sequence=max_stored_sequence,
+            failure_kind="mcp_startup_failed",
+        )
+        effective_config = runtime._effective_runtime_config_from_metadata(session.metadata)
+        tool_registry = runtime._tool_registry_for_effective_config(effective_config)
+        skill_registry = runtime._skill_registry_for_effective_config(effective_config)
+
+        resumed_skill_snapshot = runtime._build_skill_snapshot(
+            skill_registry,
+            metadata=session.metadata,
+            agent=effective_config.agent,
+            source="resume",
+        )
+        graph_request = GraphRunRequest(
+            session=session,
+            prompt=prompt,
+            available_tools=tool_registry.definitions(),
+            applied_skills=resumed_skill_snapshot.applied_skill_payloads,
+            skill_prompt_context=resumed_skill_snapshot.skill_prompt_context,
+            context_window=runtime._prepare_provider_context_window(
+                prompt=prompt,
+                tool_results=tuple(tool_results),
+                session_metadata=session.metadata,
+            ),
+            metadata={
+                **session.metadata,
+                "agent_preset": serialize_runtime_agent_config(effective_config.agent),
+                "provider_attempt": (
+                    session.metadata.get("provider_attempt", 0)
+                    if isinstance(session.metadata.get("provider_attempt", 0), int)
+                    else 0
+                ),
+            },
+        )
+        provider_attempt = runtime._provider_attempt_from_metadata(graph_request.metadata)
+        graph = runtime._graph_for_session_metadata(session.metadata)
+        if provider_attempt > 0:
+            graph = runtime._graph_selection_for_effective_config(
+                runtime._effective_runtime_config_from_metadata(session.metadata),
+                provider_attempt=provider_attempt,
+            ).graph
+
+        emitted_sequence = max_stored_sequence
+        if binding_mismatch_payload is not None:
+            emitted_sequence += 1
+            mismatch_event = EventEnvelope(
+                session_id=session.session.id,
+                sequence=emitted_sequence,
+                event_type=RUNTIME_SKILLS_BINDING_MISMATCH,
+                source="runtime",
+                payload={
+                    **binding_mismatch_payload,
+                    "resume": True,
+                    "approval_request_id": pending.request_id,
+                },
+            )
+            loop_events.append(mismatch_event)
+            yield RuntimeStreamChunk(kind="event", session=session, event=mismatch_event)
+        for chunk in mcp_startup_chunks:
+            emitted_sequence += 1
+            resequenced_event = runtime._resequence_event(
+                cast(EventEnvelope, chunk.event), sequence=emitted_sequence
+            )
+            loop_events.append(resequenced_event)
+            yield RuntimeStreamChunk(kind="event", session=chunk.session, event=resequenced_event)
+        if mcp_failed_chunk is not None:
+            emitted_sequence += 1
+            resequenced_failed = runtime._resequence_event(
+                cast(EventEnvelope, mcp_failed_chunk.event), sequence=emitted_sequence
+            )
+            response = RuntimeResponse(
+                session=mcp_failed_chunk.session,
+                events=stored.events + tuple(loop_events) + (resequenced_failed,),
+                output=output,
+            )
+            request = RuntimeRequest(
+                prompt=prompt,
+                session_id=stored.session.session.id,
+                parent_session_id=stored.session.session.parent_id,
+            )
+            runtime._persist_response(request=request, response=response)
+            yield RuntimeStreamChunk(
+                kind="event",
+                session=mcp_failed_chunk.session,
+                event=resequenced_failed,
+            )
+            return
+
+        deferred_startup_acp_events: tuple[object, ...] = ()
+        if runtime.current_acp_state().configuration.configured_enabled is True:
+            try:
+                deferred_startup_acp_events = runtime._acp_adapter.connect()
+            except Exception as exc:
+                startup_chunks, session, last_sequence = runtime._emit_current_acp_drain(
+                    session=session,
+                    start_sequence=max_stored_sequence + 1,
+                )
+                startup_failed_chunk = runtime._failed_chunk(
+                    session=runtime._session_with_current_acp_metadata(session),
+                    sequence=last_sequence + 1,
+                    error=str(exc),
+                    payload={"kind": "acp_startup_failed"},
+                )
+            else:
+                session = runtime._session_with_current_acp_metadata(session)
+                startup_chunks = ()
+                startup_failed_chunk = None
+        else:
+            startup_chunks = ()
+            startup_failed_chunk = None
+        for chunk in startup_chunks:
+            emitted_sequence += 1
+            resequenced_event = runtime._resequence_event(
+                cast(EventEnvelope, chunk.event), sequence=emitted_sequence
+            )
+            loop_events.append(resequenced_event)
+            yield RuntimeStreamChunk(kind="event", session=chunk.session, event=resequenced_event)
+        if startup_failed_chunk is not None:
+            emitted_sequence += 1
+            resequenced_failed = runtime._resequence_event(
+                cast(EventEnvelope, startup_failed_chunk.event),
+                sequence=emitted_sequence,
+            )
+            response = RuntimeResponse(
+                session=startup_failed_chunk.session,
+                events=stored.events + tuple(loop_events) + (resequenced_failed,),
+                output=output,
+            )
+            request = RuntimeRequest(
+                prompt=prompt,
+                session_id=stored.session.session.id,
+                parent_session_id=stored.session.session.parent_id,
+            )
+            runtime._persist_response(request=request, response=response)
+            yield RuntimeStreamChunk(
+                kind="event",
+                session=startup_failed_chunk.session,
+                event=resequenced_failed,
+            )
+            return
+
+        resume_start_hook_outcome = runtime._run_lifecycle_hooks(
+            session=session,
+            sequence=emitted_sequence,
+            surface="session_start",
+            payload={"resume": True, "approval_request_id": pending.request_id},
+        )
+        for hook_chunk in resume_start_hook_outcome.chunks:
+            hook_event = cast(EventEnvelope, hook_chunk.event)
+            emitted_sequence = hook_event.sequence
+            loop_events.append(hook_event)
+            yield hook_chunk
+        if resume_start_hook_outcome.failed_error is not None:
+            failed_chunk = runtime._failed_chunk(
+                session=session,
+                sequence=resume_start_hook_outcome.last_sequence + 1,
+                error=resume_start_hook_outcome.failed_error,
+            )
+            failed_event = cast(EventEnvelope, failed_chunk.event)
+            loop_events.append(failed_event)
+            response = RuntimeResponse(
+                session=failed_chunk.session,
+                events=stored.events + tuple(loop_events),
+                output=output,
+            )
+            request = RuntimeRequest(
+                prompt=prompt,
+                session_id=stored.session.session.id,
+                parent_session_id=stored.session.session.parent_id,
+            )
+            runtime._persist_response(request=request, response=response)
+            yield failed_chunk
+            return
+
+        sequence = max_stored_sequence
+        try:
+            for chunk in runtime._execute_graph_loop(
+                graph=graph,
+                tool_registry=tool_registry,
+                session=session,
+                sequence=sequence,
+                graph_request=graph_request,
+                tool_results=tool_results,
+                approval_resolution=(pending, approval_decision),
+                permission_policy=runtime._permission_policy_for_session(session.metadata),
+                preserved_continuity_state=preserved_continuity_state,
+            ):
+                if deferred_startup_acp_events and (
+                    (
+                        chunk.event is not None
+                        and chunk.event.event_type
+                        in {"runtime.approval_resolved", "runtime.failed"}
+                    )
+                    or chunk.kind == "output"
+                ):
+                    startup_chunks, updated_session, _ = runtime._emit_acp_events(
+                        session=chunk.session,
+                        start_sequence=emitted_sequence + 1,
+                        acp_events=deferred_startup_acp_events,
+                    )
+                    deferred_startup_acp_events = ()
+                    for startup_chunk in startup_chunks:
+                        startup_event = cast(EventEnvelope, startup_chunk.event)
+                        emitted_sequence = startup_event.sequence
+                        loop_events.append(startup_event)
+                        yield startup_chunk
+                    if chunk.event is not None:
+                        chunk = RuntimeStreamChunk(
+                            kind="event",
+                            session=updated_session,
+                            event=chunk.event,
+                        )
+                    elif chunk.kind == "output":
+                        chunk = RuntimeStreamChunk(
+                            kind="output",
+                            session=updated_session,
+                            output=chunk.output,
+                        )
+                if chunk.event is not None:
+                    emitted_sequence += 1
+                    resequenced_event = runtime._resequence_event(
+                        chunk.event, sequence=emitted_sequence
+                    )
+                    loop_events.append(resequenced_event)
+                    yield RuntimeStreamChunk(
+                        kind="event", session=chunk.session, event=resequenced_event
+                    )
+                if chunk.kind == "output":
+                    output = chunk.output
+                    yield chunk
+                session = chunk.session
+        except Exception:
+            if session.status == "failed":
+                response = RuntimeResponse(
+                    session=session,
+                    events=stored.events + tuple(loop_events),
+                    output=output,
+                )
+                request = RuntimeRequest(
+                    prompt=prompt,
+                    session_id=stored.session.session.id,
+                    parent_session_id=stored.session.session.parent_id,
+                )
+                runtime._persist_response(request=request, response=response)
+                return
+            raise
+
+        if deferred_startup_acp_events:
+            startup_chunks, session, _ = runtime._emit_acp_events(
+                session=session,
+                start_sequence=emitted_sequence + 1,
+                acp_events=deferred_startup_acp_events,
+            )
+            for startup_chunk in startup_chunks:
+                startup_event = cast(EventEnvelope, startup_chunk.event)
+                emitted_sequence = startup_event.sequence
+                loop_events.append(startup_event)
+                yield startup_chunk
+
+        last_sequence = emitted_sequence
+        if session.status == "waiting":
+            session = runtime._disconnect_acp_for_session_state(session)
+            idle_hook_outcome = runtime._run_lifecycle_hooks(
+                session=session,
+                sequence=last_sequence,
+                surface="session_idle",
+                payload={"reason": "waiting_for_approval", "resume": True},
+            )
+            for hook_chunk in idle_hook_outcome.chunks:
+                hook_event = cast(EventEnvelope, hook_chunk.event)
+                emitted_sequence = hook_event.sequence
+                loop_events.append(hook_event)
+                yield hook_chunk
+            if idle_hook_outcome.failed_error is not None:
+                failed_chunk = runtime._failed_chunk(
+                    session=session,
+                    sequence=idle_hook_outcome.last_sequence + 1,
+                    error=idle_hook_outcome.failed_error,
+                )
+                failed_event = cast(EventEnvelope, failed_chunk.event)
+                loop_events.append(failed_event)
+                session = failed_chunk.session
+                yield failed_chunk
+        else:
+            final_chunks, session, _ = runtime._finalize_run_acp(
+                session=session,
+                sequence=last_sequence,
+            )
+            for chunk in final_chunks:
+                if chunk.event is not None:
+                    emitted_sequence += 1
+                    resequenced_event = runtime._resequence_event(
+                        chunk.event, sequence=emitted_sequence
+                    )
+                    loop_events.append(resequenced_event)
+                    yield RuntimeStreamChunk(
+                        kind="event", session=chunk.session, event=resequenced_event
+                    )
+            end_hook_outcome = runtime._run_lifecycle_hooks(
+                session=session,
+                sequence=emitted_sequence,
+                surface="session_end",
+                payload={"session_status": session.status, "resume": True},
+            )
+            for hook_chunk in end_hook_outcome.chunks:
+                hook_event = cast(EventEnvelope, hook_chunk.event)
+                emitted_sequence = hook_event.sequence
+                loop_events.append(hook_event)
+                yield hook_chunk
+            if end_hook_outcome.failed_error is not None:
+                failed_chunk = runtime._failed_chunk(
+                    session=session,
+                    sequence=end_hook_outcome.last_sequence + 1,
+                    error=end_hook_outcome.failed_error,
+                )
+                failed_event = cast(EventEnvelope, failed_chunk.event)
+                loop_events.append(failed_event)
+                session = failed_chunk.session
+                yield failed_chunk
+
+        response = RuntimeResponse(
+            session=session,
+            events=stored.events + tuple(loop_events),
+            output=output,
+        )
+        request = RuntimeRequest(
+            prompt=prompt,
+            session_id=stored.session.session.id,
+            parent_session_id=stored.session.session.parent_id,
+        )
+        runtime._persist_response(request=request, response=response)
+
+    def approval_resume_state_from_checkpoint(
+        self,
+        *,
+        checkpoint: dict[str, object] | None,
+        pending: PendingApproval,
+        stored_metadata: dict[str, object],
+    ) -> ApprovalResumeCheckpointState | None:
+        checkpoint_envelope = self.validated_resume_checkpoint_envelope(
+            checkpoint=checkpoint,
+            expected_kind="approval_wait",
+        )
+        if checkpoint_envelope is None:
+            return None
+        checkpoint_payload = checkpoint_envelope.payload
+        if checkpoint_payload.get("pending_approval_request_id") != pending.request_id:
+            raise ValueError(
+                "persisted approval resume checkpoint request id does not match pending approval"
+            )
+        checkpoint_snapshot_hash = checkpoint_payload.get("skill_snapshot_hash")
+        stored_snapshot_payload = cast(
+            dict[str, object] | None,
+            stored_metadata.get("skill_snapshot"),
+        )
+        stored_snapshot_hash = (
+            stored_snapshot_payload.get("snapshot_hash")
+            if isinstance(stored_snapshot_payload, dict)
+            else None
+        )
+        if (
+            checkpoint_snapshot_hash is not None
+            and stored_snapshot_hash is not None
+            and checkpoint_snapshot_hash != stored_snapshot_hash
+        ):
+            return None
+        prompt = checkpoint_payload.get("prompt")
+        session_metadata = checkpoint_payload.get("session_metadata")
+        raw_tool_results = checkpoint_payload.get("tool_results")
+        if not isinstance(prompt, str):
+            raise ValueError("persisted approval resume checkpoint prompt must be a string")
+        if not isinstance(session_metadata, dict):
+            raise ValueError(
+                "persisted approval resume checkpoint session_metadata must be an object"
+            )
+        if cast(dict[str, object], session_metadata) != stored_metadata:
+            return None
+        if not isinstance(raw_tool_results, list):
+            raise ValueError("persisted approval resume checkpoint tool_results must be a list")
+        return ApprovalResumeCheckpointState(
+            prompt=prompt,
+            session_metadata=cast(dict[str, object], session_metadata),
+            tool_results=self.tool_results_from_checkpoint(cast(list[object], raw_tool_results)),
+        )
+
+    def question_resume_state_from_checkpoint(
+        self,
+        *,
+        checkpoint: dict[str, object] | None,
+        pending: PendingQuestion,
+        stored_metadata: dict[str, object],
+    ) -> ApprovalResumeCheckpointState | None:
+        checkpoint_envelope = self.validated_resume_checkpoint_envelope(
+            checkpoint=checkpoint,
+            expected_kind="question_wait",
+        )
+        if checkpoint_envelope is None:
+            return None
+        checkpoint_payload = checkpoint_envelope.payload
+        if checkpoint_payload.get("pending_question_request_id") != pending.request_id:
+            raise ValueError(
+                "persisted question resume checkpoint request id does not match pending question"
+            )
+        prompt = checkpoint_payload.get("prompt")
+        session_metadata = checkpoint_payload.get("session_metadata")
+        raw_tool_results = checkpoint_payload.get("tool_results")
+        if not isinstance(prompt, str):
+            raise ValueError("persisted question resume checkpoint prompt must be a string")
+        if not isinstance(session_metadata, dict):
+            raise ValueError(
+                "persisted question resume checkpoint session_metadata must be an object"
+            )
+        if cast(dict[str, object], session_metadata) != stored_metadata:
+            return None
+        if not isinstance(raw_tool_results, list):
+            raise ValueError("persisted question resume checkpoint tool_results must be a list")
+        return ApprovalResumeCheckpointState(
+            prompt=prompt,
+            session_metadata=cast(dict[str, object], session_metadata),
+            tool_results=self.tool_results_from_checkpoint(cast(list[object], raw_tool_results)),
+        )
+
+    @staticmethod
+    def validated_resume_checkpoint_envelope(
+        *, checkpoint: dict[str, object] | None, expected_kind: str
+    ) -> PersistedResumeCheckpointEnvelope | None:
+        if checkpoint is None:
+            return None
+        kind = checkpoint.get("kind")
+        if not isinstance(kind, str):
+            raise ValueError("persisted resume checkpoint kind must be a string")
+        if kind != expected_kind:
+            raise ValueError(
+                f"persisted resume checkpoint kind mismatch: "
+                f"expected {expected_kind!r}, got {kind!r}"
+            )
+        version = checkpoint.get("version")
+        if version != 1:
+            raise ValueError(
+                f"persisted resume checkpoint version mismatch: expected 1, got {version!r}"
+            )
+        return PersistedResumeCheckpointEnvelope(kind=kind, version=1, payload=checkpoint)
+
+    def load_resume_checkpoint(self, *, session_id: str) -> dict[str, object] | None:
+        load_checkpoint = getattr(self._runtime._session_store, "load_resume_checkpoint", None)
+        if load_checkpoint is None:
+            return None
+        return cast(
+            dict[str, object] | None,
+            load_checkpoint(workspace=self._runtime._workspace, session_id=session_id),
+        )
+
+    @staticmethod
+    def tool_results_from_checkpoint(raw_tool_results: list[object]) -> tuple[ToolResult, ...]:
+        parsed: list[ToolResult] = []
+        for raw_tool_result in raw_tool_results:
+            if not isinstance(raw_tool_result, dict):
+                raise ValueError("persisted resume checkpoint tool_results must contain objects")
+            payload = cast(dict[str, object], raw_tool_result)
+            tool_name = payload.get("tool_name")
+            status = payload.get("status")
+            data = payload.get("data")
+            content = payload.get("content")
+            error = payload.get("error")
+            if (
+                not isinstance(tool_name, str)
+                or status not in ("ok", "error")
+                or not isinstance(data, dict)
+            ):
+                raise ValueError("persisted resume checkpoint tool_results are malformed")
+            if content is not None and not isinstance(content, str):
+                raise ValueError(
+                    "persisted resume checkpoint tool result content must be a string or null"
+                )
+            if error is not None and not isinstance(error, str):
+                raise ValueError(
+                    "persisted resume checkpoint tool result error must be a string or null"
+                )
+            tool_status: ToolResultStatus = status
+            parsed.append(
+                ToolResult(
+                    tool_name=tool_name,
+                    content=content,
+                    status=tool_status,
+                    data=cast(dict[str, object], data),
+                    error=error,
+                )
+            )
+        return tuple(parsed)
+
+    def _load_pending_approval_context(
+        self,
+        *,
+        session_id: str,
+        approval_request_id: str,
+    ) -> tuple[Any, PendingApproval, dict[str, object] | None]:
+        runtime = self._runtime
+        stored_response = runtime._session_store.load_session(
+            workspace=runtime._workspace,
+            session_id=session_id,
+        )
+        runtime._validate_session_workspace(stored_response.session, session_id=session_id)
+        pending = runtime._session_store.load_pending_approval(
+            workspace=runtime._workspace,
+            session_id=session_id,
+        )
+        checkpoint = self.load_resume_checkpoint(session_id=session_id)
+        if pending is None:
+            raise ValueError(f"no pending approval for session: {session_id}")
+        if pending.request_id != approval_request_id:
+            raise ValueError("approval request id does not match pending session approval")
+        runtime._validate_pending_approval_matches_recorded_request(
+            stored=stored_response,
+            pending=pending,
+            checkpoint=checkpoint,
+        )
+        return stored_response, pending, checkpoint
+
+    def _load_pending_question_context(
+        self,
+        *,
+        session_id: str,
+        question_request_id: str,
+        responses: tuple[QuestionResponse, ...],
+    ) -> tuple[Any, PendingQuestion, dict[str, object] | None, tuple[QuestionResponse, ...]]:
+        runtime = self._runtime
+        stored_response = runtime._session_store.load_session(
+            workspace=runtime._workspace,
+            session_id=session_id,
+        )
+        runtime._validate_session_workspace(stored_response.session, session_id=session_id)
+        pending = runtime._session_store.load_pending_question(
+            workspace=runtime._workspace,
+            session_id=session_id,
+        )
+        checkpoint = self.load_resume_checkpoint(session_id=session_id)
+        if pending is None:
+            raise NoPendingQuestionError(f"no pending question for session: {session_id}")
+        if pending.request_id != question_request_id:
+            raise ValueError("question request id does not match pending session question")
+        runtime._validate_pending_question_matches_recorded_request(
+            stored=stored_response,
+            pending=pending,
+            checkpoint=checkpoint,
+        )
+        normalized_responses = QuestionTool.validate_responses(pending.prompts, responses)
+        return stored_response, pending, checkpoint, normalized_responses
+
+    def _resume_prompt_and_tool_results_from_stored_events(
+        self,
+        stored_events: tuple[EventEnvelope, ...],
+    ) -> tuple[str, list[ToolResult]]:
+        prompt = self._runtime._prompt_from_events(stored_events)
+        tool_results: list[ToolResult] = []
+        for event in stored_events:
+            if event.event_type != "runtime.tool_completed":
+                continue
+            error_value = event.payload.get("error")
+            raw_content = event.payload.get("content")
+            is_err = error_value is not None
+            tool_results.append(
+                ToolResult(
+                    tool_name=str(event.payload.get("tool", "unknown")),
+                    content=str(raw_content) if raw_content is not None and not is_err else None,
+                    status="error" if is_err else "ok",
+                    data=event.payload,
+                    error=str(error_value) if is_err else None,
+                )
+            )
+        return prompt, tool_results

--- a/src/voidcode/runtime/resume.py
+++ b/src/voidcode/runtime/resume.py
@@ -286,6 +286,7 @@ class RuntimeResumeCoordinator:
         graph = runtime._graph_for_session_metadata(session.metadata)
         output: str | None = None
         final_session = session
+        last_sequence = sequence
         try:
             for chunk in runtime._execute_graph_loop(
                 graph=graph,
@@ -301,6 +302,7 @@ class RuntimeResumeCoordinator:
             ):
                 final_session = chunk.session
                 if chunk.event is not None:
+                    last_sequence = chunk.event.sequence
                     loop_events.append(chunk.event)
                 if chunk.kind == "output":
                     output = chunk.output
@@ -320,6 +322,72 @@ class RuntimeResumeCoordinator:
                 runtime._persist_response(request=request, response=response)
                 return
             raise
+
+        if final_session.status == "waiting":
+            final_session = runtime._disconnect_acp_for_session_state(final_session)
+            waiting_response = RuntimeResponse(
+                session=final_session,
+                events=stored.events + tuple(loop_events),
+                output=output,
+            )
+            idle_reason = runtime._resume_waiting_reason(waiting_response)
+            idle_hook_outcome = runtime._run_lifecycle_hooks(
+                session=final_session,
+                sequence=last_sequence,
+                surface="session_idle",
+                payload={"reason": idle_reason, "resume": True},
+            )
+            for hook_chunk in idle_hook_outcome.chunks:
+                hook_event = cast(EventEnvelope, hook_chunk.event)
+                last_sequence = hook_event.sequence
+                loop_events.append(hook_event)
+                yield hook_chunk
+            if idle_hook_outcome.failed_error is not None:
+                failed_chunk = runtime._failed_chunk(
+                    session=final_session,
+                    sequence=idle_hook_outcome.last_sequence + 1,
+                    error=idle_hook_outcome.failed_error,
+                )
+                failed_event = cast(EventEnvelope, failed_chunk.event)
+                loop_events.append(failed_event)
+                final_session = failed_chunk.session
+                yield failed_chunk
+        else:
+            final_chunks, final_session, final_sequence = runtime._finalize_run_acp(
+                session=final_session,
+                sequence=last_sequence,
+            )
+            for chunk in final_chunks:
+                if chunk.event is not None:
+                    last_sequence += 1
+                    resequenced_event = runtime._resequence_event(
+                        chunk.event, sequence=last_sequence
+                    )
+                    loop_events.append(resequenced_event)
+                    yield RuntimeStreamChunk(
+                        kind="event", session=chunk.session, event=resequenced_event
+                    )
+            end_hook_outcome = runtime._run_lifecycle_hooks(
+                session=final_session,
+                sequence=max(last_sequence, final_sequence),
+                surface="session_end",
+                payload={"session_status": final_session.status, "resume": True},
+            )
+            for hook_chunk in end_hook_outcome.chunks:
+                hook_event = cast(EventEnvelope, hook_chunk.event)
+                last_sequence = hook_event.sequence
+                loop_events.append(hook_event)
+                yield hook_chunk
+            if end_hook_outcome.failed_error is not None:
+                failed_chunk = runtime._failed_chunk(
+                    session=final_session,
+                    sequence=end_hook_outcome.last_sequence + 1,
+                    error=end_hook_outcome.failed_error,
+                )
+                failed_event = cast(EventEnvelope, failed_chunk.event)
+                loop_events.append(failed_event)
+                final_session = failed_chunk.session
+                yield failed_chunk
 
         response = RuntimeResponse(
             session=final_session,

--- a/src/voidcode/runtime/resume.py
+++ b/src/voidcode/runtime/resume.py
@@ -633,39 +633,6 @@ class RuntimeResumeCoordinator:
             )
             return
 
-        resume_start_hook_outcome = runtime._run_lifecycle_hooks(
-            session=session,
-            sequence=emitted_sequence,
-            surface="session_start",
-            payload={"resume": True, "approval_request_id": pending.request_id},
-        )
-        for hook_chunk in resume_start_hook_outcome.chunks:
-            hook_event = cast(EventEnvelope, hook_chunk.event)
-            emitted_sequence = hook_event.sequence
-            loop_events.append(hook_event)
-            yield hook_chunk
-        if resume_start_hook_outcome.failed_error is not None:
-            failed_chunk = runtime._failed_chunk(
-                session=session,
-                sequence=resume_start_hook_outcome.last_sequence + 1,
-                error=resume_start_hook_outcome.failed_error,
-            )
-            failed_event = cast(EventEnvelope, failed_chunk.event)
-            loop_events.append(failed_event)
-            response = RuntimeResponse(
-                session=failed_chunk.session,
-                events=stored.events + tuple(loop_events),
-                output=output,
-            )
-            request = RuntimeRequest(
-                prompt=prompt,
-                session_id=stored.session.session.id,
-                parent_session_id=stored.session.session.parent_id,
-            )
-            runtime._persist_response(request=request, response=response)
-            yield failed_chunk
-            return
-
         sequence = max_stored_sequence
         try:
             for chunk in runtime._execute_graph_loop(

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -1,0 +1,591 @@
+# pyright: reportPrivateUsage=false
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+from ..graph.contracts import GraphRunRequest, RuntimeGraph
+from ..provider.errors import (
+    ProviderExecutionError,
+    SingleAgentContextLimitError,
+    classify_provider_error,
+    format_fallback_exhausted_error,
+)
+from ..tools.contracts import RuntimeTimeoutAwareTool, RuntimeToolTimeoutError, ToolResult
+from ..tools.question import QuestionTool
+from ..tools.runtime_context import RuntimeToolInvocationContext, bind_runtime_tool_context
+from .context_window import RuntimeContextWindow, RuntimeContinuityState
+from .contracts import RuntimeStreamChunk
+from .events import (
+    RUNTIME_MEMORY_REFRESHED,
+    RUNTIME_QUESTION_REQUESTED,
+    RUNTIME_TOOL_STARTED,
+    EventEnvelope,
+)
+from .permission import PendingApproval, PermissionPolicy, PermissionResolution
+from .question import PendingQuestion
+from .session import SessionState
+
+if TYPE_CHECKING:
+    from .service import ToolRegistry, VoidCodeRuntime
+
+logger = logging.getLogger(__name__)
+
+
+class RuntimeRunLoopCoordinator:
+    def __init__(self, runtime: VoidCodeRuntime) -> None:
+        self._runtime = runtime
+
+    def execute_graph_loop(
+        self,
+        *,
+        graph: RuntimeGraph,
+        tool_registry: ToolRegistry,
+        session: SessionState,
+        sequence: int,
+        graph_request: GraphRunRequest,
+        tool_results: list[ToolResult],
+        approval_resolution: tuple[PendingApproval, PermissionResolution] | None = None,
+        permission_policy: PermissionPolicy | None = None,
+        preserved_continuity_state: RuntimeContinuityState | None = None,
+    ) -> Iterator[RuntimeStreamChunk]:
+        runtime = self._runtime
+        active_permission_policy = permission_policy or runtime._permission_policy
+        continuity_to_reinject: RuntimeContinuityState | None = preserved_continuity_state
+        provider_attempt = runtime._provider_attempt_from_metadata(graph_request.metadata)
+        while True:
+            current_session = session
+            base_context = runtime._prepare_provider_context_window(
+                prompt=graph_request.prompt,
+                tool_results=tuple(tool_results),
+                session_metadata=current_session.metadata,
+            )
+            reinjected_continuity = continuity_to_reinject
+            if reinjected_continuity is not None:
+                context_window = RuntimeContextWindow(
+                    prompt=base_context.prompt,
+                    tool_results=base_context.tool_results,
+                    compacted=base_context.compacted,
+                    compaction_reason=base_context.compaction_reason,
+                    original_tool_result_count=base_context.original_tool_result_count,
+                    retained_tool_result_count=base_context.retained_tool_result_count,
+                    max_tool_result_count=base_context.max_tool_result_count,
+                    continuity_state=reinjected_continuity,
+                )
+            else:
+                context_window = base_context
+            continuity_to_reinject = None
+            session = runtime._session_with_context_window_metadata(current_session, context_window)
+            graph_request = GraphRunRequest(
+                session=session,
+                prompt=graph_request.prompt,
+                available_tools=graph_request.available_tools,
+                applied_skills=graph_request.applied_skills,
+                skill_prompt_context=graph_request.skill_prompt_context,
+                context_window=context_window,
+                metadata=graph_request.metadata,
+            )
+            if context_window.compacted and reinjected_continuity is None:
+                sequence += 1
+                yield RuntimeStreamChunk(
+                    kind="event",
+                    session=session,
+                    event=EventEnvelope(
+                        session_id=session.session.id,
+                        sequence=sequence,
+                        event_type=RUNTIME_MEMORY_REFRESHED,
+                        source="runtime",
+                        payload={
+                            "reason": context_window.compaction_reason,
+                            "original_tool_result_count": context_window.original_tool_result_count,
+                            "retained_tool_result_count": context_window.retained_tool_result_count,
+                            "compacted": True,
+                            "continuity_state": (
+                                context_window.continuity_state.metadata_payload()
+                                if context_window.continuity_state is not None
+                                else None
+                            ),
+                        },
+                    ),
+                )
+            try:
+                graph_step = graph.step(
+                    graph_request,
+                    tool_results=tuple(tool_results),
+                    session=session,
+                )
+            except Exception as exc:
+                current_provider_attempt = runtime._provider_attempt_from_metadata(
+                    {"provider_attempt": provider_attempt}
+                )
+                provider_error = exc if isinstance(exc, ProviderExecutionError) else None
+                if provider_error is not None:
+                    if provider_error.kind == "cancelled":
+                        yield runtime._failed_chunk(
+                            session=session,
+                            sequence=sequence + 1,
+                            error=str(provider_error),
+                            payload={
+                                "provider_error_kind": provider_error.kind,
+                                "provider": provider_error.provider_name,
+                                "model": provider_error.model_name,
+                                "cancelled": True,
+                            },
+                        )
+                        return
+                    fallback_selection = runtime._fallback_graph_selection(
+                        error=provider_error,
+                        session_metadata=session.metadata,
+                        provider_attempt=current_provider_attempt,
+                    )
+                    next_attempt = current_provider_attempt + 1
+                    if fallback_selection is not None:
+                        next_target = fallback_selection.provider_target
+                        logger.info(
+                            (
+                                "provider fallback for session %s: %s/%s -> %s/%s "
+                                "(reason=%s, attempt=%s)"
+                            ),
+                            session.session.id,
+                            provider_error.provider_name,
+                            provider_error.model_name,
+                            next_target.selection.provider,
+                            next_target.selection.model,
+                            provider_error.kind,
+                            next_attempt,
+                        )
+                        sequence += 1
+                        yield RuntimeStreamChunk(
+                            kind="event",
+                            session=session,
+                            event=EventEnvelope(
+                                session_id=session.session.id,
+                                sequence=sequence,
+                                event_type="runtime.provider_fallback",
+                                source="runtime",
+                                payload={
+                                    "reason": provider_error.kind,
+                                    "from_provider": provider_error.provider_name,
+                                    "from_model": provider_error.model_name,
+                                    "to_provider": next_target.selection.provider,
+                                    "to_model": next_target.selection.model,
+                                    "attempt": next_attempt,
+                                    **(
+                                        {"provider_error_details": provider_error.details}
+                                        if provider_error.details is not None
+                                        else {}
+                                    ),
+                                },
+                            ),
+                        )
+                        provider_attempt = fallback_selection.provider_attempt
+                        session = SessionState(
+                            session=session.session,
+                            status=session.status,
+                            turn=session.turn,
+                            metadata={**session.metadata, "provider_attempt": provider_attempt},
+                        )
+                        graph = fallback_selection.graph
+                        graph_request = GraphRunRequest(
+                            session=session,
+                            prompt=graph_request.prompt,
+                            available_tools=graph_request.available_tools,
+                            applied_skills=graph_request.applied_skills,
+                            skill_prompt_context=graph_request.skill_prompt_context,
+                            metadata={
+                                **graph_request.metadata,
+                                "provider_attempt": provider_attempt,
+                            },
+                        )
+                        continue
+                    if provider_error.kind in {"rate_limit", "invalid_model", "transient_failure"}:
+                        yield runtime._failed_chunk(
+                            session=session,
+                            sequence=sequence + 1,
+                            error=format_fallback_exhausted_error(
+                                provider_name=provider_error.provider_name,
+                                model_name=provider_error.model_name,
+                                attempt=next_attempt,
+                            ),
+                            payload={
+                                "provider_error_kind": provider_error.kind,
+                                "provider": provider_error.provider_name,
+                                "model": provider_error.model_name,
+                                "fallback_exhausted": True,
+                                **(
+                                    {"provider_error_details": provider_error.details}
+                                    if provider_error.details is not None
+                                    else {}
+                                ),
+                            },
+                        )
+                        return
+                if provider_error is not None:
+                    yield runtime._failed_chunk(
+                        session=session,
+                        sequence=sequence + 1,
+                        error=str(provider_error),
+                        payload={
+                            "provider_error_kind": provider_error.kind,
+                            "provider": provider_error.provider_name,
+                            "model": provider_error.model_name,
+                            **(
+                                {"provider_error_details": provider_error.details}
+                                if provider_error.details is not None
+                                else {}
+                            ),
+                        },
+                    )
+                    return
+                classified_error = classify_provider_error(exc)
+                yield runtime._failed_chunk(
+                    session=session,
+                    sequence=sequence + 1,
+                    error=str(exc),
+                    payload=(
+                        {"kind": "provider_context_limit"}
+                        if isinstance(classified_error, SingleAgentContextLimitError)
+                        else None
+                    ),
+                )
+                if isinstance(classified_error, SingleAgentContextLimitError):
+                    return
+                raise
+
+            is_final_step = (
+                getattr(graph_step, "is_finished", False)
+                or getattr(graph_step, "output", None) is not None
+            )
+            current_chunk_session = session
+            if is_final_step:
+                current_chunk_session = runtime._session_with_plan_state(
+                    SessionState(
+                        session=session.session,
+                        status="completed",
+                        turn=session.turn,
+                        metadata=session.metadata,
+                    ),
+                    status="completed",
+                )
+
+            for event in runtime._renumber_events(
+                getattr(graph_step, "events", ()),
+                session_id=session.session.id,
+                start_sequence=sequence + 1,
+            ):
+                sequence = event.sequence
+                yield RuntimeStreamChunk(kind="event", session=current_chunk_session, event=event)
+
+            if is_final_step:
+                if getattr(graph_step, "output", None) is not None:
+                    yield RuntimeStreamChunk(
+                        kind="output",
+                        session=current_chunk_session,
+                        output=graph_step.output,
+                    )
+                break
+
+            plan_tool_call = getattr(graph_step, "tool_call", None)
+            if plan_tool_call is None:
+                yield runtime._failed_chunk(
+                    session=session,
+                    sequence=sequence + 1,
+                    error="graph step did not produce a tool call or output",
+                )
+                raise ValueError("graph step did not produce a tool call or output")
+
+            sequence += 1
+            yield RuntimeStreamChunk(
+                kind="event",
+                session=session,
+                event=EventEnvelope(
+                    session_id=session.session.id,
+                    sequence=sequence,
+                    event_type="graph.tool_request_created",
+                    source="graph",
+                    payload={
+                        "tool": plan_tool_call.tool_name,
+                        "arguments": dict(plan_tool_call.arguments),
+                        **(
+                            {"path": path}
+                            if isinstance((path := plan_tool_call.arguments.get("path")), str)
+                            else {}
+                        ),
+                    },
+                ),
+            )
+
+            try:
+                tool = tool_registry.resolve(plan_tool_call.tool_name)
+            except Exception as exc:
+                yield runtime._failed_chunk(session=session, sequence=sequence + 1, error=str(exc))
+                raise
+
+            sequence += 1
+            yield RuntimeStreamChunk(
+                kind="event",
+                session=session,
+                event=EventEnvelope(
+                    session_id=session.session.id,
+                    sequence=sequence,
+                    event_type="runtime.tool_lookup_succeeded",
+                    source="runtime",
+                    payload={"tool": plan_tool_call.tool_name},
+                ),
+            )
+
+            sequence += 1
+            if approval_resolution is not None:
+                pending, decision = approval_resolution
+                if (
+                    plan_tool_call.tool_name == pending.tool_name
+                    and dict(plan_tool_call.arguments) == pending.arguments
+                ):
+                    sequence += 1
+                    permission_chunks = runtime._approval_resolution_outcome(
+                        session=session,
+                        pending=pending,
+                        decision=decision,
+                        sequence=sequence,
+                    )
+                    approval_resolution = None
+                else:
+                    msg = (
+                        f"graph step produced a different tool call "
+                        f"({plan_tool_call.tool_name}) than the pending "
+                        f"approval ({pending.tool_name})"
+                    )
+                    raise ValueError(msg)
+            else:
+                permission_chunks = runtime._resolve_permission(
+                    session=session,
+                    tool=tool.definition,
+                    tool_call=plan_tool_call,
+                    sequence=sequence,
+                    permission_policy=active_permission_policy,
+                )
+            yield from permission_chunks.chunks
+            if permission_chunks.chunks:
+                session = permission_chunks.chunks[-1].session
+            if permission_chunks.pending_approval is not None:
+                return
+            if permission_chunks.denied:
+                return
+
+            sequence = permission_chunks.last_sequence
+
+            pre_hook_outcome = runtime._run_tool_hooks(
+                session=session,
+                sequence=sequence,
+                tool_name=plan_tool_call.tool_name,
+                phase="pre",
+            )
+            yield from pre_hook_outcome.chunks
+            sequence = pre_hook_outcome.last_sequence
+            if pre_hook_outcome.failed_error is not None:
+                yield runtime._failed_chunk(
+                    session=session,
+                    sequence=sequence + 1,
+                    error=pre_hook_outcome.failed_error,
+                )
+                raise RuntimeError(pre_hook_outcome.failed_error)
+
+            tool_timeout = runtime._effective_runtime_config_from_metadata(
+                session.metadata
+            ).tool_timeout_seconds
+            sequence += 1
+            yield RuntimeStreamChunk(
+                kind="event",
+                session=session,
+                event=EventEnvelope(
+                    session_id=session.session.id,
+                    sequence=sequence,
+                    event_type=RUNTIME_TOOL_STARTED,
+                    source="runtime",
+                    payload={"tool": plan_tool_call.tool_name},
+                ),
+            )
+            try:
+                with bind_runtime_tool_context(
+                    RuntimeToolInvocationContext(
+                        session_id=session.session.id,
+                        parent_session_id=session.session.parent_id,
+                        delegation_depth=runtime._delegation_depth_from_metadata(session.metadata),
+                        remaining_spawn_budget=runtime._remaining_spawn_budget_from_metadata(
+                            session.metadata
+                        ),
+                    )
+                ):
+                    if tool_timeout is None:
+                        tool_result = tool.invoke(plan_tool_call, workspace=runtime._workspace)
+                    elif isinstance(tool, RuntimeTimeoutAwareTool):
+                        tool_result = tool.invoke_with_runtime_timeout(
+                            plan_tool_call,
+                            workspace=runtime._workspace,
+                            timeout_seconds=tool_timeout,
+                        )
+                    else:
+                        tool_result = tool.invoke(plan_tool_call, workspace=runtime._workspace)
+            except Exception as exc:
+                drained_chunks, session, sequence = self._drain_runtime_events(
+                    session=session,
+                    start_sequence=sequence + 1,
+                )
+                yield from drained_chunks
+                if isinstance(exc, RuntimeToolTimeoutError):
+                    sequence += 1
+                    yield RuntimeStreamChunk(
+                        kind="event",
+                        session=session,
+                        event=EventEnvelope(
+                            session_id=session.session.id,
+                            sequence=sequence,
+                            event_type="runtime.tool_timeout",
+                            source="runtime",
+                            payload={
+                                "tool": plan_tool_call.tool_name,
+                                "timeout_seconds": tool_timeout,
+                            },
+                        ),
+                    )
+                    yield runtime._failed_chunk(
+                        session=session, sequence=sequence + 1, error=str(exc)
+                    )
+                    return
+                yield runtime._failed_chunk(session=session, sequence=sequence + 1, error=str(exc))
+                raise
+
+            drained_chunks, session, sequence = self._drain_runtime_events(
+                session=session,
+                start_sequence=sequence + 1,
+            )
+            yield from drained_chunks
+
+            if plan_tool_call.tool_name == QuestionTool.definition.name:
+                pending_question = PendingQuestion(
+                    request_id=f"question-{uuid4().hex}",
+                    tool_name=plan_tool_call.tool_name,
+                    arguments=dict(plan_tool_call.arguments),
+                    prompts=QuestionTool.parse_prompts(plan_tool_call.arguments),
+                )
+                waiting_session = runtime._session_with_plan_state(
+                    SessionState(
+                        session=session.session,
+                        status="waiting",
+                        turn=session.turn,
+                        metadata=session.metadata,
+                    ),
+                    status="waiting_question",
+                    blocked_tool=pending_question.tool_name,
+                )
+                sequence += 1
+                yield RuntimeStreamChunk(
+                    kind="event",
+                    session=waiting_session,
+                    event=EventEnvelope(
+                        session_id=session.session.id,
+                        sequence=sequence,
+                        event_type=RUNTIME_QUESTION_REQUESTED,
+                        source="runtime",
+                        payload={
+                            "request_id": pending_question.request_id,
+                            "tool": pending_question.tool_name,
+                            "question_count": len(pending_question.prompts),
+                            "questions": [
+                                {
+                                    "header": prompt.header,
+                                    "question": prompt.question,
+                                    "multiple": prompt.multiple,
+                                    "options": [
+                                        {
+                                            "label": option.label,
+                                            "description": option.description,
+                                        }
+                                        for option in prompt.options
+                                    ],
+                                }
+                                for prompt in pending_question.prompts
+                            ],
+                        },
+                    ),
+                )
+                return
+
+            sequence += 1
+            yield RuntimeStreamChunk(
+                kind="event",
+                session=session,
+                event=EventEnvelope(
+                    session_id=session.session.id,
+                    sequence=sequence,
+                    event_type="runtime.tool_completed",
+                    source="tool",
+                    payload={
+                        "tool": tool_result.tool_name,
+                        "status": tool_result.status,
+                        "content": tool_result.content,
+                        "error": tool_result.error,
+                        **tool_result.data,
+                    },
+                ),
+            )
+
+            post_hook_outcome = runtime._run_tool_hooks(
+                session=session,
+                sequence=sequence,
+                tool_name=plan_tool_call.tool_name,
+                phase="post",
+            )
+            yield from post_hook_outcome.chunks
+            sequence = post_hook_outcome.last_sequence
+            if post_hook_outcome.failed_error is not None:
+                yield runtime._failed_chunk(
+                    session=session,
+                    sequence=sequence + 1,
+                    error=post_hook_outcome.failed_error,
+                )
+                raise RuntimeError(post_hook_outcome.failed_error)
+
+            tool_results.append(tool_result)
+
+    def _drain_runtime_events(
+        self,
+        *,
+        session: Any,
+        start_sequence: int,
+    ) -> tuple[tuple[RuntimeStreamChunk, ...], SessionState, int]:
+        runtime = self._runtime
+        emitted: list[RuntimeStreamChunk] = []
+        sequence = start_sequence - 1
+        current_session = session
+        for acp_event in runtime._envelopes_for_acp_events(
+            session_id=session.session.id,
+            start_sequence=start_sequence,
+            acp_events=runtime._acp_adapter.drain_events(),
+        ):
+            sequence = acp_event.sequence
+            current_session = runtime._session_with_current_acp_metadata(current_session)
+            emitted.append(
+                RuntimeStreamChunk(kind="event", session=current_session, event=acp_event)
+            )
+        for mcp_event in runtime._envelopes_for_mcp_events(
+            session_id=session.session.id,
+            start_sequence=sequence + 1,
+            mcp_events=runtime._mcp_manager.drain_events(),
+        ):
+            sequence = mcp_event.sequence
+            emitted.append(
+                RuntimeStreamChunk(kind="event", session=current_session, event=mcp_event)
+            )
+        for lsp_event in runtime._envelopes_for_lsp_events(
+            session_id=session.session.id,
+            start_sequence=sequence + 1,
+            lsp_events=runtime._lsp_manager.drain_events(),
+        ):
+            sequence = lsp_event.sequence
+            emitted.append(
+                RuntimeStreamChunk(kind="event", session=current_session, event=lsp_event)
+            )
+        return tuple(emitted), current_session, sequence

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -1,3 +1,4 @@
+# pyright: reportUnusedFunction=false, reportUnusedImport=false
 from __future__ import annotations
 
 import json
@@ -5,11 +6,10 @@ import logging
 import os
 import threading
 from collections.abc import Callable, Iterable, Iterator
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, cast, final
-from uuid import uuid4
 
 from ..acp import AcpDelegatedExecution, AcpEventEnvelope, AcpRequestEnvelope, AcpResponseEnvelope
 from ..agent import get_builtin_agent_manifest
@@ -23,12 +23,7 @@ from ..hook.executor import (
     run_tool_hooks,
 )
 from ..provider.auth import ProviderAuthResolver
-from ..provider.errors import (
-    SingleAgentContextLimitError,
-    classify_provider_error,
-    format_fallback_exhausted_error,
-    format_invalid_provider_config_error,
-)
+from ..provider.errors import format_invalid_provider_config_error
 from ..provider.models import (
     ResolvedProviderChain,
     ResolvedProviderConfig,
@@ -44,20 +39,17 @@ from ..skills import SkillRegistry
 from ..tools.background_cancel import BackgroundCancelTool
 from ..tools.background_output import BackgroundOutputTool
 from ..tools.contracts import (
-    RuntimeTimeoutAwareTool,
-    RuntimeToolTimeoutError,
     Tool,
     ToolCall,
     ToolDefinition,
     ToolResult,
-    ToolResultStatus,
 )
 from ..tools.guidance import definition_with_guidance
 from ..tools.question import QuestionTool
-from ..tools.runtime_context import RuntimeToolInvocationContext, bind_runtime_tool_context
 from ..tools.skill import SkillTool
 from ..tools.task import TaskTool
 from .acp import AcpAdapter, AcpAdapterState, build_acp_adapter
+from .background_tasks import RuntimeBackgroundTaskSupervisor
 from .config import (
     ExecutionEngineName,
     RuntimeAgentConfig,
@@ -85,8 +77,6 @@ from .context_window import (
 )
 from .contracts import (
     BackgroundTaskResult,
-    InternalRuntimeRequestMetadata,
-    NoPendingQuestionError,
     RuntimeNotification,
     RuntimeRequest,
     RuntimeRequestError,
@@ -106,11 +96,6 @@ from .events import (
     RUNTIME_ACP_DISCONNECTED,
     RUNTIME_ACP_FAILED,
     RUNTIME_APPROVAL_REQUESTED,
-    RUNTIME_BACKGROUND_TASK_CANCELLED,
-    RUNTIME_BACKGROUND_TASK_COMPLETED,
-    RUNTIME_BACKGROUND_TASK_FAILED,
-    RUNTIME_BACKGROUND_TASK_WAITING_APPROVAL,
-    RUNTIME_FAILED,
     RUNTIME_LSP_SERVER_FAILED,
     RUNTIME_LSP_SERVER_REUSED,
     RUNTIME_LSP_SERVER_STARTED,
@@ -119,13 +104,10 @@ from .events import (
     RUNTIME_MCP_SERVER_FAILED,
     RUNTIME_MCP_SERVER_STARTED,
     RUNTIME_MCP_SERVER_STOPPED,
-    RUNTIME_MEMORY_REFRESHED,
     RUNTIME_QUESTION_ANSWERED,
     RUNTIME_QUESTION_REQUESTED,
     RUNTIME_SKILLS_APPLIED,
-    RUNTIME_SKILLS_BINDING_MISMATCH,
     RUNTIME_SKILLS_LOADED,
-    RUNTIME_TOOL_STARTED,
     EventEnvelope,
 )
 from .execution_seams import (
@@ -151,6 +133,8 @@ from .plan import (
 )
 from .provider_protocol import ProviderExecutionError
 from .question import PendingQuestion, QuestionResponse
+from .resume import RuntimeResumeCoordinator
+from .run_loop import RuntimeRunLoopCoordinator
 from .session import SessionRef, SessionState, SessionStatus, StoredSessionSummary
 from .skills import (
     SkillExecutionSnapshot,
@@ -164,10 +148,7 @@ from .skills import (
 )
 from .storage import SessionEventAppender, SessionStore, SqliteSessionStore
 from .task import (
-    BackgroundTaskRef,
-    BackgroundTaskRequestSnapshot,
     BackgroundTaskState,
-    BackgroundTaskStatus,
     StoredBackgroundTaskSummary,
     validate_background_task_id,
 )
@@ -391,6 +372,9 @@ class VoidCodeRuntime:
     _plan_contributor: PlanContributor
     _background_task_threads: dict[str, threading.Thread]
     _background_tasks_reconciled: bool
+    _run_loop_coordinator: RuntimeRunLoopCoordinator
+    _resume_coordinator: RuntimeResumeCoordinator
+    _background_task_supervisor: RuntimeBackgroundTaskSupervisor
     _hook_recursion_env_var = "VOIDCODE_RUNNING_TOOL_HOOK"
     _default_context_window_policy = ContextWindowPolicy()
 
@@ -496,6 +480,9 @@ class VoidCodeRuntime:
         self._background_task_threads = {}
         self._background_tasks_reconciled = False
         self._default_context_window_policy = context_window_policy or ContextWindowPolicy()
+        self._run_loop_coordinator = RuntimeRunLoopCoordinator(self)
+        self._resume_coordinator = RuntimeResumeCoordinator(self)
+        self._background_task_supervisor = RuntimeBackgroundTaskSupervisor(self)
 
     def __enter__(self) -> VoidCodeRuntime:
         return self
@@ -658,6 +645,7 @@ class VoidCodeRuntime:
 
     @staticmethod
     def _resequence_event(event: EventEnvelope, *, sequence: int) -> EventEnvelope:
+        # Referenced via extracted collaborators.
         return EventEnvelope(
             session_id=event.session_id,
             sequence=sequence,
@@ -764,6 +752,7 @@ class VoidCodeRuntime:
         *,
         provider_attempt: int = 0,
     ) -> RuntimeGraphSelection:
+        # Referenced via extracted run-loop/resume collaborators.
         return select_graph_for_effective_config(
             config=config,
             provider_attempt=provider_attempt,
@@ -776,6 +765,7 @@ class VoidCodeRuntime:
         session_metadata: dict[str, object],
         provider_attempt: int,
     ) -> RuntimeGraphSelection | None:
+        # Referenced via extracted run-loop collaborator.
         return fallback_graph_for_provider_error(
             error=error,
             provider_chain=self._provider_chain_for_session_metadata(session_metadata),
@@ -784,6 +774,7 @@ class VoidCodeRuntime:
         )
 
     def _session_routing_for_request(self, request: RuntimeRequest) -> RuntimeSessionRouting:
+        # Referenced via extracted background-task collaborator.
         return resolve_runtime_session_routing(request)
 
     def _runtime_config_for_request(self, request: RuntimeRequest) -> EffectiveRuntimeConfig:
@@ -1094,6 +1085,7 @@ class VoidCodeRuntime:
         approval_blocked: bool | None = None,
         result_available: bool | None = None,
     ) -> None:
+        # Referenced via extracted background-task collaborator.
         if self.current_acp_state().status != "connected":
             return
         delegation = self._delegated_execution_for_task(
@@ -1123,6 +1115,7 @@ class VoidCodeRuntime:
         approval_blocked: bool | None = None,
         result_available: bool | None = None,
     ) -> None:
+        # Referenced via extracted background-task collaborator.
         parent_session_id = task.parent_session_id
         if parent_session_id is None:
             return
@@ -1494,544 +1487,17 @@ class VoidCodeRuntime:
         permission_policy: PermissionPolicy | None = None,
         preserved_continuity_state: RuntimeContinuityState | None = None,
     ) -> Iterator[RuntimeStreamChunk]:
-        active_permission_policy = permission_policy or self._permission_policy
-        # Continuity memory reinjection boundary: allow a continuity state to be
-        # carried into the next iteration after a memory compaction (if any).
-        continuity_to_reinject: RuntimeContinuityState | None = preserved_continuity_state
-        provider_attempt = self._provider_attempt_from_metadata(graph_request.metadata)
-        while True:
-            current_session = session
-            base_context = self._prepare_provider_context_window(
-                prompt=graph_request.prompt,
-                tool_results=tuple(tool_results),
-                session_metadata=current_session.metadata,
-            )
-            reinjected_continuity = continuity_to_reinject
-            # Apply reinjected continuity state if present, giving reinjection
-            # semantics after a compaction boundary.
-            if reinjected_continuity is not None:
-                context_window = RuntimeContextWindow(
-                    prompt=base_context.prompt,
-                    tool_results=base_context.tool_results,
-                    compacted=base_context.compacted,
-                    compaction_reason=base_context.compaction_reason,
-                    original_tool_result_count=base_context.original_tool_result_count,
-                    retained_tool_result_count=base_context.retained_tool_result_count,
-                    max_tool_result_count=base_context.max_tool_result_count,
-                    continuity_state=reinjected_continuity,
-                )
-            else:
-                context_window = base_context
-            continuity_to_reinject = None
-            session = self._session_with_context_window_metadata(current_session, context_window)
-            graph_request = GraphRunRequest(
-                session=session,
-                prompt=graph_request.prompt,
-                available_tools=graph_request.available_tools,
-                applied_skills=graph_request.applied_skills,
-                skill_prompt_context=graph_request.skill_prompt_context,
-                context_window=context_window,
-                metadata=graph_request.metadata,
-            )
-            if context_window.compacted and reinjected_continuity is None:
-                sequence += 1
-                yield RuntimeStreamChunk(
-                    kind="event",
-                    session=session,
-                    event=EventEnvelope(
-                        session_id=session.session.id,
-                        sequence=sequence,
-                        event_type=RUNTIME_MEMORY_REFRESHED,
-                        source="runtime",
-                        payload={
-                            "reason": context_window.compaction_reason,
-                            "original_tool_result_count": context_window.original_tool_result_count,
-                            "retained_tool_result_count": context_window.retained_tool_result_count,
-                            "compacted": True,
-                            "continuity_state": (
-                                context_window.continuity_state.metadata_payload()
-                                if context_window.continuity_state is not None
-                                else None
-                            ),
-                        },
-                    ),
-                )
-            try:
-                graph_step = graph.step(
-                    graph_request,
-                    tool_results=tuple(tool_results),
-                    session=session,
-                )
-            except Exception as exc:
-                current_provider_attempt = self._provider_attempt_from_metadata(
-                    {"provider_attempt": provider_attempt}
-                )
-                provider_error = exc if isinstance(exc, ProviderExecutionError) else None
-                if provider_error is not None:
-                    if provider_error.kind == "cancelled":
-                        yield self._failed_chunk(
-                            session=session,
-                            sequence=sequence + 1,
-                            error=str(provider_error),
-                            payload={
-                                "provider_error_kind": provider_error.kind,
-                                "provider": provider_error.provider_name,
-                                "model": provider_error.model_name,
-                                "cancelled": True,
-                            },
-                        )
-                        return
-                    fallback_selection = self._fallback_graph_selection(
-                        error=provider_error,
-                        session_metadata=session.metadata,
-                        provider_attempt=current_provider_attempt,
-                    )
-                    next_attempt: int = current_provider_attempt + 1
-                    if fallback_selection is not None:
-                        next_target = fallback_selection.provider_target
-                        logger.info(
-                            (
-                                "provider fallback for session %s: %s/%s -> %s/%s "
-                                "(reason=%s, attempt=%s)"
-                            ),
-                            session.session.id,
-                            provider_error.provider_name,
-                            provider_error.model_name,
-                            next_target.selection.provider,
-                            next_target.selection.model,
-                            provider_error.kind,
-                            next_attempt,
-                        )
-                        sequence += 1
-                        yield RuntimeStreamChunk(
-                            kind="event",
-                            session=session,
-                            event=EventEnvelope(
-                                session_id=session.session.id,
-                                sequence=sequence,
-                                event_type="runtime.provider_fallback",
-                                source="runtime",
-                                payload={
-                                    "reason": provider_error.kind,
-                                    "from_provider": provider_error.provider_name,
-                                    "from_model": provider_error.model_name,
-                                    "to_provider": next_target.selection.provider,
-                                    "to_model": next_target.selection.model,
-                                    "attempt": next_attempt,
-                                    **(
-                                        {"provider_error_details": provider_error.details}
-                                        if provider_error.details is not None
-                                        else {}
-                                    ),
-                                },
-                            ),
-                        )
-                        provider_attempt = fallback_selection.provider_attempt
-                        session = SessionState(
-                            session=session.session,
-                            status=session.status,
-                            turn=session.turn,
-                            metadata={
-                                **session.metadata,
-                                "provider_attempt": provider_attempt,
-                            },
-                        )
-                        graph = fallback_selection.graph
-                        graph_request = GraphRunRequest(
-                            session=session,
-                            prompt=graph_request.prompt,
-                            available_tools=graph_request.available_tools,
-                            applied_skills=graph_request.applied_skills,
-                            skill_prompt_context=graph_request.skill_prompt_context,
-                            metadata={
-                                **graph_request.metadata,
-                                "provider_attempt": provider_attempt,
-                            },
-                        )
-                        continue
-                    if provider_error.kind in {"rate_limit", "invalid_model", "transient_failure"}:
-                        yield self._failed_chunk(
-                            session=session,
-                            sequence=sequence + 1,
-                            error=format_fallback_exhausted_error(
-                                provider_name=provider_error.provider_name,
-                                model_name=provider_error.model_name,
-                                attempt=next_attempt,
-                            ),
-                            payload={
-                                "provider_error_kind": provider_error.kind,
-                                "provider": provider_error.provider_name,
-                                "model": provider_error.model_name,
-                                "fallback_exhausted": True,
-                                **(
-                                    {"provider_error_details": provider_error.details}
-                                    if provider_error.details is not None
-                                    else {}
-                                ),
-                            },
-                        )
-                        return
-                if provider_error is not None:
-                    yield self._failed_chunk(
-                        session=session,
-                        sequence=sequence + 1,
-                        error=str(provider_error),
-                        payload={
-                            "provider_error_kind": provider_error.kind,
-                            "provider": provider_error.provider_name,
-                            "model": provider_error.model_name,
-                            **(
-                                {"provider_error_details": provider_error.details}
-                                if provider_error.details is not None
-                                else {}
-                            ),
-                        },
-                    )
-                    return
-                classified_error = classify_provider_error(exc)
-                yield self._failed_chunk(
-                    session=session,
-                    sequence=sequence + 1,
-                    error=str(exc),
-                    payload=(
-                        {"kind": "provider_context_limit"}
-                        if isinstance(classified_error, SingleAgentContextLimitError)
-                        else None
-                    ),
-                )
-                if isinstance(classified_error, SingleAgentContextLimitError):
-                    return
-                raise
-
-            is_final_step = (
-                getattr(graph_step, "is_finished", False)
-                or getattr(graph_step, "output", None) is not None
-            )
-            current_chunk_session = session
-            if is_final_step:
-                current_chunk_session = self._session_with_plan_state(
-                    SessionState(
-                        session=session.session,
-                        status="completed",
-                        turn=session.turn,
-                        metadata=session.metadata,
-                    ),
-                    status="completed",
-                )
-
-            for event in self._renumber_events(
-                getattr(graph_step, "events", ()),
-                session_id=session.session.id,
-                start_sequence=sequence + 1,
-            ):
-                sequence = event.sequence
-                yield RuntimeStreamChunk(kind="event", session=current_chunk_session, event=event)
-
-            if is_final_step:
-                if getattr(graph_step, "output", None) is not None:
-                    yield RuntimeStreamChunk(
-                        kind="output",
-                        session=current_chunk_session,
-                        output=graph_step.output,
-                    )
-                break
-
-            plan_tool_call = getattr(graph_step, "tool_call", None)
-            if plan_tool_call is None:
-                yield self._failed_chunk(
-                    session=session,
-                    sequence=sequence + 1,
-                    error="graph step did not produce a tool call or output",
-                )
-                raise ValueError("graph step did not produce a tool call or output")
-
-            sequence += 1
-            yield RuntimeStreamChunk(
-                kind="event",
-                session=session,
-                event=EventEnvelope(
-                    session_id=session.session.id,
-                    sequence=sequence,
-                    event_type="graph.tool_request_created",
-                    source="graph",
-                    payload={
-                        "tool": plan_tool_call.tool_name,
-                        "arguments": dict(plan_tool_call.arguments),
-                        **(
-                            {"path": path}
-                            if isinstance((path := plan_tool_call.arguments.get("path")), str)
-                            else {}
-                        ),
-                    },
-                ),
-            )
-
-            try:
-                tool = tool_registry.resolve(plan_tool_call.tool_name)
-            except Exception as exc:
-                yield self._failed_chunk(session=session, sequence=sequence + 1, error=str(exc))
-                raise
-
-            sequence += 1
-            yield RuntimeStreamChunk(
-                kind="event",
-                session=session,
-                event=EventEnvelope(
-                    session_id=session.session.id,
-                    sequence=sequence,
-                    event_type="runtime.tool_lookup_succeeded",
-                    source="runtime",
-                    payload={"tool": plan_tool_call.tool_name},
-                ),
-            )
-
-            sequence += 1
-            if approval_resolution is not None:
-                pending, decision = approval_resolution
-                if (
-                    plan_tool_call.tool_name == pending.tool_name
-                    and dict(plan_tool_call.arguments) == pending.arguments
-                ):
-                    sequence += 1
-                    permission_chunks = self._approval_resolution_outcome(
-                        session=session,
-                        pending=pending,
-                        decision=decision,
-                        sequence=sequence,
-                    )
-                    approval_resolution = None
-                else:
-                    msg = (
-                        f"graph step produced a different tool call "
-                        f"({plan_tool_call.tool_name}) than the pending "
-                        f"approval ({pending.tool_name})"
-                    )
-                    raise ValueError(msg)
-            else:
-                permission_chunks = self._resolve_permission(
-                    session=session,
-                    tool=tool.definition,
-                    tool_call=plan_tool_call,
-                    sequence=sequence,
-                    permission_policy=active_permission_policy,
-                )
-            yield from permission_chunks.chunks
-            if permission_chunks.chunks:
-                session = permission_chunks.chunks[-1].session
-            if permission_chunks.pending_approval is not None:
-                return
-            if permission_chunks.denied:
-                return
-
-            sequence = permission_chunks.last_sequence
-
-            pre_hook_outcome = self._run_tool_hooks(
-                session=session,
-                sequence=sequence,
-                tool_name=plan_tool_call.tool_name,
-                phase="pre",
-            )
-            yield from pre_hook_outcome.chunks
-            sequence = pre_hook_outcome.last_sequence
-            if pre_hook_outcome.failed_error is not None:
-                yield self._failed_chunk(
-                    session=session,
-                    sequence=sequence + 1,
-                    error=pre_hook_outcome.failed_error,
-                )
-                raise RuntimeError(pre_hook_outcome.failed_error)
-
-            _tool_timeout = self._effective_runtime_config_from_metadata(
-                session.metadata
-            ).tool_timeout_seconds
-            sequence += 1
-            yield RuntimeStreamChunk(
-                kind="event",
-                session=session,
-                event=EventEnvelope(
-                    session_id=session.session.id,
-                    sequence=sequence,
-                    event_type=RUNTIME_TOOL_STARTED,
-                    source="runtime",
-                    payload={"tool": plan_tool_call.tool_name},
-                ),
-            )
-            try:
-                with bind_runtime_tool_context(
-                    RuntimeToolInvocationContext(
-                        session_id=session.session.id,
-                        parent_session_id=session.session.parent_id,
-                        delegation_depth=self._delegation_depth_from_metadata(session.metadata),
-                        remaining_spawn_budget=self._remaining_spawn_budget_from_metadata(
-                            session.metadata
-                        ),
-                    )
-                ):
-                    if _tool_timeout is None:
-                        tool_result = tool.invoke(plan_tool_call, workspace=self._workspace)
-                    elif isinstance(tool, RuntimeTimeoutAwareTool):
-                        tool_result = tool.invoke_with_runtime_timeout(
-                            plan_tool_call,
-                            workspace=self._workspace,
-                            timeout_seconds=_tool_timeout,
-                        )
-                    else:
-                        tool_result = tool.invoke(plan_tool_call, workspace=self._workspace)
-            except Exception as exc:
-                for acp_event in self._envelopes_for_acp_events(
-                    session_id=session.session.id,
-                    start_sequence=sequence + 1,
-                    acp_events=self._acp_adapter.drain_events(),
-                ):
-                    sequence = acp_event.sequence
-                    session = self._session_with_current_acp_metadata(session)
-                    yield RuntimeStreamChunk(kind="event", session=session, event=acp_event)
-                for mcp_event in self._envelopes_for_mcp_events(
-                    session_id=session.session.id,
-                    start_sequence=sequence + 1,
-                    mcp_events=self._mcp_manager.drain_events(),
-                ):
-                    sequence = mcp_event.sequence
-                    yield RuntimeStreamChunk(kind="event", session=session, event=mcp_event)
-                for lsp_event in self._envelopes_for_lsp_events(
-                    session_id=session.session.id,
-                    start_sequence=sequence + 1,
-                    lsp_events=self._lsp_manager.drain_events(),
-                ):
-                    sequence = lsp_event.sequence
-                    yield RuntimeStreamChunk(kind="event", session=session, event=lsp_event)
-                if isinstance(exc, RuntimeToolTimeoutError):
-                    sequence += 1
-                    yield RuntimeStreamChunk(
-                        kind="event",
-                        session=session,
-                        event=EventEnvelope(
-                            session_id=session.session.id,
-                            sequence=sequence,
-                            event_type="runtime.tool_timeout",
-                            source="runtime",
-                            payload={
-                                "tool": plan_tool_call.tool_name,
-                                "timeout_seconds": _tool_timeout,
-                            },
-                        ),
-                    )
-                    yield self._failed_chunk(session=session, sequence=sequence + 1, error=str(exc))
-                    return
-                yield self._failed_chunk(session=session, sequence=sequence + 1, error=str(exc))
-                raise
-
-            for acp_event in self._envelopes_for_acp_events(
-                session_id=session.session.id,
-                start_sequence=sequence + 1,
-                acp_events=self._acp_adapter.drain_events(),
-            ):
-                sequence = acp_event.sequence
-                session = self._session_with_current_acp_metadata(session)
-                yield RuntimeStreamChunk(kind="event", session=session, event=acp_event)
-
-            for mcp_event in self._envelopes_for_mcp_events(
-                session_id=session.session.id,
-                start_sequence=sequence + 1,
-                mcp_events=self._mcp_manager.drain_events(),
-            ):
-                sequence = mcp_event.sequence
-                yield RuntimeStreamChunk(kind="event", session=session, event=mcp_event)
-
-            for lsp_event in self._envelopes_for_lsp_events(
-                session_id=session.session.id,
-                start_sequence=sequence + 1,
-                lsp_events=self._lsp_manager.drain_events(),
-            ):
-                sequence = lsp_event.sequence
-                yield RuntimeStreamChunk(kind="event", session=session, event=lsp_event)
-
-            if plan_tool_call.tool_name == QuestionTool.definition.name:
-                pending_question = PendingQuestion(
-                    request_id=f"question-{uuid4().hex}",
-                    tool_name=plan_tool_call.tool_name,
-                    arguments=dict(plan_tool_call.arguments),
-                    prompts=QuestionTool.parse_prompts(plan_tool_call.arguments),
-                )
-                waiting_session = self._session_with_plan_state(
-                    SessionState(
-                        session=session.session,
-                        status="waiting",
-                        turn=session.turn,
-                        metadata=session.metadata,
-                    ),
-                    status="waiting_question",
-                    blocked_tool=pending_question.tool_name,
-                )
-                sequence += 1
-                yield RuntimeStreamChunk(
-                    kind="event",
-                    session=waiting_session,
-                    event=EventEnvelope(
-                        session_id=session.session.id,
-                        sequence=sequence,
-                        event_type=RUNTIME_QUESTION_REQUESTED,
-                        source="runtime",
-                        payload={
-                            "request_id": pending_question.request_id,
-                            "tool": pending_question.tool_name,
-                            "question_count": len(pending_question.prompts),
-                            "questions": [
-                                {
-                                    "header": prompt.header,
-                                    "question": prompt.question,
-                                    "multiple": prompt.multiple,
-                                    "options": [
-                                        {
-                                            "label": option.label,
-                                            "description": option.description,
-                                        }
-                                        for option in prompt.options
-                                    ],
-                                }
-                                for prompt in pending_question.prompts
-                            ],
-                        },
-                    ),
-                )
-                return
-
-            sequence += 1
-            yield RuntimeStreamChunk(
-                kind="event",
-                session=session,
-                event=EventEnvelope(
-                    session_id=session.session.id,
-                    sequence=sequence,
-                    event_type="runtime.tool_completed",
-                    source="tool",
-                    payload={
-                        "tool": tool_result.tool_name,
-                        "status": tool_result.status,
-                        "content": tool_result.content,
-                        "error": tool_result.error,
-                        **tool_result.data,
-                    },
-                ),
-            )
-
-            post_hook_outcome = self._run_tool_hooks(
-                session=session,
-                sequence=sequence,
-                tool_name=plan_tool_call.tool_name,
-                phase="post",
-            )
-            yield from post_hook_outcome.chunks
-            sequence = post_hook_outcome.last_sequence
-            if post_hook_outcome.failed_error is not None:
-                yield self._failed_chunk(
-                    session=session,
-                    sequence=sequence + 1,
-                    error=post_hook_outcome.failed_error,
-                )
-                raise RuntimeError(post_hook_outcome.failed_error)
-
-            tool_results.append(tool_result)
+        yield from self._run_loop_coordinator.execute_graph_loop(
+            graph=graph,
+            tool_registry=tool_registry,
+            session=session,
+            sequence=sequence,
+            graph_request=graph_request,
+            tool_results=tool_results,
+            approval_resolution=approval_resolution,
+            permission_policy=permission_policy,
+            preserved_continuity_state=preserved_continuity_state,
+        )
 
     def _run_lifecycle_hooks(
         self,
@@ -2081,6 +1547,7 @@ class VoidCodeRuntime:
         tool_name: str,
         phase: Literal["pre", "post"],
     ) -> _HookOutcome:
+        # Referenced via extracted run-loop collaborator.
         outcome: HookExecutionOutcome = run_tool_hooks(
             HookExecutionRequest(
                 hooks=self._config.hooks,
@@ -2174,6 +1641,7 @@ class VoidCodeRuntime:
         sequence: int,
         permission_policy: PermissionPolicy,
     ) -> _PermissionOutcome:
+        # Referenced via extracted run-loop collaborator.
         permission = resolve_permission(
             tool,
             tool_call,
@@ -2245,12 +1713,13 @@ class VoidCodeRuntime:
                 "delegated_task_id": pending.delegated_task_id,
             },
         )
+        pending = replace(pending, request_event_sequence=request_event.sequence)
         return _PermissionOutcome(
             chunks=(
                 RuntimeStreamChunk(kind="event", session=waiting_session, event=request_event),
             ),
             last_sequence=sequence,
-            pending_approval=pending_approval,
+            pending_approval=pending,
         )
 
     def _approval_resolution_outcome(
@@ -2309,30 +1778,7 @@ class VoidCodeRuntime:
         return self._session_store.list_sessions(workspace=self._workspace)
 
     def start_background_task(self, request: RuntimeRequest) -> BackgroundTaskState:
-        self._reconcile_background_tasks_if_needed()
-        validated_request = self._validated_request(request)
-        task_id = f"task-{uuid4().hex}"
-        initial_state = BackgroundTaskState(
-            task=BackgroundTaskRef(id=task_id),
-            status="queued",
-            request=BackgroundTaskRequestSnapshot(
-                prompt=validated_request.prompt,
-                session_id=validated_request.session_id,
-                parent_session_id=validated_request.parent_session_id,
-                metadata=dict(validated_request.metadata),
-                allocate_session_id=validated_request.allocate_session_id,
-            ),
-        )
-        self._session_store.create_background_task(workspace=self._workspace, task=initial_state)
-        worker = threading.Thread(
-            target=self._run_background_task_worker,
-            args=(task_id,),
-            name=f"voidcode-background-task-{task_id}",
-            daemon=True,
-        )
-        self._background_task_threads[task_id] = worker
-        worker.start()
-        return self.load_background_task(task_id)
+        return self._background_task_supervisor.start_background_task(request)
 
     def load_background_task(self, task_id: str) -> BackgroundTaskState:
         self._reconcile_background_tasks_if_needed()
@@ -2340,18 +1786,16 @@ class VoidCodeRuntime:
         return self._session_store.load_background_task(workspace=self._workspace, task_id=task_id)
 
     def load_background_task_result(self, task_id: str) -> BackgroundTaskResult:
-        task = self.load_background_task(task_id)
-        self._backfill_parent_background_task_event(task=task)
-        return self._background_task_result(task=task)
+        return self._background_task_supervisor.load_background_task_result(task_id)
 
     def list_background_tasks(self) -> tuple[StoredBackgroundTaskSummary, ...]:
-        self._reconcile_background_tasks_if_needed()
+        self._background_task_supervisor.reconcile_background_tasks_if_needed()
         return self._session_store.list_background_tasks(workspace=self._workspace)
 
     def list_background_tasks_by_parent_session(
         self, *, parent_session_id: str
     ) -> tuple[StoredBackgroundTaskSummary, ...]:
-        self._reconcile_background_tasks_if_needed()
+        self._background_task_supervisor.reconcile_background_tasks_if_needed()
         validated_parent_session_id = validate_session_reference_id(
             parent_session_id,
             field_name="parent_session_id",
@@ -2362,74 +1806,7 @@ class VoidCodeRuntime:
         )
 
     def cancel_background_task(self, task_id: str) -> BackgroundTaskState:
-        validate_background_task_id(task_id)
-        self._reconcile_background_tasks_if_needed()
-        previous_task = self._session_store.load_background_task(
-            workspace=self._workspace,
-            task_id=task_id,
-        )
-        task = self._session_store.request_background_task_cancel(
-            workspace=self._workspace,
-            task_id=task_id,
-        )
-        if task.status == "running" and task.session_id is not None:
-            child_response = self._load_background_task_child_response(task=task)
-            if child_response is not None and child_response.session.status == "waiting":
-                self._session_store.clear_pending_approval(
-                    workspace=self._workspace,
-                    session_id=task.session_id,
-                )
-                self._session_store.clear_pending_question(
-                    workspace=self._workspace,
-                    session_id=task.session_id,
-                )
-                cancelled_metadata = dict(child_response.session.metadata)
-                cancelled_metadata["abort_requested"] = True
-                cancelled_response = RuntimeResponse(
-                    session=SessionState(
-                        session=child_response.session.session,
-                        status="failed",
-                        turn=child_response.session.turn,
-                        metadata=cancelled_metadata,
-                    ),
-                    events=child_response.events
-                    + (
-                        EventEnvelope(
-                            session_id=task.session_id,
-                            sequence=(
-                                child_response.events[-1].sequence if child_response.events else 0
-                            )
-                            + 1,
-                            event_type=RUNTIME_FAILED,
-                            source="runtime",
-                            payload={
-                                "error": "cancelled by parent while child session was waiting",
-                                "cancelled": True,
-                                "delegated_task_id": task.task.id,
-                            },
-                        ),
-                    ),
-                    output=child_response.output,
-                )
-                self._session_store.save_run(
-                    workspace=self._workspace,
-                    request=RuntimeRequest(
-                        prompt=self._prompt_from_events(child_response.events),
-                        session_id=task.session_id,
-                        parent_session_id=task.parent_session_id,
-                        metadata=cast(RuntimeRequestMetadataPayload, cancelled_metadata),
-                    ),
-                    response=cancelled_response,
-                )
-                task = self._session_store.mark_background_task_terminal(
-                    workspace=self._workspace,
-                    task_id=task_id,
-                    status="cancelled",
-                    error="cancelled by parent while child session was waiting",
-                )
-        if previous_task.status != "cancelled" and task.status == "cancelled":
-            self._run_background_task_lifecycle_hook(task)
-        return task
+        return self._background_task_supervisor.cancel_background_task(task_id)
 
     def session_result(self, *, session_id: str) -> RuntimeSessionResult:
         validate_session_id(session_id)
@@ -2438,7 +1815,9 @@ class VoidCodeRuntime:
             session_id=session_id,
         )
         self._validate_session_workspace(result.session, session_id=session_id)
-        self._reconcile_parent_background_task_events_for_session(parent_session_id=session_id)
+        self._background_task_supervisor.reconcile_parent_background_task_events_for_session(
+            parent_session_id=session_id
+        )
         result = self._session_store.load_session_result(
             workspace=self._workspace,
             session_id=session_id,
@@ -2611,7 +1990,9 @@ class VoidCodeRuntime:
                 workspace=self._workspace, session_id=session_id
             )
             self._validate_session_workspace(response.session, session_id=session_id)
-            self._reconcile_parent_background_task_events_for_session(parent_session_id=session_id)
+            self._background_task_supervisor.reconcile_parent_background_task_events_for_session(
+                parent_session_id=session_id
+            )
             response = self._session_store.load_session(
                 workspace=self._workspace, session_id=session_id
             )
@@ -2628,7 +2009,9 @@ class VoidCodeRuntime:
             approval_request_id=approval_request_id,
             approval_decision=approval_decision,
         )
-        self._finalize_background_task_from_session_response(session_response=response)
+        self._background_task_supervisor.finalize_background_task_from_session_response(
+            session_response=response
+        )
         return response
 
     def resume_stream(
@@ -2644,7 +2027,9 @@ class VoidCodeRuntime:
                 workspace=self._workspace, session_id=session_id
             )
             self._validate_session_workspace(response.session, session_id=session_id)
-            self._reconcile_parent_background_task_events_for_session(parent_session_id=session_id)
+            self._background_task_supervisor.reconcile_parent_background_task_events_for_session(
+                parent_session_id=session_id
+            )
             response = self._session_store.load_session(
                 workspace=self._workspace, session_id=session_id
             )
@@ -2670,6 +2055,48 @@ class VoidCodeRuntime:
         session_id: str,
         approval_request_id: str,
     ) -> None:
+        self._validate_waiting_request_target_ownership(
+            session_id=session_id,
+            request_id=approval_request_id,
+            request_kind="approval",
+        )
+        pending = self._session_store.load_pending_approval(
+            workspace=self._workspace,
+            session_id=session_id,
+        )
+        if pending is None:
+            return
+        if pending.owner_session_id is not None and pending.owner_session_id != session_id:
+            raise ValueError(
+                "approval resume must target the child session that owns the approval request"
+            )
+        if pending.request_id != approval_request_id:
+            return
+
+    def _validate_question_targets_owned_request(
+        self,
+        *,
+        session_id: str,
+        question_request_id: str,
+    ) -> None:
+        self._validate_waiting_request_target_ownership(
+            session_id=session_id,
+            request_id=question_request_id,
+            request_kind="question",
+        )
+
+    def _validate_waiting_request_target_ownership(
+        self,
+        *,
+        session_id: str,
+        request_id: str,
+        request_kind: Literal["approval", "question"],
+    ) -> None:
+        wrong_target_error = (
+            "approval resume must target the child session that owns the approval request"
+            if request_kind == "approval"
+            else "question answer must target the child session that owns the question request"
+        )
         list_by_parent = cast(
             Callable[..., tuple[StoredBackgroundTaskSummary, ...]] | None,
             getattr(
@@ -2689,28 +2116,19 @@ class VoidCodeRuntime:
                 )
                 child_response = self._load_background_task_child_response(task=task)
                 owned_request_id = (
-                    self._approval_request_id_from_waiting_response(child_response)
-                    if child_response is not None
-                    else task.approval_request_id
-                )
-                if owned_request_id == approval_request_id:
-                    raise ValueError(
-                        "approval resume must target the child session that owns "
-                        "the approval request"
+                    self._waiting_request_id_from_response(
+                        child_response,
+                        request_kind=request_kind,
                     )
-
-        pending = self._session_store.load_pending_approval(
-            workspace=self._workspace,
-            session_id=session_id,
-        )
-        if pending is None:
-            return
-        if pending.owner_session_id is not None and pending.owner_session_id != session_id:
-            raise ValueError(
-                "approval resume must target the child session that owns the approval request"
-            )
-        if pending.request_id != approval_request_id:
-            return
+                    if child_response is not None
+                    else (
+                        task.approval_request_id
+                        if request_kind == "approval"
+                        else task.question_request_id
+                    )
+                )
+                if owned_request_id == request_id:
+                    raise ValueError(wrong_target_error)
 
     def answer_question(
         self,
@@ -2720,12 +2138,18 @@ class VoidCodeRuntime:
         responses: tuple[QuestionResponse, ...],
     ) -> RuntimeResponse:
         validate_session_id(session_id)
+        self._validate_question_targets_owned_request(
+            session_id=session_id,
+            question_request_id=question_request_id,
+        )
         _, response = self._answer_pending_question_response(
             session_id=session_id,
             question_request_id=question_request_id,
             responses=responses,
         )
-        self._finalize_background_task_from_session_response(session_response=response)
+        self._background_task_supervisor.finalize_background_task_from_session_response(
+            session_response=response
+        )
         return response
 
     def answer_question_stream(
@@ -2736,6 +2160,10 @@ class VoidCodeRuntime:
         responses: tuple[QuestionResponse, ...],
     ) -> Iterator[RuntimeStreamChunk]:
         validate_session_id(session_id)
+        self._validate_question_targets_owned_request(
+            session_id=session_id,
+            question_request_id=question_request_id,
+        )
         yield from self._answer_pending_question_stream(
             session_id=session_id,
             question_request_id=question_request_id,
@@ -2766,6 +2194,7 @@ class VoidCodeRuntime:
             target_summary=str(payload.get("target_summary", "")),
             reason=str(payload.get("reason", "")),
             policy_mode=raw_policy_mode,
+            request_event_sequence=approval_event.sequence,
             owner_session_id=(
                 str(payload["owner_session_id"])
                 if payload.get("owner_session_id") is not None
@@ -2782,6 +2211,188 @@ class VoidCodeRuntime:
                 else None
             ),
         )
+
+    @staticmethod
+    def _request_event_and_resolution_state(
+        events: tuple[EventEnvelope, ...],
+        *,
+        request_kind: Literal["approval", "question"],
+        request_id: str,
+    ) -> tuple[EventEnvelope | None, bool]:
+        request_event_type = (
+            RUNTIME_APPROVAL_REQUESTED if request_kind == "approval" else RUNTIME_QUESTION_REQUESTED
+        )
+        resolution_event_type = (
+            "runtime.approval_resolved" if request_kind == "approval" else RUNTIME_QUESTION_ANSWERED
+        )
+        request_event: EventEnvelope | None = None
+        resolved = False
+        for event in events:
+            event_request_id = event.payload.get("request_id")
+            if event_request_id != request_id:
+                continue
+            if event.event_type == request_event_type:
+                request_event = event
+            elif event.event_type == resolution_event_type:
+                resolved = True
+        return request_event, resolved
+
+    def _validate_pending_approval_matches_recorded_request(
+        self,
+        *,
+        stored: RuntimeResponse,
+        pending: PendingApproval,
+        checkpoint: dict[str, object] | None,
+    ) -> None:
+        # Referenced via extracted resume collaborator.
+        request_event, resolved = self._request_event_and_resolution_state(
+            stored.events,
+            request_kind="approval",
+            request_id=pending.request_id,
+        )
+        if resolved:
+            raise ValueError(
+                "approval request was already resolved; stale approval replay is not allowed"
+            )
+        if request_event is None:
+            if checkpoint is None:
+                raise ValueError(
+                    "persisted pending approval has no matching approval request event"
+                )
+            if checkpoint.get("pending_approval_request_id") != pending.request_id:
+                raise ValueError(
+                    "persisted approval resume checkpoint request id "
+                    "does not match pending approval"
+                )
+            if (
+                checkpoint.get("pending_approval_tool_name") != pending.tool_name
+                or checkpoint.get("pending_approval_arguments") != pending.arguments
+            ):
+                raise ValueError(
+                    "persisted pending approval no longer matches "
+                    "the recorded approval request payload"
+                )
+            if checkpoint.get("pending_approval_owner_session_id") != pending.owner_session_id:
+                raise ValueError(
+                    "persisted pending approval owner_session_id "
+                    "does not match the recorded approval request"
+                )
+            if (
+                checkpoint.get("pending_approval_owner_parent_session_id")
+                != pending.owner_parent_session_id
+            ):
+                raise ValueError(
+                    "persisted pending approval owner_parent_session_id "
+                    "does not match the recorded approval request"
+                )
+            if checkpoint.get("pending_approval_delegated_task_id") != pending.delegated_task_id:
+                raise ValueError(
+                    "persisted pending approval delegated_task_id "
+                    "does not match the recorded approval request"
+                )
+            checkpoint_sequence = checkpoint.get("pending_approval_request_event_sequence")
+            if (
+                pending.request_event_sequence is not None
+                and checkpoint_sequence is not None
+                and checkpoint_sequence != pending.request_event_sequence
+            ):
+                raise ValueError(
+                    "persisted pending approval sequence "
+                    "does not match the recorded approval request"
+                )
+            return
+        if (
+            pending.request_event_sequence is not None
+            and request_event.sequence != pending.request_event_sequence
+        ):
+            raise ValueError(
+                "persisted pending approval sequence does not match the recorded approval request"
+            )
+        payload = request_event.payload
+        if (
+            payload.get("tool") != pending.tool_name
+            or payload.get("arguments") != pending.arguments
+        ):
+            raise ValueError(
+                "persisted pending approval no longer matches the recorded approval request payload"
+            )
+        if payload.get("owner_session_id") != pending.owner_session_id:
+            raise ValueError(
+                "persisted pending approval owner_session_id "
+                "does not match the recorded approval request"
+            )
+        if payload.get("owner_parent_session_id") != pending.owner_parent_session_id:
+            raise ValueError(
+                "persisted pending approval owner_parent_session_id "
+                "does not match the recorded approval request"
+            )
+        if payload.get("delegated_task_id") != pending.delegated_task_id:
+            raise ValueError(
+                "persisted pending approval delegated_task_id "
+                "does not match the recorded approval request"
+            )
+
+    def _validate_pending_question_matches_recorded_request(
+        self,
+        *,
+        stored: RuntimeResponse,
+        pending: PendingQuestion,
+        checkpoint: dict[str, object] | None,
+    ) -> None:
+        # Referenced via extracted resume collaborator.
+        request_event, resolved = self._request_event_and_resolution_state(
+            stored.events,
+            request_kind="question",
+            request_id=pending.request_id,
+        )
+        if resolved:
+            raise ValueError(
+                "question request was already answered; stale question replay is not allowed"
+            )
+        expected_questions = [
+            {
+                "header": prompt.header,
+                "question": prompt.question,
+                "multiple": prompt.multiple,
+                "options": [
+                    {
+                        "label": option.label,
+                        "description": option.description,
+                    }
+                    for option in prompt.options
+                ],
+            }
+            for prompt in pending.prompts
+        ]
+        if request_event is None:
+            if checkpoint is None:
+                raise ValueError(
+                    "persisted pending question has no matching question request event"
+                )
+            if checkpoint.get("pending_question_request_id") != pending.request_id:
+                raise ValueError(
+                    "persisted question resume checkpoint request id "
+                    "does not match pending question"
+                )
+            if checkpoint.get("pending_question_tool_name") != pending.tool_name:
+                raise ValueError(
+                    "persisted pending question tool does not match the recorded question request"
+                )
+            if checkpoint.get("pending_question_prompts") != expected_questions:
+                raise ValueError(
+                    "persisted pending question no longer matches "
+                    "the recorded question request payload"
+                )
+            return
+        payload = request_event.payload
+        if payload.get("tool") != pending.tool_name:
+            raise ValueError(
+                "persisted pending question tool does not match the recorded question request"
+            )
+        if payload.get("questions") != expected_questions:
+            raise ValueError(
+                "persisted pending question no longer matches the recorded question request payload"
+            )
 
     def _pending_question_from_response(self, response: RuntimeResponse) -> PendingQuestion | None:
         answered_request_ids = {
@@ -2817,40 +2428,12 @@ class VoidCodeRuntime:
         approval_decision: PermissionResolution,
         finalize_background_task: bool = False,
     ) -> Iterator[RuntimeStreamChunk]:
-        stored_response = self._session_store.load_session(
-            workspace=self._workspace, session_id=session_id
-        )
-        pending = self._session_store.load_pending_approval(
-            workspace=self._workspace, session_id=session_id
-        )
-        checkpoint = self._load_resume_checkpoint(session_id=session_id)
-        if pending is None:
-            raise ValueError(f"no pending approval for session: {session_id}")
-        if pending.request_id != approval_request_id:
-            raise ValueError("approval request id does not match pending session approval")
-        streamed_events: list[EventEnvelope] = []
-        output: str | None = None
-        final_session: SessionState | None = None
-        for chunk in self._resume_pending_approval_impl(
-            stored=stored_response,
-            pending=pending,
+        yield from self._resume_coordinator.resume_pending_approval_stream(
+            session_id=session_id,
+            approval_request_id=approval_request_id,
             approval_decision=approval_decision,
-            checkpoint=checkpoint,
-        ):
-            final_session = chunk.session
-            if chunk.event is not None:
-                streamed_events.append(chunk.event)
-            if chunk.kind == "output":
-                output = chunk.output
-            yield chunk
-        if finalize_background_task:
-            response = self._response_from_resumed_chunks(
-                stored_response=stored_response,
-                streamed_events=streamed_events,
-                output=output,
-                final_session=final_session,
-            )
-            self._finalize_background_task_from_session_response(session_response=response)
+            finalize_background_task=finalize_background_task,
+        )
 
     def _resume_pending_approval_response(
         self,
@@ -2859,43 +2442,11 @@ class VoidCodeRuntime:
         approval_request_id: str,
         approval_decision: PermissionResolution,
     ) -> tuple[tuple[EventEnvelope, ...], RuntimeResponse]:
-        stored_response = self._session_store.load_session(
-            workspace=self._workspace,
+        return self._resume_coordinator.resume_pending_approval_response(
             session_id=session_id,
-        )
-        pending = self._session_store.load_pending_approval(
-            workspace=self._workspace, session_id=session_id
-        )
-        checkpoint = self._load_resume_checkpoint(session_id=session_id)
-        if pending is None:
-            raise ValueError(f"no pending approval for session: {session_id}")
-        if pending.request_id != approval_request_id:
-            raise ValueError("approval request id does not match pending session approval")
-
-        stored_events = stored_response.events
-        streamed_events: list[EventEnvelope] = []
-        output: str | None = None
-        final_session: SessionState | None = None
-
-        for chunk in self._resume_pending_approval_impl(
-            stored=stored_response,
-            pending=pending,
+            approval_request_id=approval_request_id,
             approval_decision=approval_decision,
-            checkpoint=checkpoint,
-        ):
-            final_session = chunk.session
-            if chunk.event is not None:
-                streamed_events.append(chunk.event)
-            if chunk.kind == "output":
-                output = chunk.output
-
-        response = self._response_from_resumed_chunks(
-            stored_response=stored_response,
-            streamed_events=streamed_events,
-            output=output,
-            final_session=final_session,
         )
-        return stored_events, response
 
     def _answer_pending_question_stream(
         self,
@@ -2905,41 +2456,12 @@ class VoidCodeRuntime:
         responses: tuple[QuestionResponse, ...],
         finalize_background_task: bool = False,
     ) -> Iterator[RuntimeStreamChunk]:
-        stored_response = self._session_store.load_session(
-            workspace=self._workspace, session_id=session_id
+        yield from self._resume_coordinator.answer_pending_question_stream(
+            session_id=session_id,
+            question_request_id=question_request_id,
+            responses=responses,
+            finalize_background_task=finalize_background_task,
         )
-        pending = self._session_store.load_pending_question(
-            workspace=self._workspace, session_id=session_id
-        )
-        checkpoint = self._load_resume_checkpoint(session_id=session_id)
-        if pending is None:
-            raise NoPendingQuestionError(f"no pending question for session: {session_id}")
-        if pending.request_id != question_request_id:
-            raise ValueError("question request id does not match pending session question")
-        normalized_responses = QuestionTool.validate_responses(pending.prompts, responses)
-        streamed_events: list[EventEnvelope] = []
-        output: str | None = None
-        final_session: SessionState | None = None
-        for chunk in self._answer_pending_question_impl(
-            stored=stored_response,
-            pending=pending,
-            responses=normalized_responses,
-            checkpoint=checkpoint,
-        ):
-            final_session = chunk.session
-            if chunk.event is not None:
-                streamed_events.append(chunk.event)
-            if chunk.kind == "output":
-                output = chunk.output
-            yield chunk
-        if finalize_background_task:
-            response = self._response_from_resumed_chunks(
-                stored_response=stored_response,
-                streamed_events=streamed_events,
-                output=output,
-                final_session=final_session,
-            )
-            self._finalize_background_task_from_session_response(session_response=response)
 
     def _answer_pending_question_response(
         self,
@@ -2948,43 +2470,11 @@ class VoidCodeRuntime:
         question_request_id: str,
         responses: tuple[QuestionResponse, ...],
     ) -> tuple[tuple[EventEnvelope, ...], RuntimeResponse]:
-        stored_response = self._session_store.load_session(
-            workspace=self._workspace,
+        return self._resume_coordinator.answer_pending_question_response(
             session_id=session_id,
+            question_request_id=question_request_id,
+            responses=responses,
         )
-        pending = self._session_store.load_pending_question(
-            workspace=self._workspace, session_id=session_id
-        )
-        checkpoint = self._load_resume_checkpoint(session_id=session_id)
-        if pending is None:
-            raise NoPendingQuestionError(f"no pending question for session: {session_id}")
-        if pending.request_id != question_request_id:
-            raise ValueError("question request id does not match pending session question")
-        normalized_responses = QuestionTool.validate_responses(pending.prompts, responses)
-
-        streamed_events: list[EventEnvelope] = []
-        output: str | None = None
-        final_session: SessionState | None = None
-
-        for chunk in self._answer_pending_question_impl(
-            stored=stored_response,
-            pending=pending,
-            responses=normalized_responses,
-            checkpoint=checkpoint,
-        ):
-            final_session = chunk.session
-            if chunk.event is not None:
-                streamed_events.append(chunk.event)
-            if chunk.kind == "output":
-                output = chunk.output
-
-        response = self._response_from_resumed_chunks(
-            stored_response=stored_response,
-            streamed_events=streamed_events,
-            output=output,
-            final_session=final_session,
-        )
-        return stored_response.events, response
 
     def _answer_pending_question_impl(
         self,
@@ -2994,224 +2484,12 @@ class VoidCodeRuntime:
         responses: tuple[QuestionResponse, ...],
         checkpoint: dict[str, object] | None,
     ) -> Iterator[RuntimeStreamChunk]:
-        session = SessionState(
-            session=stored.session.session,
-            status="running",
-            turn=stored.session.turn,
-            metadata=stored.session.metadata,
-        )
-        max_stored_sequence = stored.events[-1].sequence if stored.events else 0
-        question_answer_result = QuestionTool.answer_tool_result(responses)
-
-        checkpoint_state = self._question_resume_state_from_checkpoint(
-            checkpoint=checkpoint,
+        yield from self._resume_coordinator.answer_pending_question_impl(
+            stored=stored,
             pending=pending,
-            stored_metadata=stored.session.metadata,
+            responses=responses,
+            checkpoint=checkpoint,
         )
-        if checkpoint_state is not None:
-            prompt = checkpoint_state.prompt
-            session = SessionState(
-                session=stored.session.session,
-                status="running",
-                turn=stored.session.turn,
-                metadata=checkpoint_state.session_metadata,
-            )
-            tool_results: list[ToolResult] = list(checkpoint_state.tool_results)
-        else:
-            prompt = self._prompt_from_events(stored.events)
-            tool_results = []
-            for event in stored.events:
-                if event.event_type == "runtime.tool_completed":
-                    error_value = event.payload.get("error")
-                    raw_content = event.payload.get("content")
-                    is_err = error_value is not None
-                    tool_results.append(
-                        ToolResult(
-                            tool_name=str(event.payload.get("tool", "unknown")),
-                            content=(
-                                str(raw_content) if raw_content is not None and not is_err else None
-                            ),
-                            status="error" if is_err else "ok",
-                            data=event.payload,
-                            error=str(error_value) if is_err else None,
-                        )
-                    )
-        tool_results.append(question_answer_result)
-
-        sequence = max_stored_sequence + 1
-        answered_event = EventEnvelope(
-            session_id=session.session.id,
-            sequence=sequence,
-            event_type=RUNTIME_QUESTION_ANSWERED,
-            source="runtime",
-            payload={
-                "request_id": pending.request_id,
-                "responses": [
-                    {"header": response.header, "answers": list(response.answers)}
-                    for response in responses
-                ],
-            },
-        )
-        yield RuntimeStreamChunk(kind="event", session=session, event=answered_event)
-        sequence += 1
-        loop_events = [answered_event]
-        tool_completed_event = EventEnvelope(
-            session_id=session.session.id,
-            sequence=sequence,
-            event_type="runtime.tool_completed",
-            source="tool",
-            payload={
-                "tool": question_answer_result.tool_name,
-                "status": question_answer_result.status,
-                "content": question_answer_result.content,
-                "error": question_answer_result.error,
-                **question_answer_result.data,
-            },
-        )
-        yield RuntimeStreamChunk(kind="event", session=session, event=tool_completed_event)
-        loop_events.append(tool_completed_event)
-
-        effective_config = self._effective_runtime_config_from_metadata(session.metadata)
-        tool_registry = self._tool_registry_for_effective_config(effective_config)
-        skill_registry = self._skill_registry_for_effective_config(effective_config)
-        resumed_skill_snapshot = self._build_skill_snapshot(
-            skill_registry,
-            metadata=session.metadata,
-            agent=effective_config.agent,
-            source="resume",
-        )
-        graph_request = GraphRunRequest(
-            session=session,
-            prompt=prompt,
-            available_tools=tool_registry.definitions(),
-            applied_skills=resumed_skill_snapshot.applied_skill_payloads,
-            skill_prompt_context=resumed_skill_snapshot.skill_prompt_context,
-            context_window=self._prepare_provider_context_window(
-                prompt=prompt,
-                tool_results=tuple(tool_results),
-                session_metadata=session.metadata,
-            ),
-            metadata={
-                **session.metadata,
-                "agent_preset": serialize_runtime_agent_config(effective_config.agent),
-                "provider_attempt": (
-                    session.metadata.get("provider_attempt", 0)
-                    if isinstance(session.metadata.get("provider_attempt", 0), int)
-                    else 0
-                ),
-            },
-        )
-        graph = self._graph_for_session_metadata(session.metadata)
-        output: str | None = None
-        final_session = session
-        last_sequence = sequence
-        try:
-            for chunk in self._execute_graph_loop(
-                graph=graph,
-                tool_registry=tool_registry,
-                session=session,
-                sequence=sequence,
-                graph_request=graph_request,
-                tool_results=tool_results,
-                permission_policy=self._permission_policy_for_session(session.metadata),
-                preserved_continuity_state=self._continuity_state_from_session_metadata(
-                    session.metadata
-                ),
-            ):
-                final_session = chunk.session
-                if chunk.event is not None:
-                    last_sequence = chunk.event.sequence
-                    loop_events.append(chunk.event)
-                if chunk.kind == "output":
-                    output = chunk.output
-                yield chunk
-        except Exception:
-            if final_session.status == "failed":
-                response = RuntimeResponse(
-                    session=final_session,
-                    events=stored.events + tuple(loop_events),
-                    output=output,
-                )
-                request = RuntimeRequest(
-                    prompt=prompt,
-                    session_id=stored.session.session.id,
-                    parent_session_id=stored.session.session.parent_id,
-                )
-                self._persist_response(request=request, response=response)
-                return
-            raise
-
-        if final_session.status == "waiting":
-            final_session = self._disconnect_acp_for_session_state(final_session)
-            waiting_response = RuntimeResponse(
-                session=final_session,
-                events=stored.events + tuple(loop_events),
-                output=output,
-            )
-            idle_reason = self._resume_waiting_reason(waiting_response)
-            idle_hook_outcome = self._run_lifecycle_hooks(
-                session=final_session,
-                sequence=last_sequence,
-                surface="session_idle",
-                payload={"reason": idle_reason, "resume": True},
-            )
-            for hook_chunk in idle_hook_outcome.chunks:
-                hook_event = cast(EventEnvelope, hook_chunk.event)
-                last_sequence = hook_event.sequence
-                loop_events.append(hook_event)
-                yield hook_chunk
-            if idle_hook_outcome.failed_error is not None:
-                failed_chunk = self._failed_chunk(
-                    session=final_session,
-                    sequence=idle_hook_outcome.last_sequence + 1,
-                    error=idle_hook_outcome.failed_error,
-                )
-                failed_event = cast(EventEnvelope, failed_chunk.event)
-                loop_events.append(failed_event)
-                final_session = failed_chunk.session
-                yield failed_chunk
-        else:
-            final_chunks, final_session, final_sequence = self._finalize_run_acp(
-                session=final_session,
-                sequence=last_sequence,
-            )
-            for chunk in final_chunks:
-                if chunk.event is not None:
-                    last_sequence += 1
-                    resequenced_event = self._resequence_event(chunk.event, sequence=last_sequence)
-                    loop_events.append(resequenced_event)
-                    yield RuntimeStreamChunk(
-                        kind="event", session=chunk.session, event=resequenced_event
-                    )
-            end_hook_outcome = self._run_lifecycle_hooks(
-                session=final_session,
-                sequence=max(last_sequence, final_sequence),
-                surface="session_end",
-                payload={"session_status": final_session.status, "resume": True},
-            )
-            for hook_chunk in end_hook_outcome.chunks:
-                hook_event = cast(EventEnvelope, hook_chunk.event)
-                last_sequence = hook_event.sequence
-                loop_events.append(hook_event)
-                yield hook_chunk
-            if end_hook_outcome.failed_error is not None:
-                logger.warning(
-                    "session_end hook failed for %s during question resume: %s",
-                    final_session.session.id,
-                    end_hook_outcome.failed_error,
-                )
-
-        response = RuntimeResponse(
-            session=final_session,
-            events=stored.events + tuple(loop_events),
-            output=output,
-        )
-        request = RuntimeRequest(
-            prompt=prompt,
-            session_id=stored.session.session.id,
-            parent_session_id=stored.session.session.parent_id,
-        )
-        self._persist_response(request=request, response=response)
 
     def _resume_waiting_reason(self, response: RuntimeResponse) -> str:
         try:
@@ -3232,14 +2510,11 @@ class VoidCodeRuntime:
         output: str | None,
         final_session: SessionState | None,
     ) -> RuntimeResponse:
-        if final_session is None:
-            raise ValueError("runtime stream emitted no chunks")
-        if final_session.status == "waiting":
-            final_session = self._reload_persisted_session(session_id=final_session.session.id)
-        return RuntimeResponse(
-            session=final_session,
-            events=stored_response.events + tuple(streamed_events),
+        return self._resume_coordinator.response_from_resumed_chunks(
+            stored_response=stored_response,
+            streamed_events=streamed_events,
             output=output,
+            final_session=final_session,
         )
 
     def _resume_pending_approval_impl(
@@ -3250,388 +2525,12 @@ class VoidCodeRuntime:
         approval_decision: PermissionResolution,
         checkpoint: dict[str, object] | None,
     ) -> Iterator[RuntimeStreamChunk]:
-        session = SessionState(
-            session=stored.session.session,
-            status="running",
-            turn=stored.session.turn,
-            metadata=stored.session.metadata,
-        )
-
-        max_stored_sequence = stored.events[-1].sequence if stored.events else 0
-        loop_events: list[EventEnvelope] = []
-        output: str | None = None
-
-        checkpoint_state = self._approval_resume_state_from_checkpoint(
-            checkpoint=checkpoint,
+        yield from self._resume_coordinator.resume_pending_approval_impl(
+            stored=stored,
             pending=pending,
-            stored_metadata=stored.session.metadata,
+            approval_decision=approval_decision,
+            checkpoint=checkpoint,
         )
-        binding_mismatch_payload: dict[str, object] | None = None
-        if checkpoint is not None:
-            checkpoint_binding = checkpoint.get("skill_binding_snapshot")
-            checkpoint_binding_payload = (
-                cast(dict[str, object], checkpoint_binding)
-                if isinstance(checkpoint_binding, dict)
-                else None
-            )
-            if checkpoint_binding_payload is not None:
-                stored_snapshot_payload = cast(
-                    dict[str, object] | None,
-                    stored.session.metadata.get("skill_snapshot"),
-                )
-                stored_binding_payload = (
-                    cast(dict[str, object], stored_snapshot_payload.get("binding_snapshot"))
-                    if isinstance(stored_snapshot_payload, dict)
-                    and isinstance(stored_snapshot_payload.get("binding_snapshot"), dict)
-                    else None
-                )
-                mismatch_payload = self._skill_binding_mismatch_payload(
-                    checkpoint_binding_payload,
-                    stored_binding_payload,
-                )
-                if cast(bool, mismatch_payload["mismatch"]):
-                    binding_mismatch_payload = mismatch_payload
-        if checkpoint_state is not None:
-            prompt = checkpoint_state.prompt
-            session = SessionState(
-                session=stored.session.session,
-                status="running",
-                turn=stored.session.turn,
-                metadata=checkpoint_state.session_metadata,
-            )
-            tool_results: list[ToolResult] = list(checkpoint_state.tool_results)
-        else:
-            prompt = self._prompt_from_events(stored.events)
-            tool_results = []
-            for event in stored.events:
-                if event.event_type == "runtime.tool_completed":
-                    error_value = event.payload.get("error")
-                    raw_content = event.payload.get("content")
-                    is_err = error_value is not None
-                    tool_results.append(
-                        ToolResult(
-                            tool_name=str(event.payload.get("tool", "unknown")),
-                            content=(
-                                str(raw_content) if raw_content is not None and not is_err else None
-                            ),
-                            status="error" if is_err else "ok",
-                            data=event.payload,
-                            error=str(error_value) if is_err else None,
-                        )
-                    )
-
-        session = self._session_with_current_acp_metadata(session)
-        preserved_continuity_state = self._continuity_state_from_session_metadata(session.metadata)
-        mcp_startup_chunks, session, _, mcp_failed_chunk = self._refresh_mcp_tools_for_session(
-            session=session,
-            sequence=max_stored_sequence,
-            failure_kind="mcp_startup_failed",
-        )
-        effective_config = self._effective_runtime_config_from_metadata(session.metadata)
-        tool_registry = self._tool_registry_for_effective_config(effective_config)
-        skill_registry = self._skill_registry_for_effective_config(effective_config)
-
-        resumed_skill_snapshot = self._build_skill_snapshot(
-            skill_registry,
-            metadata=session.metadata,
-            agent=effective_config.agent,
-            source="resume",
-        )
-        resumed_applied_skills = resumed_skill_snapshot.applied_skill_payloads
-        graph_request = GraphRunRequest(
-            session=session,
-            prompt=prompt,
-            available_tools=tool_registry.definitions(),
-            applied_skills=resumed_applied_skills,
-            skill_prompt_context=resumed_skill_snapshot.skill_prompt_context,
-            context_window=self._prepare_provider_context_window(
-                prompt=prompt,
-                tool_results=tuple(tool_results),
-                session_metadata=session.metadata,
-            ),
-            metadata={
-                **session.metadata,
-                "agent_preset": serialize_runtime_agent_config(effective_config.agent),
-                "provider_attempt": (
-                    session.metadata.get("provider_attempt", 0)
-                    if isinstance(session.metadata.get("provider_attempt", 0), int)
-                    else 0
-                ),
-            },
-        )
-        provider_attempt = self._provider_attempt_from_metadata(graph_request.metadata)
-        graph = self._graph_for_session_metadata(session.metadata)
-        if provider_attempt > 0:
-            graph = self._graph_selection_for_effective_config(
-                self._effective_runtime_config_from_metadata(session.metadata),
-                provider_attempt=provider_attempt,
-            ).graph
-
-        emitted_sequence = max_stored_sequence
-        if binding_mismatch_payload is not None:
-            emitted_sequence += 1
-            mismatch_event = EventEnvelope(
-                session_id=session.session.id,
-                sequence=emitted_sequence,
-                event_type=RUNTIME_SKILLS_BINDING_MISMATCH,
-                source="runtime",
-                payload={
-                    **binding_mismatch_payload,
-                    "resume": True,
-                    "approval_request_id": pending.request_id,
-                },
-            )
-            loop_events.append(mismatch_event)
-            yield RuntimeStreamChunk(kind="event", session=session, event=mismatch_event)
-        for chunk in mcp_startup_chunks:
-            emitted_sequence += 1
-            resequenced_event = self._resequence_event(
-                cast(EventEnvelope, chunk.event), sequence=emitted_sequence
-            )
-            resequenced_chunk = RuntimeStreamChunk(
-                kind="event", session=chunk.session, event=resequenced_event
-            )
-            loop_events.append(resequenced_event)
-            yield resequenced_chunk
-        if mcp_failed_chunk is not None:
-            emitted_sequence += 1
-            resequenced_failed = self._resequence_event(
-                cast(EventEnvelope, mcp_failed_chunk.event), sequence=emitted_sequence
-            )
-            failed_chunk = RuntimeStreamChunk(
-                kind="event",
-                session=mcp_failed_chunk.session,
-                event=resequenced_failed,
-            )
-            loop_events.append(resequenced_failed)
-            response = RuntimeResponse(
-                session=mcp_failed_chunk.session,
-                events=stored.events + tuple(loop_events),
-                output=output,
-            )
-            request = RuntimeRequest(
-                prompt=prompt,
-                session_id=stored.session.session.id,
-                parent_session_id=stored.session.session.parent_id,
-            )
-            self._persist_response(request=request, response=response)
-            yield failed_chunk
-            return
-
-        deferred_startup_acp_events: tuple[object, ...] = ()
-        if self.current_acp_state().configuration.configured_enabled is True:
-            try:
-                deferred_startup_acp_events = self._acp_adapter.connect()
-            except Exception as exc:
-                startup_chunks, session, last_sequence = self._emit_current_acp_drain(
-                    session=session,
-                    start_sequence=max_stored_sequence + 1,
-                )
-                startup_failed_chunk = self._failed_chunk(
-                    session=self._session_with_current_acp_metadata(session),
-                    sequence=last_sequence + 1,
-                    error=str(exc),
-                    payload={"kind": "acp_startup_failed"},
-                )
-            else:
-                session = self._session_with_current_acp_metadata(session)
-                startup_chunks = ()
-                startup_failed_chunk = None
-        else:
-            startup_chunks = ()
-            startup_failed_chunk = None
-        for chunk in startup_chunks:
-            emitted_sequence += 1
-            resequenced_event = self._resequence_event(
-                cast(EventEnvelope, chunk.event), sequence=emitted_sequence
-            )
-            resequenced_chunk = RuntimeStreamChunk(
-                kind="event", session=chunk.session, event=resequenced_event
-            )
-            loop_events.append(resequenced_event)
-            yield resequenced_chunk
-        if startup_failed_chunk is not None:
-            emitted_sequence += 1
-            resequenced_failed = self._resequence_event(
-                cast(EventEnvelope, startup_failed_chunk.event),
-                sequence=emitted_sequence,
-            )
-            failed_chunk = RuntimeStreamChunk(
-                kind="event",
-                session=startup_failed_chunk.session,
-                event=resequenced_failed,
-            )
-            loop_events.append(resequenced_failed)
-            response = RuntimeResponse(
-                session=startup_failed_chunk.session,
-                events=stored.events + tuple(loop_events),
-                output=output,
-            )
-            request = RuntimeRequest(
-                prompt=prompt,
-                session_id=stored.session.session.id,
-                parent_session_id=stored.session.session.parent_id,
-            )
-            self._persist_response(request=request, response=response)
-            yield failed_chunk
-            return
-
-        sequence = max_stored_sequence
-        try:
-            for chunk in self._execute_graph_loop(
-                graph=graph,
-                tool_registry=tool_registry,
-                session=session,
-                sequence=sequence,
-                graph_request=graph_request,
-                tool_results=tool_results,
-                approval_resolution=(pending, approval_decision),
-                permission_policy=self._permission_policy_for_session(session.metadata),
-                preserved_continuity_state=preserved_continuity_state,
-            ):
-                if deferred_startup_acp_events and (
-                    (
-                        chunk.event is not None
-                        and chunk.event.event_type
-                        in {"runtime.approval_resolved", "runtime.failed"}
-                    )
-                    or chunk.kind == "output"
-                ):
-                    startup_chunks, updated_session, _ = self._emit_acp_events(
-                        session=chunk.session,
-                        start_sequence=emitted_sequence + 1,
-                        acp_events=deferred_startup_acp_events,
-                    )
-                    deferred_startup_acp_events = ()
-                    for startup_chunk in startup_chunks:
-                        startup_event = cast(EventEnvelope, startup_chunk.event)
-                        emitted_sequence = startup_event.sequence
-                        loop_events.append(startup_event)
-                        yield startup_chunk
-                    if chunk.event is not None:
-                        chunk = RuntimeStreamChunk(
-                            kind="event",
-                            session=updated_session,
-                            event=chunk.event,
-                        )
-                    elif chunk.kind == "output":
-                        chunk = RuntimeStreamChunk(
-                            kind="output",
-                            session=updated_session,
-                            output=chunk.output,
-                        )
-                if chunk.event is not None:
-                    emitted_sequence += 1
-                    resequenced_event = self._resequence_event(
-                        chunk.event, sequence=emitted_sequence
-                    )
-                    loop_events.append(resequenced_event)
-                    yield RuntimeStreamChunk(
-                        kind="event", session=chunk.session, event=resequenced_event
-                    )
-                if chunk.kind == "output":
-                    output = chunk.output
-                    yield chunk
-                session = chunk.session
-        except Exception:
-            if session.status == "failed":
-                response = RuntimeResponse(
-                    session=session,
-                    events=stored.events + tuple(loop_events),
-                    output=output,
-                )
-                request = RuntimeRequest(
-                    prompt=prompt,
-                    session_id=stored.session.session.id,
-                    parent_session_id=stored.session.session.parent_id,
-                )
-                self._persist_response(request=request, response=response)
-                return
-            raise
-
-        if deferred_startup_acp_events:
-            startup_chunks, session, _ = self._emit_acp_events(
-                session=session,
-                start_sequence=emitted_sequence + 1,
-                acp_events=deferred_startup_acp_events,
-            )
-            deferred_startup_acp_events = ()
-            for startup_chunk in startup_chunks:
-                startup_event = cast(EventEnvelope, startup_chunk.event)
-                emitted_sequence = startup_event.sequence
-                loop_events.append(startup_event)
-                yield startup_chunk
-
-        last_sequence = emitted_sequence
-        if session.status == "waiting":
-            session = self._disconnect_acp_for_session_state(session)
-            idle_hook_outcome = self._run_lifecycle_hooks(
-                session=session,
-                sequence=last_sequence,
-                surface="session_idle",
-                payload={"reason": "waiting_for_approval", "resume": True},
-            )
-            for hook_chunk in idle_hook_outcome.chunks:
-                hook_event = cast(EventEnvelope, hook_chunk.event)
-                emitted_sequence = hook_event.sequence
-                loop_events.append(hook_event)
-                yield hook_chunk
-            if idle_hook_outcome.failed_error is not None:
-                failed_chunk = self._failed_chunk(
-                    session=session,
-                    sequence=idle_hook_outcome.last_sequence + 1,
-                    error=idle_hook_outcome.failed_error,
-                )
-                failed_event = cast(EventEnvelope, failed_chunk.event)
-                loop_events.append(failed_event)
-                session = failed_chunk.session
-                yield failed_chunk
-        else:
-            final_chunks, session, _ = self._finalize_run_acp(
-                session=session,
-                sequence=last_sequence,
-            )
-            for chunk in final_chunks:
-                if chunk.event is not None:
-                    emitted_sequence += 1
-                    resequenced_event = self._resequence_event(
-                        chunk.event, sequence=emitted_sequence
-                    )
-                    loop_events.append(resequenced_event)
-                    yield RuntimeStreamChunk(
-                        kind="event", session=chunk.session, event=resequenced_event
-                    )
-            end_hook_outcome = self._run_lifecycle_hooks(
-                session=session,
-                sequence=emitted_sequence,
-                surface="session_end",
-                payload={"session_status": session.status, "resume": True},
-            )
-            for hook_chunk in end_hook_outcome.chunks:
-                hook_event = cast(EventEnvelope, hook_chunk.event)
-                emitted_sequence = hook_event.sequence
-                loop_events.append(hook_event)
-                yield hook_chunk
-            if end_hook_outcome.failed_error is not None:
-                logger.warning(
-                    "session_end hook failed for %s during resume: %s",
-                    session.session.id,
-                    end_hook_outcome.failed_error,
-                )
-
-        response = RuntimeResponse(
-            session=session,
-            events=stored.events + tuple(loop_events),
-            output=output,
-        )
-
-        request = RuntimeRequest(
-            prompt=prompt,
-            session_id=stored.session.session.id,
-            parent_session_id=stored.session.session.parent_id,
-        )
-        self._persist_response(request=request, response=response)
-        return
 
     def _approval_resume_state_from_checkpoint(
         self,
@@ -3640,48 +2539,17 @@ class VoidCodeRuntime:
         pending: PendingApproval,
         stored_metadata: dict[str, object],
     ) -> _ApprovalResumeCheckpointState | None:
-        if checkpoint is None:
-            return None
-        if checkpoint.get("kind") != "approval_wait":
-            return None
-        if checkpoint.get("version") != 1:
-            return None
-        if checkpoint.get("pending_approval_request_id") != pending.request_id:
-            return None
-        checkpoint_snapshot_hash = checkpoint.get("skill_snapshot_hash")
-        stored_snapshot_payload = cast(
-            dict[str, object] | None,
-            stored_metadata.get("skill_snapshot"),
+        state = self._resume_coordinator.approval_resume_state_from_checkpoint(
+            checkpoint=checkpoint,
+            pending=pending,
+            stored_metadata=stored_metadata,
         )
-        stored_snapshot_hash = (
-            stored_snapshot_payload.get("snapshot_hash")
-            if isinstance(stored_snapshot_payload, dict)
-            else None
-        )
-        if (
-            checkpoint_snapshot_hash is not None
-            and stored_snapshot_hash is not None
-            and checkpoint_snapshot_hash != stored_snapshot_hash
-        ):
-            return None
-        prompt = checkpoint.get("prompt")
-        session_metadata = checkpoint.get("session_metadata")
-        raw_tool_results = checkpoint.get("tool_results")
-        if not isinstance(prompt, str) or not isinstance(session_metadata, dict):
-            return None
-        if cast(dict[str, object], session_metadata) != stored_metadata:
-            return None
-        if not isinstance(raw_tool_results, list):
-            return None
-        checkpoint_tool_results = cast(list[object], raw_tool_results)
-        try:
-            tool_results = self._tool_results_from_checkpoint(checkpoint_tool_results)
-        except (TypeError, ValueError):
+        if state is None:
             return None
         return _ApprovalResumeCheckpointState(
-            prompt=prompt,
-            session_metadata=cast(dict[str, object], session_metadata),
-            tool_results=tool_results,
+            prompt=state.prompt,
+            session_metadata=state.session_metadata,
+            tool_results=state.tool_results,
         )
 
     def _question_resume_state_from_checkpoint(
@@ -3691,80 +2559,41 @@ class VoidCodeRuntime:
         pending: PendingQuestion,
         stored_metadata: dict[str, object],
     ) -> _ApprovalResumeCheckpointState | None:
-        if checkpoint is None:
-            return None
-        if checkpoint.get("kind") != "question_wait":
-            return None
-        if checkpoint.get("version") != 1:
-            return None
-        if checkpoint.get("pending_question_request_id") != pending.request_id:
-            return None
-        prompt = checkpoint.get("prompt")
-        session_metadata = checkpoint.get("session_metadata")
-        raw_tool_results = checkpoint.get("tool_results")
-        if not isinstance(prompt, str) or not isinstance(session_metadata, dict):
-            return None
-        if cast(dict[str, object], session_metadata) != stored_metadata:
-            return None
-        if not isinstance(raw_tool_results, list):
-            return None
-        checkpoint_tool_results = cast(list[object], raw_tool_results)
-        try:
-            tool_results = self._tool_results_from_checkpoint(checkpoint_tool_results)
-        except (TypeError, ValueError):
+        state = self._resume_coordinator.question_resume_state_from_checkpoint(
+            checkpoint=checkpoint,
+            pending=pending,
+            stored_metadata=stored_metadata,
+        )
+        if state is None:
             return None
         return _ApprovalResumeCheckpointState(
-            prompt=prompt,
-            session_metadata=cast(dict[str, object], session_metadata),
-            tool_results=tool_results,
-        )
-
-    def _load_resume_checkpoint(self, *, session_id: str) -> dict[str, object] | None:
-        load_checkpoint = getattr(self._session_store, "load_resume_checkpoint", None)
-        if load_checkpoint is None:
-            return None
-        return cast(
-            dict[str, object] | None,
-            load_checkpoint(workspace=self._workspace, session_id=session_id),
+            prompt=state.prompt,
+            session_metadata=state.session_metadata,
+            tool_results=state.tool_results,
         )
 
     @staticmethod
+    def _validated_resume_checkpoint_envelope(
+        *, checkpoint: dict[str, object] | None, expected_kind: str
+    ) -> _PersistedResumeCheckpointEnvelope | None:
+        envelope = RuntimeResumeCoordinator.validated_resume_checkpoint_envelope(
+            checkpoint=checkpoint,
+            expected_kind=expected_kind,
+        )
+        if envelope is None:
+            return None
+        return _PersistedResumeCheckpointEnvelope(
+            kind=envelope.kind,
+            version=envelope.version,
+            payload=envelope.payload,
+        )
+
+    def _load_resume_checkpoint(self, *, session_id: str) -> dict[str, object] | None:
+        return self._resume_coordinator.load_resume_checkpoint(session_id=session_id)
+
+    @staticmethod
     def _tool_results_from_checkpoint(raw_tool_results: list[object]) -> tuple[ToolResult, ...]:
-        parsed: list[ToolResult] = []
-        for raw_tool_result in raw_tool_results:
-            if not isinstance(raw_tool_result, dict):
-                raise ValueError("persisted resume checkpoint tool_results must contain objects")
-            payload = cast(dict[str, object], raw_tool_result)
-            tool_name = payload.get("tool_name")
-            status = payload.get("status")
-            data = payload.get("data")
-            content = payload.get("content")
-            error = payload.get("error")
-            if (
-                not isinstance(tool_name, str)
-                or status not in ("ok", "error")
-                or not isinstance(data, dict)
-            ):
-                raise ValueError("persisted resume checkpoint tool_results are malformed")
-            if content is not None and not isinstance(content, str):
-                raise ValueError(
-                    "persisted resume checkpoint tool result content must be a string or null"
-                )
-            if error is not None and not isinstance(error, str):
-                raise ValueError(
-                    "persisted resume checkpoint tool result error must be a string or null"
-                )
-            tool_status: ToolResultStatus = status
-            parsed.append(
-                ToolResult(
-                    tool_name=tool_name,
-                    content=content,
-                    status=tool_status,
-                    data=cast(dict[str, object], data),
-                    error=error,
-                )
-            )
-        return tuple(parsed)
+        return RuntimeResumeCoordinator.tool_results_from_checkpoint(raw_tool_results)
 
     @staticmethod
     def _replay_response(response: RuntimeResponse) -> Iterator[RuntimeStreamChunk]:
@@ -3973,6 +2802,7 @@ class VoidCodeRuntime:
 
     @staticmethod
     def _prompt_from_events(events: tuple[EventEnvelope, ...]) -> str:
+        # Referenced via extracted collaborators.
         if not events:
             return ""
         prompt = events[0].payload.get("prompt")
@@ -3982,6 +2812,7 @@ class VoidCodeRuntime:
 
     @staticmethod
     def _provider_attempt_from_metadata(metadata: dict[str, object]) -> int:
+        # Referenced via extracted collaborators.
         raw_provider_attempt = metadata.get("provider_attempt", 0)
         return raw_provider_attempt if isinstance(raw_provider_attempt, int) else 0
 
@@ -4004,6 +2835,7 @@ class VoidCodeRuntime:
     def _continuity_state_from_session_metadata(
         session_metadata: dict[str, object],
     ) -> RuntimeContinuityState | None:
+        # Referenced via extracted collaborators.
         runtime_state = session_metadata.get("runtime_state")
         if not isinstance(runtime_state, dict):
             return None
@@ -4039,6 +2871,7 @@ class VoidCodeRuntime:
     def _session_with_context_window_metadata(
         session: SessionState, context_window: RuntimeContextWindow
     ) -> SessionState:
+        # Referenced via extracted run-loop collaborator.
         raw_runtime_state = session.metadata.get("runtime_state")
         runtime_state = (
             dict(cast(dict[str, object], raw_runtime_state))
@@ -4070,6 +2903,7 @@ class VoidCodeRuntime:
     def _renumber_events(
         events: tuple[GraphEvent, ...], *, session_id: str, start_sequence: int
     ) -> tuple[EventEnvelope, ...]:
+        # Referenced via extracted run-loop collaborator.
         return tuple(
             EventEnvelope(
                 session_id=session_id,
@@ -4184,6 +3018,7 @@ class VoidCodeRuntime:
         expected: dict[str, object] | None,
         actual: dict[str, object] | None,
     ) -> dict[str, object]:
+        # Referenced via extracted resume collaborator.
         expected_payload = expected if isinstance(expected, dict) else {}
         actual_payload = actual if isinstance(actual, dict) else {}
         keys = sorted(set(expected_payload.keys()) | set(actual_payload.keys()))
@@ -4707,6 +3542,7 @@ class VoidCodeRuntime:
     def _permission_policy_for_session(
         self, metadata: dict[str, object] | None
     ) -> PermissionPolicy:
+        # Referenced via extracted resume collaborator.
         approval_mode: PermissionDecision = self._permission_policy.mode
         if metadata is not None:
             persisted_runtime_config = metadata.get("runtime_config")
@@ -4719,10 +3555,22 @@ class VoidCodeRuntime:
 
     @staticmethod
     def _approval_request_id_from_waiting_response(response: RuntimeResponse) -> str | None:
+        # Referenced via extracted background-task collaborator.
+        return VoidCodeRuntime._waiting_request_id_from_response(response, request_kind="approval")
+
+    @staticmethod
+    def _waiting_request_id_from_response(
+        response: RuntimeResponse,
+        *,
+        request_kind: Literal["approval", "question"],
+    ) -> str | None:
         if response.session.status != "waiting":
             return None
+        target_event_type = (
+            RUNTIME_APPROVAL_REQUESTED if request_kind == "approval" else RUNTIME_QUESTION_REQUESTED
+        )
         for event in reversed(response.events):
-            if event.event_type in {RUNTIME_APPROVAL_REQUESTED, RUNTIME_QUESTION_REQUESTED}:
+            if event.event_type == target_event_type:
                 request_id = event.payload.get("request_id")
                 return str(request_id) if request_id is not None else None
         return None
@@ -4732,167 +3580,38 @@ class VoidCodeRuntime:
         *,
         task: BackgroundTaskState,
     ) -> RuntimeResponse | None:
-        child_session_id = task.session_id
-        if child_session_id is None:
-            return None
-        try:
-            response = self._session_store.load_session(
-                workspace=self._workspace,
-                session_id=child_session_id,
-            )
-        except UnknownSessionError:
-            return None
-        self._validate_session_workspace(response.session, session_id=child_session_id)
-        return response
+        # Compatibility wrapper for tests/callers.
+        return self._background_task_supervisor.load_background_task_child_response(task=task)
 
     def _load_background_task_child_result(
         self,
         *,
         task: BackgroundTaskState,
     ) -> RuntimeSessionResult | None:
-        child_session_id = task.session_id
-        if child_session_id is None:
-            return None
-        try:
-            result = self._session_store.load_session_result(
-                workspace=self._workspace,
-                session_id=child_session_id,
-            )
-        except UnknownSessionError:
-            return None
-        self._validate_session_workspace(result.session, session_id=child_session_id)
-        return result
+        # Compatibility wrapper for tests/callers.
+        return self._background_task_supervisor.load_background_task_child_result(task=task)
 
     def _background_task_result(self, *, task: BackgroundTaskState) -> BackgroundTaskResult:
-        child_result = self._load_background_task_child_result(task=task)
-        approval_blocked = child_result is not None and child_result.status == "waiting"
-        summary_output = child_result.summary if child_result is not None else None
-        error = (
-            child_result.error if child_result is not None and child_result.error else task.error
-        )
-        result_available = task.result_available
-        if not result_available and task.status != "cancelled" and child_result is not None:
-            result_available = True
-        return BackgroundTaskResult(
-            task_id=task.task.id,
-            parent_session_id=task.parent_session_id,
-            child_session_id=task.session_id,
-            status=task.status,
-            requested_child_session_id=task.request.session_id or task.session_id,
-            routing=task.routing_identity,
-            approval_request_id=task.approval_request_id,
-            question_request_id=task.question_request_id,
-            approval_blocked=approval_blocked,
-            summary_output=summary_output,
-            error=error,
-            result_available=result_available,
-            cancellation_cause=task.cancellation_cause,
-        )
+        # Compatibility wrapper for tests/callers.
+        return self._background_task_supervisor.background_task_result(task=task)
 
     def _emit_background_task_parent_terminal_event(self, *, task: BackgroundTaskState) -> None:
-        parent_session_id = task.parent_session_id
-        if parent_session_id is None or task.status not in ("completed", "failed", "cancelled"):
-            return
-        session_event_appender = self._session_store
-        if not isinstance(session_event_appender, SessionEventAppender):
-            logger.debug(
-                "skipping background terminal parent event for session store without append support"
-            )
-            return
-        result = self._background_task_result(task=task)
-        event_type_by_status: dict[BackgroundTaskStatus, str] = {
-            "completed": RUNTIME_BACKGROUND_TASK_COMPLETED,
-            "failed": RUNTIME_BACKGROUND_TASK_FAILED,
-            "cancelled": RUNTIME_BACKGROUND_TASK_CANCELLED,
-        }
-        event_type = event_type_by_status[task.status]
-        payload: dict[str, object] = {
-            "task_id": task.task.id,
-            "parent_session_id": parent_session_id,
-            "status": task.status,
-            "result_available": result.result_available,
-            "delegation": result.delegated_execution.as_payload(),
-            "message": result.delegated_message.as_payload(),
-        }
-        if result.child_session_id is not None:
-            payload["child_session_id"] = result.child_session_id
-        if task.status == "completed" and result.summary_output is not None:
-            payload["summary_output"] = result.summary_output
-        if task.status in ("failed", "cancelled") and result.error is not None:
-            payload["error"] = result.error
-        if task.approval_request_id is not None:
-            payload["approval_request_id"] = task.approval_request_id
-        if task.question_request_id is not None:
-            payload["question_request_id"] = task.question_request_id
-        try:
-            _ = session_event_appender.append_session_event(
-                workspace=self._workspace,
-                session_id=parent_session_id,
-                event_type=event_type,
-                source="runtime",
-                payload=payload,
-                dedupe_key=f"{event_type}:{task.task.id}",
-            )
-            self._append_parent_acp_delegated_lifecycle_event(
-                task=task,
-                lifecycle_status=task.status,
-                result_available=result.result_available,
-                payload=payload,
-            )
-            self._publish_delegated_acp_event(
-                task=task,
-                lifecycle_status=task.status,
-                result_available=result.result_available,
-                payload=payload,
-            )
-        except UnknownSessionError:
-            logger.debug(
-                "skipping background terminal event for unavailable parent session: %s",
-                parent_session_id,
-            )
+        # Compatibility wrapper for tests/callers.
+        self._background_task_supervisor.emit_background_task_parent_terminal_event(task=task)
 
     def _backfill_parent_background_task_event(self, *, task: BackgroundTaskState) -> None:
-        if task.parent_session_id is None:
-            return
-        if task.status in ("completed", "failed", "cancelled"):
-            self._emit_background_task_parent_terminal_event(task=task)
-            return
-        if task.status != "running":
-            return
-        child_response = self._load_background_task_child_response(task=task)
-        if child_response is None or child_response.session.status != "waiting":
-            return
-        self._emit_background_task_waiting_approval(
-            task=task,
-            child_response=child_response,
-        )
+        # Compatibility wrapper for tests/callers.
+        self._background_task_supervisor.backfill_parent_background_task_event(task=task)
 
     def _reconcile_parent_background_task_events_for_session(
         self,
         *,
         parent_session_id: str,
     ) -> None:
-        task_summaries = self._session_store.list_background_tasks_by_parent_session(
-            workspace=self._workspace,
-            parent_session_id=parent_session_id,
+        # Compatibility wrapper for tests/callers.
+        self._background_task_supervisor.reconcile_parent_background_task_events_for_session(
+            parent_session_id=parent_session_id
         )
-        for task_summary in task_summaries:
-            task = self._session_store.load_background_task(
-                workspace=self._workspace,
-                task_id=task_summary.task.id,
-            )
-            if task.status == "running" and task.session_id is not None:
-                child_response = self._load_background_task_child_response(task=task)
-                if child_response is not None and child_response.session.status in (
-                    "waiting",
-                    "completed",
-                    "failed",
-                ):
-                    self._finalize_background_task_from_session_response(
-                        session_response=child_response
-                    )
-                    continue
-            self._backfill_parent_background_task_event(task=task)
 
     def _emit_background_task_waiting_approval(
         self,
@@ -4900,140 +3619,25 @@ class VoidCodeRuntime:
         task: BackgroundTaskState,
         child_response: RuntimeResponse,
     ) -> None:
-        parent_session_id = task.parent_session_id
-        child_session_id = task.session_id
-        if parent_session_id is None or child_session_id is None:
-            return
-        approval_request_id = self._approval_request_id_from_waiting_response(child_response)
-        dedupe_key = (
-            f"background_task_waiting_approval:{task.task.id}:{approval_request_id}"
-            if approval_request_id is not None
-            else f"background_task_waiting_approval:{task.task.id}:{child_session_id}"
+        # Compatibility wrapper for tests/callers.
+        self._background_task_supervisor.emit_background_task_waiting_approval(
+            task=task,
+            child_response=child_response,
         )
-        session_event_appender = self._session_store
-        if not isinstance(session_event_appender, SessionEventAppender):
-            logger.debug(
-                "skipping background waiting event for session store without append support"
-            )
-            return
-        result = self._background_task_result(task=task)
-        try:
-            _ = session_event_appender.append_session_event(
-                workspace=self._workspace,
-                session_id=parent_session_id,
-                event_type=RUNTIME_BACKGROUND_TASK_WAITING_APPROVAL,
-                source="runtime",
-                payload={
-                    "task_id": task.task.id,
-                    "parent_session_id": parent_session_id,
-                    "child_session_id": child_session_id,
-                    "status": "running",
-                    "approval_blocked": True,
-                    "delegation": result.delegated_execution.as_payload(),
-                    "message": result.delegated_message.as_payload(),
-                    **(
-                        {"approval_request_id": approval_request_id}
-                        if approval_request_id is not None
-                        else {}
-                    ),
-                },
-                dedupe_key=dedupe_key,
-            )
-            acp_payload: dict[str, object] = {
-                "task_id": task.task.id,
-                "parent_session_id": parent_session_id,
-                "child_session_id": child_session_id,
-                "approval_request_id": approval_request_id,
-                "status": "running",
-                "approval_blocked": True,
-            }
-            self._append_parent_acp_delegated_lifecycle_event(
-                task=task,
-                lifecycle_status="waiting_approval",
-                approval_blocked=True,
-                payload=acp_payload,
-            )
-            self._publish_delegated_acp_event(
-                task=task,
-                lifecycle_status="waiting_approval",
-                approval_blocked=True,
-                payload=acp_payload,
-            )
-        except UnknownSessionError:
-            logger.debug(
-                "skipping background waiting event for unavailable parent session: %s",
-                parent_session_id,
-            )
 
     def _finalize_background_task_from_session_response(
         self,
         *,
         session_response: RuntimeResponse,
     ) -> None:
-        metadata = session_response.session.metadata
-        background_task_id = metadata.get("background_task_id")
-        background_run = metadata.get("background_run")
-        if not isinstance(background_task_id, str) or background_run is not True:
-            return
-        current_task = self._session_store.load_background_task(
-            workspace=self._workspace,
-            task_id=background_task_id,
+        # Compatibility wrapper for tests/callers.
+        self._background_task_supervisor.finalize_background_task_from_session_response(
+            session_response=session_response
         )
-        if current_task.status == "cancelled":
-            return
-        if session_response.session.status == "waiting":
-            if current_task.status in ("completed", "failed"):
-                return
-            self._emit_background_task_waiting_approval(
-                task=current_task,
-                child_response=session_response,
-            )
-            return
-        terminal_status: BackgroundTaskStatus = (
-            "completed" if session_response.session.status == "completed" else "failed"
-        )
-        if current_task.status == terminal_status:
-            return
-        error: str | None = None
-        if terminal_status == "failed":
-            for event in reversed(session_response.events):
-                if event.event_type == RUNTIME_FAILED:
-                    event_error = event.payload.get("error")
-                    error = str(event_error) if event_error is not None else None
-                    break
-        terminal_task = self._session_store.mark_background_task_terminal(
-            workspace=self._workspace,
-            task_id=background_task_id,
-            status=terminal_status,
-            error=error,
-        )
-        self._run_background_task_lifecycle_hook(terminal_task)
 
     def _run_background_task_lifecycle_hook(self, task: BackgroundTaskState) -> None:
-        surface_by_status: dict[BackgroundTaskStatus, RuntimeHookSurface] = {
-            "completed": "background_task_completed",
-            "failed": "background_task_failed",
-            "cancelled": "background_task_cancelled",
-        }
-        surface = surface_by_status.get(task.status)
-        if surface is None:
-            return
-        self._run_background_task_lifecycle_surface(
-            task=task,
-            surface=surface,
-            session_id=task.session_id or task.request.session_id or "runtime",
-        )
-        self._emit_background_task_parent_terminal_event(task=task)
-        if task.status == "completed" and task.parent_session_id is not None:
-            self._run_background_task_lifecycle_surface(
-                task=task,
-                surface="delegated_result_available",
-                session_id=task.parent_session_id,
-                extra_payload={
-                    "delegated_session_id": task.session_id or "",
-                    "parent_session_id": task.parent_session_id,
-                },
-            )
+        # Compatibility wrapper for tests/callers.
+        self._background_task_supervisor.run_background_task_lifecycle_hook(task)
 
     def _run_background_task_lifecycle_surface(
         self,
@@ -5043,187 +3647,21 @@ class VoidCodeRuntime:
         session_id: str,
         extra_payload: dict[str, object] | None = None,
     ) -> None:
-        outcome = run_lifecycle_hooks(
-            LifecycleHookExecutionRequest(
-                hooks=self._config.hooks,
-                workspace=self._workspace,
-                session_id=session_id,
-                surface=surface,
-                recursion_env_var=self._hook_recursion_env_var,
-                environment=os.environ,
-                sequence_start=0,
-                payload={
-                    "background_task_id": task.task.id,
-                    "background_task_status": task.status,
-                    **({"background_task_error": task.error} if task.error is not None else {}),
-                    **(extra_payload or {}),
-                },
-            )
+        # Compatibility wrapper for tests/callers.
+        self._background_task_supervisor.run_background_task_lifecycle_surface(
+            task=task,
+            surface=surface,
+            session_id=session_id,
+            extra_payload=extra_payload,
         )
-        if outcome.failed_error is not None:
-            logger.warning("background task lifecycle hook failed: %s", outcome.failed_error)
 
     def _reconcile_background_tasks_if_needed(self) -> None:
-        if self._background_tasks_reconciled:
-            return
-        task_summaries = self._session_store.list_background_tasks(workspace=self._workspace)
-        for task_summary in task_summaries:
-            if task_summary.status != "running" or task_summary.session_id is None:
-                continue
-            task = self._session_store.load_background_task(
-                workspace=self._workspace,
-                task_id=task_summary.task.id,
-            )
-            child_response = self._load_background_task_child_response(task=task)
-            if child_response is None:
-                continue
-            if child_response.session.status in ("waiting", "completed", "failed"):
-                self._finalize_background_task_from_session_response(
-                    session_response=child_response
-                )
-        fail_incomplete = getattr(self._session_store, "fail_incomplete_background_tasks", None)
-        if callable(fail_incomplete):
-            failed_tasks = cast(
-                tuple[BackgroundTaskState, ...],
-                fail_incomplete(
-                    workspace=self._workspace,
-                    message="background task interrupted before completion",
-                ),
-            )
-            for failed_task in failed_tasks:
-                self._run_background_task_lifecycle_hook(failed_task)
-        task_summaries = self._session_store.list_background_tasks(workspace=self._workspace)
-        for task_summary in task_summaries:
-            task = self._session_store.load_background_task(
-                workspace=self._workspace,
-                task_id=task_summary.task.id,
-            )
-            self._backfill_parent_background_task_event(task=task)
-        self._background_tasks_reconciled = True
+        # Compatibility wrapper for tests/callers.
+        self._background_task_supervisor.reconcile_background_tasks_if_needed()
 
     def _run_background_task_worker(self, task_id: str) -> None:
-        try:
-            task = self.load_background_task(task_id)
-            if task.status == "cancelled":
-                return
-            request = RuntimeRequest(
-                prompt=task.request.prompt,
-                session_id=task.request.session_id,
-                parent_session_id=task.request.parent_session_id,
-                metadata=cast(RuntimeRequestMetadataPayload, task.request.metadata),
-                allocate_session_id=task.request.allocate_session_id,
-            )
-            routing = self._session_routing_for_request(request)
-            session_id = routing.session_id
-            running_task = self._session_store.mark_background_task_running(
-                workspace=self._workspace,
-                task_id=task_id,
-                session_id=session_id,
-            )
-            if running_task.status != "running":
-                return
-            dispatch_task = self.load_background_task(task_id)
-            if dispatch_task.status != "running":
-                return
-            if dispatch_task.cancel_requested_at is not None:
-                terminal_task = self._session_store.mark_background_task_terminal(
-                    workspace=self._workspace,
-                    task_id=task_id,
-                    status="cancelled",
-                    error="cancelled before dispatch",
-                )
-                self._run_background_task_lifecycle_hook(terminal_task)
-                return
-            events: list[EventEnvelope] = []
-            output: str | None = None
-            final_session: SessionState | None = None
-            internal_request = RuntimeRequest(
-                prompt=dispatch_task.request.prompt,
-                session_id=session_id,
-                parent_session_id=dispatch_task.request.parent_session_id,
-                metadata=cast(
-                    InternalRuntimeRequestMetadata,
-                    {
-                        **dispatch_task.request.metadata,
-                        "background_task_id": task_id,
-                        "background_run": True,
-                    },
-                ),
-                allocate_session_id=False,
-            )
-            for chunk in self._run_with_persistence(
-                internal_request,
-                allow_internal_metadata=True,
-            ):
-                final_session = chunk.session
-                if chunk.event is not None:
-                    events.append(chunk.event)
-                if chunk.kind == "output":
-                    output = chunk.output
-                current_task_state = self._session_store.load_background_task(
-                    workspace=self._workspace,
-                    task_id=task_id,
-                )
-                if current_task_state.cancel_requested_at is not None:
-                    cancel_metadata = dict(final_session.metadata)
-                    cancel_metadata["abort_requested"] = True
-                    cancelled_response = RuntimeResponse(
-                        session=SessionState(
-                            session=final_session.session,
-                            status="failed",
-                            turn=final_session.turn,
-                            metadata=cancel_metadata,
-                        ),
-                        events=tuple(events)
-                        + (
-                            EventEnvelope(
-                                session_id=session_id,
-                                sequence=(events[-1].sequence if events else 0) + 1,
-                                event_type=RUNTIME_FAILED,
-                                source="runtime",
-                                payload={
-                                    "error": "cancelled by parent during delegated execution",
-                                    "cancelled": True,
-                                    "delegated_task_id": task_id,
-                                },
-                            ),
-                        ),
-                        output=output,
-                    )
-                    self._session_store.save_run(
-                        workspace=self._workspace,
-                        request=internal_request,
-                        response=cancelled_response,
-                    )
-                    terminal_task = self._session_store.mark_background_task_terminal(
-                        workspace=self._workspace,
-                        task_id=task_id,
-                        status="cancelled",
-                        error="cancelled by parent during delegated execution",
-                    )
-                    self._run_background_task_lifecycle_hook(terminal_task)
-                    return
-            if final_session is None:
-                raise ValueError("runtime stream emitted no chunks")
-            if final_session.status == "waiting":
-                final_session = self._reload_persisted_session(session_id=final_session.session.id)
-            response = RuntimeResponse(
-                session=final_session,
-                events=tuple(events),
-                output=output,
-            )
-            self._finalize_background_task_from_session_response(session_response=response)
-        except Exception as exc:
-            logger.exception("background task failed: %s", task_id)
-            terminal_task = self._session_store.mark_background_task_terminal(
-                workspace=self._workspace,
-                task_id=task_id,
-                status="failed",
-                error=str(exc),
-            )
-            self._run_background_task_lifecycle_hook(terminal_task)
-        finally:
-            self._background_task_threads.pop(task_id, None)
+        # Compatibility wrapper for tests/callers.
+        self._background_task_supervisor.run_background_task_worker(task_id)
 
     def _effective_runtime_config_from_metadata(
         self, metadata: dict[str, object] | None
@@ -5338,6 +3776,7 @@ class VoidCodeRuntime:
                         str(exc),
                     )
                 ) from exc
+        plan = None
         if "plan" in runtime_config:
             try:
                 plan = parse_runtime_plan_payload(
@@ -5490,6 +3929,13 @@ class _ApprovalResumeCheckpointState:
     prompt: str
     session_metadata: dict[str, object]
     tool_results: tuple[ToolResult, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _PersistedResumeCheckpointEnvelope:
+    kind: str
+    version: int
+    payload: dict[str, object]
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/voidcode/runtime/storage.py
+++ b/src/voidcode/runtime/storage.py
@@ -33,6 +33,8 @@ from .task import (
     BackgroundTaskState,
     BackgroundTaskStatus,
     StoredBackgroundTaskSummary,
+    is_background_task_terminal,
+    is_background_task_transition_allowed,
     validate_background_task_id,
 )
 
@@ -162,6 +164,86 @@ class SessionEventAppender(Protocol):
 @final
 class SqliteSessionStore:
     _database_path: Path | None
+    _RESUME_CHECKPOINT_KINDS = frozenset({"approval_wait", "question_wait", "terminal"})
+
+    _CANONICAL_SCHEMA: dict[str, tuple[tuple[str, str, int, str | None, int], ...]] = {
+        "sessions": (
+            ("session_id", "TEXT", 0, None, 1),
+            ("parent_session_id", "TEXT", 0, None, 0),
+            ("workspace", "TEXT", 1, None, 0),
+            ("status", "TEXT", 1, None, 0),
+            ("turn", "INTEGER", 1, None, 0),
+            ("prompt", "TEXT", 1, None, 0),
+            ("output", "TEXT", 0, None, 0),
+            ("metadata_json", "TEXT", 1, None, 0),
+            ("pending_approval_json", "TEXT", 0, None, 0),
+            ("pending_question_json", "TEXT", 0, None, 0),
+            ("resume_checkpoint_json", "TEXT", 0, None, 0),
+            ("created_at", "INTEGER", 1, None, 0),
+            ("updated_at", "INTEGER", 1, None, 0),
+            ("last_event_sequence", "INTEGER", 1, None, 0),
+        ),
+        "session_events": (
+            ("session_id", "TEXT", 1, None, 1),
+            ("sequence", "INTEGER", 1, None, 2),
+            ("event_type", "TEXT", 1, None, 0),
+            ("source", "TEXT", 1, None, 0),
+            ("payload_json", "TEXT", 1, None, 0),
+        ),
+        "background_tasks": (
+            ("task_id", "TEXT", 0, None, 1),
+            ("workspace", "TEXT", 1, None, 0),
+            ("status", "TEXT", 1, None, 0),
+            ("prompt", "TEXT", 1, None, 0),
+            ("request_session_id", "TEXT", 0, None, 0),
+            ("request_parent_session_id", "TEXT", 0, None, 0),
+            ("request_metadata_json", "TEXT", 1, None, 0),
+            ("requested_child_session_id", "TEXT", 0, None, 0),
+            ("routing_mode", "TEXT", 0, None, 0),
+            ("routing_category", "TEXT", 0, None, 0),
+            ("routing_subagent_type", "TEXT", 0, None, 0),
+            ("routing_description", "TEXT", 0, None, 0),
+            ("routing_command", "TEXT", 0, None, 0),
+            ("approval_request_id", "TEXT", 0, None, 0),
+            ("question_request_id", "TEXT", 0, None, 0),
+            ("cancellation_cause", "TEXT", 0, None, 0),
+            ("result_available", "INTEGER", 1, "0", 0),
+            ("allocate_session_id", "INTEGER", 1, None, 0),
+            ("session_id", "TEXT", 0, None, 0),
+            ("error", "TEXT", 0, None, 0),
+            ("cancel_requested_at", "INTEGER", 0, None, 0),
+            ("created_at", "INTEGER", 1, None, 0),
+            ("updated_at", "INTEGER", 1, None, 0),
+            ("started_at", "INTEGER", 0, None, 0),
+            ("finished_at", "INTEGER", 0, None, 0),
+        ),
+        "session_notifications": (
+            ("notification_id", "TEXT", 0, None, 1),
+            ("workspace", "TEXT", 1, None, 0),
+            ("session_id", "TEXT", 1, None, 0),
+            ("kind", "TEXT", 1, None, 0),
+            ("status", "TEXT", 1, None, 0),
+            ("summary", "TEXT", 1, None, 0),
+            ("payload_json", "TEXT", 1, None, 0),
+            ("event_sequence", "INTEGER", 1, None, 0),
+            ("dedupe_key", "TEXT", 1, None, 0),
+            ("created_at", "INTEGER", 1, None, 0),
+            ("acknowledged_at", "INTEGER", 0, None, 0),
+        ),
+        "session_event_deliveries": (
+            ("workspace", "TEXT", 1, None, 1),
+            ("session_id", "TEXT", 1, None, 2),
+            ("dedupe_key", "TEXT", 1, None, 3),
+            ("delivered_at", "INTEGER", 1, None, 0),
+        ),
+    }
+    _CANONICAL_UNIQUE_INDEXES: dict[str, frozenset[tuple[str, ...]]] = {
+        "sessions": frozenset(),
+        "session_events": frozenset(),
+        "background_tasks": frozenset(),
+        "session_notifications": frozenset({("workspace", "dedupe_key")}),
+        "session_event_deliveries": frozenset(),
+    }
 
     def __init__(self, *, database_path: Path | None = None) -> None:
         self._database_path = database_path
@@ -178,12 +260,12 @@ class SqliteSessionStore:
         connection = sqlite3.connect(database_path)
         try:
             connection.row_factory = sqlite3.Row
-            self._ensure_schema(connection)
+            self._ensure_schema(connection=connection, database_path=database_path)
             yield connection
         finally:
             connection.close()
 
-    def _ensure_schema(self, connection: sqlite3.Connection) -> None:
+    def _ensure_schema(self, *, connection: sqlite3.Connection, database_path: Path) -> None:
         _ = connection.execute(
             """
             CREATE TABLE IF NOT EXISTS sessions (
@@ -276,99 +358,142 @@ class SqliteSessionStore:
             )
             """
         )
-        user_version = self._read_user_version(connection=connection)
-        columns = {
-            cast(str, row["name"])
-            for row in cast(
-                list[sqlite3.Row], connection.execute("PRAGMA table_info(sessions)").fetchall()
-            )
-        }
-        background_task_columns = {
+        self._assert_canonical_schema(connection=connection, database_path=database_path)
+        connection.commit()
+
+    @classmethod
+    def _assert_canonical_schema(
+        cls, *, connection: sqlite3.Connection, database_path: Path
+    ) -> None:
+        existing_tables = {
             cast(str, row["name"])
             for row in cast(
                 list[sqlite3.Row],
-                connection.execute("PRAGMA table_info(background_tasks)").fetchall(),
+                connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table'"
+                ).fetchall(),
             )
         }
-        target_user_version = user_version
-        if "parent_session_id" not in columns:
-            _ = connection.execute("ALTER TABLE sessions ADD COLUMN parent_session_id TEXT")
-            target_user_version = max(target_user_version, 5)
-        if "pending_approval_json" not in columns:
-            _ = connection.execute("ALTER TABLE sessions ADD COLUMN pending_approval_json TEXT")
-            target_user_version = max(target_user_version, 1)
-        if "pending_question_json" not in columns:
-            _ = connection.execute("ALTER TABLE sessions ADD COLUMN pending_question_json TEXT")
-            target_user_version = max(target_user_version, 7)
-        if "resume_checkpoint_json" not in columns:
-            _ = connection.execute("ALTER TABLE sessions ADD COLUMN resume_checkpoint_json TEXT")
-            target_user_version = max(target_user_version, 3)
-        if "request_parent_session_id" not in background_task_columns:
-            _ = connection.execute(
-                "ALTER TABLE background_tasks ADD COLUMN request_parent_session_id TEXT"
+        missing_tables = sorted(set(cls._CANONICAL_SCHEMA) - existing_tables)
+        if missing_tables:
+            cls._raise_schema_mismatch(
+                database_path=database_path,
+                detail=f"missing tables: {', '.join(missing_tables)}",
             )
-            target_user_version = max(target_user_version, 6)
-        if "requested_child_session_id" not in background_task_columns:
-            _ = connection.execute(
-                "ALTER TABLE background_tasks ADD COLUMN requested_child_session_id TEXT"
+        for table_name, expected_columns in cls._CANONICAL_SCHEMA.items():
+            cls._assert_canonical_table_shape(
+                connection=connection,
+                database_path=database_path,
+                table_name=table_name,
+                expected_columns=expected_columns,
             )
-            target_user_version = max(target_user_version, 8)
-        if "routing_mode" not in background_task_columns:
-            _ = connection.execute("ALTER TABLE background_tasks ADD COLUMN routing_mode TEXT")
-            target_user_version = max(target_user_version, 8)
-        if "routing_category" not in background_task_columns:
-            _ = connection.execute("ALTER TABLE background_tasks ADD COLUMN routing_category TEXT")
-            target_user_version = max(target_user_version, 8)
-        if "routing_subagent_type" not in background_task_columns:
-            _ = connection.execute(
-                "ALTER TABLE background_tasks ADD COLUMN routing_subagent_type TEXT"
+        for table_name, expected_indexes in cls._CANONICAL_UNIQUE_INDEXES.items():
+            cls._assert_canonical_unique_indexes(
+                connection=connection,
+                database_path=database_path,
+                table_name=table_name,
+                expected_indexes=expected_indexes,
             )
-            target_user_version = max(target_user_version, 8)
-        if "routing_description" not in background_task_columns:
-            _ = connection.execute(
-                "ALTER TABLE background_tasks ADD COLUMN routing_description TEXT"
+
+    @classmethod
+    def _assert_canonical_table_shape(
+        cls,
+        *,
+        connection: sqlite3.Connection,
+        database_path: Path,
+        table_name: str,
+        expected_columns: tuple[tuple[str, str, int, str | None, int], ...],
+    ) -> None:
+        actual_columns = cls._table_columns(connection=connection, table_name=table_name)
+        expected_column_names = {column[0] for column in expected_columns}
+        actual_column_names = {column[0] for column in actual_columns}
+        missing_columns = sorted(expected_column_names - actual_column_names)
+        if missing_columns:
+            cls._raise_schema_mismatch(
+                database_path=database_path,
+                detail=f"table '{table_name}' missing columns: {', '.join(missing_columns)}",
             )
-            target_user_version = max(target_user_version, 8)
-        if "routing_command" not in background_task_columns:
-            _ = connection.execute("ALTER TABLE background_tasks ADD COLUMN routing_command TEXT")
-            target_user_version = max(target_user_version, 8)
-        if "approval_request_id" not in background_task_columns:
-            _ = connection.execute(
-                "ALTER TABLE background_tasks ADD COLUMN approval_request_id TEXT"
+        unexpected_columns = sorted(actual_column_names - expected_column_names)
+        if unexpected_columns:
+            cls._raise_schema_mismatch(
+                database_path=database_path,
+                detail=(
+                    f"table '{table_name}' has unexpected columns: {', '.join(unexpected_columns)}"
+                ),
             )
-            target_user_version = max(target_user_version, 8)
-        if "question_request_id" not in background_task_columns:
-            _ = connection.execute(
-                "ALTER TABLE background_tasks ADD COLUMN question_request_id TEXT"
+        if actual_columns != expected_columns:
+            cls._raise_schema_mismatch(
+                database_path=database_path,
+                detail=f"table '{table_name}' shape does not match canonical runtime schema",
             )
-            target_user_version = max(target_user_version, 8)
-        if "cancellation_cause" not in background_task_columns:
-            _ = connection.execute(
-                "ALTER TABLE background_tasks ADD COLUMN cancellation_cause TEXT"
+
+    @classmethod
+    def _assert_canonical_unique_indexes(
+        cls,
+        *,
+        connection: sqlite3.Connection,
+        database_path: Path,
+        table_name: str,
+        expected_indexes: frozenset[tuple[str, ...]],
+    ) -> None:
+        actual_indexes = cls._table_unique_indexes(connection=connection, table_name=table_name)
+        if actual_indexes == expected_indexes:
+            return
+        expected = ", ".join("(" + ", ".join(index) + ")" for index in sorted(expected_indexes))
+        actual = ", ".join("(" + ", ".join(index) + ")" for index in sorted(actual_indexes))
+        cls._raise_schema_mismatch(
+            database_path=database_path,
+            detail=(
+                f"table '{table_name}' unique indexes do not match canonical runtime schema: "
+                f"expected [{expected}] got [{actual}]"
+            ),
+        )
+
+    @staticmethod
+    def _table_columns(
+        *, connection: sqlite3.Connection, table_name: str
+    ) -> tuple[tuple[str, str, int, str | None, int], ...]:
+        return tuple(
+            (
+                cast(str, row["name"]),
+                cast(str, row["type"]),
+                cast(int, row["notnull"]),
+                cast(str | None, row["dflt_value"]),
+                cast(int, row["pk"]),
             )
-            target_user_version = max(target_user_version, 8)
-        if "result_available" not in background_task_columns:
-            _ = connection.execute(
-                "ALTER TABLE background_tasks ADD COLUMN result_available INTEGER NOT NULL DEFAULT 0"  # noqa: E501
+            for row in cast(
+                list[sqlite3.Row],
+                connection.execute(f"PRAGMA table_info({table_name})").fetchall(),
             )
-            target_user_version = max(target_user_version, 8)
-        if user_version < 2:
-            target_user_version = max(target_user_version, 2)
-        if user_version < 3:
-            target_user_version = max(target_user_version, 3)
-        if user_version < 4:
-            target_user_version = max(target_user_version, 4)
-        if user_version < 5:
-            target_user_version = max(target_user_version, 5)
-        if user_version < 6:
-            target_user_version = max(target_user_version, 6)
-        if user_version < 7:
-            target_user_version = max(target_user_version, 7)
-        if user_version < 8:
-            target_user_version = max(target_user_version, 8)
-        if target_user_version != user_version:
-            _ = connection.execute(f"PRAGMA user_version = {target_user_version}")
-        connection.commit()
+        )
+
+    @staticmethod
+    def _table_unique_indexes(
+        *, connection: sqlite3.Connection, table_name: str
+    ) -> frozenset[tuple[str, ...]]:
+        return frozenset(
+            tuple(
+                cast(str, column_row["name"])
+                for column_row in cast(
+                    list[sqlite3.Row],
+                    connection.execute(
+                        f"PRAGMA index_info({cast(str, index_row['name'])})"
+                    ).fetchall(),
+                )
+            )
+            for index_row in cast(
+                list[sqlite3.Row],
+                connection.execute(f"PRAGMA index_list({table_name})").fetchall(),
+            )
+            if cast(int, index_row["unique"]) == 1 and cast(str, index_row["origin"]) == "u"
+        )
+
+    @staticmethod
+    def _raise_schema_mismatch(*, database_path: Path, detail: str) -> None:
+        raise RuntimeError(
+            "sqlite runtime schema mismatch: "
+            f"{detail}. Remove '{database_path}' and rerun to reset local runtime storage."
+        )
 
     @staticmethod
     def _parse_session_status(value: str) -> SessionStatus:
@@ -397,6 +522,249 @@ class SqliteSessionStore:
             raise ValueError(f"invalid background task status: {value}")
         return value
 
+    @staticmethod
+    def _session_last_event_sequence(events: tuple[EventEnvelope, ...]) -> int:
+        return events[-1].sequence if events else 0
+
+    @staticmethod
+    def _session_events_payload(
+        events: tuple[EventEnvelope, ...],
+    ) -> list[tuple[str, int, str, str, str]]:
+        return [
+            (
+                event.session_id,
+                event.sequence,
+                event.event_type,
+                event.source,
+                json.dumps(event.payload, sort_keys=True),
+            )
+            for event in events
+        ]
+
+    def _replace_session_events(
+        self,
+        *,
+        connection: sqlite3.Connection,
+        session_id: str,
+        events: tuple[EventEnvelope, ...],
+    ) -> None:
+        _ = connection.execute("DELETE FROM session_events WHERE session_id = ?", (session_id,))
+        _ = connection.executemany(
+            """
+            INSERT INTO session_events (session_id, sequence, event_type, source, payload_json)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            self._session_events_payload(events),
+        )
+
+    def _write_session_snapshot(
+        self,
+        *,
+        connection: sqlite3.Connection,
+        workspace: Path,
+        request: RuntimeRequest,
+        response: RuntimeResponse,
+        pending_approval_json: str | None,
+        pending_question_json: str | None,
+        resume_checkpoint: dict[str, object],
+    ) -> int:
+        session_id = response.session.session.id
+        created_at = self._read_created_at(connection=connection, session_id=session_id)
+        updated_at = self._next_timestamp(connection=connection)
+        _ = connection.execute(
+            """
+            INSERT OR REPLACE INTO sessions (
+                session_id, parent_session_id, workspace, status, turn, prompt, output,
+                metadata_json, pending_approval_json, pending_question_json,
+                resume_checkpoint_json, created_at, updated_at,
+                last_event_sequence
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                session_id,
+                response.session.session.parent_id,
+                str(workspace),
+                response.session.status,
+                response.session.turn,
+                request.prompt,
+                response.output,
+                json.dumps(response.session.metadata, sort_keys=True),
+                pending_approval_json,
+                pending_question_json,
+                json.dumps(resume_checkpoint, sort_keys=True),
+                created_at,
+                updated_at,
+                self._session_last_event_sequence(response.events),
+            ),
+        )
+        self._replace_session_events(
+            connection=connection,
+            session_id=session_id,
+            events=response.events,
+        )
+        return updated_at
+
+    @staticmethod
+    def _checkpoint_skill_snapshot(
+        metadata: dict[str, object],
+    ) -> tuple[object | None, object | None, dict[str, object]]:
+        snapshot_payload = metadata.get("skill_snapshot")
+        snapshot = (
+            cast(dict[str, object], snapshot_payload) if isinstance(snapshot_payload, dict) else {}
+        )
+        binding_payload = snapshot.get("binding_snapshot")
+        binding_snapshot = (
+            cast(dict[str, object], binding_payload) if isinstance(binding_payload, dict) else {}
+        )
+        return snapshot.get("snapshot_hash"), snapshot.get("snapshot_version"), binding_snapshot
+
+    @classmethod
+    def _resume_checkpoint_base(
+        cls,
+        *,
+        request: RuntimeRequest,
+        response: RuntimeResponse,
+        kind: str,
+    ) -> dict[str, object]:
+        snapshot_hash, snapshot_version, binding_snapshot = cls._checkpoint_skill_snapshot(
+            response.session.metadata
+        )
+        return {
+            "version": 1,
+            "kind": kind,
+            "prompt": request.prompt,
+            "session_status": response.session.status,
+            "session_metadata": response.session.metadata,
+            "skill_snapshot_hash": snapshot_hash,
+            "skill_snapshot_version": snapshot_version,
+            "skill_binding_snapshot": binding_snapshot,
+            "tool_results": cls._tool_results_from_events(response.events),
+            "last_event_sequence": cls._session_last_event_sequence(response.events),
+            "output": response.output,
+        }
+
+    @staticmethod
+    def _decode_json_object_payload(
+        payload: str,
+        *,
+        malformed_message: str,
+        non_object_message: str,
+    ) -> dict[str, object]:
+        try:
+            decoded = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise ValueError(malformed_message) from exc
+        if not isinstance(decoded, dict):
+            raise ValueError(non_object_message)
+        return cast(dict[str, object], decoded)
+
+    @classmethod
+    def _decode_resume_checkpoint_payload(cls, payload: str) -> dict[str, object]:
+        checkpoint = cls._decode_json_object_payload(
+            payload,
+            malformed_message="persisted resume checkpoint JSON is malformed",
+            non_object_message="persisted resume checkpoint payload must decode to an object",
+        )
+        kind = checkpoint.get("kind")
+        if not isinstance(kind, str) or kind not in cls._RESUME_CHECKPOINT_KINDS:
+            raise ValueError(f"persisted resume checkpoint kind is invalid: {kind!r}")
+        return checkpoint
+
+    @staticmethod
+    def _background_task_runtime_state_defaults() -> dict[str, object]:
+        return {
+            "approval_request_id": None,
+            "question_request_id": None,
+            "cancellation_cause": None,
+            "result_available": 0,
+        }
+
+    @classmethod
+    def _request_id_from_pending_payload(cls, payload: str | None) -> str | None:
+        if payload is None:
+            return None
+        parsed = json.loads(payload)
+        if not isinstance(parsed, dict):
+            return None
+        request_id = cast(dict[str, object], parsed).get("request_id")
+        return request_id if isinstance(request_id, str) else None
+
+    @classmethod
+    def _background_task_runtime_state_from_session_row(
+        cls, row: sqlite3.Row | None
+    ) -> dict[str, object]:
+        if row is None:
+            return cls._background_task_runtime_state_defaults()
+        status = cast(str, row["status"])
+        return {
+            "approval_request_id": cls._request_id_from_pending_payload(
+                cast(str | None, row["pending_approval_json"])
+            ),
+            "question_request_id": cls._request_id_from_pending_payload(
+                cast(str | None, row["pending_question_json"])
+            ),
+            "cancellation_cause": None,
+            "result_available": 1 if status in {"waiting", "completed", "failed"} else 0,
+        }
+
+    @classmethod
+    def _background_task_summary_from_row(cls, row: sqlite3.Row) -> StoredBackgroundTaskSummary:
+        return StoredBackgroundTaskSummary(
+            task=BackgroundTaskRef(id=cast(str, row["task_id"])),
+            status=cls._parse_background_task_status(cast(str, row["status"])),
+            prompt=cast(str, row["prompt"]),
+            session_id=cast(str | None, row["session_id"]),
+            error=cast(str | None, row["error"]),
+            created_at=cast(int, row["created_at"]),
+            updated_at=cast(int, row["updated_at"]),
+        )
+
+    @staticmethod
+    def _background_task_durable_payload(row: sqlite3.Row) -> dict[str, object]:
+        durable_payload: dict[str, object] = {
+            "task_id": cast(str, row["task_id"]),
+            "parent_session_id": cast(str | None, row["request_parent_session_id"]),
+            "status": cast(str, row["status"]),
+            "result_available": bool(cast(int, row["result_available"])),
+        }
+        optional_fields: tuple[tuple[str, str], ...] = (
+            ("requested_child_session_id", "requested_child_session_id"),
+            ("child_session_id", "session_id"),
+            ("approval_request_id", "approval_request_id"),
+            ("question_request_id", "question_request_id"),
+            ("routing_mode", "routing_mode"),
+            ("routing_category", "routing_category"),
+            ("routing_subagent_type", "routing_subagent_type"),
+            ("routing_description", "routing_description"),
+            ("routing_command", "routing_command"),
+            ("cancellation_cause", "cancellation_cause"),
+        )
+        for payload_key, row_key in optional_fields:
+            value = row[row_key]
+            if value is not None:
+                durable_payload[payload_key] = cast(object, value)
+        return durable_payload
+
+    @staticmethod
+    def _pending_question_payload(pending_question: PendingQuestion) -> dict[str, object]:
+        return {
+            "request_id": pending_question.request_id,
+            "tool_name": pending_question.tool_name,
+            "arguments": pending_question.arguments,
+            "prompts": [
+                {
+                    "question": prompt.question,
+                    "header": prompt.header,
+                    "multiple": prompt.multiple,
+                    "options": [
+                        {"label": option.label, "description": option.description}
+                        for option in prompt.options
+                    ],
+                }
+                for prompt in pending_question.prompts
+            ],
+        }
+
     def save_run(
         self,
         *,
@@ -407,60 +775,23 @@ class SqliteSessionStore:
     ) -> None:
         session_id = response.session.session.id
         with self._connect(workspace) as connection:
-            created_at = self._read_created_at(connection=connection, session_id=session_id)
-            updated_at = self._next_timestamp(connection=connection)
-            _ = connection.execute(
-                """
-                INSERT OR REPLACE INTO sessions (
-                    session_id, parent_session_id, workspace, status, turn, prompt, output,
-                    metadata_json, pending_approval_json, pending_question_json,
-                    resume_checkpoint_json, created_at, updated_at,
-                    last_event_sequence
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,  # noqa: E501
-                (
-                    session_id,
-                    response.session.session.parent_id,
-                    str(workspace),
-                    response.session.status,
-                    response.session.turn,
-                    request.prompt,
-                    response.output,
-                    json.dumps(response.session.metadata, sort_keys=True),
+            updated_at = self._write_session_snapshot(
+                connection=connection,
+                workspace=workspace,
+                request=request,
+                response=response,
+                pending_approval_json=(
                     None
                     if clear_pending_approval
                     else self._read_pending_approval_json(
                         connection=connection, session_id=session_id
-                    ),
-                    None,
-                    json.dumps(
-                        self._terminal_resume_checkpoint(
-                            request=request,
-                            response=response,
-                        ),
-                        sort_keys=True,
-                    ),
-                    created_at,
-                    updated_at,
-                    response.events[-1].sequence if response.events else 0,
-                ),
-            )
-            _ = connection.execute("DELETE FROM session_events WHERE session_id = ?", (session_id,))
-            _ = connection.executemany(
-                """
-                INSERT INTO session_events (session_id, sequence, event_type, source, payload_json)
-                VALUES (?, ?, ?, ?, ?)
-                """,
-                [
-                    (
-                        event.session_id,
-                        event.sequence,
-                        event.event_type,
-                        event.source,
-                        json.dumps(event.payload, sort_keys=True),
                     )
-                    for event in response.events
-                ],
+                ),
+                pending_question_json=None,
+                resume_checkpoint=self._terminal_resume_checkpoint(
+                    request=request,
+                    response=response,
+                ),
             )
             self._sync_background_task_durable_state(
                 connection=connection,
@@ -514,59 +845,19 @@ class SqliteSessionStore:
         response: RuntimeResponse,
         pending_approval: PendingApproval,
     ) -> None:
-        session_id = response.session.session.id
         with self._connect(workspace) as connection:
-            created_at = self._read_created_at(connection=connection, session_id=session_id)
-            updated_at = self._next_timestamp(connection=connection)
-            _ = connection.execute(
-                """
-                INSERT OR REPLACE INTO sessions (
-                    session_id, parent_session_id, workspace, status, turn, prompt, output,
-                    metadata_json, pending_approval_json, pending_question_json,
-                    resume_checkpoint_json, created_at, updated_at,
-                    last_event_sequence
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,  # noqa: E501
-                (
-                    session_id,
-                    response.session.session.parent_id,
-                    str(workspace),
-                    response.session.status,
-                    response.session.turn,
-                    request.prompt,
-                    response.output,
-                    json.dumps(response.session.metadata, sort_keys=True),
-                    json.dumps(asdict(pending_approval), sort_keys=True),
-                    None,
-                    json.dumps(
-                        self._approval_wait_resume_checkpoint(
-                            request=request,
-                            response=response,
-                            pending_approval=pending_approval,
-                        ),
-                        sort_keys=True,
-                    ),
-                    created_at,
-                    updated_at,
-                    response.events[-1].sequence if response.events else 0,
+            updated_at = self._write_session_snapshot(
+                connection=connection,
+                workspace=workspace,
+                request=request,
+                response=response,
+                pending_approval_json=json.dumps(asdict(pending_approval), sort_keys=True),
+                pending_question_json=None,
+                resume_checkpoint=self._approval_wait_resume_checkpoint(
+                    request=request,
+                    response=response,
+                    pending_approval=pending_approval,
                 ),
-            )
-            _ = connection.execute("DELETE FROM session_events WHERE session_id = ?", (session_id,))
-            _ = connection.executemany(
-                """
-                INSERT INTO session_events (session_id, sequence, event_type, source, payload_json)
-                VALUES (?, ?, ?, ?, ?)
-                """,
-                [
-                    (
-                        event.session_id,
-                        event.sequence,
-                        event.event_type,
-                        event.source,
-                        json.dumps(event.payload, sort_keys=True),
-                    )
-                    for event in response.events
-                ],
             )
             self._sync_background_task_durable_state(
                 connection=connection,
@@ -614,6 +905,11 @@ class SqliteSessionStore:
             target_summary=cast(str, data.get("target_summary", "")),
             reason=cast(str, data.get("reason", "")),
             policy_mode=raw_policy_mode,
+            request_event_sequence=(
+                cast(int, data["request_event_sequence"])
+                if isinstance(data.get("request_event_sequence"), int)
+                else None
+            ),
             owner_session_id=(
                 cast(str, data["owner_session_id"])
                 if isinstance(data.get("owner_session_id"), str)
@@ -647,76 +943,21 @@ class SqliteSessionStore:
         response: RuntimeResponse,
         pending_question: PendingQuestion,
     ) -> None:
-        session_id = response.session.session.id
         with self._connect(workspace) as connection:
-            created_at = self._read_created_at(connection=connection, session_id=session_id)
-            updated_at = self._next_timestamp(connection=connection)
-            payload = {
-                "request_id": pending_question.request_id,
-                "tool_name": pending_question.tool_name,
-                "arguments": pending_question.arguments,
-                "prompts": [
-                    {
-                        "question": prompt.question,
-                        "header": prompt.header,
-                        "multiple": prompt.multiple,
-                        "options": [
-                            {"label": option.label, "description": option.description}
-                            for option in prompt.options
-                        ],
-                    }
-                    for prompt in pending_question.prompts
-                ],
-            }
-            _ = connection.execute(
-                """
-                INSERT OR REPLACE INTO sessions (
-                    session_id, parent_session_id, workspace, status, turn, prompt, output,
-                    metadata_json, pending_approval_json, pending_question_json,
-                    resume_checkpoint_json, created_at, updated_at,
-                    last_event_sequence
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    session_id,
-                    response.session.session.parent_id,
-                    str(workspace),
-                    response.session.status,
-                    response.session.turn,
-                    request.prompt,
-                    response.output,
-                    json.dumps(response.session.metadata, sort_keys=True),
-                    None,
-                    json.dumps(payload, sort_keys=True),
-                    json.dumps(
-                        self._question_wait_resume_checkpoint(
-                            request=request,
-                            response=response,
-                            pending_question=pending_question,
-                        ),
-                        sort_keys=True,
-                    ),
-                    created_at,
-                    updated_at,
-                    response.events[-1].sequence if response.events else 0,
+            updated_at = self._write_session_snapshot(
+                connection=connection,
+                workspace=workspace,
+                request=request,
+                response=response,
+                pending_approval_json=None,
+                pending_question_json=json.dumps(
+                    self._pending_question_payload(pending_question), sort_keys=True
                 ),
-            )
-            _ = connection.execute("DELETE FROM session_events WHERE session_id = ?", (session_id,))
-            _ = connection.executemany(
-                """
-                INSERT INTO session_events (session_id, sequence, event_type, source, payload_json)
-                VALUES (?, ?, ?, ?, ?)
-                """,
-                [
-                    (
-                        event.session_id,
-                        event.sequence,
-                        event.event_type,
-                        event.source,
-                        json.dumps(event.payload, sort_keys=True),
-                    )
-                    for event in response.events
-                ],
+                resume_checkpoint=self._question_wait_resume_checkpoint(
+                    request=request,
+                    response=response,
+                    pending_question=pending_question,
+                ),
             )
             self._sync_background_task_durable_state(
                 connection=connection,
@@ -813,13 +1054,7 @@ class SqliteSessionStore:
         payload = cast(str | None, row["resume_checkpoint_json"])
         if payload is None:
             return None
-        try:
-            checkpoint = json.loads(payload)
-        except json.JSONDecodeError:
-            return None
-        if not isinstance(checkpoint, dict):
-            return None
-        return cast(dict[str, object], checkpoint)
+        return self._decode_resume_checkpoint_payload(payload)
 
     def append_session_event(
         self,
@@ -987,29 +1222,7 @@ class SqliteSessionStore:
             )
         except ValueError:
             return payload
-        durable_payload: dict[str, object] = {
-            "task_id": cast(str, row["task_id"]),
-            "parent_session_id": cast(str | None, row["request_parent_session_id"]),
-            "status": cast(str, row["status"]),
-            "result_available": bool(cast(int, row["result_available"])),
-        }
-        optional_fields: tuple[tuple[str, str], ...] = (
-            ("requested_child_session_id", "requested_child_session_id"),
-            ("child_session_id", "session_id"),
-            ("approval_request_id", "approval_request_id"),
-            ("question_request_id", "question_request_id"),
-            ("routing_mode", "routing_mode"),
-            ("routing_category", "routing_category"),
-            ("routing_subagent_type", "routing_subagent_type"),
-            ("routing_description", "routing_description"),
-            ("routing_command", "routing_command"),
-            ("cancellation_cause", "cancellation_cause"),
-        )
-        for payload_key, row_key in optional_fields:
-            value = row[row_key]
-            if value is not None:
-                durable_payload[payload_key] = cast(object, value)
-        return {**payload, **durable_payload}
+        return {**payload, **self._background_task_durable_payload(row)}
 
     def _read_pending_approval_json(
         self, *, connection: sqlite3.Connection, session_id: str
@@ -1032,81 +1245,59 @@ class SqliteSessionStore:
         response: RuntimeResponse,
         pending_approval: PendingApproval,
     ) -> dict[str, object]:
-        snapshot_payload = response.session.metadata.get("skill_snapshot")
-        snapshot = (
-            cast(dict[str, object], snapshot_payload) if isinstance(snapshot_payload, dict) else {}
-        )
-        binding_payload = snapshot.get("binding_snapshot")
-        binding_snapshot = (
-            cast(dict[str, object], binding_payload) if isinstance(binding_payload, dict) else {}
-        )
         return {
-            "version": 1,
-            "kind": "approval_wait",
-            "prompt": request.prompt,
-            "session_status": response.session.status,
-            "session_metadata": response.session.metadata,
-            "skill_snapshot_hash": snapshot.get("snapshot_hash"),
-            "skill_snapshot_version": snapshot.get("snapshot_version"),
-            "skill_binding_snapshot": binding_snapshot,
-            "tool_results": SqliteSessionStore._tool_results_from_events(response.events),
-            "last_event_sequence": response.events[-1].sequence if response.events else 0,
+            **SqliteSessionStore._resume_checkpoint_base(
+                request=request,
+                response=response,
+                kind="approval_wait",
+            ),
             "pending_approval_request_id": pending_approval.request_id,
-            "output": response.output,
+            "pending_approval_tool_name": pending_approval.tool_name,
+            "pending_approval_arguments": pending_approval.arguments,
+            "pending_approval_request_event_sequence": pending_approval.request_event_sequence,
+            "pending_approval_owner_session_id": pending_approval.owner_session_id,
+            "pending_approval_owner_parent_session_id": pending_approval.owner_parent_session_id,
+            "pending_approval_delegated_task_id": pending_approval.delegated_task_id,
         }
 
     @staticmethod
     def _question_wait_resume_checkpoint(
         *, request: RuntimeRequest, response: RuntimeResponse, pending_question: PendingQuestion
     ) -> dict[str, object]:
-        snapshot_payload = response.session.metadata.get("skill_snapshot")
-        snapshot = (
-            cast(dict[str, object], snapshot_payload) if isinstance(snapshot_payload, dict) else {}
-        )
-        binding_payload = snapshot.get("binding_snapshot")
-        binding_snapshot = (
-            cast(dict[str, object], binding_payload) if isinstance(binding_payload, dict) else {}
-        )
         return {
-            "version": 1,
-            "kind": "question_wait",
-            "prompt": request.prompt,
-            "session_status": response.session.status,
-            "session_metadata": response.session.metadata,
-            "skill_snapshot_hash": snapshot.get("snapshot_hash"),
-            "skill_snapshot_version": snapshot.get("snapshot_version"),
-            "skill_binding_snapshot": binding_snapshot,
-            "tool_results": SqliteSessionStore._tool_results_from_events(response.events),
-            "last_event_sequence": response.events[-1].sequence if response.events else 0,
+            **SqliteSessionStore._resume_checkpoint_base(
+                request=request,
+                response=response,
+                kind="question_wait",
+            ),
             "pending_question_request_id": pending_question.request_id,
-            "output": response.output,
+            "pending_question_tool_name": pending_question.tool_name,
+            "pending_question_prompts": [
+                {
+                    "header": prompt.header,
+                    "question": prompt.question,
+                    "multiple": prompt.multiple,
+                    "options": [
+                        {
+                            "label": option.label,
+                            "description": option.description,
+                        }
+                        for option in prompt.options
+                    ],
+                }
+                for prompt in pending_question.prompts
+            ],
         }
 
     @staticmethod
     def _terminal_resume_checkpoint(
         *, request: RuntimeRequest, response: RuntimeResponse
     ) -> dict[str, object]:
-        snapshot_payload = response.session.metadata.get("skill_snapshot")
-        snapshot = (
-            cast(dict[str, object], snapshot_payload) if isinstance(snapshot_payload, dict) else {}
+        return SqliteSessionStore._resume_checkpoint_base(
+            request=request,
+            response=response,
+            kind="terminal",
         )
-        binding_payload = snapshot.get("binding_snapshot")
-        binding_snapshot = (
-            cast(dict[str, object], binding_payload) if isinstance(binding_payload, dict) else {}
-        )
-        return {
-            "version": 1,
-            "kind": "terminal",
-            "prompt": request.prompt,
-            "session_status": response.session.status,
-            "session_metadata": response.session.metadata,
-            "skill_snapshot_hash": snapshot.get("snapshot_hash"),
-            "skill_snapshot_version": snapshot.get("snapshot_version"),
-            "skill_binding_snapshot": binding_snapshot,
-            "tool_results": SqliteSessionStore._tool_results_from_events(response.events),
-            "last_event_sequence": response.events[-1].sequence if response.events else 0,
-            "output": response.output,
-        }
 
     @staticmethod
     def _tool_results_from_events(events: tuple[EventEnvelope, ...]) -> list[dict[str, object]]:
@@ -1339,18 +1530,7 @@ class SqliteSessionStore:
                     (str(workspace),),
                 ).fetchall(),
             )
-        return tuple(
-            StoredBackgroundTaskSummary(
-                task=BackgroundTaskRef(id=cast(str, row["task_id"])),
-                status=self._parse_background_task_status(cast(str, row["status"])),
-                prompt=cast(str, row["prompt"]),
-                session_id=cast(str | None, row["session_id"]),
-                error=cast(str | None, row["error"]),
-                created_at=cast(int, row["created_at"]),
-                updated_at=cast(int, row["updated_at"]),
-            )
-            for row in rows
-        )
+        return tuple(self._background_task_summary_from_row(row) for row in rows)
 
     def list_background_tasks_by_parent_session(
         self, *, workspace: Path, parent_session_id: str
@@ -1368,18 +1548,7 @@ class SqliteSessionStore:
                     (str(workspace), parent_session_id),
                 ).fetchall(),
             )
-        return tuple(
-            StoredBackgroundTaskSummary(
-                task=BackgroundTaskRef(id=cast(str, row["task_id"])),
-                status=self._parse_background_task_status(cast(str, row["status"])),
-                prompt=cast(str, row["prompt"]),
-                session_id=cast(str | None, row["session_id"]),
-                error=cast(str | None, row["error"]),
-                created_at=cast(int, row["created_at"]),
-                updated_at=cast(int, row["updated_at"]),
-            )
-            for row in rows
-        )
+        return tuple(self._background_task_summary_from_row(row) for row in rows)
 
     def mark_background_task_running(
         self,
@@ -1390,8 +1559,20 @@ class SqliteSessionStore:
     ) -> BackgroundTaskState:
         task_id = validate_background_task_id(task_id)
         with self._connect(workspace) as connection:
+            current = self._background_task_runtime_row(
+                connection=connection,
+                workspace=workspace,
+                task_id=task_id,
+            )
+            current_status = self._parse_background_task_status(cast(str, current["status"]))
+            if not is_background_task_transition_allowed(
+                current_status=current_status,
+                next_status="running",
+            ):
+                connection.commit()
+                return self._background_task_state_from_row(current)
             updated_at = self._next_background_task_timestamp(connection=connection)
-            updated = connection.execute(
+            _ = connection.execute(
                 """
                 UPDATE background_tasks
                 SET status = ?, session_id = ?, started_at = COALESCE(started_at, ?), updated_at = ?
@@ -1405,11 +1586,14 @@ class SqliteSessionStore:
                     str(workspace),
                     task_id,
                 ),
-            ).rowcount
+            )
+            updated_row = self._background_task_runtime_row(
+                connection=connection,
+                workspace=workspace,
+                task_id=task_id,
+            )
             connection.commit()
-        if updated == 0:
-            return self.load_background_task(workspace=workspace, task_id=task_id)
-        return self.load_background_task(workspace=workspace, task_id=task_id)
+        return self._background_task_state_from_row(updated_row)
 
     def mark_background_task_terminal(
         self,
@@ -1424,16 +1608,23 @@ class SqliteSessionStore:
                 "background task terminal status must be completed, failed, or cancelled"
             )
         task_id = validate_background_task_id(task_id)
-        result_available = 1 if status in ("completed", "failed") else 0
         with self._connect(workspace) as connection:
             current = self._background_task_runtime_row(
                 connection=connection,
                 workspace=workspace,
                 task_id=task_id,
             )
+            current_status = self._parse_background_task_status(cast(str, current["status"]))
+            if not is_background_task_transition_allowed(
+                current_status=current_status,
+                next_status=status,
+            ):
+                connection.commit()
+                return self._background_task_state_from_row(current)
             cancellation_cause = cast(str | None, current["cancellation_cause"])
             if status == "cancelled" and error is not None:
                 cancellation_cause = error
+            result_available = 1 if status in ("completed", "failed") else 0
             updated_at = self._next_background_task_timestamp(connection=connection)
             _ = connection.execute(
                 """
@@ -1453,8 +1644,13 @@ class SqliteSessionStore:
                     task_id,
                 ),
             )
+            updated_row = self._background_task_runtime_row(
+                connection=connection,
+                workspace=workspace,
+                task_id=task_id,
+            )
             connection.commit()
-        return self.load_background_task(workspace=workspace, task_id=task_id)
+        return self._background_task_state_from_row(updated_row)
 
     def request_background_task_cancel(
         self,
@@ -1463,9 +1659,17 @@ class SqliteSessionStore:
         task_id: str,
     ) -> BackgroundTaskState:
         task_id = validate_background_task_id(task_id)
-        current = self.load_background_task(workspace=workspace, task_id=task_id)
-        if current.status == "queued":
-            with self._connect(workspace) as connection:
+        with self._connect(workspace) as connection:
+            current = self._background_task_runtime_row(
+                connection=connection,
+                workspace=workspace,
+                task_id=task_id,
+            )
+            current_status = self._parse_background_task_status(cast(str, current["status"]))
+            if is_background_task_terminal(current_status):
+                connection.commit()
+                return self._background_task_state_from_row(current)
+            if current_status == "queued":
                 updated_at = self._next_background_task_timestamp(connection=connection)
                 cancelled = connection.execute(
                     """
@@ -1483,13 +1687,23 @@ class SqliteSessionStore:
                         task_id,
                     ),
                 ).rowcount
-                connection.commit()
-            if cancelled == 1:
-                return self.load_background_task(workspace=workspace, task_id=task_id)
-            current = self.load_background_task(workspace=workspace, task_id=task_id)
-        if current.status in ("completed", "failed", "cancelled"):
-            return current
-        with self._connect(workspace) as connection:
+                if cancelled == 1:
+                    updated_row = self._background_task_runtime_row(
+                        connection=connection,
+                        workspace=workspace,
+                        task_id=task_id,
+                    )
+                    connection.commit()
+                    return self._background_task_state_from_row(updated_row)
+                current = self._background_task_runtime_row(
+                    connection=connection,
+                    workspace=workspace,
+                    task_id=task_id,
+                )
+                current_status = self._parse_background_task_status(cast(str, current["status"]))
+                if is_background_task_terminal(current_status):
+                    connection.commit()
+                    return self._background_task_state_from_row(current)
             updated_at = self._next_background_task_timestamp(connection=connection)
             _ = connection.execute(
                 """
@@ -1500,8 +1714,13 @@ class SqliteSessionStore:
                 """,
                 (updated_at, updated_at, str(workspace), task_id),
             )
+            updated_row = self._background_task_runtime_row(
+                connection=connection,
+                workspace=workspace,
+                task_id=task_id,
+            )
             connection.commit()
-        return self.load_background_task(workspace=workspace, task_id=task_id)
+        return self._background_task_state_from_row(updated_row)
 
     def fail_incomplete_background_tasks(
         self,
@@ -1514,7 +1733,7 @@ class SqliteSessionStore:
                 list[sqlite3.Row],
                 connection.execute(
                     """
-                    SELECT background_tasks.task_id
+                    SELECT background_tasks.task_id, background_tasks.cancel_requested_at
                     FROM background_tasks
                     LEFT JOIN sessions
                       ON sessions.workspace = background_tasks.workspace
@@ -1537,22 +1756,56 @@ class SqliteSessionStore:
             )
             if not rows:
                 return ()
-            task_ids = tuple(cast(str, row["task_id"]) for row in rows)
-            placeholders = ", ".join("?" for _ in task_ids)
-            updated_at = self._next_background_task_timestamp(connection=connection)
-            _ = connection.execute(
-                f"""
-                UPDATE background_tasks
-                SET status = 'failed', error = ?, finished_at = ?,
-                    updated_at = ?, result_available = 1
-                WHERE workspace = ? AND task_id IN ({placeholders})
-                """,
-                (message, updated_at, updated_at, str(workspace), *task_ids),
-            )
+            reconciled_task_ids: list[str] = []
+            for row in rows:
+                task_id = cast(str, row["task_id"])
+                cancel_requested_at = cast(int | None, row["cancel_requested_at"])
+                updated_at = self._next_background_task_timestamp(connection=connection)
+                if cancel_requested_at is not None:
+                    _ = connection.execute(
+                        """
+                        UPDATE background_tasks
+                        SET status = 'cancelled',
+                            error = ?,
+                            cancellation_cause = COALESCE(cancellation_cause, ?),
+                            finished_at = ?,
+                            updated_at = ?,
+                            result_available = 0
+                        WHERE workspace = ?
+                          AND task_id = ?
+                          AND status = 'running'
+                          AND cancel_requested_at IS NOT NULL
+                        """,
+                        (
+                            "cancelled by parent during delegated execution",
+                            "cancelled by parent during delegated execution",
+                            updated_at,
+                            updated_at,
+                            str(workspace),
+                            task_id,
+                        ),
+                    )
+                else:
+                    _ = connection.execute(
+                        """
+                        UPDATE background_tasks
+                        SET status = 'failed',
+                            error = ?,
+                            finished_at = ?,
+                            updated_at = ?,
+                            result_available = 1
+                        WHERE workspace = ?
+                          AND task_id = ?
+                          AND status IN ('queued', 'running')
+                          AND cancel_requested_at IS NULL
+                        """,
+                        (message, updated_at, updated_at, str(workspace), task_id),
+                    )
+                reconciled_task_ids.append(task_id)
             connection.commit()
         return tuple(
-            self.load_background_task(workspace=workspace, task_id=cast(str, row["task_id"]))
-            for row in rows
+            self.load_background_task(workspace=workspace, task_id=task_id)
+            for task_id in reconciled_task_ids
         )
 
     def persist_background_task_runtime_state(
@@ -1572,6 +1825,11 @@ class SqliteSessionStore:
                 workspace=workspace,
                 task_id=task_id,
             )
+            if is_background_task_terminal(
+                self._parse_background_task_status(cast(str, current["status"]))
+            ):
+                connection.commit()
+                return self._background_task_state_from_row(current)
             updated_at = self._next_background_task_timestamp(connection=connection)
             _ = connection.execute(
                 """
@@ -1673,12 +1931,7 @@ class SqliteSessionStore:
         session_id: str | None,
     ) -> dict[str, object]:
         if session_id is None:
-            return {
-                "approval_request_id": None,
-                "question_request_id": None,
-                "cancellation_cause": None,
-                "result_available": 0,
-            }
+            return self._background_task_runtime_state_defaults()
         row = cast(
             sqlite3.Row | None,
             connection.execute(
@@ -1690,39 +1943,7 @@ class SqliteSessionStore:
                 (str(workspace), session_id),
             ).fetchone(),
         )
-        if row is None:
-            return {
-                "approval_request_id": None,
-                "question_request_id": None,
-                "cancellation_cause": None,
-                "result_available": 0,
-            }
-        approval_request_id: str | None = None
-        question_request_id: str | None = None
-        approval_payload = cast(str | None, row["pending_approval_json"])
-        if approval_payload is not None:
-            parsed = json.loads(approval_payload)
-            if isinstance(parsed, dict):
-                parsed_payload = cast(dict[str, object], parsed)
-                request_id = parsed_payload.get("request_id")
-                if isinstance(request_id, str):
-                    approval_request_id = request_id
-        question_payload = cast(str | None, row["pending_question_json"])
-        if question_payload is not None:
-            parsed = json.loads(question_payload)
-            if isinstance(parsed, dict):
-                parsed_payload = cast(dict[str, object], parsed)
-                request_id = parsed_payload.get("request_id")
-                if isinstance(request_id, str):
-                    question_request_id = request_id
-        status = cast(str, row["status"])
-        result_available = 1 if status in {"waiting", "completed", "failed"} else 0
-        return {
-            "approval_request_id": approval_request_id,
-            "question_request_id": question_request_id,
-            "cancellation_cause": None,
-            "result_available": result_available,
-        }
+        return self._background_task_runtime_state_from_session_row(row)
 
     def acknowledge_notification(
         self, *, workspace: Path, notification_id: str
@@ -1927,54 +2148,95 @@ class SqliteSessionStore:
         pending_question: PendingQuestion | None,
         notification_run_id: int,
     ) -> dict[str, object] | None:
-        session_id = response.session.session.id
         if pending_approval is not None:
-            summary, _ = self._result_summary(response=response, prompt=request.prompt)
-            event_sequence = response.events[-1].sequence if response.events else 0
-            dedupe_key = f"{session_id}:approval_blocked:{pending_approval.request_id}"
-            return {
-                "notification_id": dedupe_key,
-                "dedupe_key": dedupe_key,
-                "kind": "approval_blocked",
-                "summary": summary,
-                "event_sequence": event_sequence,
-                "payload": {
-                    "request_id": pending_approval.request_id,
-                    "tool": pending_approval.tool_name,
-                    "arguments": pending_approval.arguments,
-                    "target_summary": pending_approval.target_summary,
-                    "reason": pending_approval.reason,
-                },
-            }
+            return self._approval_notification_candidate(
+                request=request,
+                response=response,
+                pending_approval=pending_approval,
+            )
         if pending_question is not None:
-            summary, _ = self._result_summary(response=response, prompt=request.prompt)
-            event_sequence = response.events[-1].sequence if response.events else 0
-            dedupe_key = f"{session_id}:question_blocked:{pending_question.request_id}"
-            return {
-                "notification_id": dedupe_key,
-                "dedupe_key": dedupe_key,
-                "kind": "question_blocked",
-                "summary": summary,
-                "event_sequence": event_sequence,
-                "payload": {
-                    "request_id": pending_question.request_id,
-                    "questions": [
-                        {
-                            "header": prompt.header,
-                            "question": prompt.question,
-                            "multiple": prompt.multiple,
-                            "options": [
-                                {"label": option.label, "description": option.description}
-                                for option in prompt.options
-                            ],
-                        }
-                        for prompt in pending_question.prompts
-                    ],
-                },
-            }
+            return self._question_notification_candidate(
+                request=request,
+                response=response,
+                pending_question=pending_question,
+            )
+        return self._terminal_notification_candidate(
+            request=request,
+            response=response,
+            notification_run_id=notification_run_id,
+        )
+
+    def _approval_notification_candidate(
+        self,
+        *,
+        request: RuntimeRequest,
+        response: RuntimeResponse,
+        pending_approval: PendingApproval,
+    ) -> dict[str, object]:
+        session_id = response.session.session.id
+        summary, _ = self._result_summary(response=response, prompt=request.prompt)
+        event_sequence = self._session_last_event_sequence(response.events)
+        dedupe_key = f"{session_id}:approval_blocked:{pending_approval.request_id}"
+        return {
+            "notification_id": dedupe_key,
+            "dedupe_key": dedupe_key,
+            "kind": "approval_blocked",
+            "summary": summary,
+            "event_sequence": event_sequence,
+            "payload": {
+                "request_id": pending_approval.request_id,
+                "tool": pending_approval.tool_name,
+                "arguments": pending_approval.arguments,
+                "target_summary": pending_approval.target_summary,
+                "reason": pending_approval.reason,
+            },
+        }
+
+    def _question_notification_candidate(
+        self,
+        *,
+        request: RuntimeRequest,
+        response: RuntimeResponse,
+        pending_question: PendingQuestion,
+    ) -> dict[str, object]:
+        session_id = response.session.session.id
+        summary, _ = self._result_summary(response=response, prompt=request.prompt)
+        event_sequence = self._session_last_event_sequence(response.events)
+        dedupe_key = f"{session_id}:question_blocked:{pending_question.request_id}"
+        return {
+            "notification_id": dedupe_key,
+            "dedupe_key": dedupe_key,
+            "kind": "question_blocked",
+            "summary": summary,
+            "event_sequence": event_sequence,
+            "payload": {
+                "request_id": pending_question.request_id,
+                "questions": [
+                    {
+                        "header": prompt.header,
+                        "question": prompt.question,
+                        "multiple": prompt.multiple,
+                        "options": [
+                            {"label": option.label, "description": option.description}
+                            for option in prompt.options
+                        ],
+                    }
+                    for prompt in pending_question.prompts
+                ],
+            },
+        }
+
+    def _terminal_notification_candidate(
+        self,
+        *,
+        request: RuntimeRequest,
+        response: RuntimeResponse,
+        notification_run_id: int,
+    ) -> dict[str, object] | None:
+        session_id = response.session.session.id
+        event_sequence = self._session_last_event_sequence(response.events)
         if response.session.status == "completed":
             summary, _ = self._result_summary(response=response, prompt=request.prompt)
-            event_sequence = response.events[-1].sequence if response.events else 0
             dedupe_key = f"{session_id}:completion:{notification_run_id}"
             return {
                 "notification_id": dedupe_key,
@@ -1986,7 +2248,6 @@ class SqliteSessionStore:
             }
         if response.session.status == "failed":
             summary, error = self._result_summary(response=response, prompt=request.prompt)
-            event_sequence = response.events[-1].sequence if response.events else 0
             dedupe_key = f"{session_id}:failure:{notification_run_id}"
             return {
                 "notification_id": dedupe_key,
@@ -2014,15 +2275,6 @@ class SqliteSessionStore:
             acknowledged_at=cast(int | None, row["acknowledged_at"]),
             payload=cast(dict[str, object], json.loads(cast(str, row["payload_json"]))),
         )
-
-    def _read_user_version(self, *, connection: sqlite3.Connection) -> int:
-        row = cast(
-            sqlite3.Row | tuple[object, ...] | None,
-            connection.execute("PRAGMA user_version").fetchone(),
-        )
-        if row is None:
-            return 0
-        return cast(int, row[0])
 
     def _read_created_at(self, *, connection: sqlite3.Connection, session_id: str) -> int:
         row = cast(

--- a/src/voidcode/runtime/task.py
+++ b/src/voidcode/runtime/task.py
@@ -93,6 +93,16 @@ _CATEGORY_TO_SUBAGENT_PRESET: dict[str, SubagentExecutablePreset] = {
 }
 
 _CALLABLE_SUBAGENT_PRESETS = frozenset({"advisor", "explore", "product", "researcher", "worker"})
+_BACKGROUND_TASK_TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled"})
+_BACKGROUND_TASK_ALLOWED_TRANSITIONS: dict[
+    BackgroundTaskStatus, frozenset[BackgroundTaskStatus]
+] = {
+    "queued": frozenset({"running", "completed", "failed", "cancelled"}),
+    "running": frozenset({"completed", "failed", "cancelled"}),
+    "completed": frozenset(),
+    "failed": frozenset(),
+    "cancelled": frozenset(),
+}
 
 
 def resolve_subagent_route(requested: SubagentRoutingIdentity) -> ResolvedSubagentRoute:
@@ -119,6 +129,20 @@ def resolve_subagent_route(requested: SubagentRoutingIdentity) -> ResolvedSubage
             f"{valid_categories}"
         )
     return ResolvedSubagentRoute(requested=requested, selected_preset=selected_preset)
+
+
+def is_background_task_terminal(status: BackgroundTaskStatus) -> bool:
+    return status in _BACKGROUND_TASK_TERMINAL_STATUSES
+
+
+def is_background_task_transition_allowed(
+    *,
+    current_status: BackgroundTaskStatus,
+    next_status: BackgroundTaskStatus,
+) -> bool:
+    if current_status == next_status:
+        return True
+    return next_status in _BACKGROUND_TASK_ALLOWED_TRANSITIONS[current_status]
 
 
 def subagent_routing_identity_from_metadata(

--- a/src/voidcode/tools/lsp.py
+++ b/src/voidcode/tools/lsp.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import enum
+from importlib import import_module
 from pathlib import Path
 from typing import Any, ClassVar, Protocol, cast
 
@@ -55,6 +56,29 @@ class LspTool:
     def __init__(self, *, requester: LspRequester) -> None:
         self._requester = requester
         self._converter = lsp_converters.get_converter()
+
+    @staticmethod
+    def _invoke_requester(
+        requester: LspRequester,
+        *,
+        server_name: str | None,
+        method: str,
+        params: dict[str, object],
+        workspace: Path,
+    ) -> Any:
+        try:
+            return requester(
+                server_name=server_name,
+                method=method,
+                params=params,
+                workspace=workspace,
+            )
+        except ValueError as exc:
+            runtime_lsp = import_module("voidcode.runtime.lsp")
+            runtime_error = getattr(runtime_lsp, "LspRuntimeError", None)
+            if runtime_error is not None and isinstance(exc, runtime_error):
+                raise ValueError(f"LSP protocol error: {exc}") from exc
+            raise
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
         op_value = call.arguments.get("operation")
@@ -119,7 +143,8 @@ class LspTool:
             )
 
         if operation in (LspOperation.INCOMING_CALLS, LspOperation.OUTGOING_CALLS):
-            prepare_result = self._requester(
+            prepare_result = self._invoke_requester(
+                self._requester,
                 server_name=server,
                 method=LspOperation.PREPARE_CALL_HIERARCHY.value,
                 params=self._converter.unstructure(
@@ -148,7 +173,8 @@ class LspTool:
                 raise ValueError("LSP prepareCallHierarchy returned no item")
             params = {"item": item}
 
-            response = self._requester(
+            response = self._invoke_requester(
+                self._requester,
                 server_name=server,
                 method=operation.value,
                 params=params,
@@ -163,7 +189,8 @@ class LspTool:
                 data={"lsp_response": response.response},
             )
 
-        response = self._requester(
+        response = self._invoke_requester(
+            self._requester,
             server_name=server,
             method=operation.value,
             params=params,

--- a/tests/integration/test_http_delegated_parity.py
+++ b/tests/integration/test_http_delegated_parity.py
@@ -1026,7 +1026,7 @@ def test_http_approval_resolution_endpoint_resumes_real_waiting_background_task(
     assert output_payload["output"] == "delegated"
 
 
-def test_http_approval_resolution_repairs_stale_task_status_across_runtime_instances(
+def test_http_approval_resolution_preserves_stale_terminal_task_status_across_runtime_instances(
     tmp_path: Path,
 ) -> None:
     runtime_request, runtime_class = _load_runtime_types()
@@ -1088,8 +1088,8 @@ def test_http_approval_resolution_repairs_stale_task_status_across_runtime_insta
     assert task_status == 200
     assert output_status == 200
     assert cast(dict[str, object], resume_payload["session"])["status"] == "completed"
-    assert task_payload["status"] == "completed"
-    assert output_task_payload["status"] == "completed"
+    assert task_payload["status"] == "failed"
+    assert output_task_payload["status"] == "failed"
     assert output_payload["output"] == "delegated"
 
 

--- a/tests/integration/test_lsp_tool_integration.py
+++ b/tests/integration/test_lsp_tool_integration.py
@@ -102,6 +102,12 @@ def _build_runtime_with_lsp(tmp_path: Path, *, command: tuple[str, ...]) -> Void
     return runtime
 
 
+def _build_runtime_with_lsp_script(tmp_path: Path, script_body: str) -> VoidCodeRuntime:
+    server_script = tmp_path / "fake_lsp_server.py"
+    server_script.write_text(script_body, encoding="utf-8")
+    return _build_runtime_with_lsp(tmp_path, command=(sys.executable, "-u", str(server_script)))
+
+
 @dataclass(slots=True)
 class _StubLspStep:
     tool_call: ToolCall | None = None
@@ -285,3 +291,71 @@ def test_runtime_managed_lsp_tool_uses_builtin_root_markers_for_workspace_select
     )
 
     assert started_event.payload["workspace_root"] == str(project_root)
+
+
+def test_runtime_managed_lsp_tool_surfaces_protocol_failure_from_server(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.py"
+    sample_file.write_text("x = 1\n", encoding="utf-8")
+    runtime = _build_runtime_with_lsp_script(
+        tmp_path,
+        "import json\n"
+        "import sys\n\n"
+        "def read_message():\n"
+        '    header = b""\n'
+        '    while b"\\r\\n\\r\\n" not in header:\n'
+        "        chunk = sys.stdin.buffer.read(1)\n"
+        "        if not chunk:\n"
+        "            return None\n"
+        "        header += chunk\n"
+        "    content_length = None\n"
+        '    for line in header.decode("ascii", errors="ignore").split("\\r\\n"):\n'
+        '        if line.lower().startswith("content-length:"):\n'
+        '            content_length = int(line.split(":", 1)[1].strip())\n'
+        "            break\n"
+        "    if content_length is None:\n"
+        "        return None\n"
+        "    body = sys.stdin.buffer.read(content_length)\n"
+        "    if not body:\n"
+        "        return None\n"
+        '    return json.loads(body.decode("utf-8"))\n\n'
+        "def send_raw(payload):\n"
+        '    body = payload.encode("utf-8")\n'
+        '    header = f"Content-Length: {len(body)}\\r\\n\\r\\n".encode("ascii")\n'
+        "    sys.stdout.buffer.write(header + body)\n"
+        "    sys.stdout.buffer.flush()\n\n"
+        "while True:\n"
+        "    message = read_message()\n"
+        "    if message is None:\n"
+        "        break\n"
+        '    method = message.get("method")\n'
+        '    request_id = message.get("id")\n'
+        '    if method == "initialize":\n'
+        "        send_raw(\n"
+        "            json.dumps(\n"
+        '                {"jsonrpc": "2.0", "id": request_id, "result": {"capabilities": {}}}\n'
+        "            )\n"
+        "        )\n"
+        "        continue\n"
+        '    if method in {"initialized", "shutdown", "exit"}:\n'
+        '        if method == "shutdown":\n'
+        '            send_raw(json.dumps({"jsonrpc": "2.0", "id": request_id, "result": None}))\n'
+        '        if method == "exit":\n'
+        "            break\n"
+        "        continue\n"
+        '    send_raw("[]")\n',
+    )
+    tool = LspTool(requester=runtime.request_lsp)
+
+    with pytest.raises(ValueError, match="LSP protocol error"):
+        _ = tool.invoke(
+            ToolCall(
+                tool_name="lsp",
+                arguments={
+                    "operation": "textDocument/definition",
+                    "filePath": "sample.py",
+                    "line": 1,
+                    "character": 1,
+                },
+            ),
+            workspace=tmp_path,
+        )

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -1378,8 +1378,8 @@ def test_runtime_background_task_cancel_reconciles_orphaned_task_from_fresh_runt
     second_runtime = cast(RuntimeRunner, cast(object, runtime_class(workspace=tmp_path)))
     cancelled = second_runtime.cancel_background_task("task-fresh-cancel")
 
-    assert cancelled.status == "failed"
-    assert cancelled.error == "background task interrupted before completion"
+    assert cancelled.status == "cancelled"
+    assert cancelled.error == "cancelled before start"
     assert cancelled.cancel_requested_at is None
 
 
@@ -1531,6 +1531,80 @@ def test_runtime_persists_pending_approval_until_single_resume_resolution(tmp_pa
     with pytest.raises(ValueError, match="no pending approval"):
         _ = resumed_runtime.resume(
             "persisted-approval",
+            approval_request_id=approval_request_id,
+            approval_decision="allow",
+        )
+
+
+def test_runtime_rejects_stale_duplicate_approval_replay_after_resolution_even_if_pending_state_is_restored(  # noqa: E501
+    tmp_path: Path,
+) -> None:
+    runtime_request, runtime = _approval_runtime(tmp_path, mode="ask")
+
+    waiting = runtime.run(
+        runtime_request(prompt="write danger.txt stale replay", session_id="stale-replay-session")
+    )
+    approval_request_id = cast(str, waiting.events[-1].payload["request_id"])
+    resolved = runtime.resume(
+        "stale-replay-session",
+        approval_request_id=approval_request_id,
+        approval_decision="allow",
+    )
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        approval_event = next(
+            event for event in resolved.events if event.event_type == "runtime.approval_requested"
+        )
+        _ = connection.execute(
+            (
+                "UPDATE sessions SET pending_approval_json = ?, resume_checkpoint_json = ? "
+                "WHERE session_id = ?"
+            ),
+            (
+                json.dumps(
+                    {
+                        "request_id": approval_request_id,
+                        "tool_name": "write_file",
+                        "arguments": {"path": "danger.txt", "content": "stale replay"},
+                        "target_summary": "write_file danger.txt",
+                        "reason": "non-read-only tool invocation",
+                        "policy_mode": "ask",
+                        "request_event_sequence": approval_event.sequence,
+                        "owner_session_id": "stale-replay-session",
+                        "owner_parent_session_id": None,
+                        "delegated_task_id": None,
+                    },
+                    sort_keys=True,
+                ),
+                json.dumps(
+                    {
+                        "version": 1,
+                        "kind": "approval_wait",
+                        "prompt": "write danger.txt stale replay",
+                        "session_status": "waiting",
+                        "session_metadata": resolved.session.metadata,
+                        "tool_results": [],
+                        "last_event_sequence": approval_event.sequence,
+                        "pending_approval_request_id": approval_request_id,
+                        "output": None,
+                    },
+                    sort_keys=True,
+                ),
+                "stale-replay-session",
+            ),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    with pytest.raises(
+        ValueError,
+        match="approval request was already resolved; stale approval replay is not allowed",
+    ):
+        _ = runtime.resume(
+            "stale-replay-session",
             approval_request_id=approval_request_id,
             approval_decision="allow",
         )
@@ -1713,7 +1787,7 @@ def test_runtime_denied_multi_step_loop_stops_before_follow_up_tools(tmp_path: P
     assert (tmp_path / "copied.txt").exists() is False
 
 
-def test_runtime_migrates_legacy_session_schema_for_pending_approval(tmp_path: Path) -> None:
+def test_runtime_rejects_legacy_session_schema_for_pending_approval(tmp_path: Path) -> None:
     runtime_request, runtime = _approval_runtime(tmp_path, mode="ask")
     database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
     database_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1753,40 +1827,10 @@ def test_runtime_migrates_legacy_session_schema_for_pending_approval(tmp_path: P
     finally:
         connection.close()
 
-    waiting = runtime.run(
-        runtime_request(prompt="write danger.txt legacy approval", session_id="legacy-session")
-    )
-
-    assert waiting.session.status == "waiting"
-
-    check = sqlite3.connect(database_path)
-    try:
-        session_rows = cast(
-            list[tuple[object, ...]], check.execute("PRAGMA table_info(sessions)").fetchall()
+    with pytest.raises(RuntimeError, match="sqlite runtime schema mismatch"):
+        _ = runtime.run(
+            runtime_request(prompt="write danger.txt legacy approval", session_id="legacy-session")
         )
-        background_task_rows = cast(
-            list[tuple[object, ...]],
-            check.execute("PRAGMA table_info(background_tasks)").fetchall(),
-        )
-        delivery_tables = cast(
-            list[tuple[object, ...]],
-            check.execute(
-                "SELECT name FROM sqlite_master "
-                "WHERE type = 'table' AND name = 'session_event_deliveries'"
-            ).fetchall(),
-        )
-        columns = [cast(str, row[1]) for row in session_rows]
-        background_task_columns = [cast(str, row[1]) for row in background_task_rows]
-        user_version = cast(int, check.execute("PRAGMA user_version").fetchone()[0])
-    finally:
-        check.close()
-
-    assert "parent_session_id" in columns
-    assert "pending_approval_json" in columns
-    assert "resume_checkpoint_json" in columns
-    assert "request_parent_session_id" in background_task_columns
-    assert delivery_tables == [("session_event_deliveries",)]
-    assert user_version == 8
 
 
 def test_runtime_replay_is_unchanged_when_resume_checkpoint_exists(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_background_task_storage.py
+++ b/tests/unit/runtime/test_background_task_storage.py
@@ -857,6 +857,62 @@ def test_background_task_storage_does_not_overwrite_terminal_task_when_marking_r
     assert running.started_at is None
 
 
+@pytest.mark.parametrize(
+    ("initial_status", "next_status", "initial_error"),
+    (
+        ("completed", "failed", None),
+        ("completed", "cancelled", None),
+        ("failed", "completed", "boom"),
+        ("failed", "cancelled", "boom"),
+        ("cancelled", "completed", "operator cancelled"),
+        ("cancelled", "failed", "operator cancelled"),
+    ),
+)
+def test_background_task_storage_terminal_states_are_immutable_across_terminal_rewrites(
+    tmp_path: Path,
+    initial_status: BackgroundTaskStatus,
+    next_status: BackgroundTaskStatus,
+    initial_error: str | None,
+) -> None:
+    store = SqliteSessionStore()
+    task_id = f"task-{initial_status}-immutable-{next_status}"
+    store.create_background_task(workspace=tmp_path, task=_task(task_id=task_id))
+
+    terminal = store.mark_background_task_terminal(
+        workspace=tmp_path,
+        task_id=task_id,
+        status=initial_status,
+        error=initial_error,
+    )
+    rewritten = store.mark_background_task_terminal(
+        workspace=tmp_path,
+        task_id=task_id,
+        status=next_status,
+        error="should be ignored",
+    )
+
+    assert rewritten == terminal
+    assert rewritten.status == initial_status
+    assert rewritten.error == initial_error
+
+
+def test_background_task_storage_rejects_non_terminal_status_in_terminal_marker(
+    tmp_path: Path,
+) -> None:
+    store = SqliteSessionStore()
+    store.create_background_task(workspace=tmp_path, task=_task(task_id="task-illegal-terminal"))
+
+    with pytest.raises(
+        ValueError,
+        match="background task terminal status must be completed, failed, or cancelled",
+    ):
+        _ = store.mark_background_task_terminal(
+            workspace=tmp_path,
+            task_id="task-illegal-terminal",
+            status=cast(BackgroundTaskStatus, "running"),
+        )
+
+
 def test_background_task_storage_reconciles_incomplete_tasks_on_restart(tmp_path: Path) -> None:
     store = SqliteSessionStore()
     store.create_background_task(workspace=tmp_path, task=_task(task_id="task-e"))
@@ -875,6 +931,39 @@ def test_background_task_storage_reconciles_incomplete_tasks_on_restart(tmp_path
     assert [task.task.id for task in reconciled] == ["task-e", "task-f"]
     assert all(task.status == "failed" for task in reconciled)
     assert all(task.error == "background task interrupted before completion" for task in reconciled)
+
+
+def test_background_task_storage_reconciliation_converts_cancel_requested_running_task_to_cancelled(
+    tmp_path: Path,
+) -> None:
+    store = SqliteSessionStore()
+    store.create_background_task(workspace=tmp_path, task=_task(task_id="task-reconcile-cancelled"))
+    _ = store.mark_background_task_running(
+        workspace=tmp_path,
+        task_id="task-reconcile-cancelled",
+        session_id="session-reconcile-cancelled",
+    )
+    requested_cancel = store.request_background_task_cancel(
+        workspace=tmp_path,
+        task_id="task-reconcile-cancelled",
+    )
+
+    reconciled = store.fail_incomplete_background_tasks(
+        workspace=tmp_path,
+        message="background task interrupted before completion",
+    )
+    cancelled = store.load_background_task(
+        workspace=tmp_path,
+        task_id="task-reconcile-cancelled",
+    )
+
+    assert requested_cancel.status == "running"
+    assert requested_cancel.cancel_requested_at is not None
+    assert [task.task.id for task in reconciled] == ["task-reconcile-cancelled"]
+    assert cancelled.status == "cancelled"
+    assert cancelled.error == "cancelled by parent during delegated execution"
+    assert cancelled.cancellation_cause == "cancelled by parent during delegated execution"
+    assert cancelled.result_available is False
 
 
 def test_background_task_storage_reconciliation_preserves_approval_blocked_child_with_durable_correlation(  # noqa: E501

--- a/tests/unit/runtime/test_lsp.py
+++ b/tests/unit/runtime/test_lsp.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 from importlib import import_module
 from pathlib import Path
@@ -20,7 +21,10 @@ def _load_lsp_symbols() -> tuple[Any, ...]:
     return (
         module.DisabledLspManager,
         module.LspConfigState,
+        module.LspMessageBoundsError,
+        module.LspProtocolError,
         module.ManagedLspManager,
+        module.MAX_LSP_MESSAGE_BYTES,
         module.LspRequest,
         module.build_lsp_manager,
     )
@@ -28,13 +32,19 @@ def _load_lsp_symbols() -> tuple[Any, ...]:
 
 DisabledLspManager: Any
 LspConfigState: Any
+LspMessageBoundsError: Any
+LspProtocolError: Any
 ManagedLspManager: Any
+MAX_LSP_MESSAGE_BYTES: int
 LspRequest: Any
 build_lsp_manager: Any
 (
     DisabledLspManager,
     LspConfigState,
+    LspMessageBoundsError,
+    LspProtocolError,
     ManagedLspManager,
+    MAX_LSP_MESSAGE_BYTES,
     LspRequest,
     build_lsp_manager,
 ) = _load_lsp_symbols()
@@ -211,6 +221,119 @@ def test_managed_lsp_manager_marks_failed_startup_when_command_is_missing(tmp_pa
     assert state.servers["broken"].last_error is not None
     assert "installed and available on PATH" in str(exc_info.value)
     assert "lsp.servers.broken.command" in str(exc_info.value)
+
+
+def test_read_message_rejects_oversized_content_length() -> None:
+    read_fd, write_fd = os.pipe()
+    try:
+        os.write(write_fd, f"Content-Length: {MAX_LSP_MESSAGE_BYTES + 1}\r\n\r\n".encode("ascii"))
+
+        class _FakeProcess:
+            def __init__(self, stdout: Any) -> None:
+                self.stdout = stdout
+
+        with os.fdopen(read_fd, "rb", buffering=0) as stdout:
+            process = _FakeProcess(stdout)
+            with pytest.raises(LspMessageBoundsError, match="Content-Length"):
+                _ = ManagedLspManager._read_message(process)
+    finally:
+        os.close(write_fd)
+
+
+def test_read_message_rejects_invalid_json_payload() -> None:
+    body = b"{invalid json"
+    payload = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii") + body
+    read_fd, write_fd = os.pipe()
+    try:
+        os.write(write_fd, payload)
+
+        class _FakeProcess:
+            def __init__(self, stdout: Any) -> None:
+                self.stdout = stdout
+
+        with os.fdopen(read_fd, "rb", buffering=0) as stdout:
+            process = _FakeProcess(stdout)
+            with pytest.raises(LspProtocolError, match="invalid JSON"):
+                _ = ManagedLspManager._read_message(process)
+    finally:
+        os.close(write_fd)
+
+
+def test_read_message_rejects_non_object_json_payload() -> None:
+    body = b"[]"
+    payload = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii") + body
+    read_fd, write_fd = os.pipe()
+    try:
+        os.write(write_fd, payload)
+
+        class _FakeProcess:
+            def __init__(self, stdout: Any) -> None:
+                self.stdout = stdout
+
+        with os.fdopen(read_fd, "rb", buffering=0) as stdout:
+            process = _FakeProcess(stdout)
+            with pytest.raises(LspProtocolError, match="JSON-RPC object"):
+                _ = ManagedLspManager._read_message(process)
+    finally:
+        os.close(write_fd)
+
+
+def test_send_request_matches_generated_request_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    manager = ManagedLspManager(
+        RuntimeLspConfig(
+            enabled=True,
+            servers={"pyright": RuntimeLspServerConfig(command=("pyright-langserver", "--stdio"))},
+        )
+    )
+    module = import_module("voidcode.runtime.lsp")
+    running_server_cls = module._RunningLspServer
+
+    class _FakeProcess:
+        pass
+
+    fake_process = _FakeProcess()
+    server_config = manager.configuration.resolve("pyright")
+    assert server_config is not None
+    running_server = running_server_cls(
+        config=server_config,
+        process=fake_process,
+        workspace_root=Path("."),
+    )
+
+    sent_ids: list[int] = []
+    responses: list[dict[str, object] | None] = [
+        {"jsonrpc": "2.0", "method": "window/logMessage", "params": {"type": 3}},
+        {"jsonrpc": "2.0", "id": 1, "result": {"value": "first"}},
+        {"jsonrpc": "2.0", "id": 2, "result": {"value": "second"}},
+    ]
+
+    def _fake_write_message(*, process: object, message: dict[str, object]) -> None:
+        _ = process
+        sent_ids.append(int(message["id"]))
+
+    def _fake_read_message(*, process: object, timeout: float = 30.0) -> dict[str, object] | None:
+        _ = process, timeout
+        return responses.pop(0)
+
+    monkeypatch.setattr(manager, "_write_message", _fake_write_message)
+    monkeypatch.setattr(manager, "_read_message", _fake_read_message)
+
+    first = manager._send_request(
+        running_server,
+        method="textDocument/definition",
+        params={},
+        server_name="pyright",
+    )
+    second = manager._send_request(
+        running_server,
+        method="textDocument/references",
+        params={},
+        server_name="pyright",
+    )
+
+    assert sent_ids == [1, 2]
+    assert first["result"] == {"value": "first"}
+    assert second["result"] == {"value": "second"}
 
 
 def test_managed_lsp_manager_terminates_process_when_initialize_fails(tmp_path: Path) -> None:
@@ -672,6 +795,115 @@ def test_stale_shared_server_release_does_not_stop_replacement_process(
     shutdown_events = manager_three.shutdown()
     assert [event.event_type for event in shutdown_events] == ["runtime.lsp_server_stopped"]
     assert popen_processes[1].terminated is True
+    registry._entries.clear()
+    registry._next_generation = 1
+
+
+def test_managed_lsp_manager_shared_server_uses_single_request_id_sequence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sample_file = tmp_path / "sample.py"
+    sample_file.write_text("x = 1\n", encoding="utf-8")
+    module = import_module("voidcode.runtime.lsp")
+    registry = module._WORKSPACE_SCOPED_LSP_REGISTRY
+    registry._entries.clear()
+    registry._next_generation = 1
+
+    class _FakeProcess:
+        stdin = object()
+        stdout = object()
+
+        def __init__(self) -> None:
+            self.terminated = False
+
+        def poll(self) -> int | None:
+            return 0 if self.terminated else None
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+        def kill(self) -> None:
+            self.terminated = True
+
+        def wait(self, timeout: float = 0.0) -> int:
+            _ = timeout
+            self.terminated = True
+            return 0
+
+    popen_calls: list[tuple[list[str], Path]] = []
+    sent_ids: list[int] = []
+    responses: list[dict[str, object]] = [
+        {"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}},
+        {"jsonrpc": "2.0", "id": 2, "result": {"ok": "one"}},
+        {"jsonrpc": "2.0", "id": 3, "result": {"ok": "two"}},
+        {"jsonrpc": "2.0", "id": 4, "result": None},
+    ]
+
+    def _fake_popen(
+        command: list[str], *, cwd: Path, stdin: object, stdout: object, stderr: object
+    ) -> _FakeProcess:
+        _ = stdin, stdout, stderr
+        popen_calls.append((command, cwd))
+        return _FakeProcess()
+
+    def _fake_write_message(*, process: object, message: dict[str, object]) -> None:
+        _ = process
+        message_id = message.get("id")
+        if isinstance(message_id, int):
+            sent_ids.append(message_id)
+
+    def _fake_read_message(*, process: object, timeout: float = 30.0) -> dict[str, object] | None:
+        _ = process, timeout
+        if not responses:
+            return None
+        return responses.pop(0)
+
+    def _fake_send_notification(*args: object, **kwargs: object) -> None:
+        _ = args, kwargs
+
+    monkeypatch.setattr(module.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(ManagedLspManager, "_write_message", staticmethod(_fake_write_message))
+    monkeypatch.setattr(ManagedLspManager, "_read_message", staticmethod(_fake_read_message))
+    monkeypatch.setattr(ManagedLspManager, "_send_notification", _fake_send_notification)
+
+    manager_one = ManagedLspManager(
+        RuntimeLspConfig(
+            enabled=True,
+            servers={"pyright": RuntimeLspServerConfig(command=("pyright-langserver", "--stdio"))},
+        )
+    )
+    manager_two = ManagedLspManager(
+        RuntimeLspConfig(
+            enabled=True,
+            servers={"pyright": RuntimeLspServerConfig(command=("pyright-langserver", "--stdio"))},
+        )
+    )
+    request = LspRequest(
+        server_name="pyright",
+        method="textDocument/definition",
+        params={"textDocument": {"uri": sample_file.as_uri()}},
+        workspace=tmp_path,
+    )
+
+    first_response = manager_one.request(request)
+    second_response = manager_two.request(request)
+
+    assert first_response.response["result"] == {"ok": "one"}
+    assert second_response.response["result"] == {"ok": "two"}
+    assert popen_calls == [(["pyright-langserver", "--stdio"], tmp_path)]
+    assert sent_ids == [1, 2, 3]
+
+    assert [event.event_type for event in manager_one.drain_events()] == [
+        "runtime.lsp_server_started"
+    ]
+    assert [event.event_type for event in manager_two.drain_events()] == [
+        "runtime.lsp_server_reused"
+    ]
+
+    assert manager_one.shutdown() == ()
+    shutdown_events = manager_two.shutdown()
+    assert sent_ids == [1, 2, 3, 4]
+    assert [event.event_type for event in shutdown_events] == ["runtime.lsp_server_stopped"]
     registry._entries.clear()
     registry._next_generation = 1
 

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 from typing import cast
 
@@ -26,6 +27,7 @@ from voidcode.runtime.config import (
     RUNTIME_CONFIG_FILE_NAME,
     TOOL_TIMEOUT_ENV_VAR,
     RuntimeAgentConfig,
+    RuntimeConfig,
     RuntimeFormatterPresetConfig,
     RuntimeHooksConfig,
     RuntimeLspConfig,
@@ -48,6 +50,7 @@ from voidcode.runtime.config import (
     serialize_runtime_agent_config,
     user_runtime_config_path,
 )
+from voidcode.runtime.service import RuntimeRequest, VoidCodeRuntime
 
 _parse_tui_config = runtime_config.__dict__["_parse_tui_config"]
 _parse_tools_config = runtime_config.__dict__["_parse_tools_config"]
@@ -2147,3 +2150,100 @@ def test_runtime_config_repo_provider_overrides_environment_provider_credentials
 
     assert config.providers is not None
     assert config.providers.opencode_go == SimplifiedProviderConfig(api_key="repo-key")
+
+
+def test_runtime_config_resume_prefers_persisted_session_values_over_fresh_defaults(
+    tmp_path: Path,
+) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("resume precedence\n", encoding="utf-8")
+
+    initial_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            approval_mode="allow",
+            model="session/model",
+            execution_engine="provider",
+            max_steps=7,
+        ),
+    )
+    _ = initial_runtime.run(
+        RuntimeRequest(prompt="read sample.txt", session_id="resume-config-precedence")
+    )
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            approval_mode="deny",
+            model="fresh/model",
+            execution_engine="deterministic",
+            max_steps=3,
+        ),
+    )
+    effective = resumed_runtime.effective_runtime_config(session_id="resume-config-precedence")
+
+    assert effective.approval_mode == "allow"
+    assert effective.model == "session/model"
+    assert effective.execution_engine == "provider"
+    assert effective.max_steps == 7
+
+
+def test_runtime_config_resume_preserves_persisted_none_plan_precedence(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("resume plan precedence\n", encoding="utf-8")
+
+    initial_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(plan=None),
+    )
+    _ = initial_runtime.run(
+        RuntimeRequest(prompt="read sample.txt", session_id="resume-plan-none-precedence")
+    )
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        row = connection.execute(
+            "SELECT metadata_json FROM sessions WHERE session_id = ?",
+            ("resume-plan-none-precedence",),
+        ).fetchone()
+        assert row is not None
+        metadata = json.loads(str(row[0]))
+        assert isinstance(metadata, dict)
+        runtime_config_metadata = cast(dict[str, object], metadata["runtime_config"])
+        assert runtime_config_metadata["plan"] is None
+    finally:
+        connection.close()
+
+    extension_file = tmp_path / "plan_extension.py"
+    extension_file.write_text(
+        "\n".join(
+            (
+                "from voidcode.runtime.plan import PlanPatch",
+                "",
+                "def build(options):",
+                "    contributor_type = type(",
+                "        'Contributor',",
+                "        (),",
+                "        {'apply': lambda self, context: PlanPatch()},",
+                "    )",
+                "    return contributor_type()",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            plan=RuntimePlanConfig(
+                provider="custom",
+                module=str(extension_file),
+                factory="build",
+                options={"mode": "fresh"},
+            )
+        ),
+    )
+    effective = resumed_runtime.effective_runtime_config(session_id="resume-plan-none-precedence")
+
+    assert effective.plan is None

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1967,6 +1967,243 @@ def test_runtime_waiting_approval_event_records_child_ownership(tmp_path: Path) 
     assert approval_event.payload["delegated_task_id"] is None
 
 
+def test_runtime_resume_rejects_malformed_persisted_pending_approval_policy_mode(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    waiting = runtime.run(RuntimeRequest(prompt="go", session_id="malformed-pending-approval"))
+    approval_request_id = str(waiting.events[-1].payload["request_id"])
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        row = connection.execute(
+            "SELECT pending_approval_json FROM sessions WHERE session_id = ?",
+            ("malformed-pending-approval",),
+        ).fetchone()
+        assert row is not None
+        pending_approval = json.loads(str(row[0]))
+        assert isinstance(pending_approval, dict)
+        pending_approval["policy_mode"] = "not-a-real-mode"
+        _ = connection.execute(
+            "UPDATE sessions SET pending_approval_json = ? WHERE session_id = ?",
+            (json.dumps(pending_approval, sort_keys=True), "malformed-pending-approval"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    with pytest.raises(ValueError, match="invalid permission policy mode: not-a-real-mode"):
+        _ = resumed_runtime.resume(
+            "malformed-pending-approval",
+            approval_request_id=approval_request_id,
+            approval_decision="allow",
+        )
+
+
+def test_runtime_resume_rejects_persisted_approval_owned_by_different_session(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    waiting = runtime.run(RuntimeRequest(prompt="go", session_id="owned-approval-child"))
+    approval_request_id = str(waiting.events[-1].payload["request_id"])
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        row = connection.execute(
+            "SELECT pending_approval_json FROM sessions WHERE session_id = ?",
+            ("owned-approval-child",),
+        ).fetchone()
+        assert row is not None
+        pending_approval = json.loads(str(row[0]))
+        assert isinstance(pending_approval, dict)
+        pending_approval["owner_session_id"] = "different-child-session"
+        _ = connection.execute(
+            "UPDATE sessions SET pending_approval_json = ? WHERE session_id = ?",
+            (json.dumps(pending_approval, sort_keys=True), "owned-approval-child"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="approval resume must target the child session that owns the approval request",
+    ):
+        _ = resumed_runtime.resume(
+            "owned-approval-child",
+            approval_request_id=approval_request_id,
+            approval_decision="allow",
+        )
+
+
+def test_runtime_resume_rejects_tampered_pending_approval_payload_against_recorded_request(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    waiting = runtime.run(RuntimeRequest(prompt="go", session_id="approval-binding-mismatch"))
+    approval_request_id = str(waiting.events[-1].payload["request_id"])
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        row = connection.execute(
+            "SELECT pending_approval_json FROM sessions WHERE session_id = ?",
+            ("approval-binding-mismatch",),
+        ).fetchone()
+        assert row is not None
+        pending_approval = json.loads(str(row[0]))
+        assert isinstance(pending_approval, dict)
+        pending_approval["arguments"] = {"path": "beta.txt", "content": "1"}
+        _ = connection.execute(
+            "UPDATE sessions SET pending_approval_json = ? WHERE session_id = ?",
+            (json.dumps(pending_approval, sort_keys=True), "approval-binding-mismatch"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="persisted pending approval no longer matches the recorded approval request payload",
+    ):
+        _ = resumed_runtime.resume(
+            "approval-binding-mismatch",
+            approval_request_id=approval_request_id,
+            approval_decision="allow",
+        )
+
+
+def test_runtime_resume_rejects_stale_duplicate_approval_replay_when_pending_state_is_reinserted(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    waiting = runtime.run(RuntimeRequest(prompt="go", session_id="stale-approval-replay"))
+    approval_request_id = str(waiting.events[-1].payload["request_id"])
+    resolved = runtime.resume(
+        "stale-approval-replay",
+        approval_request_id=approval_request_id,
+        approval_decision="allow",
+    )
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        row = connection.execute(
+            (
+                "SELECT pending_approval_json, resume_checkpoint_json "
+                "FROM sessions WHERE session_id = ?"
+            ),
+            ("stale-approval-replay",),
+        ).fetchone()
+        assert row is not None
+        approval_event = next(
+            event for event in resolved.events if event.event_type == "runtime.approval_requested"
+        )
+        stale_pending = {
+            "request_id": approval_request_id,
+            "tool_name": "write_file",
+            "arguments": {"path": "alpha.txt", "content": "1"},
+            "target_summary": "write_file alpha.txt",
+            "reason": "non-read-only tool invocation",
+            "policy_mode": "ask",
+            "request_event_sequence": approval_event.sequence,
+            "owner_session_id": "stale-approval-replay",
+            "owner_parent_session_id": None,
+            "delegated_task_id": None,
+        }
+        _ = connection.execute(
+            (
+                "UPDATE sessions SET pending_approval_json = ?, resume_checkpoint_json = ? "
+                "WHERE session_id = ?"
+            ),
+            (
+                json.dumps(stale_pending, sort_keys=True),
+                json.dumps(
+                    {
+                        "version": 1,
+                        "kind": "approval_wait",
+                        "prompt": "go",
+                        "session_status": "waiting",
+                        "session_metadata": resolved.session.metadata,
+                        "tool_results": [],
+                        "last_event_sequence": approval_event.sequence,
+                        "pending_approval_request_id": approval_request_id,
+                        "output": None,
+                    },
+                    sort_keys=True,
+                ),
+                "stale-approval-replay",
+            ),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="approval request was already resolved; stale approval replay is not allowed",
+    ):
+        _ = resumed_runtime.resume(
+            "stale-approval-replay",
+            approval_request_id=approval_request_id,
+            approval_decision="allow",
+        )
+
+
 def test_runtime_background_task_waiting_approval_resume_finalizes_task(
     tmp_path: Path,
 ) -> None:
@@ -2083,6 +2320,58 @@ def test_runtime_background_task_waiting_approval_resume_with_fresh_runtime_pres
     assert finalized.error is None
 
 
+def test_runtime_background_task_parent_notifications_keep_waiting_then_completion_sequence(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+    _ = runtime.run(RuntimeRequest(prompt="leader", session_id="leader-session"))
+
+    started = runtime.start_background_task(
+        RuntimeRequest(prompt="background child", parent_session_id="leader-session")
+    )
+    running = _wait_for_background_task_session(runtime, started.task.id)
+    child_session_id = cast(str, running.session_id)
+    child_response = _wait_for_session_event(
+        runtime,
+        child_session_id,
+        "runtime.approval_requested",
+    )
+    approval_request_id = cast(str, child_response.events[-1].payload["request_id"])
+
+    _ = runtime.resume(
+        child_session_id,
+        approval_request_id=approval_request_id,
+        approval_decision="allow",
+    )
+    leader_response = _wait_for_session_event(
+        runtime,
+        "leader-session",
+        RUNTIME_BACKGROUND_TASK_COMPLETED,
+    )
+
+    delegated_events = [
+        event
+        for event in leader_response.events
+        if event.event_type
+        in (RUNTIME_BACKGROUND_TASK_WAITING_APPROVAL, RUNTIME_BACKGROUND_TASK_COMPLETED)
+    ]
+
+    assert [event.event_type for event in delegated_events] == [
+        RUNTIME_BACKGROUND_TASK_WAITING_APPROVAL,
+        RUNTIME_BACKGROUND_TASK_COMPLETED,
+    ]
+    assert [event.sequence for event in delegated_events] == sorted(
+        event.sequence for event in delegated_events
+    )
+    assert delegated_events[1].sequence > delegated_events[0].sequence
+    assert len({event.sequence for event in delegated_events}) == 2
+
+
 def test_runtime_background_task_approval_resume_overrides_stale_failed_task_status(
     tmp_path: Path,
 ) -> None:
@@ -2131,10 +2420,10 @@ def test_runtime_background_task_approval_resume_overrides_stale_failed_task_sta
 
     assert stale.status == "failed"
     assert resumed.session.status == "completed"
-    assert finalized.status == "completed"
-    assert finalized.error is None
-    assert result.status == "completed"
-    assert result.error is None
+    assert finalized.status == "failed"
+    assert finalized.error == "background task interrupted before completion"
+    assert result.status == "failed"
+    assert result.error == "background task interrupted before completion"
 
 
 def test_runtime_resume_rejects_parent_session_for_child_owned_approval(tmp_path: Path) -> None:
@@ -2166,6 +2455,189 @@ def test_runtime_resume_rejects_parent_session_for_child_owned_approval(tmp_path
             "leader-session",
             approval_request_id=approval_request_id,
             approval_decision="allow",
+        )
+
+
+def test_runtime_answer_question_rejects_parent_session_for_child_owned_question(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_QuestionThenDoneGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+    _ = runtime.run(RuntimeRequest(prompt="leader", session_id="leader-session"))
+
+    started = runtime.start_background_task(
+        RuntimeRequest(prompt="background child", parent_session_id="leader-session")
+    )
+    running = _wait_for_background_task_session(runtime, started.task.id)
+    child_session_id = cast(str, running.session_id)
+    child_response = _wait_for_session_event(
+        runtime,
+        child_session_id,
+        "runtime.question_requested",
+    )
+    question_request_id = cast(str, child_response.events[-1].payload["request_id"])
+
+    with pytest.raises(
+        ValueError,
+        match="question answer must target the child session that owns the question request",
+    ):
+        _ = runtime.answer_question(
+            session_id="leader-session",
+            question_request_id=question_request_id,
+            responses=(QuestionResponse(header="Runtime path", answers=("Reuse existing",)),),
+        )
+
+
+def test_runtime_resume_rejects_wrong_workspace_metadata_on_approval_resume(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    waiting = runtime.run(RuntimeRequest(prompt="go", session_id="wrong-workspace-approval"))
+    approval_request_id = str(waiting.events[-1].payload["request_id"])
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        row = connection.execute(
+            "SELECT metadata_json FROM sessions WHERE session_id = ?",
+            ("wrong-workspace-approval",),
+        ).fetchone()
+        assert row is not None
+        metadata = json.loads(str(row[0]))
+        assert isinstance(metadata, dict)
+        metadata_dict = cast(dict[str, object], metadata)
+        metadata_dict["workspace"] = "/tmp/other-workspace"
+        _ = connection.execute(
+            "UPDATE sessions SET metadata_json = ? WHERE session_id = ?",
+            (json.dumps(metadata_dict, sort_keys=True), "wrong-workspace-approval"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=f"session wrong-workspace-approval does not belong to workspace {tmp_path}",
+    ):
+        _ = resumed_runtime.resume(
+            "wrong-workspace-approval",
+            approval_request_id=approval_request_id,
+            approval_decision="allow",
+        )
+
+
+def test_runtime_answer_question_rejects_wrong_workspace_metadata(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_QuestionThenDoneGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    waiting = runtime.run(RuntimeRequest(prompt="go", session_id="wrong-workspace-question"))
+    question_request_id = str(waiting.events[-1].payload["request_id"])
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        row = connection.execute(
+            "SELECT metadata_json FROM sessions WHERE session_id = ?",
+            ("wrong-workspace-question",),
+        ).fetchone()
+        assert row is not None
+        metadata = json.loads(str(row[0]))
+        assert isinstance(metadata, dict)
+        metadata_dict = cast(dict[str, object], metadata)
+        metadata_dict["workspace"] = "/tmp/other-workspace"
+        _ = connection.execute(
+            "UPDATE sessions SET metadata_json = ? WHERE session_id = ?",
+            (json.dumps(metadata_dict, sort_keys=True), "wrong-workspace-question"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_QuestionThenDoneGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=f"session wrong-workspace-question does not belong to workspace {tmp_path}",
+    ):
+        _ = resumed_runtime.answer_question(
+            session_id="wrong-workspace-question",
+            question_request_id=question_request_id,
+            responses=(QuestionResponse(header="Runtime path", answers=("Reuse existing",)),),
+        )
+
+
+def test_runtime_answer_question_rejects_tampered_pending_question_payload_against_recorded_request(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_QuestionThenDoneGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    waiting = runtime.run(RuntimeRequest(prompt="go", session_id="question-binding-mismatch"))
+    question_request_id = str(waiting.events[-1].payload["request_id"])
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        row = connection.execute(
+            "SELECT pending_question_json FROM sessions WHERE session_id = ?",
+            ("question-binding-mismatch",),
+        ).fetchone()
+        assert row is not None
+        pending_question = json.loads(str(row[0]))
+        assert isinstance(pending_question, dict)
+        prompts = cast(list[dict[str, object]], pending_question["prompts"])
+        prompts[0]["header"] = "Wrong header"
+        _ = connection.execute(
+            "UPDATE sessions SET pending_question_json = ? WHERE session_id = ?",
+            (json.dumps(pending_question, sort_keys=True), "question-binding-mismatch"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_QuestionThenDoneGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="persisted pending question no longer matches the recorded question request payload",
+    ):
+        _ = resumed_runtime.answer_question(
+            session_id="question-binding-mismatch",
+            question_request_id=question_request_id,
+            responses=(QuestionResponse(header="Wrong header", answers=("Reuse existing",)),),
         )
 
 
@@ -2457,8 +2929,8 @@ def test_runtime_cancel_background_task_reconciles_orphaned_queued_task(tmp_path
 
     cancelled = runtime.cancel_background_task("task-pre-cancel")
 
-    assert cancelled.status == "failed"
-    assert cancelled.error == "background task interrupted before completion"
+    assert cancelled.status == "cancelled"
+    assert cancelled.error == "cancelled before start"
     assert cancelled.cancel_requested_at is None
 
 
@@ -2554,6 +3026,125 @@ def test_runtime_background_task_worker_rechecks_cancel_before_dispatch(tmp_path
     assert final_task.status == "cancelled"
     assert final_task.error == "cancelled before dispatch"
     run_mock.assert_not_called()
+
+
+def test_runtime_reconciliation_preserves_terminal_task_even_if_child_session_disagrees(
+    tmp_path: Path,
+) -> None:
+    initial_runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    _ = initial_runtime.run(RuntimeRequest(prompt="leader", session_id="leader-session"))
+    store = _private_attr(initial_runtime, "_session_store")
+    task_module = importlib.import_module("voidcode.runtime.task")
+    store.create_background_task(
+        workspace=tmp_path,
+        task=task_module.BackgroundTaskState(
+            task=task_module.BackgroundTaskRef(id="task-terminal-truth"),
+            status="completed",
+            request=task_module.BackgroundTaskRequestSnapshot(
+                prompt="background child",
+                parent_session_id="leader-session",
+            ),
+            session_id="child-session-terminal-truth",
+            created_at=1,
+            updated_at=2,
+            started_at=1,
+            finished_at=2,
+        ),
+    )
+    store.save_run(
+        workspace=tmp_path,
+        request=RuntimeRequest(
+            prompt="background child",
+            session_id="child-session-terminal-truth",
+            parent_session_id="leader-session",
+            metadata={
+                "background_run": True,
+                "background_task_id": "task-terminal-truth",
+            },
+        ),
+        response=RuntimeResponse(
+            session=SessionState(
+                session=runtime_service_module.SessionRef(
+                    id="child-session-terminal-truth",
+                    parent_id="leader-session",
+                ),
+                status="failed",
+                turn=1,
+                metadata={
+                    "background_run": True,
+                    "background_task_id": "task-terminal-truth",
+                },
+            ),
+            events=(
+                EventEnvelope(
+                    session_id="child-session-terminal-truth",
+                    sequence=1,
+                    event_type="runtime.request_received",
+                    source="runtime",
+                    payload={"prompt": "background child"},
+                ),
+                EventEnvelope(
+                    session_id="child-session-terminal-truth",
+                    sequence=2,
+                    event_type="runtime.failed",
+                    source="runtime",
+                    payload={"error": "child failed later"},
+                ),
+            ),
+            output=None,
+        ),
+    )
+
+    resumed_runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+
+    reconciled = resumed_runtime.load_background_task("task-terminal-truth")
+    leader_response = _wait_for_session_event(
+        resumed_runtime,
+        "leader-session",
+        RUNTIME_BACKGROUND_TASK_COMPLETED,
+    )
+
+    assert reconciled.status == "completed"
+    assert reconciled.error is None
+    assert (
+        sum(
+            event.event_type == RUNTIME_BACKGROUND_TASK_COMPLETED
+            for event in leader_response.events
+        )
+        == 1
+    )
+
+
+def test_runtime_reconciliation_turns_cancel_requested_running_task_into_cancelled(
+    tmp_path: Path,
+) -> None:
+    first_runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    store = _private_attr(first_runtime, "_session_store")
+    task_module = importlib.import_module("voidcode.runtime.task")
+    store.create_background_task(
+        workspace=tmp_path,
+        task=task_module.BackgroundTaskState(
+            task=task_module.BackgroundTaskRef(id="task-orphan-cancel-request"),
+            status="running",
+            request=task_module.BackgroundTaskRequestSnapshot(prompt="orphan cancel"),
+            session_id="orphan-cancel-session",
+            created_at=1,
+            updated_at=1,
+            started_at=1,
+        ),
+    )
+    _ = store.request_background_task_cancel(
+        workspace=tmp_path,
+        task_id="task-orphan-cancel-request",
+    )
+
+    second_runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    reconciled = second_runtime.load_background_task("task-orphan-cancel-request")
+
+    assert reconciled.status == "cancelled"
+    assert reconciled.error == "cancelled by parent during delegated execution"
+    assert reconciled.cancellation_cause == "cancelled by parent during delegated execution"
+    assert reconciled.result_available is False
 
 
 def test_runtime_initializes_extension_state_from_config_when_enabled(tmp_path: Path) -> None:
@@ -5447,6 +6038,57 @@ def test_runtime_effective_config_restores_persisted_plan_metadata(tmp_path: Pat
     assert effective.plan == plan_config
 
 
+def test_runtime_effective_runtime_config_preserves_explicit_none_plan_over_fresh_default(
+    tmp_path: Path,
+) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("plan none\n", encoding="utf-8")
+
+    initial_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(plan=None),
+    )
+    response = initial_runtime.run(
+        RuntimeRequest(prompt="read sample.txt", session_id="plan-none-session")
+    )
+    runtime_config_metadata = cast(dict[str, object], response.session.metadata["runtime_config"])
+
+    assert runtime_config_metadata["plan"] is None
+
+    extension_file = tmp_path / "resume_plan_extension.py"
+    extension_file.write_text(
+        "\n".join(
+            (
+                "from voidcode.runtime.plan import PlanPatch",
+                "",
+                "def build(options):",
+                "    contributor_type = type(",
+                "        'Contributor',",
+                "        (),",
+                "        {'apply': lambda self, context: PlanPatch()},",
+                "    )",
+                "    return contributor_type()",
+            )
+        ),
+        encoding="utf-8",
+    )
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            plan=RuntimePlanConfig(
+                provider="custom",
+                module=str(extension_file),
+                factory="build",
+                options={"mode": "fresh"},
+            )
+        ),
+    )
+
+    effective = resumed_runtime.effective_runtime_config(session_id="plan-none-session")
+
+    assert effective.plan is None
+
+
 @pytest.mark.parametrize(
     "invalid_max_steps",
     [0, -1, "4", 1.5, [], {}],
@@ -7665,7 +8307,7 @@ def test_runtime_resume_falls_back_when_persisted_checkpoint_is_missing(tmp_path
     assert resumed.output == "done"
 
 
-def test_runtime_resume_falls_back_when_persisted_checkpoint_json_is_corrupt(
+def test_runtime_resume_rejects_persisted_checkpoint_json_is_corrupt(
     tmp_path: Path,
 ) -> None:
     runtime = VoidCodeRuntime(
@@ -7696,17 +8338,15 @@ def test_runtime_resume_falls_back_when_persisted_checkpoint_json_is_corrupt(
         permission_policy=PermissionPolicy(mode="ask"),
     )
 
-    resumed = resumed_runtime.resume(
-        session_id="checkpoint-corrupt-json-session",
-        approval_request_id=approval_request_id,
-        approval_decision="allow",
-    )
-
-    assert resumed.session.status == "completed"
-    assert resumed.output == "done"
+    with pytest.raises(ValueError, match="persisted resume checkpoint JSON is malformed"):
+        _ = resumed_runtime.resume(
+            session_id="checkpoint-corrupt-json-session",
+            approval_request_id=approval_request_id,
+            approval_decision="allow",
+        )
 
 
-def test_runtime_resume_falls_back_when_persisted_checkpoint_payload_is_not_object(
+def test_runtime_resume_rejects_persisted_checkpoint_payload_is_not_object(
     tmp_path: Path,
 ) -> None:
     runtime = VoidCodeRuntime(
@@ -7737,14 +8377,281 @@ def test_runtime_resume_falls_back_when_persisted_checkpoint_payload_is_not_obje
         permission_policy=PermissionPolicy(mode="ask"),
     )
 
-    resumed = resumed_runtime.resume(
-        session_id="checkpoint-non-object-session",
-        approval_request_id=approval_request_id,
-        approval_decision="allow",
+    with pytest.raises(
+        ValueError,
+        match="persisted resume checkpoint payload must decode to an object",
+    ):
+        _ = resumed_runtime.resume(
+            session_id="checkpoint-non-object-session",
+            approval_request_id=approval_request_id,
+            approval_decision="allow",
+        )
+
+
+def test_runtime_resume_rejects_malformed_persisted_checkpoint_payload_with_valid_json_object(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
     )
 
-    assert resumed.session.status == "completed"
-    assert resumed.output == "done"
+    waiting = runtime.run(RuntimeRequest(prompt="go", session_id="checkpoint-malformed-object"))
+    approval_request_id = str(waiting.events[-1].payload["request_id"])
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        _ = connection.execute(
+            "UPDATE sessions SET resume_checkpoint_json = ? WHERE session_id = ?",
+            (
+                json.dumps(
+                    {
+                        "kind": "approval_wait",
+                        "version": 1,
+                        "pending_approval_request_id": approval_request_id,
+                        "session_metadata": waiting.session.metadata,
+                        "tool_results": [],
+                    },
+                    sort_keys=True,
+                ),
+                "checkpoint-malformed-object",
+            ),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="persisted approval resume checkpoint prompt must be a string",
+    ):
+        _ = resumed_runtime.resume(
+            session_id="checkpoint-malformed-object",
+            approval_request_id=approval_request_id,
+            approval_decision="allow",
+        )
+
+
+def test_runtime_resume_rejects_checkpoint_kind_mismatch(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    waiting = runtime.run(RuntimeRequest(prompt="go", session_id="checkpoint-kind-mismatch"))
+    approval_request_id = str(waiting.events[-1].payload["request_id"])
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        row = connection.execute(
+            "SELECT resume_checkpoint_json FROM sessions WHERE session_id = ?",
+            ("checkpoint-kind-mismatch",),
+        ).fetchone()
+        assert row is not None
+        checkpoint = cast(dict[str, object], json.loads(str(row[0])))
+        checkpoint["kind"] = "question_wait"
+        _ = connection.execute(
+            "UPDATE sessions SET resume_checkpoint_json = ? WHERE session_id = ?",
+            (json.dumps(checkpoint, sort_keys=True), "checkpoint-kind-mismatch"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"persisted resume checkpoint kind mismatch: "
+            r"expected 'approval_wait', got 'question_wait'"
+        ),
+    ):
+        _ = resumed_runtime.resume(
+            session_id="checkpoint-kind-mismatch",
+            approval_request_id=approval_request_id,
+            approval_decision="allow",
+        )
+
+
+def test_runtime_resume_rejects_checkpoint_version_mismatch(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    waiting = runtime.run(RuntimeRequest(prompt="go", session_id="checkpoint-version-mismatch"))
+    approval_request_id = str(waiting.events[-1].payload["request_id"])
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        row = connection.execute(
+            "SELECT resume_checkpoint_json FROM sessions WHERE session_id = ?",
+            ("checkpoint-version-mismatch",),
+        ).fetchone()
+        assert row is not None
+        checkpoint = cast(dict[str, object], json.loads(str(row[0])))
+        checkpoint["version"] = 99
+        _ = connection.execute(
+            "UPDATE sessions SET resume_checkpoint_json = ? WHERE session_id = ?",
+            (json.dumps(checkpoint, sort_keys=True), "checkpoint-version-mismatch"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_ApprovalThenCaptureSkillGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"persisted resume checkpoint version mismatch: expected 1, got 99",
+    ):
+        _ = resumed_runtime.resume(
+            session_id="checkpoint-version-mismatch",
+            approval_request_id=approval_request_id,
+            approval_decision="allow",
+        )
+
+
+def test_runtime_resume_rejects_malformed_persisted_checkpoint_tool_result_entry(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_MultiStepStubGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    waiting = runtime.run(RuntimeRequest(prompt="go", session_id="checkpoint-bad-tool-result"))
+    first_approval_request_id = str(waiting.events[-1].payload["request_id"])
+    second_waiting = runtime.resume(
+        session_id="checkpoint-bad-tool-result",
+        approval_request_id=first_approval_request_id,
+        approval_decision="allow",
+    )
+    second_approval_request_id = str(second_waiting.events[-1].payload["request_id"])
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        row = connection.execute(
+            "SELECT resume_checkpoint_json FROM sessions WHERE session_id = ?",
+            ("checkpoint-bad-tool-result",),
+        ).fetchone()
+        assert row is not None
+        checkpoint = cast(dict[str, object], json.loads(str(row[0])))
+        checkpoint["tool_results"] = [
+            {
+                "tool_name": "write_file",
+                "status": "ok",
+                "data": "not-an-object",
+                "content": None,
+                "error": None,
+            }
+        ]
+        _ = connection.execute(
+            "UPDATE sessions SET resume_checkpoint_json = ? WHERE session_id = ?",
+            (json.dumps(checkpoint, sort_keys=True), "checkpoint-bad-tool-result"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_MultiStepStubGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="persisted resume checkpoint tool_results are malformed",
+    ):
+        _ = resumed_runtime.resume(
+            session_id="checkpoint-bad-tool-result",
+            approval_request_id=second_approval_request_id,
+            approval_decision="allow",
+        )
+
+
+def test_runtime_answer_question_rejects_checkpoint_kind_mismatch(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_QuestionThenDoneGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    waiting = runtime.run(
+        RuntimeRequest(prompt="go", session_id="question-checkpoint-kind-mismatch")
+    )
+    question_request_id = str(waiting.events[-1].payload["request_id"])
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        row = connection.execute(
+            "SELECT resume_checkpoint_json FROM sessions WHERE session_id = ?",
+            ("question-checkpoint-kind-mismatch",),
+        ).fetchone()
+        assert row is not None
+        checkpoint = cast(dict[str, object], json.loads(str(row[0])))
+        checkpoint["kind"] = "approval_wait"
+        _ = connection.execute(
+            "UPDATE sessions SET resume_checkpoint_json = ? WHERE session_id = ?",
+            (json.dumps(checkpoint, sort_keys=True), "question-checkpoint-kind-mismatch"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    resumed_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_QuestionThenDoneGraph(),
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"persisted resume checkpoint kind mismatch: "
+            r"expected 'question_wait', got 'approval_wait'"
+        ),
+    ):
+        _ = resumed_runtime.answer_question(
+            session_id="question-checkpoint-kind-mismatch",
+            question_request_id=question_request_id,
+            responses=(QuestionResponse(header="Runtime path", answers=("Reuse existing",)),),
+        )
 
 
 def test_runtime_resume_fallback_keeps_successful_tool_results_with_null_error(

--- a/tests/unit/runtime/test_session_storage.py
+++ b/tests/unit/runtime/test_session_storage.py
@@ -6,6 +6,8 @@ from contextlib import closing
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from voidcode.runtime.contracts import RuntimeRequest, RuntimeResponse
 from voidcode.runtime.events import EventEnvelope
 from voidcode.runtime.question import PendingQuestion, PendingQuestionOption, PendingQuestionPrompt
@@ -60,8 +62,66 @@ def test_session_storage_persists_parent_lineage_across_read_surfaces(tmp_path: 
     assert notifications[0].session.parent_id == "leader-session"
 
 
-def test_session_storage_migrates_legacy_schema_for_parent_lineage(tmp_path: Path) -> None:
-    database_path = tmp_path / "legacy-sessions.sqlite3"
+def test_session_storage_bootstraps_canonical_schema_for_fresh_database(tmp_path: Path) -> None:
+    database_path = tmp_path / "fresh-sessions.sqlite3"
+    store = SqliteSessionStore(database_path=database_path)
+    request = RuntimeRequest(prompt="fresh bootstrap", session_id="fresh-session")
+    response = RuntimeResponse(
+        session=SessionState(
+            session=SessionRef(id="fresh-session"),
+            status="completed",
+            turn=1,
+            metadata={},
+        ),
+        events=(
+            EventEnvelope(
+                session_id="fresh-session",
+                sequence=1,
+                event_type="graph.response_ready",
+                source="graph",
+            ),
+        ),
+        output="done",
+    )
+
+    store.save_run(workspace=tmp_path, request=request, response=response)
+
+    with closing(sqlite3.connect(database_path)) as connection:
+        session_columns = [
+            row[1] for row in connection.execute("PRAGMA table_info(sessions)").fetchall()
+        ]
+        delivery_columns = [
+            row[1]
+            for row in connection.execute("PRAGMA table_info(session_event_deliveries)").fetchall()
+        ]
+        notification_indexes = connection.execute(
+            "PRAGMA index_list(session_notifications)"
+        ).fetchall()
+
+    assert session_columns == [
+        "session_id",
+        "parent_session_id",
+        "workspace",
+        "status",
+        "turn",
+        "prompt",
+        "output",
+        "metadata_json",
+        "pending_approval_json",
+        "pending_question_json",
+        "resume_checkpoint_json",
+        "created_at",
+        "updated_at",
+        "last_event_sequence",
+    ]
+    assert delivery_columns == ["workspace", "session_id", "dedupe_key", "delivered_at"]
+    assert any(row[2] == 1 and row[3] == "u" for row in notification_indexes)
+
+
+def test_session_storage_rejects_non_canonical_schema_missing_runtime_columns(
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "invalid-sessions.sqlite3"
     with closing(sqlite3.connect(database_path)) as connection:
         _ = connection.execute(
             """
@@ -73,8 +133,6 @@ def test_session_storage_migrates_legacy_schema_for_parent_lineage(tmp_path: Pat
                 prompt TEXT NOT NULL,
                 output TEXT,
                 metadata_json TEXT NOT NULL,
-                pending_approval_json TEXT,
-                resume_checkpoint_json TEXT,
                 created_at INTEGER NOT NULL,
                 updated_at INTEGER NOT NULL,
                 last_event_sequence INTEGER NOT NULL
@@ -131,71 +189,143 @@ def test_session_storage_migrates_legacy_schema_for_parent_lineage(tmp_path: Pat
             )
             """
         )
-        _ = connection.execute(
-            """
-            INSERT INTO sessions (
-                session_id, workspace, status, turn, prompt, output, metadata_json,
-                pending_approval_json, resume_checkpoint_json, created_at, updated_at,
-                last_event_sequence
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                "legacy-session",
-                str(tmp_path),
-                "completed",
-                1,
-                "legacy",
-                "done",
-                "{}",
-                None,
-                None,
-                1,
-                1,
-                0,
-            ),
-        )
-        _ = connection.execute("PRAGMA user_version = 4")
         connection.commit()
 
     store = SqliteSessionStore(database_path=database_path)
-    loaded = store.load_session(workspace=tmp_path, session_id="legacy-session")
-    task = BackgroundTaskState(
-        task=BackgroundTaskRef(id="task-parent-lineage"),
-        request=BackgroundTaskRequestSnapshot(
-            prompt="child background task",
-            parent_session_id="leader-session",
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"table 'sessions' missing columns: .*"
+            r"Remove '.*/invalid-sessions\.sqlite3' and rerun to reset local runtime storage\."
         ),
-        created_at=1,
-        updated_at=1,
-    )
-
-    store.create_background_task(workspace=tmp_path, task=task)
-    loaded_task = store.load_background_task(
-        workspace=tmp_path,
-        task_id="task-parent-lineage",
-    )
+    ):
+        store.list_sessions(workspace=tmp_path)
 
     with closing(sqlite3.connect(database_path)) as connection:
         session_columns = {
             row[1] for row in connection.execute("PRAGMA table_info(sessions)").fetchall()
         }
-        background_task_columns = {
-            row[1] for row in connection.execute("PRAGMA table_info(background_tasks)").fetchall()
-        }
-        delivery_tables = {
-            row[0]
-            for row in connection.execute(
-                "SELECT name FROM sqlite_master WHERE type = 'table'"
-            ).fetchall()
-        }
-        user_version = connection.execute("PRAGMA user_version").fetchone()[0]
 
-    assert loaded.session.session.parent_id is None
-    assert "parent_session_id" in session_columns
-    assert "request_parent_session_id" in background_task_columns
-    assert "session_event_deliveries" in delivery_tables
-    assert loaded_task.request.parent_session_id == "leader-session"
-    assert user_version == 8
+    assert "parent_session_id" not in session_columns
+    assert "pending_approval_json" not in session_columns
+
+
+def test_session_storage_rejects_non_canonical_schema_with_wrong_existing_table_shape(
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "wrong-table-shape.sqlite3"
+    with closing(sqlite3.connect(database_path)) as connection:
+        _ = connection.execute(
+            """
+            CREATE TABLE sessions (
+                session_id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                workspace TEXT NOT NULL,
+                status TEXT NOT NULL,
+                turn INTEGER NOT NULL,
+                prompt TEXT NOT NULL,
+                output TEXT,
+                metadata_json TEXT NOT NULL,
+                pending_approval_json TEXT,
+                pending_question_json TEXT,
+                resume_checkpoint_json TEXT,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                last_event_sequence INTEGER NOT NULL
+            )
+            """
+        )
+        _ = connection.execute(
+            """
+            CREATE TABLE session_events (
+                session_id TEXT NOT NULL,
+                sequence INTEGER NOT NULL,
+                event_type TEXT NOT NULL,
+                source TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                PRIMARY KEY (session_id, sequence)
+            )
+            """
+        )
+        _ = connection.execute(
+            """
+            CREATE TABLE background_tasks (
+                task_id TEXT PRIMARY KEY,
+                workspace TEXT NOT NULL,
+                status TEXT NOT NULL,
+                prompt TEXT NOT NULL,
+                request_session_id TEXT,
+                request_parent_session_id TEXT,
+                request_metadata_json TEXT NOT NULL,
+                requested_child_session_id TEXT,
+                routing_mode TEXT,
+                routing_category TEXT,
+                routing_subagent_type TEXT,
+                routing_description TEXT,
+                routing_command TEXT,
+                approval_request_id TEXT,
+                question_request_id TEXT,
+                cancellation_cause TEXT,
+                result_available INTEGER NOT NULL DEFAULT 0,
+                allocate_session_id INTEGER NOT NULL,
+                session_id TEXT,
+                error TEXT,
+                cancel_requested_at INTEGER,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                started_at INTEGER,
+                finished_at INTEGER
+            )
+            """
+        )
+        _ = connection.execute(
+            """
+            CREATE TABLE session_notifications (
+                notification_id TEXT PRIMARY KEY,
+                workspace TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                status TEXT NOT NULL,
+                summary TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                event_sequence INTEGER NOT NULL,
+                dedupe_key TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                acknowledged_at INTEGER,
+                UNIQUE(workspace, dedupe_key)
+            )
+            """
+        )
+        _ = connection.execute(
+            """
+            CREATE TABLE session_event_deliveries (
+                workspace TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                delivered_at INTEGER NOT NULL,
+                PRIMARY KEY (workspace, session_id)
+            )
+            """
+        )
+        connection.commit()
+
+    store = SqliteSessionStore(database_path=database_path)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"table 'session_event_deliveries' missing columns: dedupe_key.*"
+            r"Remove '.*/wrong-table-shape\.sqlite3' and rerun to reset local runtime storage\."
+        ),
+    ):
+        store.list_notifications(workspace=tmp_path)
+
+    with closing(sqlite3.connect(database_path)) as connection:
+        delivery_columns = {
+            row[1]
+            for row in connection.execute("PRAGMA table_info(session_event_deliveries)").fetchall()
+        }
+
+    assert "dedupe_key" not in delivery_columns
 
 
 def test_tool_results_from_events_keeps_success_payloads_with_null_error() -> None:
@@ -270,6 +400,63 @@ def test_tool_results_from_events_preserves_successful_null_content() -> None:
             "error": None,
         }
     ]
+
+
+def test_session_storage_load_resume_checkpoint_rejects_corrupt_json(tmp_path: Path) -> None:
+    store = SqliteSessionStore()
+    request = RuntimeRequest(prompt="go", session_id="checkpoint-corrupt-json")
+    response = RuntimeResponse(
+        session=SessionState(
+            session=SessionRef(id="checkpoint-corrupt-json"),
+            status="waiting",
+            turn=1,
+            metadata={},
+        ),
+        events=(),
+    )
+    store.save_run(workspace=tmp_path, request=request, response=response)
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    with closing(sqlite3.connect(database_path)) as connection:
+        _ = connection.execute(
+            "UPDATE sessions SET resume_checkpoint_json = ? WHERE session_id = ?",
+            ("{broken json", "checkpoint-corrupt-json"),
+        )
+        connection.commit()
+
+    with pytest.raises(ValueError, match="persisted resume checkpoint JSON is malformed"):
+        _ = store.load_resume_checkpoint(workspace=tmp_path, session_id="checkpoint-corrupt-json")
+
+
+def test_session_storage_load_resume_checkpoint_rejects_invalid_kind(tmp_path: Path) -> None:
+    store = SqliteSessionStore()
+    request = RuntimeRequest(prompt="go", session_id="checkpoint-invalid-kind")
+    response = RuntimeResponse(
+        session=SessionState(
+            session=SessionRef(id="checkpoint-invalid-kind"),
+            status="waiting",
+            turn=1,
+            metadata={},
+        ),
+        events=(),
+    )
+    store.save_run(workspace=tmp_path, request=request, response=response)
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    with closing(sqlite3.connect(database_path)) as connection:
+        _ = connection.execute(
+            "UPDATE sessions SET resume_checkpoint_json = ? WHERE session_id = ?",
+            (
+                '{"kind":"not-real","version":1}',
+                "checkpoint-invalid-kind",
+            ),
+        )
+        connection.commit()
+
+    with pytest.raises(
+        ValueError, match=r"persisted resume checkpoint kind is invalid: 'not-real'"
+    ):
+        _ = store.load_resume_checkpoint(workspace=tmp_path, session_id="checkpoint-invalid-kind")
 
 
 def test_session_storage_append_session_event_assigns_sequence_and_dedupes(


### PR DESCRIPTION
## Summary
- harden runtime LSP request handling with shared request sequencing, header/body bounds, and malformed-message protocol errors
- normalize tool-facing LSP protocol failures so callers receive stable validation-style errors instead of leaking runtime internals
- add unit and integration regressions covering oversized messages, invalid payloads, shared-server request ids, and protocol failure surfacing

## Verification
- uv run pytest tests/unit/runtime/test_lsp.py -q
- uv run pytest tests/integration/test_lsp_tool_integration.py -q
- uv run ruff check .
- uv run basedpyright --warnings src
- uv run pytest
- bun run lint
- bun run typecheck
- bun run test:run

Closes #212