### PR TITLE
feat: introduce modular command system

### DIFF
--- a/src/voidcode/command/README.md
+++ b/src/voidcode/command/README.md
@@ -1,0 +1,31 @@
+# Command system
+
+`voidcode.command` owns command definitions, discovery, resolution, and command-adjacent events.
+
+## Boundaries
+
+- **Prompt commands / slash commands** render into runtime prompts before graph execution.
+- **Tool instructions** (`read`, `grep`, `run`, `write`) are parsed here so graph and provider paths share one implementation.
+- **TUI commands** are local UI actions identified by stable IDs and are intentionally separate from prompt commands.
+
+## Sources
+
+The MVP loader merges commands in this order, with later sources overriding earlier ones:
+
+1. builtin commands
+2. optional user command directory
+3. project-local `commands/**/*.md`
+4. project-local `.voidcode/commands/**/*.md`
+
+Markdown command files may include simple YAML-like frontmatter:
+
+```md
+---
+description: Review a target
+agent: reviewer
+enabled: true
+---
+Review $1 with full context: $ARGUMENTS
+```
+
+Templates currently support `$ARGUMENTS` and `$1` through `$9`. Argument splitting uses `shlex` so quoted arguments are preserved.

--- a/src/voidcode/command/__init__.py
+++ b/src/voidcode/command/__init__.py
@@ -4,7 +4,7 @@ from .events import COMMAND_EXECUTE_AFTER, COMMAND_EXECUTE_BEFORE, COMMAND_FAILE
 from .loader import builtin_commands, load_command_registry, load_markdown_commands
 from .models import CommandDefinition, CommandInvocation, CommandResolution, UICommandDefinition
 from .registry import CommandRegistry, UICommandRegistry
-from .resolver import resolve_prompt_command, resolve_tool_instruction
+from .resolver import is_prompt_command, resolve_prompt_command, resolve_tool_instruction
 from .ui import DEFAULT_TUI_COMMANDS, default_tui_command_registry
 
 __all__ = [
@@ -21,6 +21,7 @@ __all__ = [
     "UICommandRegistry",
     "builtin_commands",
     "default_tui_command_registry",
+    "is_prompt_command",
     "load_command_registry",
     "load_markdown_commands",
     "resolve_prompt_command",

--- a/src/voidcode/command/__init__.py
+++ b/src/voidcode/command/__init__.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from .events import COMMAND_EXECUTE_AFTER, COMMAND_EXECUTE_BEFORE, COMMAND_FAILED, COMMAND_RESOLVED
+from .loader import builtin_commands, load_command_registry, load_markdown_commands
+from .models import CommandDefinition, CommandInvocation, CommandResolution, UICommandDefinition
+from .registry import CommandRegistry, UICommandRegistry
+from .resolver import resolve_prompt_command, resolve_tool_instruction
+from .ui import DEFAULT_TUI_COMMANDS, default_tui_command_registry
+
+__all__ = [
+    "COMMAND_EXECUTE_AFTER",
+    "COMMAND_EXECUTE_BEFORE",
+    "COMMAND_FAILED",
+    "COMMAND_RESOLVED",
+    "DEFAULT_TUI_COMMANDS",
+    "CommandDefinition",
+    "CommandInvocation",
+    "CommandRegistry",
+    "CommandResolution",
+    "UICommandDefinition",
+    "UICommandRegistry",
+    "builtin_commands",
+    "default_tui_command_registry",
+    "load_command_registry",
+    "load_markdown_commands",
+    "resolve_prompt_command",
+    "resolve_tool_instruction",
+]

--- a/src/voidcode/command/events.py
+++ b/src/voidcode/command/events.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+COMMAND_RESOLVED = "command.resolved"
+COMMAND_EXECUTE_BEFORE = "command.execute.before"
+COMMAND_EXECUTE_AFTER = "command.execute.after"
+COMMAND_FAILED = "command.failed"

--- a/src/voidcode/command/loader.py
+++ b/src/voidcode/command/loader.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+from .models import CommandDefinition, CommandSource
+from .registry import CommandRegistry
+
+_BUILTIN_COMMANDS: tuple[CommandDefinition, ...] = (
+    CommandDefinition(
+        name="help",
+        description="Explain the available VoidCode command surfaces and how to use them.",
+        template=(
+            "Explain the available VoidCode prompt commands, runtime tools, and TUI commands. "
+            "Include any user-provided focus: $ARGUMENTS"
+        ),
+        source="builtin",
+    ),
+    CommandDefinition(
+        name="review",
+        description="Review the requested code or change set.",
+        template="Review the following target and report findings with severity: $ARGUMENTS",
+        source="builtin",
+    ),
+)
+
+_SOURCE_PRECEDENCE: tuple[CommandSource, ...] = ("builtin", "user", "project", "skill", "mcp")
+
+
+def builtin_commands() -> tuple[CommandDefinition, ...]:
+    return _BUILTIN_COMMANDS
+
+
+def load_command_registry(
+    *,
+    workspace: Path,
+    user_commands_dir: Path | None = None,
+) -> CommandRegistry:
+    registry = CommandRegistry()
+    for command in _commands_by_precedence(
+        workspace=workspace, user_commands_dir=user_commands_dir
+    ):
+        registry.register(command)
+    return registry
+
+
+def _commands_by_precedence(
+    *,
+    workspace: Path,
+    user_commands_dir: Path | None,
+) -> Iterable[CommandDefinition]:
+    yield from builtin_commands()
+    if user_commands_dir is not None:
+        yield from load_markdown_commands(user_commands_dir, source="user")
+    yield from load_markdown_commands(workspace / "commands", source="project")
+    yield from load_markdown_commands(workspace / ".voidcode" / "commands", source="project")
+
+
+def load_markdown_commands(
+    directory: Path, *, source: CommandSource
+) -> tuple[CommandDefinition, ...]:
+    if source not in _SOURCE_PRECEDENCE:
+        raise ValueError(f"unsupported command source: {source}")
+    if not directory.exists():
+        return ()
+    if not directory.is_dir():
+        raise ValueError(f"command path is not a directory: {directory}")
+
+    commands: list[CommandDefinition] = []
+    for path in sorted(directory.rglob("*.md")):
+        if not path.is_file():
+            continue
+        commands.append(_load_markdown_command(path, root=directory, source=source))
+    return tuple(commands)
+
+
+def _load_markdown_command(path: Path, *, root: Path, source: CommandSource) -> CommandDefinition:
+    text = path.read_text(encoding="utf-8")
+    metadata, template = _split_frontmatter(text)
+    relative_name = path.relative_to(root).with_suffix("").as_posix()
+    raw_name = metadata.get("name", relative_name)
+    description = metadata.get("description")
+    if not isinstance(raw_name, str) or not raw_name.strip():
+        raise ValueError(f"command {path} has invalid name")
+    if not isinstance(description, str) or not description.strip():
+        description = raw_name.strip()
+    return CommandDefinition(
+        name=raw_name,
+        description=description.strip(),
+        template=template,
+        source=source,
+        agent=_optional_string(metadata.get("agent")),
+        model=_optional_string(metadata.get("model")),
+        subtask=_metadata_bool(metadata.get("subtask"), default=False),
+        enabled=_metadata_bool(metadata.get("enabled"), default=True),
+        hidden=_metadata_bool(metadata.get("hidden"), default=False),
+        path=path,
+    )
+
+
+def _split_frontmatter(text: str) -> tuple[dict[str, object], str]:
+    if not text.startswith("---\n"):
+        return {}, text
+    end = text.find("\n---\n", 4)
+    if end < 0:
+        return {}, text
+    raw_frontmatter = text[4:end]
+    body = text[end + len("\n---\n") :]
+    return _parse_simple_frontmatter(raw_frontmatter), body
+
+
+def _parse_simple_frontmatter(raw_frontmatter: str) -> dict[str, object]:
+    metadata: dict[str, object] = {}
+    for line_number, line in enumerate(raw_frontmatter.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        key, separator, value = stripped.partition(":")
+        if not separator:
+            raise ValueError(f"invalid command frontmatter line {line_number}: {line}")
+        normalized_key = key.strip()
+        if not normalized_key:
+            raise ValueError(f"invalid command frontmatter line {line_number}: {line}")
+        metadata[normalized_key] = _parse_scalar(value.strip())
+    return metadata
+
+
+def _parse_scalar(value: str) -> object:
+    if value in {"true", "True"}:
+        return True
+    if value in {"false", "False"}:
+        return False
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    return value
+
+
+def _optional_string(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    raise ValueError("command optional string frontmatter values must be non-empty strings")
+
+
+def _metadata_bool(value: object, *, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    raise ValueError("command boolean frontmatter values must be booleans")

--- a/src/voidcode/command/models.py
+++ b/src/voidcode/command/models.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+CommandSource = Literal["builtin", "user", "project", "skill", "mcp"]
+
+
+@dataclass(frozen=True, slots=True)
+class CommandDefinition:
+    """A prompt/slash command definition that renders into a runtime prompt."""
+
+    name: str
+    description: str
+    template: str
+    source: CommandSource = "builtin"
+    arguments_schema: dict[str, object] | None = None
+    agent: str | None = None
+    model: str | None = None
+    subtask: bool = False
+    enabled: bool = True
+    hidden: bool = False
+    path: Path | None = None
+
+    def __post_init__(self) -> None:
+        normalized_name = normalize_command_name(self.name)
+        if not normalized_name:
+            raise ValueError("command name must be a non-empty string")
+        object.__setattr__(self, "name", normalized_name)
+        if not self.description:
+            raise ValueError("command description must be a non-empty string")
+        if not self.template.strip():
+            raise ValueError("command template must be a non-empty string")
+
+
+@dataclass(frozen=True, slots=True)
+class CommandInvocation:
+    """Structured representation of a resolved prompt command."""
+
+    name: str
+    source: CommandSource
+    arguments: tuple[str, ...]
+    raw_arguments: str
+    original_prompt: str
+    rendered_prompt: str
+
+
+@dataclass(frozen=True, slots=True)
+class CommandResolution:
+    definition: CommandDefinition
+    invocation: CommandInvocation
+
+
+@dataclass(frozen=True, slots=True)
+class UICommandDefinition:
+    """A command palette action that executes locally in the TUI."""
+
+    id: str
+    title: str
+    description: str
+    enabled: bool = True
+    hidden: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.id.strip():
+            raise ValueError("UI command id must be a non-empty string")
+        if not self.title.strip():
+            raise ValueError("UI command title must be a non-empty string")
+        if not self.description.strip():
+            raise ValueError("UI command description must be a non-empty string")
+
+
+def normalize_command_name(name: str) -> str:
+    return name.strip().removeprefix("/").replace("\\", "/")

--- a/src/voidcode/command/registry.py
+++ b/src/voidcode/command/registry.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from .models import CommandDefinition, UICommandDefinition, normalize_command_name
+
+
+class CommandRegistry:
+    """Mergeable registry for prompt/slash commands.
+
+    Later registrations override earlier definitions with the same name, which lets project-local
+    commands override builtin commands without special-case lookup logic.
+    """
+
+    def __init__(self, commands: Iterable[CommandDefinition] = ()) -> None:
+        self._commands: dict[str, CommandDefinition] = {}
+        for command in commands:
+            self.register(command)
+
+    def register(self, command: CommandDefinition) -> None:
+        self._commands[command.name] = command
+
+    def get(self, name: str) -> CommandDefinition | None:
+        return self._commands.get(normalize_command_name(name))
+
+    def list(
+        self, *, include_hidden: bool = False, include_disabled: bool = False
+    ) -> tuple[CommandDefinition, ...]:
+        commands = sorted(self._commands.values(), key=lambda command: command.name)
+        return tuple(
+            command
+            for command in commands
+            if (include_hidden or not command.hidden) and (include_disabled or command.enabled)
+        )
+
+
+class UICommandRegistry:
+    """Registry for local TUI commands that do not enter the LLM/runtime prompt path."""
+
+    def __init__(self, commands: Iterable[UICommandDefinition] = ()) -> None:
+        self._commands: dict[str, UICommandDefinition] = {}
+        for command in commands:
+            self.register(command)
+
+    def register(self, command: UICommandDefinition) -> None:
+        self._commands[command.id] = command
+
+    def get(self, command_id: str) -> UICommandDefinition | None:
+        return self._commands.get(command_id)
+
+    def list(
+        self, *, include_hidden: bool = False, include_disabled: bool = False
+    ) -> tuple[UICommandDefinition, ...]:
+        commands = sorted(self._commands.values(), key=lambda command: command.title)
+        return tuple(
+            command
+            for command in commands
+            if (include_hidden or not command.hidden) and (include_disabled or command.enabled)
+        )

--- a/src/voidcode/command/resolver.py
+++ b/src/voidcode/command/resolver.py
@@ -24,6 +24,10 @@ class ToolCommandResolution:
     tool_call: ToolCall
 
 
+def is_prompt_command(prompt: str) -> bool:
+    return prompt.strip().startswith("/")
+
+
 def resolve_prompt_command(prompt: str, registry: CommandRegistry) -> CommandResolution | None:
     first_line, raw_arguments = _parse_slash_command(prompt)
     if first_line is None:

--- a/src/voidcode/command/resolver.py
+++ b/src/voidcode/command/resolver.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from ..tools.contracts import ToolCall, ToolDefinition
+from .models import CommandInvocation, CommandResolution
+from .registry import CommandRegistry
+from .templating import render_command_template, split_command_arguments
+
+READ_REQUEST_PATTERN = re.compile(r"^(read|show)\s+(?P<path>.+)$", re.IGNORECASE)
+GREP_REQUEST_PATTERN = re.compile(r"^grep\s+(?P<pattern>.+?)\s+(?P<path>\S+)$", re.IGNORECASE)
+RUN_REQUEST_PATTERN = re.compile(r"^run\s+(?P<command>.+)$", re.IGNORECASE)
+WRITE_REQUEST_PATTERN = re.compile(r"^write\s+(?P<path>\S+)\s+(?P<content>.+)$", re.IGNORECASE)
+UNSUPPORTED_TOOL_COMMAND_MESSAGE = (
+    "unsupported request: use 'read <relative-path>', 'show <relative-path>', "
+    "'grep <pattern> <relative-path>', 'run <command>', or "
+    "'write <relative-path> <content>'"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCommandResolution:
+    tool_call: ToolCall
+
+
+def resolve_prompt_command(prompt: str, registry: CommandRegistry) -> CommandResolution | None:
+    first_line, raw_arguments = _parse_slash_command(prompt)
+    if first_line is None:
+        return None
+    definition = registry.get(first_line)
+    if definition is None:
+        raise ValueError(f"unknown command: /{first_line}")
+    if not definition.enabled:
+        raise ValueError(f"command is disabled: /{definition.name}")
+    arguments = split_command_arguments(raw_arguments)
+    rendered_prompt = render_command_template(
+        definition.template,
+        raw_arguments=raw_arguments,
+        arguments=arguments,
+    )
+    return CommandResolution(
+        definition=definition,
+        invocation=CommandInvocation(
+            name=definition.name,
+            source=definition.source,
+            arguments=arguments,
+            raw_arguments=raw_arguments,
+            original_prompt=prompt,
+            rendered_prompt=rendered_prompt,
+        ),
+    )
+
+
+def resolve_tool_instruction(
+    instruction: str,
+    available_tools: tuple[ToolDefinition, ...],
+    *,
+    unavailable_message_suffix: str,
+) -> ToolCommandResolution:
+    read_match = READ_REQUEST_PATTERN.match(instruction)
+    if read_match is not None:
+        path_text = read_match.group("path").strip()
+        if not path_text:
+            raise ValueError("request path must not be empty")
+        _ensure_tool(
+            available_tools, "read_file", read_only=True, suffix=unavailable_message_suffix
+        )
+        return ToolCommandResolution(
+            ToolCall(tool_name="read_file", arguments={"filePath": path_text})
+        )
+
+    grep_match = GREP_REQUEST_PATTERN.match(instruction)
+    if grep_match is not None:
+        pattern_text = grep_match.group("pattern").strip()
+        path_text = grep_match.group("path").strip()
+        if not pattern_text:
+            raise ValueError("request pattern must not be empty")
+        if not path_text:
+            raise ValueError("request path must not be empty")
+        _ensure_tool(available_tools, "grep", read_only=True, suffix=unavailable_message_suffix)
+        return ToolCommandResolution(
+            ToolCall(tool_name="grep", arguments={"pattern": pattern_text, "path": path_text})
+        )
+
+    run_match = RUN_REQUEST_PATTERN.match(instruction)
+    if run_match is not None:
+        command_text = run_match.group("command").strip()
+        if not command_text:
+            raise ValueError("request command must not be empty")
+        _ensure_tool(
+            available_tools, "shell_exec", read_only=False, suffix=unavailable_message_suffix
+        )
+        return ToolCommandResolution(
+            ToolCall(tool_name="shell_exec", arguments={"command": command_text})
+        )
+
+    write_match = WRITE_REQUEST_PATTERN.match(instruction)
+    if write_match is not None:
+        path_text = write_match.group("path").strip()
+        content_text = write_match.group("content")
+        if not path_text:
+            raise ValueError("request path must not be empty")
+        if not content_text:
+            raise ValueError("request content must not be empty")
+        _ensure_tool(
+            available_tools, "write_file", read_only=False, suffix=unavailable_message_suffix
+        )
+        return ToolCommandResolution(
+            ToolCall(tool_name="write_file", arguments={"path": path_text, "content": content_text})
+        )
+
+    raise ValueError(UNSUPPORTED_TOOL_COMMAND_MESSAGE)
+
+
+def _parse_slash_command(prompt: str) -> tuple[str | None, str]:
+    stripped = prompt.strip()
+    if not stripped.startswith("/"):
+        return None, ""
+    first_line = stripped.splitlines()[0]
+    command_text = first_line[1:].strip()
+    if not command_text:
+        raise ValueError("command name must not be empty")
+    name, separator, raw_arguments = command_text.partition(" ")
+    if not separator:
+        raw_arguments = ""
+    return name, raw_arguments.strip()
+
+
+def _ensure_tool(
+    tools: tuple[ToolDefinition, ...],
+    tool_name: str,
+    *,
+    read_only: bool,
+    suffix: str,
+) -> None:
+    if any(tool.name == tool_name and tool.read_only is read_only for tool in tools):
+        return
+    raise ValueError(f"{tool_name} tool is not registered for {suffix}")

--- a/src/voidcode/command/templating.py
+++ b/src/voidcode/command/templating.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import re
 import shlex
+
+_PLACEHOLDER_PATTERN = re.compile(r"\$(ARGUMENTS(?![A-Za-z0-9_])|[1-9](?!\d))")
 
 
 def split_command_arguments(arguments: str) -> tuple[str, ...]:
@@ -12,11 +15,13 @@ def split_command_arguments(arguments: str) -> tuple[str, ...]:
 def render_command_template(
     template: str, *, raw_arguments: str, arguments: tuple[str, ...]
 ) -> str:
-    rendered = template.replace("$ARGUMENTS", raw_arguments)
-    for index, value in enumerate(arguments, start=1):
-        rendered = rendered.replace(f"${index}", value)
-    # Unbound positional placeholders should render as empty strings rather than leaking
-    # implementation details into the prompt.
-    for index in range(len(arguments) + 1, 10):
-        rendered = rendered.replace(f"${index}", "")
-    return rendered.strip()
+    def replacement(match: re.Match[str]) -> str:
+        token = match.group(1)
+        if token == "ARGUMENTS":
+            return raw_arguments
+        index = int(token) - 1
+        if index >= len(arguments):
+            return ""
+        return arguments[index]
+
+    return _PLACEHOLDER_PATTERN.sub(replacement, template).strip()

--- a/src/voidcode/command/templating.py
+++ b/src/voidcode/command/templating.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import shlex
+
+
+def split_command_arguments(arguments: str) -> tuple[str, ...]:
+    if not arguments.strip():
+        return ()
+    return tuple(shlex.split(arguments, posix=True))
+
+
+def render_command_template(
+    template: str, *, raw_arguments: str, arguments: tuple[str, ...]
+) -> str:
+    rendered = template.replace("$ARGUMENTS", raw_arguments)
+    for index, value in enumerate(arguments, start=1):
+        rendered = rendered.replace(f"${index}", value)
+    # Unbound positional placeholders should render as empty strings rather than leaking
+    # implementation details into the prompt.
+    for index in range(len(arguments) + 1, 10):
+        rendered = rendered.replace(f"${index}", "")
+    return rendered.strip()

--- a/src/voidcode/command/ui.py
+++ b/src/voidcode/command/ui.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from .models import UICommandDefinition
+from .registry import UICommandRegistry
+
+DEFAULT_TUI_COMMANDS: tuple[UICommandDefinition, ...] = (
+    UICommandDefinition("session.new", "session: new", "Start a new local session."),
+    UICommandDefinition("session.resume", "session: resume", "Resume a persisted session."),
+    UICommandDefinition("theme.switch", "theme: switch", "Select a TUI theme."),
+    UICommandDefinition("theme.mode", "theme: mode", "Switch the TUI theme mode."),
+    UICommandDefinition("view.wrap", "view: wrap", "Toggle transcript wrapping."),
+    UICommandDefinition("view.sidebar", "view: sidebar", "Toggle the sidebar."),
+)
+
+
+def default_tui_command_registry() -> UICommandRegistry:
+    return UICommandRegistry(DEFAULT_TUI_COMMANDS)

--- a/src/voidcode/graph/deterministic_graph.py
+++ b/src/voidcode/graph/deterministic_graph.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 # pyright: reportMissingTypeStubs=false
-import re
 from dataclasses import dataclass
 from typing import Protocol, cast
 
 from langgraph.graph import END, START, StateGraph
 
+from ..command.resolver import resolve_tool_instruction
 from ..runtime.context_window import normalize_read_file_output
 from ..runtime.events import (
     GRAPH_LOOP_STEP,
@@ -16,11 +16,6 @@ from ..runtime.events import (
 from ..runtime.session import SessionState
 from ..tools.contracts import ToolCall, ToolDefinition, ToolResult
 from .contracts import GraphEvent, GraphLoopState, GraphRunRequest
-
-READ_REQUEST_PATTERN = re.compile(r"^(read|show)\s+(?P<path>.+)$", re.IGNORECASE)
-GREP_REQUEST_PATTERN = re.compile(r"^grep\s+(?P<pattern>.+?)\s+(?P<path>\S+)$", re.IGNORECASE)
-RUN_REQUEST_PATTERN = re.compile(r"^run\s+(?P<command>.+)$", re.IGNORECASE)
-WRITE_REQUEST_PATTERN = re.compile(r"^write\s+(?P<path>\S+)\s+(?P<content>.+)$", re.IGNORECASE)
 
 
 class _CompiledGraphApp(Protocol):
@@ -225,62 +220,12 @@ class DeterministicGraph:
         if step_index >= len(commands):
             return None
 
-        trimmed_prompt = commands[step_index]
-
-        read_match = READ_REQUEST_PATTERN.match(trimmed_prompt)
-        if read_match is not None:
-            path_text = read_match.group("path").strip()
-            if not path_text:
-                raise ValueError("request path must not be empty")
-
-            self._ensure_read_tool_available(available_tools)
-            return ToolCall(tool_name="read_file", arguments={"filePath": path_text})
-
-        grep_match = GREP_REQUEST_PATTERN.match(trimmed_prompt)
-        if grep_match is not None:
-            pattern_text = grep_match.group("pattern").strip()
-            path_text = grep_match.group("path").strip()
-            if not pattern_text:
-                raise ValueError("request pattern must not be empty")
-            if not path_text:
-                raise ValueError("request path must not be empty")
-
-            self._ensure_grep_tool_available(available_tools)
-            return ToolCall(
-                tool_name="grep",
-                arguments={"pattern": pattern_text, "path": path_text},
-            )
-
-        run_match = RUN_REQUEST_PATTERN.match(trimmed_prompt)
-        if run_match is not None:
-            command_text = run_match.group("command").strip()
-            if not command_text:
-                raise ValueError("request command must not be empty")
-
-            self._ensure_shell_exec_tool_available(available_tools)
-            return ToolCall(tool_name="shell_exec", arguments={"command": command_text})
-
-        write_match = WRITE_REQUEST_PATTERN.match(trimmed_prompt)
-        if write_match is not None:
-            path_text = write_match.group("path").strip()
-            content_text = write_match.group("content")
-            if not path_text:
-                raise ValueError("request path must not be empty")
-            if not content_text:
-                raise ValueError("request content must not be empty")
-
-            self._ensure_write_tool_available(available_tools)
-            return ToolCall(
-                tool_name="write_file",
-                arguments={"path": path_text, "content": content_text},
-            )
-
-        msg = (
-            "unsupported request: use 'read <relative-path>', 'show <relative-path>', "
-            "'grep <pattern> <relative-path>', 'run <command>', or "
-            "'write <relative-path> <content>'"
+        resolution = resolve_tool_instruction(
+            commands[step_index],
+            available_tools,
+            unavailable_message_suffix="graph execution",
         )
-        raise ValueError(msg)
+        return resolution.tool_call
 
     @staticmethod
     def _graph_event(event_type: str, payload: dict[str, object]) -> GraphEvent:
@@ -289,23 +234,3 @@ class DeterministicGraph:
             source="graph",
             payload=payload,
         )
-
-    def _ensure_read_tool_available(self, tools: tuple[ToolDefinition, ...]) -> None:
-        if any(tool.name == "read_file" and tool.read_only for tool in tools):
-            return
-        raise ValueError("read_file tool is not registered for graph execution")
-
-    def _ensure_grep_tool_available(self, tools: tuple[ToolDefinition, ...]) -> None:
-        if any(tool.name == "grep" and tool.read_only for tool in tools):
-            return
-        raise ValueError("grep tool is not registered for graph execution")
-
-    def _ensure_write_tool_available(self, tools: tuple[ToolDefinition, ...]) -> None:
-        if any(tool.name == "write_file" and not tool.read_only for tool in tools):
-            return
-        raise ValueError("write_file tool is not registered for graph execution")
-
-    def _ensure_shell_exec_tool_available(self, tools: tuple[ToolDefinition, ...]) -> None:
-        if any(tool.name == "shell_exec" and not tool.read_only for tool in tools):
-            return
-        raise ValueError("shell_exec tool is not registered for graph execution")

--- a/src/voidcode/provider/protocol.py
+++ b/src/voidcode/provider/protocol.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import re
 import time
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Literal, Protocol, runtime_checkable
 
+from ..command.resolver import resolve_tool_instruction
 from ..runtime.context_window import normalize_read_file_output
 from ..tools.contracts import ToolCall, ToolDefinition, ToolResult
 
@@ -13,11 +13,6 @@ type AppliedSkill = dict[str, str]
 type ProviderStreamEventKind = Literal["delta", "content", "error", "done"]
 type ProviderStreamChannel = Literal["text", "tool", "reasoning", "error"]
 type ProviderDoneReason = Literal["completed", "cancelled", "error"]
-
-READ_REQUEST_PATTERN = re.compile(r"^(read|show)\s+(?P<path>.+)$", re.IGNORECASE)
-GREP_REQUEST_PATTERN = re.compile(r"^grep\s+(?P<pattern>.+?)\s+(?P<path>\S+)$", re.IGNORECASE)
-RUN_REQUEST_PATTERN = re.compile(r"^run\s+(?P<command>.+)$", re.IGNORECASE)
-WRITE_REQUEST_PATTERN = re.compile(r"^write\s+(?P<path>\S+)\s+(?P<content>.+)$", re.IGNORECASE)
 
 
 @runtime_checkable
@@ -215,62 +210,12 @@ class StubTurnProvider:
             last_result = request.context_window.tool_results[-1]
             return ProviderTurnResult(output=_normalize_tool_output(last_result.content))
 
-        trimmed_prompt = commands[step_index]
-
-        read_match = READ_REQUEST_PATTERN.match(trimmed_prompt)
-        if read_match is not None:
-            path_text = read_match.group("path").strip()
-            if not path_text:
-                raise ValueError("request path must not be empty")
-            self._ensure_tool(request.available_tools, "read_file", read_only=True)
-            return ProviderTurnResult(tool_call=ToolCall("read_file", {"filePath": path_text}))
-
-        grep_match = GREP_REQUEST_PATTERN.match(trimmed_prompt)
-        if grep_match is not None:
-            pattern_text = grep_match.group("pattern").strip()
-            path_text = grep_match.group("path").strip()
-            if not pattern_text:
-                raise ValueError("request pattern must not be empty")
-            if not path_text:
-                raise ValueError("request path must not be empty")
-            self._ensure_tool(request.available_tools, "grep", read_only=True)
-            return ProviderTurnResult(
-                tool_call=ToolCall("grep", {"pattern": pattern_text, "path": path_text})
-            )
-
-        run_match = RUN_REQUEST_PATTERN.match(trimmed_prompt)
-        if run_match is not None:
-            command_text = run_match.group("command").strip()
-            if not command_text:
-                raise ValueError("request command must not be empty")
-            self._ensure_tool(request.available_tools, "shell_exec", read_only=False)
-            return ProviderTurnResult(tool_call=ToolCall("shell_exec", {"command": command_text}))
-
-        write_match = WRITE_REQUEST_PATTERN.match(trimmed_prompt)
-        if write_match is not None:
-            path_text = write_match.group("path").strip()
-            content_text = write_match.group("content")
-            if not path_text:
-                raise ValueError("request path must not be empty")
-            if not content_text:
-                raise ValueError("request content must not be empty")
-            self._ensure_tool(request.available_tools, "write_file", read_only=False)
-            return ProviderTurnResult(
-                tool_call=ToolCall("write_file", {"path": path_text, "content": content_text})
-            )
-
-        msg = (
-            "unsupported request: use 'read <relative-path>', 'show <relative-path>', "
-            "'grep <pattern> <relative-path>', 'run <command>', or "
-            "'write <relative-path> <content>'"
+        resolution = resolve_tool_instruction(
+            commands[step_index],
+            request.available_tools,
+            unavailable_message_suffix="single-agent execution",
         )
-        raise ValueError(msg)
-
-    @staticmethod
-    def _ensure_tool(tools: tuple[ToolDefinition, ...], tool_name: str, *, read_only: bool) -> None:
-        if any(tool.name == tool_name and tool.read_only is read_only for tool in tools):
-            return
-        raise ValueError(f"{tool_name} tool is not registered for single-agent execution")
+        return ProviderTurnResult(tool_call=resolution.tool_call)
 
 
 def _normalize_tool_output(content: str | None) -> str:

--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -36,9 +36,18 @@ class NoPendingQuestionError(ValueError):
     """Raised when a session has no pending question to answer."""
 
 
+class RuntimeCommandMetadata(TypedDict):
+    name: str
+    source: str
+    arguments: list[str]
+    raw_arguments: str
+    original_prompt: str
+
+
 class RuntimeRequestMetadata(TypedDict, total=False):
     abort_requested: bool
     agent: dict[str, object]
+    command: RuntimeCommandMetadata
     delegation: RuntimeSubagentRoutingMetadata
     max_steps: int
     provider_stream: bool
@@ -68,7 +77,7 @@ class RuntimeSubagentRoutingMetadata(TypedDict, total=False):
 
 
 _STABLE_RUNTIME_REQUEST_METADATA_KEYS = frozenset(
-    {"abort_requested", "agent", "delegation", "max_steps", "provider_stream", "skills"}
+    {"abort_requested", "agent", "command", "delegation", "max_steps", "provider_stream", "skills"}
 )
 _INTERNAL_RUNTIME_REQUEST_METADATA_KEYS = frozenset({"background_run", "background_task_id"})
 
@@ -85,6 +94,57 @@ def _validate_optional_runtime_metadata_string(
     if not isinstance(value, str) or not value:
         raise RuntimeRequestError(f"request metadata '{field_name}' must be a non-empty string")
     return value
+
+
+def validate_runtime_command_metadata(metadata: object) -> RuntimeCommandMetadata:
+    if not isinstance(metadata, dict):
+        raise RuntimeRequestError("request metadata 'command' must be an object when provided")
+    payload = cast(dict[object, object], metadata)
+    allowed_keys = {"name", "source", "arguments", "raw_arguments", "original_prompt"}
+    non_string_keys = sorted(repr(key) for key in payload if not isinstance(key, str))
+    if non_string_keys:
+        joined = ", ".join(non_string_keys)
+        raise RuntimeRequestError(
+            f"request metadata 'command' keys must be strings; received invalid key(s): {joined}"
+        )
+    command_payload = cast(dict[str, object], payload)
+    unknown_keys = sorted(key for key in command_payload if key not in allowed_keys)
+    if unknown_keys:
+        joined = ", ".join(unknown_keys)
+        raise RuntimeRequestError(f"unsupported request metadata 'command' field(s): {joined}")
+
+    name = _validate_optional_runtime_metadata_string(
+        command_payload.get("name"),
+        field_name="command.name",
+    )
+    source = _validate_optional_runtime_metadata_string(
+        command_payload.get("source"),
+        field_name="command.source",
+    )
+    raw_arguments = command_payload.get("raw_arguments", "")
+    if not isinstance(raw_arguments, str):
+        raise RuntimeRequestError("request metadata 'command.raw_arguments' must be a string")
+    original_prompt = _validate_optional_runtime_metadata_string(
+        command_payload.get("original_prompt"),
+        field_name="command.original_prompt",
+    )
+    raw_arguments_list = command_payload.get("arguments", [])
+    if not isinstance(raw_arguments_list, list):
+        raise RuntimeRequestError("request metadata 'command.arguments' must be a list")
+    arguments: list[str] = []
+    for index, argument in enumerate(cast(list[object], raw_arguments_list)):
+        if not isinstance(argument, str):
+            raise RuntimeRequestError(
+                f"request metadata 'command.arguments[{index}]' must be a string"
+            )
+        arguments.append(argument)
+    return {
+        "name": name,
+        "source": source,
+        "arguments": arguments,
+        "raw_arguments": raw_arguments,
+        "original_prompt": original_prompt,
+    }
 
 
 def validate_runtime_subagent_routing_metadata(
@@ -288,6 +348,9 @@ def validate_runtime_request_metadata(
         if not isinstance(agent, dict):
             raise RuntimeRequestError("request metadata 'agent' must be an object when provided")
         normalized["agent"] = dict(cast(dict[str, object], agent))
+
+    if "command" in metadata:
+        normalized["command"] = validate_runtime_command_metadata(metadata["command"])
 
     if "delegation" in metadata:
         normalized["delegation"] = validate_runtime_subagent_routing_metadata(

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Literal, cast, final
 
 from ..acp import AcpDelegatedExecution, AcpEventEnvelope, AcpRequestEnvelope, AcpResponseEnvelope
 from ..agent import get_builtin_agent_manifest
+from ..command import COMMAND_RESOLVED, load_command_registry, resolve_prompt_command
 from ..graph.contracts import GraphEvent, GraphRunRequest, RuntimeGraph
 from ..hook.config import RuntimeHookSurface
 from ..hook.executor import (
@@ -1302,6 +1303,24 @@ class VoidCodeRuntime:
                 },
             ),
         )
+
+        command_metadata = request_metadata.get("command")
+        if isinstance(command_metadata, dict):
+            sequence += 1
+            yield RuntimeStreamChunk(
+                kind="event",
+                session=session,
+                event=EventEnvelope(
+                    session_id=session.session.id,
+                    sequence=sequence,
+                    event_type=COMMAND_RESOLVED,
+                    source="runtime",
+                    payload={
+                        **cast(dict[str, object], command_metadata),
+                        "rendered_prompt": request.prompt,
+                    },
+                ),
+            )
 
         (
             mcp_startup_chunks,
@@ -2725,12 +2744,47 @@ class VoidCodeRuntime:
                     f"and cannot be rebound to parent session {parent_session_id}"
                 )
 
-        return RuntimeRequest(
+        prompt, metadata = self._resolve_prompt_command_for_request(
             prompt=request.prompt,
+            metadata=metadata,
+        )
+
+        return RuntimeRequest(
+            prompt=prompt,
             session_id=session_id,
             parent_session_id=resolved_parent_session_id,
             metadata=metadata,
             allocate_session_id=request.allocate_session_id,
+        )
+
+    def _resolve_prompt_command_for_request(
+        self,
+        *,
+        prompt: str,
+        metadata: RuntimeRequestMetadataPayload,
+    ) -> tuple[str, RuntimeRequestMetadataPayload]:
+        if "command" in metadata:
+            return prompt, metadata
+        try:
+            resolution = resolve_prompt_command(
+                prompt,
+                load_command_registry(workspace=self._workspace),
+            )
+        except ValueError as exc:
+            raise RuntimeRequestError(str(exc)) from exc
+        if resolution is None:
+            return prompt, metadata
+
+        normalized = dict(cast(dict[str, object], metadata))
+        normalized["command"] = {
+            "name": resolution.invocation.name,
+            "source": resolution.invocation.source,
+            "arguments": list(resolution.invocation.arguments),
+            "raw_arguments": resolution.invocation.raw_arguments,
+            "original_prompt": resolution.invocation.original_prompt,
+        }
+        return resolution.invocation.rendered_prompt, cast(
+            RuntimeRequestMetadataPayload, normalized
         )
 
     def _metadata_with_delegation_governance(

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -13,7 +13,12 @@ from typing import TYPE_CHECKING, Literal, cast, final
 
 from ..acp import AcpDelegatedExecution, AcpEventEnvelope, AcpRequestEnvelope, AcpResponseEnvelope
 from ..agent import get_builtin_agent_manifest
-from ..command import COMMAND_RESOLVED, load_command_registry, resolve_prompt_command
+from ..command import (
+    COMMAND_RESOLVED,
+    is_prompt_command,
+    load_command_registry,
+    resolve_prompt_command,
+)
 from ..graph.contracts import GraphEvent, GraphRunRequest, RuntimeGraph
 from ..hook.config import RuntimeHookSurface
 from ..hook.executor import (
@@ -2763,7 +2768,7 @@ class VoidCodeRuntime:
         prompt: str,
         metadata: RuntimeRequestMetadataPayload,
     ) -> tuple[str, RuntimeRequestMetadataPayload]:
-        if "command" in metadata:
+        if "command" in metadata or not is_prompt_command(prompt):
             return prompt, metadata
         try:
             resolution = resolve_prompt_command(

--- a/src/voidcode/tui/app.py
+++ b/src/voidcode/tui/app.py
@@ -157,13 +157,13 @@ class VoidCodeTUI(App[int]):
         self.push_screen(CommandPalette(), self._handle_command)
 
     def action_session_new(self) -> None:
-        self._handle_command("session: new")
+        self._handle_command("session.new")
 
     def action_session_resume(self) -> None:
-        self._handle_command("session: resume")
+        self._handle_command("session.resume")
 
     def _handle_command(self, command: str | None) -> None:
-        if command == "session: new":
+        if command == "session.new":
             self.session_id = None
             self._current_prompt = None
             self._set_state("Idle")
@@ -174,7 +174,7 @@ class VoidCodeTUI(App[int]):
                 Text("--- New Session ---", style="bold")
             )
             self.query_one("#composer-input", Input).focus()
-        elif command == "session: resume":
+        elif command == "session.resume":
             sessions = self.runtime.list_sessions()
             self._session_titles = {s.session.id: s.prompt for s in sessions}
 
@@ -198,15 +198,15 @@ class VoidCodeTUI(App[int]):
                     self.query_one("#composer-input", Input).focus()
 
             self.push_screen(SessionListModal(sessions), _handle_session)
-        elif command == "theme: switch":
+        elif command == "theme.switch":
             self.push_screen(
                 ThemePickerModal(self._available_theme_names()), self._handle_theme_selection
             )
-        elif command == "theme: mode":
+        elif command == "theme.mode":
             self.push_screen(ThemeModePickerModal(), self._handle_theme_mode_selection)
-        elif command == "view: wrap":
+        elif command == "view.wrap":
             self._toggle_wrap()
-        elif command == "view: sidebar":
+        elif command == "view.sidebar":
             self._toggle_sidebar()
 
     def _effective_tui_preferences(self) -> RuntimeTuiPreferences:

--- a/src/voidcode/tui/screens.py
+++ b/src/voidcode/tui/screens.py
@@ -9,17 +9,11 @@ from textual.fuzzy import Matcher
 from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Label, OptionList, Static
 
+from ..command.ui import DEFAULT_TUI_COMMANDS
 from ..runtime.events import EventEnvelope
 from ..runtime.session import StoredSessionSummary
 
-COMMAND_PALETTE_COMMANDS: tuple[str, ...] = (
-    "session: new",
-    "session: resume",
-    "theme: switch",
-    "theme: mode",
-    "view: wrap",
-    "view: sidebar",
-)
+COMMAND_PALETTE_COMMANDS = DEFAULT_TUI_COMMANDS
 
 
 class ApprovalModal(ModalScreen[Literal["allow", "deny"]]):
@@ -111,7 +105,9 @@ class CommandPalette(ModalScreen[str | None]):
         with Vertical(id="palette-dialog"):
             yield Label("Command Palette", classes="sidebar-header")
             yield Input(placeholder="Search commands...", id="palette-input")
-            yield OptionList(*COMMAND_PALETTE_COMMANDS, id="palette-options")
+            yield OptionList(
+                *(command.title for command in COMMAND_PALETTE_COMMANDS), id="palette-options"
+            )
 
     def on_mount(self) -> None:
         self.query_one(Input).focus()
@@ -121,14 +117,14 @@ class CommandPalette(ModalScreen[str | None]):
         options.clear_options()
         query = event.value.strip()
         if not query:
-            options.add_options(COMMAND_PALETTE_COMMANDS)
+            options.add_options(command.title for command in COMMAND_PALETTE_COMMANDS)
         else:
             matcher = Matcher(query)
             matches: list[tuple[float, str]] = []
-            for cmd in COMMAND_PALETTE_COMMANDS:
-                score = matcher.match(cmd)
+            for command in COMMAND_PALETTE_COMMANDS:
+                score = matcher.match(command.title)
                 if score > 0:
-                    matches.append((score, cmd))
+                    matches.append((score, command.title))
             matches.sort(key=lambda x: x[0], reverse=True)
             options.add_options([cmd for _, cmd in matches])
 
@@ -138,13 +134,20 @@ class CommandPalette(ModalScreen[str | None]):
             idx = options.highlighted if options.highlighted is not None else 0
             if idx < options.option_count:
                 opt = options.get_option_at_index(idx)
-                self.dismiss(str(opt.prompt))
+                self.dismiss(_command_id_for_title(str(opt.prompt)))
 
     def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
-        self.dismiss(str(event.option.prompt))
+        self.dismiss(_command_id_for_title(str(event.option.prompt)))
 
     def action_dismiss_palette(self) -> None:
         self.dismiss(None)
+
+
+def _command_id_for_title(title: str) -> str | None:
+    for command in COMMAND_PALETTE_COMMANDS:
+        if command.title == title:
+            return command.id
+    return None
 
 
 class SessionListModal(ModalScreen[str | None]):

--- a/tests/unit/command/test_command_registry.py
+++ b/tests/unit/command/test_command_registry.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pytest
+
+from voidcode.command import (
+    CommandDefinition,
+    CommandRegistry,
+    load_command_registry,
+    load_markdown_commands,
+    resolve_prompt_command,
+    resolve_tool_instruction,
+)
+from voidcode.tools.contracts import ToolDefinition
+
+
+def test_project_markdown_command_overrides_builtin_and_renders_arguments(tmp_path) -> None:
+    commands_dir = tmp_path / "commands"
+    commands_dir.mkdir()
+    (commands_dir / "review.md").write_text(
+        "---\n"
+        "description: Project review command\n"
+        "agent: reviewer\n"
+        "---\n"
+        "Review $1 with context: $ARGUMENTS\n",
+        encoding="utf-8",
+    )
+
+    registry = load_command_registry(workspace=tmp_path)
+    command = registry.get("review")
+
+    assert command is not None
+    assert command.source == "project"
+    assert command.agent == "reviewer"
+    resolution = resolve_prompt_command('/review "src/app.py" carefully', registry)
+    assert resolution is not None
+    assert resolution.invocation.arguments == ("src/app.py", "carefully")
+    assert resolution.invocation.rendered_prompt == (
+        'Review src/app.py with context: "src/app.py" carefully'
+    )
+
+
+def test_load_markdown_commands_rejects_invalid_frontmatter(tmp_path) -> None:
+    commands_dir = tmp_path / "commands"
+    commands_dir.mkdir()
+    (commands_dir / "bad.md").write_text(
+        "---\nenabled: sometimes\n---\nNope\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="boolean frontmatter"):
+        _ = load_markdown_commands(commands_dir, source="project")
+
+
+def test_prompt_command_rejects_unknown_command() -> None:
+    registry = CommandRegistry((CommandDefinition("known", "Known command", "Do $ARGUMENTS"),))
+
+    with pytest.raises(ValueError, match="unknown command"):
+        _ = resolve_prompt_command("/missing target", registry)
+
+
+def test_tool_instruction_resolver_is_shared_for_read_grep_run_and_write() -> None:
+    tools = (
+        ToolDefinition("read_file", "Read", read_only=True),
+        ToolDefinition("grep", "Grep", read_only=True),
+        ToolDefinition("shell_exec", "Run", read_only=False),
+        ToolDefinition("write_file", "Write", read_only=False),
+    )
+
+    assert resolve_tool_instruction(
+        "read sample.txt", tools, unavailable_message_suffix="test"
+    ).tool_call.arguments == {"filePath": "sample.txt"}
+    assert resolve_tool_instruction(
+        "grep hello src", tools, unavailable_message_suffix="test"
+    ).tool_call.arguments == {"pattern": "hello", "path": "src"}
+    assert resolve_tool_instruction(
+        "run pytest", tools, unavailable_message_suffix="test"
+    ).tool_call.arguments == {"command": "pytest"}
+    assert resolve_tool_instruction(
+        "write output.txt hello", tools, unavailable_message_suffix="test"
+    ).tool_call.arguments == {"path": "output.txt", "content": "hello"}

--- a/tests/unit/command/test_command_registry.py
+++ b/tests/unit/command/test_command_registry.py
@@ -78,3 +78,18 @@ def test_tool_instruction_resolver_is_shared_for_read_grep_run_and_write() -> No
     assert resolve_tool_instruction(
         "write output.txt hello", tools, unavailable_message_suffix="test"
     ).tool_call.arguments == {"path": "output.txt", "content": "hello"}
+
+
+def test_template_rendering_does_not_rewrite_inserted_arguments_or_dollar_literals() -> None:
+    from voidcode.command.templating import render_command_template
+
+    rendered = render_command_template(
+        "Cost $100; first=$1; second=$2; missing=$3; args=$ARGUMENTS; literal=$ARGUMENTS_suffix",
+        raw_arguments="price=$2 literal",
+        arguments=("target",),
+    )
+
+    assert rendered == (
+        "Cost $100; first=target; second=; missing=; "
+        "args=price=$2 literal; literal=$ARGUMENTS_suffix"
+    )

--- a/tests/unit/runtime/test_command_resolution.py
+++ b/tests/unit/runtime/test_command_resolution.py
@@ -4,7 +4,11 @@ from dataclasses import dataclass
 
 from voidcode.command import COMMAND_RESOLVED
 from voidcode.graph.contracts import GraphEvent, GraphRunRequest
-from voidcode.runtime.contracts import RuntimeRequest, validate_runtime_request_metadata
+from voidcode.runtime.contracts import (
+    RuntimeRequest,
+    RuntimeRequestError,
+    validate_runtime_request_metadata,
+)
 from voidcode.runtime.service import VoidCodeRuntime
 from voidcode.runtime.session import SessionState
 from voidcode.tools.contracts import ToolCall, ToolResult
@@ -69,3 +73,35 @@ def test_runtime_command_metadata_validates_structured_shape() -> None:
     )
 
     assert metadata["command"]["name"] == "review"
+
+
+def test_runtime_ignores_malformed_command_files_for_non_slash_prompt(tmp_path) -> None:
+    commands_dir = tmp_path / "commands"
+    commands_dir.mkdir()
+    (commands_dir / "broken.md").write_text(
+        "---\nenabled: sometimes\n---\nBroken command body\n",
+        encoding="utf-8",
+    )
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_EchoPromptGraph())
+
+    response = runtime.run(RuntimeRequest(prompt="normal non-slash prompt"))
+
+    assert response.output == "normal non-slash prompt"
+    assert "command" not in response.session.metadata
+
+
+def test_runtime_still_validates_command_files_for_slash_prompt(tmp_path) -> None:
+    commands_dir = tmp_path / "commands"
+    commands_dir.mkdir()
+    (commands_dir / "broken.md").write_text(
+        "---\nenabled: sometimes\n---\nBroken command body\n",
+        encoding="utf-8",
+    )
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_EchoPromptGraph())
+
+    try:
+        _ = runtime.run(RuntimeRequest(prompt="/broken target"))
+    except RuntimeRequestError as exc:
+        assert "boolean frontmatter" in str(exc)
+    else:
+        raise AssertionError("slash prompt should validate command registry")

--- a/tests/unit/runtime/test_command_resolution.py
+++ b/tests/unit/runtime/test_command_resolution.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from voidcode.command import COMMAND_RESOLVED
+from voidcode.graph.contracts import GraphEvent, GraphRunRequest
+from voidcode.runtime.contracts import RuntimeRequest, validate_runtime_request_metadata
+from voidcode.runtime.service import VoidCodeRuntime
+from voidcode.runtime.session import SessionState
+from voidcode.tools.contracts import ToolCall, ToolResult
+
+
+@dataclass(frozen=True, slots=True)
+class _FinishedStep:
+    output: str
+    events: tuple[GraphEvent, ...] = ()
+    tool_call: ToolCall | None = None
+    is_finished: bool = True
+
+
+class _EchoPromptGraph:
+    def step(
+        self,
+        request: GraphRunRequest,
+        tool_results: tuple[ToolResult, ...],
+        *,
+        session: SessionState,
+    ) -> _FinishedStep:
+        return _FinishedStep(output=request.prompt)
+
+
+def test_runtime_resolves_project_prompt_command_before_graph_execution(tmp_path) -> None:
+    commands_dir = tmp_path / "commands"
+    commands_dir.mkdir()
+    (commands_dir / "echo.md").write_text(
+        "---\ndescription: Echo the arguments\n---\nexpanded $1 from $ARGUMENTS\n",
+        encoding="utf-8",
+    )
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_EchoPromptGraph())
+
+    response = runtime.run(RuntimeRequest(prompt="/echo target.py --flag"))
+
+    assert response.output == "expanded target.py from target.py --flag"
+    assert response.session.metadata["command"] == {
+        "name": "echo",
+        "source": "project",
+        "arguments": ["target.py", "--flag"],
+        "raw_arguments": "target.py --flag",
+        "original_prompt": "/echo target.py --flag",
+    }
+    command_events = [event for event in response.events if event.event_type == COMMAND_RESOLVED]
+    assert len(command_events) == 1
+    assert (
+        command_events[0].payload["rendered_prompt"] == "expanded target.py from target.py --flag"
+    )
+
+
+def test_runtime_command_metadata_validates_structured_shape() -> None:
+    metadata = validate_runtime_request_metadata(
+        {
+            "command": {
+                "name": "review",
+                "source": "builtin",
+                "arguments": ["src"],
+                "raw_arguments": "src",
+                "original_prompt": "/review src",
+            }
+        }
+    )
+
+    assert metadata["command"]["name"] == "review"


### PR DESCRIPTION
## Summary
- Add first-class `voidcode.command` package for command definitions, registry/loader, slash resolution, templating, TUI command IDs, and command events.
- Resolve project-local markdown slash commands into runtime prompts with structured `metadata.command` and `command.resolved` events.
- Replace duplicated graph/provider prompt-command regex parsing with shared command resolver and move TUI palette strings to stable command definitions.

## Verification
- `mise run lint`
- `mise run typecheck`
- `uv run pytest` (1250 passed; existing ResourceWarning warnings in background task storage tests)
- `mise run frontend:check`

Closes #225