### PR TITLE
feat(runtime): add session debug snapshot surface

### DIFF
--- a/docs/mvp-demo-guide.md
+++ b/docs/mvp-demo-guide.md
@@ -36,7 +36,16 @@
    ```
    *预期结果*：CLI 从持久化存储中检索并完整渲染所有历史事件及 `RESULT` 块。
 
-4. **HTTP 传输观察**：通过 API 暴露会话状态。
+4. **失败诊断观察面**：通过 CLI 或 HTTP 读取 runtime-owned debug snapshot。
+   ```bash
+   uv run voidcode sessions debug <session-id> --workspace .
+
+   # 或者在 HTTP 服务启动后读取同一份诊断视图
+   curl http://127.0.0.1:8000/api/sessions/<session-id>/debug
+   ```
+   *预期结果*：可以直接看到当前/持久化 session status、是否 active、是否可 resume / replay、最近相关事件、最近失败分类，以及建议的下一步操作，而不需要直接读 SQLite 或源码。
+
+5. **HTTP 传输观察**：通过 API 暴露会话状态。
    ```bash
    # 终端 A
    uv run voidcode serve --workspace . --port 8000
@@ -44,7 +53,7 @@
    # 终端 B
    curl http://127.0.0.1:8000/api/sessions
    ```
-   *预期结果*：终端 B 收到包含该会话元数据（含 `prompt` 和 `status`）的 JSON 数组。
+   *预期结果*：终端 B 收到包含该会话元数据（含 `prompt` 和 `status`）的 JSON 数组，并可进一步访问 `/api/sessions/<session-id>/debug` 获取诊断快照。
 
 ## 验证阶梯
 
@@ -62,7 +71,7 @@
 
 ### 3. 客户端冒烟测试
 - **CLI TTY 审批**：验证在 TTY 模式下能否正确触发并响应内联审批提示。
-- **HTTP/SSE**：通过 HTTP 验证流式序列化和会话重放。
+- **HTTP/SSE**：通过 HTTP 验证流式序列化、会话重放和 session debug snapshot。
 - **命令**：`uv run pytest tests/integration/test_http_transport.py`
 
 ### 4. 手动 QA
@@ -73,7 +82,7 @@
 
 要称之为 MVP 可演示，贡献者必须提供：
 - `mise run check` 的输出（全绿）。
-- 在新工作区成功执行**规范演示流程**（步骤 1-4）的日志，特别是包含内联审批交互的部分。
+- 在新工作区成功执行**规范演示流程**（步骤 1-5）的日志，特别是包含内联审批交互和失败诊断快照的部分。
 - 验证 `.voidcode/sessions.sqlite3` 中包含对应的会话和事件行。
 
 ## 边界与已知差距

--- a/docs/mvp-todo-plan.md
+++ b/docs/mvp-todo-plan.md
@@ -178,7 +178,7 @@ VoidCode 已经拥有扎实的 pre-MVP 基础：
 - [x] 为主要产品循环添加全栈测试覆盖
 - [ ] 针对常见失败和恢复记录操作员工作流
 - [x] 通过 `#82` 定义 retention / compaction / checkpoint invalidation 语义，并保证 replay / resume 在该策略下继续成立
-- [ ] 添加调试实时会话所需的观测钩子/日志
+- [x] 添加调试实时会话所需的最小可用观测面（runtime debug snapshot + CLI/HTTP 入口）
 - [x] 更新 README 和贡献者文档以反映真实的 MVP 路径
 
 ### 验收标准

--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -467,7 +467,7 @@ def _handle_tasks_output_command(args: argparse.Namespace) -> int:
     fallback_output = (
         task_result.summary_output if task_result.summary_output is not None else task_result.error
     )
-    _print_runtime_output(session_output or fallback_output)
+    _print_runtime_output(session_output if session_output is not None else fallback_output)
     return 0
 
 

--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -23,6 +23,7 @@ from .runtime.config import RuntimeConfig, load_runtime_config, serialize_provid
 from .runtime.contracts import (
     BackgroundTaskResult,
     RuntimeRequest,
+    RuntimeSessionDebugSnapshot,
     RuntimeStreamChunk,
     validate_runtime_request_metadata,
 )
@@ -298,6 +299,95 @@ def _format_background_task_summary(task: StoredBackgroundTaskSummary) -> str:
     )
 
 
+def _serialize_session_debug_snapshot(snapshot: RuntimeSessionDebugSnapshot) -> dict[str, object]:
+    session_payload: dict[str, object] = {"id": snapshot.session.session.id}
+    if snapshot.session.session.parent_id is not None:
+        session_payload["parent_id"] = snapshot.session.session.parent_id
+    return {
+        "session": {
+            "session": session_payload,
+            "status": snapshot.session.status,
+            "turn": snapshot.session.turn,
+            "metadata": snapshot.session.metadata,
+        },
+        "prompt": snapshot.prompt,
+        "persisted_status": snapshot.persisted_status,
+        "current_status": snapshot.current_status,
+        "active": snapshot.active,
+        "resumable": snapshot.resumable,
+        "replayable": snapshot.replayable,
+        "terminal": snapshot.terminal,
+        "resume_checkpoint_kind": snapshot.resume_checkpoint_kind,
+        "pending_approval": (
+            {
+                "request_id": snapshot.pending_approval.request_id,
+                "tool_name": snapshot.pending_approval.tool_name,
+                "target_summary": snapshot.pending_approval.target_summary,
+                "reason": snapshot.pending_approval.reason,
+                "policy_mode": snapshot.pending_approval.policy_mode,
+                "arguments": snapshot.pending_approval.arguments,
+                "owner_session_id": snapshot.pending_approval.owner_session_id,
+                "owner_parent_session_id": snapshot.pending_approval.owner_parent_session_id,
+                "delegated_task_id": snapshot.pending_approval.delegated_task_id,
+            }
+            if snapshot.pending_approval is not None
+            else None
+        ),
+        "pending_question": (
+            {
+                "request_id": snapshot.pending_question.request_id,
+                "tool_name": snapshot.pending_question.tool_name,
+                "question_count": snapshot.pending_question.question_count,
+                "headers": list(snapshot.pending_question.headers),
+            }
+            if snapshot.pending_question is not None
+            else None
+        ),
+        "last_event_sequence": snapshot.last_event_sequence,
+        "last_relevant_event": (
+            {
+                "sequence": snapshot.last_relevant_event.sequence,
+                "event_type": snapshot.last_relevant_event.event_type,
+                "source": snapshot.last_relevant_event.source,
+                "payload": snapshot.last_relevant_event.payload,
+            }
+            if snapshot.last_relevant_event is not None
+            else None
+        ),
+        "last_failure_event": (
+            {
+                "sequence": snapshot.last_failure_event.sequence,
+                "event_type": snapshot.last_failure_event.event_type,
+                "source": snapshot.last_failure_event.source,
+                "payload": snapshot.last_failure_event.payload,
+            }
+            if snapshot.last_failure_event is not None
+            else None
+        ),
+        "failure": (
+            {
+                "classification": snapshot.failure.classification,
+                "message": snapshot.failure.message,
+            }
+            if snapshot.failure is not None
+            else None
+        ),
+        "last_tool": (
+            {
+                "tool_name": snapshot.last_tool.tool_name,
+                "status": snapshot.last_tool.status,
+                "summary": snapshot.last_tool.summary,
+                "arguments": snapshot.last_tool.arguments,
+                "sequence": snapshot.last_tool.sequence,
+            }
+            if snapshot.last_tool is not None
+            else None
+        ),
+        "suggested_operator_action": snapshot.suggested_operator_action,
+        "operator_guidance": snapshot.operator_guidance,
+    }
+
+
 def _handle_sessions_resume_command(args: argparse.Namespace) -> int:
     workspace = cast(Path, args.workspace)
     session_id = cast(str, args.session_id)
@@ -316,6 +406,22 @@ def _handle_sessions_resume_command(args: argparse.Namespace) -> int:
         _close_runtime(runtime)
 
     _print_runtime_response(result)
+    return 0
+
+
+def _handle_sessions_debug_command(args: argparse.Namespace) -> int:
+    workspace = cast(Path, args.workspace)
+    session_id = cast(str, args.session_id)
+    runtime = VoidCodeRuntime(workspace=workspace)
+    try:
+        try:
+            snapshot = runtime.session_debug_snapshot(session_id=session_id)
+        except ValueError as exc:
+            raise SystemExit(f"error: {exc}") from None
+    finally:
+        _close_runtime(runtime)
+
+    print(json.dumps(_serialize_session_debug_snapshot(snapshot), sort_keys=True))
     return 0
 
 
@@ -752,6 +858,24 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional approval decision applied to the pending request during resume.",
     )
     resume_parser.set_defaults(handler=_handle_sessions_resume_command)
+
+    debug_parser = sessions_subparsers.add_parser(
+        "debug", help="Show a minimal runtime-owned debug snapshot for one session."
+    )
+    _ = debug_parser.add_argument("session_id", help="Persisted session identifier to inspect.")
+    _ = debug_parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd(),
+        help="Workspace root used to resolve the local session database.",
+    )
+    _ = debug_parser.add_argument(
+        "--json",
+        action="store_true",
+        default=True,
+        help="Output JSON debug snapshot (default).",
+    )
+    debug_parser.set_defaults(handler=_handle_sessions_debug_command)
 
     tasks_status_parser = tasks_subparsers.add_parser(
         "status", help="Show delegated task lifecycle state."

--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -400,6 +400,72 @@ type RuntimeNotificationStatus = Literal["unread", "acknowledged"]
 
 
 @dataclass(frozen=True, slots=True)
+class RuntimeSessionDebugEvent:
+    sequence: int
+    event_type: str
+    source: str
+    payload: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeSessionDebugPendingApproval:
+    request_id: str
+    tool_name: str
+    target_summary: str
+    reason: str
+    policy_mode: str
+    arguments: dict[str, object] = field(default_factory=dict)
+    owner_session_id: str | None = None
+    owner_parent_session_id: str | None = None
+    delegated_task_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeSessionDebugPendingQuestion:
+    request_id: str
+    tool_name: str
+    question_count: int
+    headers: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeSessionDebugToolSummary:
+    tool_name: str
+    status: str
+    summary: str
+    arguments: dict[str, object] = field(default_factory=dict)
+    sequence: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeSessionDebugFailure:
+    classification: str
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeSessionDebugSnapshot:
+    session: SessionState
+    prompt: str
+    persisted_status: str
+    current_status: str
+    active: bool
+    resumable: bool
+    replayable: bool
+    terminal: bool
+    resume_checkpoint_kind: str | None = None
+    pending_approval: RuntimeSessionDebugPendingApproval | None = None
+    pending_question: RuntimeSessionDebugPendingQuestion | None = None
+    last_event_sequence: int = 0
+    last_relevant_event: RuntimeSessionDebugEvent | None = None
+    last_failure_event: RuntimeSessionDebugEvent | None = None
+    failure: RuntimeSessionDebugFailure | None = None
+    last_tool: RuntimeSessionDebugToolSummary | None = None
+    suggested_operator_action: str = "inspect_session"
+    operator_guidance: str = "Inspect the persisted session state."
+
+
+@dataclass(frozen=True, slots=True)
 class RuntimeSessionResult:
     session: SessionState
     prompt: str

--- a/src/voidcode/runtime/http.py
+++ b/src/voidcode/runtime/http.py
@@ -17,6 +17,7 @@ from .contracts import (
     RuntimeRequest,
     RuntimeRequestError,
     RuntimeResponse,
+    RuntimeSessionDebugSnapshot,
     RuntimeSessionResult,
     RuntimeStreamChunk,
     validate_runtime_request_metadata,
@@ -70,6 +71,8 @@ class RuntimeTransport(Protocol):
 
     def session_result(self, *, session_id: str) -> RuntimeSessionResult: ...
 
+    def session_debug_snapshot(self, *, session_id: str) -> RuntimeSessionDebugSnapshot: ...
+
     def list_notifications(self) -> tuple[RuntimeNotification, ...]: ...
 
     def acknowledge_notification(self, *, notification_id: str) -> RuntimeNotification: ...
@@ -89,6 +92,13 @@ class RuntimeTransport(Protocol):
         question_request_id: str,
         responses: tuple[QuestionResponse, ...],
     ) -> RuntimeResponse: ...
+
+
+class RuntimeSessionDebugEventLike(Protocol):
+    sequence: int
+    event_type: str
+    source: str
+    payload: dict[str, object]
 
 
 class Receive(Protocol):
@@ -270,6 +280,7 @@ class RuntimeTransportApp:
             is_approval_route = session_path.endswith("/approval")
             is_question_route = session_path.endswith("/question")
             is_result_route = session_path.endswith("/result")
+            is_debug_route = session_path.endswith("/debug")
             session_id = (
                 session_path.removesuffix("/tasks")
                 if is_task_list_route
@@ -279,6 +290,8 @@ class RuntimeTransportApp:
                 if is_question_route
                 else session_path.removesuffix("/result")
                 if is_result_route
+                else session_path.removesuffix("/debug")
+                if is_debug_route
                 else session_path
             )
             try:
@@ -310,6 +323,8 @@ class RuntimeTransportApp:
                 if is_question_route
                 else session_path.removesuffix("/result")
                 if is_result_route
+                else session_path.removesuffix("/debug")
+                if is_debug_route
                 else session_path
             )
             if is_approval_route:
@@ -349,6 +364,16 @@ class RuntimeTransportApp:
                     )
                     return
                 await self._handle_session_result(session_id=session_id, send=send)
+                return
+            if is_debug_route:
+                if method != "GET":
+                    await self._json_response(
+                        send,
+                        status=405,
+                        payload={"error": "method not allowed"},
+                    )
+                    return
+                await self._handle_session_debug(session_id=session_id, send=send)
                 return
             if method != "GET":
                 await self._json_response(
@@ -637,6 +662,21 @@ class RuntimeTransportApp:
             send,
             status=200,
             payload=self._serialize_session_result(result),
+        )
+
+    async def _handle_session_debug(self, *, session_id: str, send: Send) -> None:
+        runtime = self._runtime_factory()
+        try:
+            snapshot = runtime.session_debug_snapshot(session_id=session_id)
+        except ValueError as exc:
+            await self._json_response(send, status=404, payload={"error": str(exc)})
+            return
+        finally:
+            self._close_runtime(runtime)
+        await self._json_response(
+            send,
+            status=200,
+            payload=self._serialize_session_debug_snapshot(snapshot),
         )
 
     async def _handle_approval_resolution(
@@ -992,6 +1032,87 @@ class RuntimeTransportApp:
             "transcript": [
                 RuntimeTransportApp._serialize_event(event) for event in result.transcript
             ],
+        }
+
+    @staticmethod
+    def _serialize_session_debug_snapshot(
+        snapshot: RuntimeSessionDebugSnapshot,
+    ) -> dict[str, object]:
+        return {
+            "session": RuntimeTransportApp._serialize_session_state(snapshot.session),
+            "prompt": snapshot.prompt,
+            "persisted_status": snapshot.persisted_status,
+            "current_status": snapshot.current_status,
+            "active": snapshot.active,
+            "resumable": snapshot.resumable,
+            "replayable": snapshot.replayable,
+            "terminal": snapshot.terminal,
+            "resume_checkpoint_kind": snapshot.resume_checkpoint_kind,
+            "pending_approval": (
+                {
+                    "request_id": snapshot.pending_approval.request_id,
+                    "tool_name": snapshot.pending_approval.tool_name,
+                    "target_summary": snapshot.pending_approval.target_summary,
+                    "reason": snapshot.pending_approval.reason,
+                    "policy_mode": snapshot.pending_approval.policy_mode,
+                    "arguments": snapshot.pending_approval.arguments,
+                    "owner_session_id": snapshot.pending_approval.owner_session_id,
+                    "owner_parent_session_id": snapshot.pending_approval.owner_parent_session_id,
+                    "delegated_task_id": snapshot.pending_approval.delegated_task_id,
+                }
+                if snapshot.pending_approval is not None
+                else None
+            ),
+            "pending_question": (
+                {
+                    "request_id": snapshot.pending_question.request_id,
+                    "tool_name": snapshot.pending_question.tool_name,
+                    "question_count": snapshot.pending_question.question_count,
+                    "headers": list(snapshot.pending_question.headers),
+                }
+                if snapshot.pending_question is not None
+                else None
+            ),
+            "last_event_sequence": snapshot.last_event_sequence,
+            "last_relevant_event": RuntimeTransportApp._serialize_session_debug_event(
+                snapshot.last_relevant_event
+            ),
+            "last_failure_event": RuntimeTransportApp._serialize_session_debug_event(
+                snapshot.last_failure_event
+            ),
+            "failure": (
+                {
+                    "classification": snapshot.failure.classification,
+                    "message": snapshot.failure.message,
+                }
+                if snapshot.failure is not None
+                else None
+            ),
+            "last_tool": (
+                {
+                    "tool_name": snapshot.last_tool.tool_name,
+                    "status": snapshot.last_tool.status,
+                    "summary": snapshot.last_tool.summary,
+                    "arguments": snapshot.last_tool.arguments,
+                    "sequence": snapshot.last_tool.sequence,
+                }
+                if snapshot.last_tool is not None
+                else None
+            ),
+            "suggested_operator_action": snapshot.suggested_operator_action,
+            "operator_guidance": snapshot.operator_guidance,
+        }
+
+    @staticmethod
+    def _serialize_session_debug_event(event: object | None) -> dict[str, object] | None:
+        if event is None:
+            return None
+        typed_event = cast("RuntimeSessionDebugEventLike", event)
+        return {
+            "sequence": typed_event.sequence,
+            "event_type": typed_event.event_type,
+            "source": typed_event.source,
+            "payload": typed_event.payload,
         }
 
     @staticmethod

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -82,6 +82,12 @@ from .contracts import (
     RuntimeRequestError,
     RuntimeRequestMetadataPayload,
     RuntimeResponse,
+    RuntimeSessionDebugEvent,
+    RuntimeSessionDebugFailure,
+    RuntimeSessionDebugPendingApproval,
+    RuntimeSessionDebugPendingQuestion,
+    RuntimeSessionDebugSnapshot,
+    RuntimeSessionDebugToolSummary,
     RuntimeSessionResult,
     RuntimeStreamChunk,
     UnknownSessionError,
@@ -1190,7 +1196,11 @@ class VoidCodeRuntime:
         session_id = self._resolve_session_id(request)
         self._register_active_session_id(
             session_id,
-            metadata=dict(request.metadata),
+            metadata={
+                "prompt": request.prompt,
+                **dict(request.metadata),
+                "request_metadata": dict(request.metadata),
+            },
         )
         try:
             events: list[EventEnvelope] = []
@@ -1841,6 +1851,139 @@ class VoidCodeRuntime:
         self._validate_session_workspace(result.session, session_id=session_id)
         return result
 
+    def session_debug_snapshot(self, *, session_id: str) -> RuntimeSessionDebugSnapshot:
+        validate_session_id(session_id)
+        active = self._is_active_session_id(session_id)
+        try:
+            result = self.session_result(session_id=session_id)
+        except UnknownSessionError:
+            if not active:
+                raise
+            return self._active_only_session_debug_snapshot(session_id=session_id)
+        persistence_error: str | None = None
+        pending_approval: PendingApproval | None = None
+        pending_question: PendingQuestion | None = None
+        resume_checkpoint: dict[str, object] | None = None
+        try:
+            pending_approval = self._session_store.load_pending_approval(
+                workspace=self._workspace,
+                session_id=session_id,
+            )
+            pending_question = self._session_store.load_pending_question(
+                workspace=self._workspace,
+                session_id=session_id,
+            )
+            resume_checkpoint = self._session_store.load_resume_checkpoint(
+                workspace=self._workspace,
+                session_id=session_id,
+            )
+        except ValueError as exc:
+            persistence_error = str(exc)
+        current_status = self._current_debug_status(
+            result=result,
+            active=active,
+            pending_approval=pending_approval,
+            pending_question=pending_question,
+        )
+        terminal = result.session.status in {"completed", "failed"}
+        resumable = result.session.status == "waiting"
+        replayable = bool(result.transcript) or result.output is not None or terminal
+        last_relevant_event = self._debug_event(
+            next(
+                (
+                    event
+                    for event in reversed(result.transcript)
+                    if event.event_type
+                    in {
+                        "runtime.approval_requested",
+                        "runtime.question_requested",
+                        "runtime.approval_resolved",
+                        RUNTIME_QUESTION_ANSWERED,
+                        "runtime.failed",
+                        "runtime.tool_completed",
+                        "graph.response_ready",
+                    }
+                ),
+                result.transcript[-1] if result.transcript else None,
+            )
+        )
+        last_failure_event = self._debug_event(
+            next(
+                (
+                    event
+                    for event in reversed(result.transcript)
+                    if event.event_type == "runtime.failed"
+                ),
+                None,
+            )
+        )
+        last_tool = self._last_tool_summary(result)
+        failure = self._debug_failure(
+            result=result,
+            last_failure_event=last_failure_event,
+            last_tool=last_tool,
+            pending_approval=pending_approval,
+            pending_question=pending_question,
+            resume_checkpoint=resume_checkpoint,
+            persistence_error=persistence_error,
+        )
+        suggested_operator_action, operator_guidance = self._operator_guidance(
+            current_status=current_status,
+            pending_approval=pending_approval,
+            pending_question=pending_question,
+            active=active,
+            terminal=terminal,
+            failure=failure,
+        )
+        return RuntimeSessionDebugSnapshot(
+            session=result.session,
+            prompt=result.prompt,
+            persisted_status=result.status,
+            current_status=current_status,
+            active=active,
+            resumable=resumable,
+            replayable=replayable,
+            terminal=terminal,
+            resume_checkpoint_kind=(
+                cast(str, resume_checkpoint.get("kind"))
+                if isinstance(resume_checkpoint, dict)
+                and isinstance(resume_checkpoint.get("kind"), str)
+                else None
+            ),
+            pending_approval=(
+                RuntimeSessionDebugPendingApproval(
+                    request_id=pending_approval.request_id,
+                    tool_name=pending_approval.tool_name,
+                    target_summary=pending_approval.target_summary,
+                    reason=pending_approval.reason,
+                    policy_mode=pending_approval.policy_mode,
+                    arguments=dict(pending_approval.arguments),
+                    owner_session_id=pending_approval.owner_session_id,
+                    owner_parent_session_id=pending_approval.owner_parent_session_id,
+                    delegated_task_id=pending_approval.delegated_task_id,
+                )
+                if pending_approval is not None
+                else None
+            ),
+            pending_question=(
+                RuntimeSessionDebugPendingQuestion(
+                    request_id=pending_question.request_id,
+                    tool_name=pending_question.tool_name,
+                    question_count=len(pending_question.prompts),
+                    headers=tuple(prompt.header for prompt in pending_question.prompts),
+                )
+                if pending_question is not None
+                else None
+            ),
+            last_event_sequence=result.last_event_sequence,
+            last_relevant_event=last_relevant_event,
+            last_failure_event=last_failure_event,
+            failure=failure,
+            last_tool=last_tool,
+            suggested_operator_action=suggested_operator_action,
+            operator_guidance=operator_guidance,
+        )
+
     def list_notifications(self) -> tuple[RuntimeNotification, ...]:
         notifications = self._session_store.list_notifications(workspace=self._workspace)
         return tuple(
@@ -1991,6 +2134,231 @@ class VoidCodeRuntime:
         self._graph_cache = {}
         self._graph = self._graph_override or self._build_graph_for_engine_from_config(
             self._initial_effective_config
+        )
+
+    @staticmethod
+    def _debug_event(event: EventEnvelope | None) -> RuntimeSessionDebugEvent | None:
+        if event is None:
+            return None
+        return RuntimeSessionDebugEvent(
+            sequence=event.sequence,
+            event_type=event.event_type,
+            source=event.source,
+            payload=dict(event.payload),
+        )
+
+    @staticmethod
+    def _current_debug_status(
+        *,
+        result: RuntimeSessionResult,
+        active: bool,
+        pending_approval: PendingApproval | None,
+        pending_question: PendingQuestion | None,
+    ) -> str:
+        if active and result.session.status == "running":
+            return "running"
+        if pending_approval is not None:
+            return "waiting_for_approval"
+        if pending_question is not None:
+            return "waiting_for_question"
+        if active and result.session.status == "waiting":
+            return "waiting_active"
+        return result.session.status
+
+    @staticmethod
+    def _debug_failure(
+        *,
+        result: RuntimeSessionResult,
+        last_failure_event: RuntimeSessionDebugEvent | None,
+        last_tool: RuntimeSessionDebugToolSummary | None,
+        pending_approval: PendingApproval | None,
+        pending_question: PendingQuestion | None,
+        resume_checkpoint: dict[str, object] | None,
+        persistence_error: str | None,
+    ) -> RuntimeSessionDebugFailure | None:
+        if persistence_error is not None:
+            return RuntimeSessionDebugFailure(
+                classification="session_state_inconsistency",
+                message=persistence_error,
+            )
+        if (
+            inconsistency_message := VoidCodeRuntime._debug_session_state_inconsistency(
+                result=result,
+                pending_approval=pending_approval,
+                pending_question=pending_question,
+                resume_checkpoint=resume_checkpoint,
+            )
+        ) is not None:
+            return RuntimeSessionDebugFailure(
+                classification="session_state_inconsistency",
+                message=inconsistency_message,
+            )
+        message = None
+        classification = "runtime_internal_failure"
+        if last_failure_event is not None:
+            provider_error_kind = last_failure_event.payload.get("provider_error_kind")
+            if isinstance(provider_error_kind, str) and provider_error_kind:
+                classification = "provider_failure"
+            raw_error = last_failure_event.payload.get("error")
+            if raw_error is not None:
+                message = str(raw_error)
+        elif result.error is not None:
+            message = result.error
+        if message is None:
+            if last_tool is not None and last_tool.status == "error":
+                return RuntimeSessionDebugFailure(
+                    classification="tool_execution_failure",
+                    message=last_tool.summary,
+                )
+            return None
+        lowered = message.lower()
+        if "permission denied" in lowered:
+            classification = "approval_denied"
+        elif pending_approval is not None or "approval" in lowered or "question" in lowered:
+            classification = "approval_interruption"
+        elif "cancel" in lowered:
+            classification = "cancelled"
+        elif last_tool is not None and last_tool.status == "error":
+            classification = "tool_execution_failure"
+        elif "tool" in lowered:
+            classification = "tool_execution_failure"
+        return RuntimeSessionDebugFailure(classification=classification, message=message)
+
+    @staticmethod
+    def _debug_session_state_inconsistency(
+        *,
+        result: RuntimeSessionResult,
+        pending_approval: PendingApproval | None,
+        pending_question: PendingQuestion | None,
+        resume_checkpoint: dict[str, object] | None,
+    ) -> str | None:
+        checkpoint_kind = (
+            cast(str, resume_checkpoint.get("kind"))
+            if isinstance(resume_checkpoint, dict)
+            and isinstance(resume_checkpoint.get("kind"), str)
+            else None
+        )
+        if result.session.status == "waiting":
+            if pending_approval is None and pending_question is None:
+                return "waiting session is missing pending approval/question state"
+            if pending_approval is not None and checkpoint_kind != "approval_wait":
+                return "pending approval does not match the persisted resume checkpoint"
+            if pending_question is not None and checkpoint_kind != "question_wait":
+                return "pending question does not match the persisted resume checkpoint"
+        if result.session.status in {"completed", "failed"}:
+            if checkpoint_kind not in {None, "terminal"}:
+                return "terminal session resume checkpoint does not match persisted terminal state"
+            if pending_approval is not None or pending_question is not None:
+                return "terminal session still has pending approval/question state"
+        if result.session.status == "running" and checkpoint_kind == "terminal":
+            return "running session should not carry a terminal resume checkpoint"
+        return None
+
+    @staticmethod
+    def _last_tool_summary(result: RuntimeSessionResult) -> RuntimeSessionDebugToolSummary | None:
+        for event in reversed(result.transcript):
+            if event.event_type != "runtime.tool_completed":
+                continue
+            payload = event.payload
+            tool_name = payload.get("tool")
+            if not isinstance(tool_name, str) or not tool_name:
+                continue
+            raw_status = payload.get("status")
+            status = raw_status if isinstance(raw_status, str) and raw_status else "ok"
+            if status not in {"ok", "error"}:
+                status = "error" if payload.get("error") is not None else "ok"
+            summary_source = payload.get("error") if status == "error" else payload.get("content")
+            summary = str(summary_source).strip() if summary_source is not None else tool_name
+            if len(summary) > 160:
+                summary = summary[:157] + "..."
+            arguments = payload.get("arguments")
+            return RuntimeSessionDebugToolSummary(
+                tool_name=tool_name,
+                status=status,
+                summary=summary,
+                arguments=(
+                    dict(cast(dict[str, object], arguments)) if isinstance(arguments, dict) else {}
+                ),
+                sequence=event.sequence,
+            )
+        return None
+
+    @staticmethod
+    def _operator_guidance(
+        *,
+        current_status: str,
+        pending_approval: PendingApproval | None,
+        pending_question: PendingQuestion | None,
+        active: bool,
+        terminal: bool,
+        failure: RuntimeSessionDebugFailure | None,
+    ) -> tuple[str, str]:
+        if pending_approval is not None:
+            return (
+                "resolve_approval",
+                "Resolve approval request "
+                f"{pending_approval.request_id} for {pending_approval.tool_name}.",
+            )
+        if pending_question is not None:
+            return (
+                "answer_question",
+                f"Answer pending question request {pending_question.request_id} before resuming.",
+            )
+        if failure is not None and failure.classification == "session_state_inconsistency":
+            return (
+                "inspect_failure",
+                "Inspect persisted session state before attempting resume or replay.",
+            )
+        if active:
+            return ("wait", "Session is currently active in the runtime.")
+        if terminal and failure is not None:
+            return ("inspect_failure", f"Inspect {failure.classification} and rerun if needed.")
+        if terminal:
+            return ("replay", "Session is terminal; replay or inspect transcript if needed.")
+        if current_status == "waiting_active":
+            return (
+                "inspect_wait",
+                "Session is waiting but still marked active; inspect runtime ownership.",
+            )
+        return ("inspect_session", "Inspect the persisted session state.")
+
+    def _active_only_session_debug_snapshot(
+        self,
+        *,
+        session_id: str,
+    ) -> RuntimeSessionDebugSnapshot:
+        active_metadata = self._active_session_metadata(session_id) or {}
+        request_metadata = active_metadata.get("request_metadata")
+        session_metadata = {
+            **(
+                dict(cast(dict[str, object], request_metadata))
+                if isinstance(request_metadata, dict)
+                else {}
+            ),
+            "workspace": str(self._workspace),
+        }
+        prompt = (
+            cast(str, active_metadata["prompt"])
+            if isinstance(active_metadata.get("prompt"), str)
+            else ""
+        )
+        session = SessionState(
+            session=SessionRef(id=session_id),
+            status="running",
+            turn=1,
+            metadata=session_metadata,
+        )
+        return RuntimeSessionDebugSnapshot(
+            session=session,
+            prompt=prompt,
+            persisted_status="running",
+            current_status="running",
+            active=True,
+            resumable=False,
+            replayable=False,
+            terminal=False,
+            suggested_operator_action="wait",
+            operator_guidance="Session is currently active in the runtime.",
         )
 
     def resume(

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -1194,10 +1194,12 @@ class VoidCodeRuntime:
             allow_internal_metadata=allow_internal_metadata,
         )
         session_id = self._resolve_session_id(request)
+        run_id = os.urandom(8).hex()
         self._register_active_session_id(
             session_id,
             metadata={
                 "prompt": request.prompt,
+                "run_id": run_id,
                 **dict(request.metadata),
                 "request_metadata": dict(request.metadata),
             },
@@ -1208,7 +1210,7 @@ class VoidCodeRuntime:
             final_session: SessionState | None = None
 
             try:
-                for chunk in self._stream_chunks(request, session_id=session_id):
+                for chunk in self._stream_chunks(request, session_id=session_id, run_id=run_id):
                     final_session = chunk.session
                     if chunk.event is not None:
                         events.append(chunk.event)
@@ -1277,6 +1279,7 @@ class VoidCodeRuntime:
         request: RuntimeRequest,
         *,
         session_id: str | None = None,
+        run_id: str | None = None,
     ) -> Iterator[RuntimeStreamChunk]:
         resolved_session_id = session_id or self._resolve_session_id(request)
         effective_config = self._runtime_config_for_request(request)
@@ -1289,7 +1292,7 @@ class VoidCodeRuntime:
                 **request_metadata,
                 "workspace": str(self._workspace),
                 "runtime_config": self._runtime_config_metadata(effective_config),
-                "runtime_state": self._runtime_state_metadata(),
+                "runtime_state": self._runtime_state_metadata(run_id=run_id),
             },
         )
         sequence = 1
@@ -1853,11 +1856,17 @@ class VoidCodeRuntime:
     def session_debug_snapshot(self, *, session_id: str) -> RuntimeSessionDebugSnapshot:
         validate_session_id(session_id)
         active = self._is_active_session_id(session_id)
+        active_metadata = self._active_session_metadata(session_id) if active else None
         try:
             result = self._load_session_result(session_id=session_id)
         except UnknownSessionError:
             if not active:
                 raise
+            return self._active_only_session_debug_snapshot(session_id=session_id)
+        if self._should_prefer_active_debug_snapshot(
+            result=result,
+            active_metadata=active_metadata,
+        ):
             return self._active_only_session_debug_snapshot(session_id=session_id)
         persistence_error: str | None = None
         pending_approval: PendingApproval | None = None
@@ -2359,6 +2368,60 @@ class VoidCodeRuntime:
             suggested_operator_action="wait",
             operator_guidance="Session is currently active in the runtime.",
         )
+
+    @staticmethod
+    def _should_prefer_active_debug_snapshot(
+        *,
+        result: RuntimeSessionResult,
+        active_metadata: dict[str, object] | None,
+    ) -> bool:
+        if active_metadata is None:
+            return False
+        active_run_id = active_metadata.get("run_id")
+        persisted_run_id = VoidCodeRuntime._run_id_from_session_metadata(result.session.metadata)
+        if isinstance(active_run_id, str) and active_run_id != persisted_run_id:
+            return True
+        request_metadata = active_metadata.get("request_metadata")
+        if not isinstance(request_metadata, dict):
+            return False
+        active_request_metadata = VoidCodeRuntime._fresh_request_metadata(
+            cast(RuntimeRequestMetadataPayload, request_metadata)
+        )
+        persisted_request_metadata = VoidCodeRuntime._request_metadata_from_session_metadata(
+            result.session.metadata
+        )
+        if active_request_metadata != persisted_request_metadata:
+            return True
+        active_prompt = active_metadata.get("prompt")
+        return isinstance(active_prompt, str) and active_prompt != result.prompt
+
+    @staticmethod
+    def _request_metadata_from_session_metadata(metadata: dict[str, object]) -> dict[str, object]:
+        request_metadata_keys = {
+            "abort_requested",
+            "agent",
+            "delegation",
+            "max_steps",
+            "provider_stream",
+            "skills",
+            "background_run",
+            "background_task_id",
+        }
+        request_metadata = {
+            key: value for key, value in metadata.items() if key in request_metadata_keys
+        }
+        return VoidCodeRuntime._fresh_request_metadata(
+            cast(RuntimeRequestMetadataPayload, request_metadata)
+        )
+
+    @staticmethod
+    def _run_id_from_session_metadata(metadata: dict[str, object]) -> str | None:
+        runtime_state = metadata.get("runtime_state")
+        if not isinstance(runtime_state, dict):
+            return None
+        runtime_state_dict = cast(dict[str, object], runtime_state)
+        run_id = runtime_state_dict.get("run_id")
+        return run_id if isinstance(run_id, str) and run_id else None
 
     def resume(
         self,
@@ -3782,9 +3845,10 @@ class VoidCodeRuntime:
             allow_internal_fields=allow_internal_fields,
         )
 
-    def _runtime_state_metadata(self) -> dict[str, object]:
+    def _runtime_state_metadata(self, *, run_id: str | None = None) -> dict[str, object]:
         acp_state = self._acp_adapter.current_state()
         return {
+            **({"run_id": run_id} if run_id is not None else {}),
             "acp": {
                 "mode": acp_state.mode,
                 "configured_enabled": acp_state.configuration.configured_enabled,
@@ -3799,7 +3863,7 @@ class VoidCodeRuntime:
                     if acp_state.last_delegation is not None
                     else None
                 ),
-            }
+            },
         }
 
     @staticmethod

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -1835,15 +1835,14 @@ class VoidCodeRuntime:
         return self._background_task_supervisor.cancel_background_task(task_id)
 
     def session_result(self, *, session_id: str) -> RuntimeSessionResult:
-        validate_session_id(session_id)
-        result = self._session_store.load_session_result(
-            workspace=self._workspace,
-            session_id=session_id,
-        )
-        self._validate_session_workspace(result.session, session_id=session_id)
+        _ = self._load_session_result(session_id=session_id)
         self._background_task_supervisor.reconcile_parent_background_task_events_for_session(
             parent_session_id=session_id
         )
+        return self._load_session_result(session_id=session_id)
+
+    def _load_session_result(self, *, session_id: str) -> RuntimeSessionResult:
+        validate_session_id(session_id)
         result = self._session_store.load_session_result(
             workspace=self._workspace,
             session_id=session_id,
@@ -1855,7 +1854,7 @@ class VoidCodeRuntime:
         validate_session_id(session_id)
         active = self._is_active_session_id(session_id)
         try:
-            result = self.session_result(session_id=session_id)
+            result = self._load_session_result(session_id=session_id)
         except UnknownSessionError:
             if not active:
                 raise

--- a/tests/integration/test_http_delegated_parity.py
+++ b/tests/integration/test_http_delegated_parity.py
@@ -140,6 +140,7 @@ class RuntimeFactory(Protocol):
         *,
         workspace: Path,
         permission_policy: object | None = None,
+        graph: object | None = None,
     ) -> RuntimeRunner: ...
 
 
@@ -840,6 +841,43 @@ def test_http_background_task_output_endpoint_exposes_typed_delegated_payload_fo
         "result_available": True,
     }
     assert payload["output"] == "hello"
+
+
+def test_http_background_task_output_endpoint_preserves_empty_child_output(tmp_path: Path) -> None:
+    create_runtime_app = _load_transport_app_factory()
+    runtime_request, runtime_class = _load_runtime_types()
+
+    class _EmptyOutputGraph:
+        def step(
+            self,
+            request: object,
+            tool_results: tuple[object, ...],
+            *,
+            session: object,
+        ) -> object:
+            _ = tool_results, session
+            return type("_Step", (), {"output": "", "is_finished": True, "tool_call": None})()
+
+    runtime = runtime_class(workspace=tmp_path, graph=_EmptyOutputGraph())
+    _ = runtime.run(runtime_request(prompt="read sample.txt", session_id="leader-session"))
+    started = runtime.start_background_task(
+        runtime_request(prompt="empty child", parent_session_id="leader-session")
+    )
+    _wait_for_background_task_terminal(runtime, started.task.id)
+
+    app = create_runtime_app(workspace=tmp_path, runtime_factory=lambda: runtime)
+
+    status, _headers, body = _run_app(
+        app,
+        method="GET",
+        path=f"/api/tasks/{started.task.id}/output",
+    )
+
+    payload = cast(dict[str, object], json.loads(body.decode("utf-8")))
+
+    assert status == 200
+    assert payload["session_result"] is not None
+    assert payload["output"] == ""
 
 
 def test_http_tasks_endpoints_cover_real_runtime_completed_lifecycle(tmp_path: Path) -> None:

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -51,6 +51,10 @@ class RuntimeResponseLike(Protocol):
     output: str | None
 
 
+class RuntimeSessionDebugSnapshotLike(Protocol):
+    prompt: str
+
+
 class RuntimeRequestLike(Protocol):
     prompt: str
     session_id: str | None
@@ -100,6 +104,8 @@ class RuntimeRunner(Protocol):
         question_request_id: str,
         responses: tuple[object, ...],
     ) -> RuntimeResponseLike: ...
+
+    def session_debug_snapshot(self, *, session_id: str) -> RuntimeSessionDebugSnapshotLike: ...
 
 
 class RuntimeFactory(Protocol):
@@ -680,6 +686,50 @@ def test_transport_reads_session_result_with_transcript(tmp_path: Path) -> None:
     assert [
         event["event_type"] for event in cast(list[dict[str, object]], payload["transcript"])
     ] == [event.event_type for event in stored.events]
+
+
+def test_transport_reads_session_debug_snapshot(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    _ = sample_file.write_text("debug payload\n", encoding="utf-8")
+    runtime_request, runtime_class = _load_runtime_types()
+    create_runtime_app = _load_transport_app_factory()
+
+    runtime = runtime_class(workspace=tmp_path)
+    stored = runtime.run(runtime_request(prompt="read sample.txt", session_id="debug-session"))
+
+    app = create_runtime_app(workspace=tmp_path)
+    response = _run_app(app, method="GET", path="/api/sessions/debug-session/debug")
+    payload = cast(dict[str, object], response.json())
+
+    assert response.status == 200
+    assert payload["prompt"] == "read sample.txt"
+    assert payload["persisted_status"] == "completed"
+    assert payload["current_status"] == "completed"
+    assert payload["active"] is False
+    assert payload["resumable"] is False
+    assert payload["replayable"] is True
+    assert payload["terminal"] is True
+    assert payload["resume_checkpoint_kind"] == "terminal"
+    assert payload["pending_approval"] is None
+    assert payload["pending_question"] is None
+    assert payload["last_event_sequence"] == stored.events[-1].sequence
+    assert (
+        cast(dict[str, object], payload["last_relevant_event"])["event_type"]
+        == "graph.response_ready"
+    )
+    assert payload["last_failure_event"] is None
+    assert payload["failure"] is None
+    assert payload["suggested_operator_action"] == "replay"
+
+
+def test_transport_returns_not_found_for_missing_session_debug_snapshot(tmp_path: Path) -> None:
+    create_runtime_app = _load_transport_app_factory()
+    app = create_runtime_app(workspace=tmp_path)
+
+    response = _run_app(app, method="GET", path="/api/sessions/missing-session/debug")
+
+    assert response.status == 404
+    assert response.json() == {"error": "unknown session: missing-session"}
 
 
 def test_transport_resolves_pending_approval_allow_over_http(tmp_path: Path) -> None:

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -1213,19 +1213,20 @@ def test_provider_runtime_executes_read_path_and_persists_config(tmp_path: Path)
         },
         "tool_timeout_seconds": None,
     }
-    assert result.session.metadata["runtime_state"] == {
-        "acp": {
-            "available": False,
-            "configured_enabled": False,
-            "last_delegation": None,
-            "last_error": None,
-            "last_event_type": None,
-            "last_request_id": None,
-            "last_request_type": None,
-            "mode": "disabled",
-            "status": "disconnected",
-        }
+    runtime_state = cast(dict[str, object], result.session.metadata["runtime_state"])
+    assert runtime_state["acp"] == {
+        "available": False,
+        "configured_enabled": False,
+        "last_delegation": None,
+        "last_error": None,
+        "last_event_type": None,
+        "last_request_id": None,
+        "last_request_type": None,
+        "mode": "disabled",
+        "status": "disconnected",
     }
+    assert isinstance(runtime_state.get("run_id"), str)
+    assert cast(str, runtime_state["run_id"])
     assert result.events[3].payload["mode"] == "provider"
     assert replay.output == result.output
 
@@ -1967,19 +1968,20 @@ def test_runtime_resume_uses_persisted_runtime_config_over_fresh_resume_override
             ],
         },
     }
-    assert replay.session.metadata["runtime_state"] == {
-        "acp": {
-            "available": False,
-            "configured_enabled": False,
-            "last_delegation": None,
-            "last_error": None,
-            "last_event_type": None,
-            "last_request_id": None,
-            "last_request_type": None,
-            "mode": "disabled",
-            "status": "disconnected",
-        }
+    runtime_state = cast(dict[str, object], replay.session.metadata["runtime_state"])
+    assert runtime_state["acp"] == {
+        "available": False,
+        "configured_enabled": False,
+        "last_delegation": None,
+        "last_error": None,
+        "last_event_type": None,
+        "last_request_id": None,
+        "last_request_type": None,
+        "mode": "disabled",
+        "status": "disconnected",
     }
+    assert isinstance(runtime_state.get("run_id"), str)
+    assert cast(str, runtime_state["run_id"])
 
 
 def test_runtime_resume_accepts_legacy_sessions_without_runtime_config_metadata(
@@ -2015,28 +2017,28 @@ def test_runtime_resume_accepts_legacy_sessions_without_runtime_config_metadata(
 
     assert replay.session.status == response.session.status
     assert replay.output == response.output
-    assert replay.session.metadata == {
-        "workspace": str(tmp_path),
-        "runtime_state": {
-            "acp": {
-                "available": False,
-                "configured_enabled": False,
-                "last_delegation": None,
-                "last_error": None,
-                "last_event_type": None,
-                "last_request_id": None,
-                "last_request_type": None,
-                "mode": "disabled",
-                "status": "disconnected",
-            }
-        },
-        "context_window": {
-            "compacted": False,
-            "compaction_reason": None,
-            "original_tool_result_count": 1,
-            "retained_tool_result_count": 1,
-            "max_tool_result_count": 4,
-        },
+    replay_metadata = cast(dict[str, object], replay.session.metadata)
+    assert replay_metadata["workspace"] == str(tmp_path)
+    runtime_state = cast(dict[str, object], replay_metadata["runtime_state"])
+    assert runtime_state["acp"] == {
+        "available": False,
+        "configured_enabled": False,
+        "last_delegation": None,
+        "last_error": None,
+        "last_event_type": None,
+        "last_request_id": None,
+        "last_request_type": None,
+        "mode": "disabled",
+        "status": "disconnected",
+    }
+    assert isinstance(runtime_state.get("run_id"), str)
+    assert cast(str, runtime_state["run_id"])
+    assert replay_metadata["context_window"] == {
+        "compacted": False,
+        "compaction_reason": None,
+        "original_tool_result_count": 1,
+        "retained_tool_result_count": 1,
+        "max_tool_result_count": 4,
     }
 
 
@@ -2075,19 +2077,20 @@ def test_runtime_resume_repairs_legacy_non_dict_runtime_state_metadata(tmp_path:
 
     assert replay.session.status == "completed"
     assert replay.output == "approved later"
-    assert replay.session.metadata["runtime_state"] == {
-        "acp": {
-            "available": False,
-            "configured_enabled": False,
-            "last_delegation": None,
-            "last_error": None,
-            "last_event_type": None,
-            "last_request_id": None,
-            "last_request_type": None,
-            "mode": "disabled",
-            "status": "disconnected",
-        }
+    runtime_state = cast(dict[str, object], replay.session.metadata["runtime_state"])
+    assert runtime_state["acp"] == {
+        "available": False,
+        "configured_enabled": False,
+        "last_delegation": None,
+        "last_error": None,
+        "last_event_type": None,
+        "last_request_id": None,
+        "last_request_type": None,
+        "mode": "disabled",
+        "status": "disconnected",
     }
+    assert isinstance(runtime_state.get("run_id"), str)
+    assert cast(str, runtime_state["run_id"])
 
 
 def test_runtime_denies_non_read_only_tool_on_resume(tmp_path: Path) -> None:

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -1188,6 +1188,12 @@ def test_provider_runtime_executes_read_path_and_persists_config(tmp_path: Path)
 
     assert result.session.status == "completed"
     assert result.output == "alpha\nbeta"
+    assert set(result.session.metadata) == {
+        "workspace",
+        "runtime_config",
+        "runtime_state",
+        "context_window",
+    }
     assert result.session.metadata["runtime_config"] == {
         "approval_mode": "allow",
         "execution_engine": "provider",
@@ -1214,6 +1220,7 @@ def test_provider_runtime_executes_read_path_and_persists_config(tmp_path: Path)
         "tool_timeout_seconds": None,
     }
     runtime_state = cast(dict[str, object], result.session.metadata["runtime_state"])
+    assert set(runtime_state) == {"acp", "run_id"}
     assert runtime_state["acp"] == {
         "available": False,
         "configured_enabled": False,
@@ -1225,8 +1232,6 @@ def test_provider_runtime_executes_read_path_and_persists_config(tmp_path: Path)
         "mode": "disabled",
         "status": "disconnected",
     }
-    assert isinstance(runtime_state.get("run_id"), str)
-    assert cast(str, runtime_state["run_id"])
     assert result.events[3].payload["mode"] == "provider"
     assert replay.output == result.output
 
@@ -1943,6 +1948,12 @@ def test_runtime_resume_uses_persisted_runtime_config_over_fresh_resume_override
     )
     replay = resumed_runtime.resume("resume-config-session")
 
+    assert set(replay.session.metadata) == {
+        "workspace",
+        "runtime_config",
+        "runtime_state",
+        "context_window",
+    }
     assert replay.session.metadata["runtime_config"] == {
         "approval_mode": "allow",
         "execution_engine": "deterministic",
@@ -1969,6 +1980,7 @@ def test_runtime_resume_uses_persisted_runtime_config_over_fresh_resume_override
         },
     }
     runtime_state = cast(dict[str, object], replay.session.metadata["runtime_state"])
+    assert set(runtime_state) == {"acp", "run_id"}
     assert runtime_state["acp"] == {
         "available": False,
         "configured_enabled": False,
@@ -1980,8 +1992,6 @@ def test_runtime_resume_uses_persisted_runtime_config_over_fresh_resume_override
         "mode": "disabled",
         "status": "disconnected",
     }
-    assert isinstance(runtime_state.get("run_id"), str)
-    assert cast(str, runtime_state["run_id"])
 
 
 def test_runtime_resume_accepts_legacy_sessions_without_runtime_config_metadata(
@@ -2018,8 +2028,10 @@ def test_runtime_resume_accepts_legacy_sessions_without_runtime_config_metadata(
     assert replay.session.status == response.session.status
     assert replay.output == response.output
     replay_metadata = cast(dict[str, object], replay.session.metadata)
+    assert set(replay_metadata) == {"workspace", "runtime_state", "context_window"}
     assert replay_metadata["workspace"] == str(tmp_path)
     runtime_state = cast(dict[str, object], replay_metadata["runtime_state"])
+    assert set(runtime_state) == {"acp", "run_id"}
     assert runtime_state["acp"] == {
         "available": False,
         "configured_enabled": False,
@@ -2077,7 +2089,14 @@ def test_runtime_resume_repairs_legacy_non_dict_runtime_state_metadata(tmp_path:
 
     assert replay.session.status == "completed"
     assert replay.output == "approved later"
+    assert set(replay.session.metadata) == {
+        "workspace",
+        "runtime_config",
+        "runtime_state",
+        "context_window",
+    }
     runtime_state = cast(dict[str, object], replay.session.metadata["runtime_state"])
+    assert set(runtime_state) == {"acp"}
     assert runtime_state["acp"] == {
         "available": False,
         "configured_enabled": False,
@@ -2089,8 +2108,6 @@ def test_runtime_resume_repairs_legacy_non_dict_runtime_state_metadata(tmp_path:
         "mode": "disabled",
         "status": "disconnected",
     }
-    assert isinstance(runtime_state.get("run_id"), str)
-    assert cast(str, runtime_state["run_id"])
 
 
 def test_runtime_denies_non_read_only_tool_on_resume(tmp_path: Path) -> None:

--- a/tests/unit/interface/test_cli_delegated_parity.py
+++ b/tests/unit/interface/test_cli_delegated_parity.py
@@ -849,6 +849,42 @@ def test_cli_tasks_output_falls_back_when_child_session_lookup_fails(capsys: Any
     assert "RESULT\nFailed: delegated work" in captured.out
 
 
+def test_cli_tasks_output_preserves_empty_child_session_output(capsys: Any) -> None:
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/demo-workspace")
+    task_result = SimpleNamespace(
+        task_id="task-empty",
+        status="completed",
+        parent_session_id="leader-session",
+        requested_child_session_id="child-requested",
+        child_session_id="child-session",
+        approval_request_id=None,
+        question_request_id=None,
+        approval_blocked=False,
+        result_available=True,
+        summary_output="Completed: delegated work",
+        error=None,
+        routing=None,
+    )
+    session_result = SimpleNamespace(output="")
+
+    with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
+        runtime = runtime_class.return_value
+        runtime.load_background_task_result.return_value = task_result
+        runtime.session_result.return_value = session_result
+        result = cli.main(["tasks", "output", "task-empty", "--workspace", str(workspace)])
+
+    captured = capsys.readouterr()
+
+    assert result == 0
+    runtime.load_background_task_result.assert_called_once_with("task-empty")
+    runtime.session_result.assert_called_once_with(session_id="child-session")
+    assert "TASK id=task-empty status=completed" in captured.out
+    assert "summary_output='Completed: delegated work'" in captured.out
+    assert captured.out.endswith("RESULT\n")
+    assert "Completed: delegated work" not in captured.out.split("RESULT\n", 1)[1]
+
+
 def test_cli_tasks_cancel_delegates_to_runtime_cancel_background_task(capsys: Any) -> None:
     cli = importlib.import_module("voidcode.cli")
     workspace = Path("/tmp/demo-workspace")

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -229,6 +229,67 @@ def test_sessions_resume_surfaces_approval_resolution_errors_cleanly() -> None:
     assert "Traceback" not in resume_result.stderr
 
 
+def test_sessions_debug_outputs_json_snapshot() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        _ = (workspace / "sample.txt").write_text("sample\n", encoding="utf-8")
+        env = with_src_pythonpath(os.environ.copy())
+
+        setup_result = _run_module_cli(
+            "run",
+            "read sample.txt",
+            "--workspace",
+            str(workspace),
+            "--session-id",
+            "debug-session",
+            env=env,
+        )
+        debug_result = _run_module_cli(
+            "sessions",
+            "debug",
+            "debug-session",
+            "--workspace",
+            str(workspace),
+            env=env,
+        )
+
+    payload = json.loads(debug_result.stdout)
+    assert setup_result.returncode == 0
+    assert debug_result.returncode == 0
+    assert payload["prompt"] == "read sample.txt"
+    assert payload["persisted_status"] == "completed"
+    assert payload["current_status"] == "completed"
+    assert payload["active"] is False
+    assert payload["terminal"] is True
+    assert payload["replayable"] is True
+    assert payload["resume_checkpoint_kind"] == "terminal"
+    assert payload["pending_approval"] is None
+    assert payload["pending_question"] is None
+    assert payload["last_relevant_event"]["event_type"] == "graph.response_ready"
+    assert payload["suggested_operator_action"] == "replay"
+    assert "Traceback" not in debug_result.stderr
+
+
+def test_sessions_debug_missing_session_returns_clean_error() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        env = with_src_pythonpath(os.environ.copy())
+
+        result = _run_module_cli(
+            "sessions",
+            "debug",
+            "missing-session",
+            "--workspace",
+            str(workspace),
+            env=env,
+        )
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "error: unknown session: missing-session" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
 def test_tui_command_forwards_workspace_and_approval_mode() -> None:
     cli = importlib.import_module("voidcode.cli")
     tui = importlib.import_module("voidcode.tui")

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -6524,6 +6524,13 @@ def test_runtime_effective_runtime_config_uses_request_metadata_max_steps_for_ne
     response = runtime.run(RuntimeRequest(prompt="hello", metadata={"max_steps": 2}))
 
     assert response.session.status == "completed"
+    assert set(response.session.metadata) == {
+        "workspace",
+        "runtime_config",
+        "runtime_state",
+        "context_window",
+        "max_steps",
+    }
     assert response.session.metadata["runtime_config"] == {
         "approval_mode": "ask",
         "execution_engine": "deterministic",
@@ -6536,6 +6543,7 @@ def test_runtime_effective_runtime_config_uses_request_metadata_max_steps_for_ne
         "mcp": {"mode": "disabled", "configured_enabled": False, "servers": []},
     }
     runtime_state = cast(dict[str, object], response.session.metadata["runtime_state"])
+    assert set(runtime_state) == {"acp", "run_id"}
     assert runtime_state["acp"] == {
         "mode": "disabled",
         "configured_enabled": False,

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -2014,6 +2014,94 @@ def test_runtime_reconciles_persisted_child_terminal_truth_and_backfills_parent_
     )
 
 
+def test_runtime_session_debug_snapshot_does_not_reconcile_parent_background_events(
+    tmp_path: Path,
+) -> None:
+    initial_runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    _ = initial_runtime.run(RuntimeRequest(prompt="leader", session_id="leader-session"))
+    store = _private_attr(initial_runtime, "_session_store")
+    task_module = importlib.import_module("voidcode.runtime.task")
+    store.create_background_task(
+        workspace=tmp_path,
+        task=task_module.BackgroundTaskState(
+            task=task_module.BackgroundTaskRef(id="task-debug-inspect"),
+            status="running",
+            request=task_module.BackgroundTaskRequestSnapshot(
+                prompt="background child",
+                parent_session_id="leader-session",
+            ),
+            session_id="child-session",
+            created_at=1,
+            updated_at=1,
+            started_at=1,
+        ),
+    )
+    store.save_run(
+        workspace=tmp_path,
+        request=RuntimeRequest(
+            prompt="background child",
+            session_id="child-session",
+            parent_session_id="leader-session",
+            metadata={
+                "background_run": True,
+                "background_task_id": "task-debug-inspect",
+            },
+        ),
+        response=RuntimeResponse(
+            session=SessionState(
+                session=runtime_service_module.SessionRef(
+                    id="child-session",
+                    parent_id="leader-session",
+                ),
+                status="completed",
+                turn=1,
+                metadata={
+                    "background_run": True,
+                    "background_task_id": "task-debug-inspect",
+                },
+            ),
+            events=(
+                EventEnvelope(
+                    session_id="child-session",
+                    sequence=1,
+                    event_type="runtime.request_received",
+                    source="runtime",
+                    payload={"prompt": "background child"},
+                ),
+                EventEnvelope(
+                    session_id="child-session",
+                    sequence=2,
+                    event_type="graph.response_ready",
+                    source="graph",
+                    payload={},
+                ),
+            ),
+            output="background child",
+        ),
+    )
+
+    resumed_runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+
+    snapshot = resumed_runtime.session_debug_snapshot(session_id="leader-session")
+    before_resume = resumed_runtime._session_store.load_session_result(  # pyright: ignore[reportPrivateUsage]
+        workspace=tmp_path,
+        session_id="leader-session",
+    )
+    resumed = resumed_runtime.resume("leader-session")
+
+    assert snapshot.current_status == "completed"
+    assert (
+        sum(
+            event.event_type == RUNTIME_BACKGROUND_TASK_COMPLETED
+            for event in before_resume.transcript
+        )
+        == 0
+    )
+    assert (
+        sum(event.event_type == RUNTIME_BACKGROUND_TASK_COMPLETED for event in resumed.events) == 1
+    )
+
+
 def test_runtime_resume_does_not_fail_unrelated_background_tasks(tmp_path: Path) -> None:
     runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
     store = _private_attr(runtime, "_session_store")

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -920,6 +920,82 @@ def test_runtime_session_debug_snapshot_marks_active_running_session(tmp_path: P
     _ = list(stream)
 
 
+def test_runtime_session_debug_snapshot_prefers_active_state_for_reused_session_id(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+
+    _ = runtime.run(RuntimeRequest(prompt="old prompt", session_id="reused-debug"))
+    stream = runtime.run_stream(RuntimeRequest(prompt="new prompt", session_id="reused-debug"))
+
+    first_chunk = next(stream)
+    snapshot = runtime.session_debug_snapshot(session_id="reused-debug")
+
+    assert first_chunk.session.status == "running"
+    assert snapshot.prompt == "new prompt"
+    assert snapshot.active is True
+    assert snapshot.persisted_status == "running"
+    assert snapshot.current_status == "running"
+    assert snapshot.terminal is False
+    assert snapshot.suggested_operator_action == "wait"
+    assert snapshot.operator_guidance == "Session is currently active in the runtime."
+    _ = list(stream)
+
+
+def test_runtime_session_debug_snapshot_prefers_active_state_for_reused_session_id_with_same_prompt(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+
+    _ = runtime.run(RuntimeRequest(prompt="same prompt", session_id="same-prompt-debug"))
+    stream = runtime._run_with_persistence(  # pyright: ignore[reportPrivateUsage]
+        RuntimeRequest(prompt="same prompt", session_id="same-prompt-debug")
+    )
+
+    first_chunk = next(stream)
+    snapshot = runtime.session_debug_snapshot(session_id="same-prompt-debug")
+
+    assert first_chunk.session.status == "running"
+    assert snapshot.prompt == "same prompt"
+    assert snapshot.active is True
+    assert snapshot.persisted_status == "running"
+    assert snapshot.current_status == "running"
+    assert snapshot.terminal is False
+    assert snapshot.suggested_operator_action == "wait"
+    assert snapshot.operator_guidance == "Session is currently active in the runtime."
+    _ = list(stream)
+
+
+def test_runtime_session_debug_snapshot_preserves_fresh_terminal_state_while_active(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+
+    deferred_unregister_session_id: str | None = None
+    original_unregister = runtime._unregister_active_session_id  # pyright: ignore[reportPrivateUsage]
+
+    def _defer_unregister(session_id: str) -> None:
+        nonlocal deferred_unregister_session_id
+        deferred_unregister_session_id = session_id
+
+    monkeypatch.setattr(runtime, "_unregister_active_session_id", _defer_unregister)
+    response = runtime.run(RuntimeRequest(prompt="terminal debug", session_id="terminal-debug"))
+    try:
+        assert deferred_unregister_session_id == "terminal-debug"
+        snapshot = runtime.session_debug_snapshot(session_id="terminal-debug")
+    finally:
+        original_unregister("terminal-debug")
+
+    assert response.session.status == "completed"
+    assert snapshot.prompt == "terminal debug"
+    assert snapshot.active is True
+    assert snapshot.persisted_status == "completed"
+    assert snapshot.current_status == "completed"
+    assert snapshot.terminal is True
+    assert snapshot.suggested_operator_action == "wait"
+
+
 def test_runtime_task_tool_starts_background_task_with_skill_metadata(tmp_path: Path) -> None:
     skill_dir = tmp_path / ".voidcode" / "skills" / "demo"
     _write_demo_skill(skill_dir, content="# Demo\nUse delegated skill.")

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -6535,19 +6535,20 @@ def test_runtime_effective_runtime_config_uses_request_metadata_max_steps_for_ne
         "lsp": {"mode": "disabled", "configured_enabled": False, "servers": []},
         "mcp": {"mode": "disabled", "configured_enabled": False, "servers": []},
     }
-    assert response.session.metadata["runtime_state"] == {
-        "acp": {
-            "mode": "disabled",
-            "configured_enabled": False,
-            "status": "disconnected",
-            "available": False,
-            "last_delegation": None,
-            "last_error": None,
-            "last_event_type": None,
-            "last_request_id": None,
-            "last_request_type": None,
-        }
+    runtime_state = cast(dict[str, object], response.session.metadata["runtime_state"])
+    assert runtime_state["acp"] == {
+        "mode": "disabled",
+        "configured_enabled": False,
+        "status": "disconnected",
+        "available": False,
+        "last_delegation": None,
+        "last_error": None,
+        "last_event_type": None,
+        "last_request_id": None,
+        "last_request_type": None,
     }
+    assert isinstance(runtime_state.get("run_id"), str)
+    assert cast(str, runtime_state["run_id"])
 
 
 def test_runtime_custom_plan_contributor_can_patch_prompt_and_metadata(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -727,6 +727,199 @@ def test_runtime_background_task_executes_through_existing_runtime_path(tmp_path
     assert completed == loaded
 
 
+def test_runtime_session_debug_snapshot_reports_completed_state(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+
+    response = runtime.run(RuntimeRequest(prompt="debug hello", session_id="debug-session"))
+    snapshot = runtime.session_debug_snapshot(session_id="debug-session")
+
+    assert response.output == "debug hello"
+    assert snapshot.prompt == "debug hello"
+    assert snapshot.persisted_status == "completed"
+    assert snapshot.current_status == "completed"
+    assert snapshot.active is False
+    assert snapshot.resumable is False
+    assert snapshot.replayable is True
+    assert snapshot.terminal is True
+    assert snapshot.resume_checkpoint_kind == "terminal"
+    assert snapshot.pending_approval is None
+    assert snapshot.pending_question is None
+    assert snapshot.last_event_sequence == response.events[-1].sequence
+    assert snapshot.last_relevant_event is not None
+    assert snapshot.last_relevant_event.event_type == response.events[-1].event_type
+    assert snapshot.last_failure_event is None
+    assert snapshot.failure is None
+    assert snapshot.suggested_operator_action == "replay"
+    assert (
+        snapshot.operator_guidance == "Session is terminal; replay or inspect transcript if needed."
+    )
+
+
+def test_runtime_session_debug_snapshot_reports_pending_approval_state(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    waiting = runtime.run(
+        RuntimeRequest(prompt="write debug.txt hello", session_id="approval-debug")
+    )
+    snapshot = runtime.session_debug_snapshot(session_id="approval-debug")
+
+    assert waiting.session.status == "waiting"
+    assert snapshot.persisted_status == "waiting"
+    assert snapshot.current_status == "waiting_for_approval"
+    assert snapshot.resumable is True
+    assert snapshot.terminal is False
+    assert snapshot.resume_checkpoint_kind == "approval_wait"
+    assert snapshot.pending_approval is not None
+    assert snapshot.pending_approval.tool_name == "write_file"
+    assert snapshot.pending_approval.request_id == waiting.events[-1].payload["request_id"]
+    assert snapshot.pending_question is None
+    assert snapshot.last_relevant_event is not None
+    assert snapshot.last_relevant_event.event_type == "runtime.approval_requested"
+    assert snapshot.last_failure_event is None
+    assert snapshot.failure is None
+    assert snapshot.last_tool is None
+    assert snapshot.suggested_operator_action == "resolve_approval"
+    assert "Resolve approval request" in snapshot.operator_guidance
+
+
+def test_runtime_session_debug_snapshot_reports_pending_question_state(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_QuestionThenDoneGraph())
+
+    waiting = runtime.run(RuntimeRequest(prompt="question debug", session_id="question-debug"))
+    snapshot = runtime.session_debug_snapshot(session_id="question-debug")
+
+    assert waiting.session.status == "waiting"
+    assert snapshot.current_status == "waiting_for_question"
+    assert snapshot.resume_checkpoint_kind == "question_wait"
+    assert snapshot.pending_question is not None
+    assert snapshot.pending_question.request_id == waiting.events[-1].payload["request_id"]
+    assert snapshot.pending_question.question_count == 1
+    assert snapshot.pending_question.headers == ("Runtime path",)
+    assert snapshot.pending_approval is None
+    assert snapshot.last_relevant_event is not None
+    assert snapshot.last_relevant_event.event_type == "runtime.question_requested"
+    assert snapshot.suggested_operator_action == "answer_question"
+    assert "Answer pending question request" in snapshot.operator_guidance
+
+
+def test_runtime_session_debug_snapshot_reports_failure_classification_and_last_tool(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+    waiting = runtime.run(
+        RuntimeRequest(prompt="write debug.txt denied", session_id="failed-debug")
+    )
+
+    response = runtime.resume(
+        "failed-debug",
+        approval_request_id=cast(str, waiting.events[-1].payload["request_id"]),
+        approval_decision="deny",
+    )
+    snapshot = runtime.session_debug_snapshot(session_id="failed-debug")
+
+    assert response.session.status == "failed"
+    assert snapshot.current_status == "failed"
+    assert snapshot.terminal is True
+    assert snapshot.failure is not None
+    assert snapshot.failure.classification == "approval_denied"
+    assert snapshot.failure.message == "permission denied for tool: write_file"
+    assert snapshot.last_failure_event is not None
+    assert snapshot.last_failure_event.event_type == "runtime.failed"
+    assert snapshot.last_relevant_event is not None
+    assert snapshot.last_relevant_event.event_type == "runtime.failed"
+    assert snapshot.last_tool is None
+    assert snapshot.suggested_operator_action == "inspect_failure"
+    assert snapshot.operator_guidance == "Inspect approval_denied and rerun if needed."
+
+
+def test_runtime_session_debug_snapshot_classifies_provider_failure(tmp_path: Path) -> None:
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderExecutionError(
+                        kind="context_limit",
+                        provider_name="opencode",
+                        model_name="gpt-5.4",
+                        message="context exceeded",
+                    ),
+                ),
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="read sample.txt", session_id="provider-debug"))
+    snapshot = runtime.session_debug_snapshot(session_id="provider-debug")
+
+    assert response.session.status == "failed"
+    assert snapshot.failure is not None
+    assert snapshot.failure.classification == "provider_failure"
+    assert snapshot.failure.message == "context exceeded"
+    assert snapshot.last_failure_event is not None
+    assert snapshot.last_failure_event.payload["provider_error_kind"] == "context_limit"
+
+
+def test_runtime_session_debug_snapshot_classifies_session_state_inconsistency(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    waiting = runtime.run(
+        RuntimeRequest(prompt="write debug.txt hello", session_id="inconsistent-debug")
+    )
+    assert waiting.session.status == "waiting"
+
+    database_path = tmp_path / ".voidcode" / "sessions.sqlite3"
+    connection = sqlite3.connect(database_path)
+    try:
+        _ = connection.execute(
+            "UPDATE sessions SET pending_approval_json = NULL WHERE session_id = ?",
+            ("inconsistent-debug",),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    snapshot = runtime.session_debug_snapshot(session_id="inconsistent-debug")
+
+    assert snapshot.failure is not None
+    assert snapshot.failure.classification == "session_state_inconsistency"
+    assert snapshot.failure.message == "waiting session is missing pending approval/question state"
+    assert snapshot.suggested_operator_action == "inspect_failure"
+
+
+def test_runtime_session_debug_snapshot_marks_active_running_session(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+
+    stream = runtime.run_stream(RuntimeRequest(prompt="active debug", session_id="active-debug"))
+    first_chunk = next(stream)
+    snapshot = runtime.session_debug_snapshot(session_id="active-debug")
+
+    assert first_chunk.session.status == "running"
+    assert snapshot.active is True
+    assert snapshot.persisted_status == "running"
+    assert snapshot.current_status == "running"
+    assert snapshot.terminal is False
+    assert snapshot.suggested_operator_action == "wait"
+    assert snapshot.operator_guidance == "Session is currently active in the runtime."
+    _ = list(stream)
+
+
 def test_runtime_task_tool_starts_background_task_with_skill_metadata(tmp_path: Path) -> None:
     skill_dir = tmp_path / ".voidcode" / "skills" / "demo"
     _write_demo_skill(skill_dir, content="# Demo\nUse delegated skill.")


### PR DESCRIPTION
## Summary
- add a runtime-owned session debug snapshot surface that summarizes persisted status, active/waiting/terminal state, recent relevant events, failure classification, and operator guidance
- expose the snapshot through both `GET /api/sessions/{id}/debug` and `voidcode sessions debug <session-id>` while keeping HTTP and CLI as thin adapters over runtime state
- cover the new runtime, HTTP, and CLI behavior with targeted tests and update the MVP demo/docs to reflect the minimal observability slice delivered for #227

## Verification
- `uv run pytest`
- `uv run ruff check .`
- `uv run basedpyright --warnings src`
- `bun run lint && bun run typecheck && bun run test:run && bun run build`
- `uv build`

## Notes
- active/live visibility is intentionally MVP-minimal and same-process via the runtime's active session registry; this PR does not add a cross-process tracing system
- the snapshot is intended for local operator diagnostics and deliberately reuses runtime-owned session/event state instead of introducing a separate logging pipeline

Closes #227.