### PR TITLE
refactor(frontend): align web shell controls with OpenCode-style hierarchy

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -91,15 +91,10 @@ describe("App", () => {
     vi.useRealTimers();
   });
 
-  it("toggles language when language button is clicked", () => {
+  it("does not render a standalone language header button", () => {
     render(<App />);
 
-    const langBtn = screen.getByTitle("中文");
-    expect(langBtn).toBeInTheDocument();
-
-    fireEvent.click(langBtn);
-
-    expect(mockStore.setLanguage).toHaveBeenCalledWith("zh-CN");
+    expect(screen.queryByTitle("中文")).not.toBeInTheDocument();
   });
 
   it("renders composer and triggers runTask on submit", () => {
@@ -824,17 +819,18 @@ describe("App", () => {
 
     render(<App />);
 
-    const modelInput = screen.getByLabelText("Model");
-    expect(modelInput).toHaveValue("opencode-go/glm-5.1");
+    const modelInput = screen.getByRole("button", { name: "Model" });
+    expect(modelInput).toHaveTextContent("OpenCode Go / glm-5.1");
 
-    fireEvent.change(modelInput, { target: { value: "new-model/v1" } });
+    fireEvent.click(modelInput);
+    fireEvent.click(screen.getByRole("button", { name: "new-model/v1" }));
     expect(mockStore.setProviderModel).toHaveBeenCalledWith("new-model/v1");
   });
 
   it("renders settings panel when settings button is clicked", () => {
     render(<App />);
 
-    const settingsButton = screen.getByTitle("Settings");
+    const settingsButton = screen.getByRole("button", { name: "Settings" });
     fireEvent.click(settingsButton);
 
     expect(screen.getByTestId("settings-panel-mock")).toBeInTheDocument();

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -94,7 +94,7 @@ describe("App", () => {
   it("toggles language when language button is clicked", () => {
     render(<App />);
 
-    const langBtn = screen.getByText("中文");
+    const langBtn = screen.getByTitle("中文");
     expect(langBtn).toBeInTheDocument();
 
     fireEvent.click(langBtn);
@@ -834,7 +834,7 @@ describe("App", () => {
   it("renders settings panel when settings button is clicked", () => {
     render(<App />);
 
-    const settingsButton = screen.getByText("Settings");
+    const settingsButton = screen.getByTitle("Settings");
     fireEvent.click(settingsButton);
 
     expect(screen.getByTestId("settings-panel-mock")).toBeInTheDocument();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,8 +11,6 @@ import { deriveChatMessages } from "./lib/runtime/event-parser";
 import { RuntimeClient } from "./lib/runtime/client";
 import {
   Loader2,
-  Settings,
-  Globe,
   Server,
   CheckCircle2,
   XCircle,
@@ -160,10 +158,6 @@ function App() {
     await runTask(message);
   };
 
-  const toggleLanguage = () => {
-    setLanguage(language === "en" ? "zh-CN" : "en");
-  };
-
   const testRuntime = async () => {
     setRuntimeTestStatus("testing");
     try {
@@ -211,6 +205,7 @@ function App() {
         isReplayLoading={isReplayLoading}
         onSelectSession={selectSession}
         onOpenProjects={() => setShowProjects(true)}
+        onOpenSettings={() => setShowSettings(true)}
       />
 
       <div className="flex-1 flex flex-col min-w-0">
@@ -279,17 +274,6 @@ function App() {
 
                 <button
                   type="button"
-                  onClick={toggleLanguage}
-                  title={
-                    language === "en" ? t("language.zh") : t("language.en")
-                  }
-                  className="rounded-lg border border-slate-700 bg-transparent px-2 py-1.5 text-slate-400 hover:bg-slate-800/60 hover:text-slate-200 transition-colors"
-                >
-                  <Globe className="w-4 h-4" />
-                </button>
-
-                <button
-                  type="button"
                   onClick={testRuntime}
                   disabled={runtimeTestStatus === "testing"}
                   title={t("debug.testRuntime")}
@@ -304,15 +288,6 @@ function App() {
                   ) : (
                     <Server className="w-4 h-4" />
                   )}
-                </button>
-
-                <button
-                  type="button"
-                  onClick={() => setShowSettings(true)}
-                  title={t("nav.settings")}
-                  className="rounded-lg border border-slate-700 bg-transparent px-2 py-1.5 text-slate-400 hover:bg-slate-800/60 hover:text-slate-200 transition-colors"
-                >
-                  <Settings className="w-4 h-4" />
                 </button>
               </div>
             </header>
@@ -358,17 +333,6 @@ function App() {
               <div className="flex items-center gap-2">
                 <button
                   type="button"
-                  onClick={toggleLanguage}
-                  title={
-                    language === "en" ? t("language.zh") : t("language.en")
-                  }
-                  className="rounded-lg border border-slate-700 bg-slate-900/50 px-2 py-1.5 text-slate-400 hover:bg-slate-800/60 hover:text-slate-200 transition-colors"
-                >
-                  <Globe className="w-4 h-4" />
-                </button>
-
-                <button
-                  type="button"
                   onClick={testRuntime}
                   disabled={runtimeTestStatus === "testing"}
                   title={t("debug.testRuntime")}
@@ -383,15 +347,6 @@ function App() {
                   ) : (
                     <Server className="w-4 h-4" />
                   )}
-                </button>
-
-                <button
-                  type="button"
-                  onClick={() => setShowSettings(true)}
-                  title={t("nav.settings")}
-                  className="rounded-lg border border-slate-700 bg-slate-900/50 px-2 py-1.5 text-slate-400 hover:bg-slate-800/60 hover:text-slate-200 transition-colors"
-                >
-                  <Settings className="w-4 h-4" />
                 </button>
               </div>
             </header>
@@ -443,6 +398,8 @@ function App() {
         providers={providers}
         providersStatus={providersStatus}
         providersError={providersError}
+        language={language}
+        onToggleLanguage={() => setLanguage(language === "en" ? "zh-CN" : "en")}
         onClose={() => setShowSettings(false)}
         onLoad={loadSettings}
         onLoadProviders={loadProviders}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,16 @@ import { OpenProjectModal } from "./components/OpenProjectModal";
 import { ReviewPanel } from "./components/ReviewPanel";
 import { deriveChatMessages } from "./lib/runtime/event-parser";
 import { RuntimeClient } from "./lib/runtime/client";
-import { Loader2 } from "lucide-react";
+import {
+  Loader2,
+  Settings,
+  Globe,
+  Server,
+  CheckCircle2,
+  XCircle,
+  GitCompare,
+} from "lucide-react";
+import { StatusBar } from "./components/StatusBar";
 
 function App() {
   const {
@@ -200,23 +209,8 @@ function App() {
         sessionsError={sessionsError}
         isRunning={isRunning}
         isReplayLoading={isReplayLoading}
-        language={language}
-        runtimeTestStatus={runtimeTestStatus}
         onSelectSession={selectSession}
-        onToggleLanguage={toggleLanguage}
         onOpenProjects={() => setShowProjects(true)}
-        onToggleReview={() => setShowReview((value) => !value)}
-        onOpenSettings={() => setShowSettings(true)}
-        onTestRuntime={testRuntime}
-        showReview={showReview}
-        statusSnapshot={statusSnapshot}
-        statusStatus={statusStatus}
-        statusError={statusError}
-        mcpRetryStatus={mcpRetryStatus}
-        mcpRetryError={mcpRetryError}
-        onRetryMcp={() => {
-          void retryMcpConnections();
-        }}
       />
 
       <div className="flex-1 flex flex-col min-w-0">
@@ -256,6 +250,70 @@ function App() {
                   />
                   {isRunning ? t("session.agentBusy") : t("session.agentIdle")}
                 </span>
+
+                <div className="w-px h-4 bg-slate-800 mx-1" />
+
+                <StatusBar
+                  snapshot={statusSnapshot}
+                  status={statusStatus}
+                  error={statusError}
+                  mcpRetryStatus={mcpRetryStatus}
+                  mcpRetryError={mcpRetryError}
+                  onRetryMcp={() => {
+                    void retryMcpConnections();
+                  }}
+                />
+
+                <button
+                  type="button"
+                  onClick={() => setShowReview((value) => !value)}
+                  title={t("review.title")}
+                  className={`rounded-lg border px-2 py-1.5 text-xs font-medium transition-colors ${
+                    showReview
+                      ? "border-indigo-500/30 bg-indigo-500/10 text-indigo-300"
+                      : "border-slate-700 text-slate-400 hover:bg-slate-800/60 hover:text-slate-200"
+                  }`}
+                >
+                  <GitCompare className="w-4 h-4" />
+                </button>
+
+                <button
+                  type="button"
+                  onClick={toggleLanguage}
+                  title={
+                    language === "en" ? t("language.zh") : t("language.en")
+                  }
+                  className="rounded-lg border border-slate-700 bg-transparent px-2 py-1.5 text-slate-400 hover:bg-slate-800/60 hover:text-slate-200 transition-colors"
+                >
+                  <Globe className="w-4 h-4" />
+                </button>
+
+                <button
+                  type="button"
+                  onClick={testRuntime}
+                  disabled={runtimeTestStatus === "testing"}
+                  title={t("debug.testRuntime")}
+                  className="rounded-lg border border-slate-700 bg-transparent px-2 py-1.5 text-slate-400 hover:bg-slate-800/60 hover:text-slate-200 transition-colors"
+                >
+                  {runtimeTestStatus === "testing" ? (
+                    <Loader2 className="w-4 h-4 animate-spin text-indigo-400" />
+                  ) : runtimeTestStatus === "success" ? (
+                    <CheckCircle2 className="w-4 h-4 text-emerald-400" />
+                  ) : runtimeTestStatus === "error" ? (
+                    <XCircle className="w-4 h-4 text-rose-400" />
+                  ) : (
+                    <Server className="w-4 h-4" />
+                  )}
+                </button>
+
+                <button
+                  type="button"
+                  onClick={() => setShowSettings(true)}
+                  title={t("nav.settings")}
+                  className="rounded-lg border border-slate-700 bg-transparent px-2 py-1.5 text-slate-400 hover:bg-slate-800/60 hover:text-slate-200 transition-colors"
+                >
+                  <Settings className="w-4 h-4" />
+                </button>
               </div>
             </header>
 
@@ -295,21 +353,65 @@ function App() {
             />
           </>
         ) : (
-          <div className="flex flex-1 items-center justify-center p-6">
-            <div className="w-full max-w-md rounded-2xl border border-slate-800 bg-[#0c0c0e] p-6 text-center shadow-[0_0_30px_rgba(0,0,0,0.25)]">
-              <div className="text-lg font-semibold text-slate-100">
-                {t("project.emptyStateTitle")}
+          <div className="flex flex-1 flex-col relative">
+            <header className="h-14 flex items-center justify-end px-4 border-b border-transparent flex-shrink-0 absolute top-0 left-0 right-0 z-10">
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={toggleLanguage}
+                  title={
+                    language === "en" ? t("language.zh") : t("language.en")
+                  }
+                  className="rounded-lg border border-slate-700 bg-slate-900/50 px-2 py-1.5 text-slate-400 hover:bg-slate-800/60 hover:text-slate-200 transition-colors"
+                >
+                  <Globe className="w-4 h-4" />
+                </button>
+
+                <button
+                  type="button"
+                  onClick={testRuntime}
+                  disabled={runtimeTestStatus === "testing"}
+                  title={t("debug.testRuntime")}
+                  className="rounded-lg border border-slate-700 bg-slate-900/50 px-2 py-1.5 text-slate-400 hover:bg-slate-800/60 hover:text-slate-200 transition-colors"
+                >
+                  {runtimeTestStatus === "testing" ? (
+                    <Loader2 className="w-4 h-4 animate-spin text-indigo-400" />
+                  ) : runtimeTestStatus === "success" ? (
+                    <CheckCircle2 className="w-4 h-4 text-emerald-400" />
+                  ) : runtimeTestStatus === "error" ? (
+                    <XCircle className="w-4 h-4 text-rose-400" />
+                  ) : (
+                    <Server className="w-4 h-4" />
+                  )}
+                </button>
+
+                <button
+                  type="button"
+                  onClick={() => setShowSettings(true)}
+                  title={t("nav.settings")}
+                  className="rounded-lg border border-slate-700 bg-slate-900/50 px-2 py-1.5 text-slate-400 hover:bg-slate-800/60 hover:text-slate-200 transition-colors"
+                >
+                  <Settings className="w-4 h-4" />
+                </button>
               </div>
-              <p className="mt-2 text-sm text-slate-400">
-                {t("project.emptyStateBody")}
-              </p>
-              <button
-                type="button"
-                onClick={() => setShowProjects(true)}
-                className="mt-5 inline-flex items-center justify-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-500"
-              >
-                {t("project.openTitle")}
-              </button>
+            </header>
+
+            <div className="flex flex-1 items-center justify-center p-6 pt-14">
+              <div className="w-full max-w-md rounded-2xl border border-slate-800 bg-[#0c0c0e] p-6 text-center shadow-[0_0_30px_rgba(0,0,0,0.25)]">
+                <div className="text-lg font-semibold text-slate-100">
+                  {t("project.emptyStateTitle")}
+                </div>
+                <p className="mt-2 text-sm text-slate-400">
+                  {t("project.emptyStateBody")}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setShowProjects(true)}
+                  className="mt-5 inline-flex items-center justify-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-500"
+                >
+                  {t("project.openTitle")}
+                </button>
+              </div>
             </div>
           </div>
         )}

--- a/frontend/src/components/Composer.test.tsx
+++ b/frontend/src/components/Composer.test.tsx
@@ -37,20 +37,17 @@ describe("Composer", () => {
   it("renders agent selector with leader option", () => {
     render(<Composer {...baseProps} />);
 
-    const agentSelect = screen.getByLabelText("Agent");
-    expect(agentSelect).toBeInTheDocument();
-    expect(agentSelect).toHaveValue("leader");
+    const agentTrigger = screen.getByRole("button", { name: "Agent" });
+    expect(agentTrigger).toBeInTheDocument();
+    expect(agentTrigger).toHaveTextContent("Leader");
   });
 
   it("renders model selector grouped by provider", () => {
     render(<Composer {...baseProps} />);
 
-    const modelSelect = screen.getByLabelText("Model");
-    expect(modelSelect).toBeInTheDocument();
-    expect(modelSelect).toHaveValue("opencode-go/glm-5.1");
-
-    expect(screen.getByText("opencode-go/glm-5.1")).toBeInTheDocument();
-    expect(screen.getByText("opencode-go/glm-5.2")).toBeInTheDocument();
+    const modelTrigger = screen.getByRole("button", { name: "Model" });
+    expect(modelTrigger).toBeInTheDocument();
+    expect(modelTrigger).toHaveTextContent("OpenCode / glm-5.1");
   });
 
   it("calls onProviderModelChange when model is changed", () => {
@@ -59,10 +56,8 @@ describe("Composer", () => {
       <Composer {...baseProps} onProviderModelChange={onProviderModelChange} />,
     );
 
-    const modelSelect = screen.getByLabelText("Model");
-    fireEvent.change(modelSelect, {
-      target: { value: "opencode-go/glm-5.2" },
-    });
+    fireEvent.click(screen.getByRole("button", { name: "Model" }));
+    fireEvent.click(screen.getByRole("button", { name: "glm-5.2" }));
 
     expect(onProviderModelChange).toHaveBeenCalledWith("opencode-go/glm-5.2");
   });
@@ -73,8 +68,8 @@ describe("Composer", () => {
       <Composer {...baseProps} onAgentPresetChange={onAgentPresetChange} />,
     );
 
-    const agentSelect = screen.getByLabelText("Agent");
-    fireEvent.change(agentSelect, { target: { value: "leader" } });
+    fireEvent.click(screen.getByRole("button", { name: "Agent" }));
+    fireEvent.click(screen.getByRole("button", { name: "Leader" }));
 
     expect(onAgentPresetChange).toHaveBeenCalledWith("leader");
   });
@@ -140,8 +135,7 @@ describe("Composer", () => {
       />,
     );
 
-    expect(screen.getByText(/Configured:/i)).toBeInTheDocument();
-    expect(screen.getByText("opencode-go/kimi-k2.6")).toBeInTheDocument();
+    expect(screen.getByText("OpenCode / kimi-k2.6")).toBeInTheDocument();
     expect(screen.queryByLabelText("Model")).not.toBeInTheDocument();
     expect(
       screen.getByPlaceholderText("Ask VoidCode to do something..."),
@@ -177,8 +171,8 @@ describe("Composer", () => {
   it("disables controls when disabled prop is true", () => {
     render(<Composer {...baseProps} disabled />);
 
-    expect(screen.getByLabelText("Agent")).toBeDisabled();
-    expect(screen.getByLabelText("Model")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Agent" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Model" })).toBeDisabled();
     expect(
       screen.getByPlaceholderText("Ask VoidCode to do something..."),
     ).toBeDisabled();
@@ -225,7 +219,9 @@ describe("Composer", () => {
       />,
     );
 
-    expect(screen.getByText("opencode-go/glm-5.1")).toBeInTheDocument();
-    expect(screen.getByText("glm/glm-5")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Model" }));
+
+    expect(screen.getByText("glm-5.1")).toBeInTheDocument();
+    expect(screen.getByText("glm-5")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/Composer.test.tsx
+++ b/frontend/src/components/Composer.test.tsx
@@ -89,8 +89,12 @@ describe("Composer", () => {
       />,
     );
 
-    expect(screen.getByText(/No providers configured/i)).toBeInTheDocument();
-    expect(screen.queryByLabelText("Model")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/No providers configured/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Model" }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows empty state when no models are available for configured providers", () => {
@@ -112,11 +116,13 @@ describe("Composer", () => {
       />,
     );
 
-    expect(screen.getByText("No models available.")).toBeInTheDocument();
-    expect(screen.queryByLabelText("Model")).not.toBeInTheDocument();
+    expect(screen.queryByText("No models available.")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Model" }),
+    ).not.toBeInTheDocument();
   });
 
-  it("keeps configured model fallback visible when catalogs are empty", () => {
+  it("hides model switcher when catalogs are empty", () => {
     render(
       <Composer
         {...baseProps}
@@ -135,8 +141,10 @@ describe("Composer", () => {
       />,
     );
 
-    expect(screen.getByText("OpenCode / kimi-k2.6")).toBeInTheDocument();
-    expect(screen.queryByLabelText("Model")).not.toBeInTheDocument();
+    expect(screen.queryByText("OpenCode / kimi-k2.6")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Model" }),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByPlaceholderText("Ask VoidCode to do something..."),
     ).not.toBeDisabled();

--- a/frontend/src/components/Composer.test.tsx
+++ b/frontend/src/components/Composer.test.tsx
@@ -94,9 +94,7 @@ describe("Composer", () => {
       />,
     );
 
-    expect(
-      screen.getByText("No providers configured. Add an API key in Settings."),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/No providers configured/i)).toBeInTheDocument();
     expect(screen.queryByLabelText("Model")).not.toBeInTheDocument();
   });
 
@@ -142,7 +140,7 @@ describe("Composer", () => {
       />,
     );
 
-    expect(screen.getByText(/Using configured model/i)).toBeInTheDocument();
+    expect(screen.getByText(/Configured:/i)).toBeInTheDocument();
     expect(screen.getByText("opencode-go/kimi-k2.6")).toBeInTheDocument();
     expect(screen.queryByLabelText("Model")).not.toBeInTheDocument();
     expect(

--- a/frontend/src/components/Composer.tsx
+++ b/frontend/src/components/Composer.tsx
@@ -87,21 +87,16 @@ export function Composer({
   return (
     <div className="border-t border-slate-800 bg-[#0c0c0e] px-4 py-3">
       <div className="max-w-3xl mx-auto">
-        {agentPresets && agentPresets.length > 0 && (
-          <div className="mb-3 grid gap-3 md:grid-cols-2">
-            <div className="space-y-1.5">
-              <label
-                className="text-xs font-medium text-slate-400"
-                htmlFor="composer-agent"
-              >
-                Agent
-              </label>
+        <div className="relative flex flex-col bg-slate-900 border border-slate-700 rounded-xl focus-within:border-indigo-500 focus-within:ring-1 focus-within:ring-indigo-500 transition-colors overflow-hidden">
+          {agentPresets && agentPresets.length > 0 && (
+            <div className="flex items-center gap-2 px-3 py-1.5 border-b border-slate-800/60 bg-slate-900/30 text-xs">
               <select
                 id="composer-agent"
+                aria-label="Agent"
                 value={agentPreset ?? "leader"}
                 onChange={(event) => onAgentPresetChange?.(event.target.value)}
                 disabled={disabled}
-                className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-200 disabled:opacity-50"
+                className="bg-transparent border-none text-slate-300 font-medium outline-none max-w-[150px] cursor-pointer appearance-none hover:text-white disabled:opacity-50"
               >
                 {agentPresets.map((agent) => (
                   <option key={agent.id} value={agent.id}>
@@ -109,42 +104,34 @@ export function Composer({
                   </option>
                 ))}
               </select>
-            </div>
 
-            {configuredProviders.length === 0 ? (
-              <div className="rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-2 text-xs text-slate-400 md:col-span-1">
-                No providers configured. Add an API key in Settings.
-              </div>
-            ) : availableModelGroups.length === 0 ? (
-              <div className="rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-2 text-xs text-slate-400 md:col-span-1">
-                {showConfiguredModelFallback ? (
-                  <>
-                    Using configured model{" "}
-                    <span className="font-mono text-slate-300">
-                      {selectedModel}
-                    </span>
-                    , catalog unavailable.
-                  </>
-                ) : (
-                  <>No models available.</>
-                )}
-              </div>
-            ) : (
-              <div className="space-y-1.5">
-                <label
-                  className="text-xs font-medium text-slate-400"
-                  htmlFor="composer-model"
-                >
-                  Model
-                </label>
+              <div className="w-px h-3 bg-slate-700" />
+
+              {configuredProviders.length === 0 ? (
+                <div className="text-slate-500 truncate flex-1">
+                  No providers configured.
+                </div>
+              ) : availableModelGroups.length === 0 ? (
+                <div className="text-slate-500 truncate flex-1">
+                  {showConfiguredModelFallback ? (
+                    <>
+                      Configured:{" "}
+                      <span className="font-mono">{selectedModel}</span>
+                    </>
+                  ) : (
+                    <>No models available.</>
+                  )}
+                </div>
+              ) : (
                 <select
                   id="composer-model"
+                  aria-label="Model"
                   value={selectedModelAvailable ? selectedModel : ""}
                   onChange={(event) =>
                     onProviderModelChange?.(event.target.value)
                   }
                   disabled={disabled}
-                  className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-200 disabled:opacity-50"
+                  className="bg-transparent border-none text-slate-400 outline-none flex-1 cursor-pointer appearance-none hover:text-slate-200 disabled:opacity-50 truncate"
                 >
                   {availableModelGroups.map(({ provider, models }) => (
                     <optgroup key={provider.name} label={provider.label}>
@@ -156,34 +143,34 @@ export function Composer({
                     </optgroup>
                   ))}
                 </select>
-              </div>
-            )}
-          </div>
-        )}
+              )}
+            </div>
+          )}
 
-        <div className="relative flex items-end gap-2 bg-slate-900 border border-slate-700 rounded-xl px-3 py-2 focus-within:border-indigo-500 focus-within:ring-1 focus-within:ring-indigo-500 transition-colors">
-          <textarea
-            ref={textareaRef}
-            value={input}
-            onChange={handleChange}
-            onKeyDown={handleKeyDown}
-            placeholder={placeholder || t("chat.placeholder")}
-            disabled={disabled}
-            rows={1}
-            className="flex-1 bg-transparent text-sm text-slate-200 placeholder:text-slate-500 resize-none outline-none py-1.5 max-h-[200px] disabled:opacity-50"
-          />
-          <button
-            type="button"
-            onClick={handleSubmit}
-            disabled={disabled || !input.trim()}
-            className="flex-shrink-0 w-8 h-8 flex items-center justify-center rounded-lg bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed text-white transition-colors mb-0.5"
-          >
-            {isRunning ? (
-              <Loader2 className="w-4 h-4 animate-spin" />
-            ) : (
-              <Send className="w-4 h-4" />
-            )}
-          </button>
+          <div className="flex items-end gap-2 px-3 py-2 bg-transparent">
+            <textarea
+              ref={textareaRef}
+              value={input}
+              onChange={handleChange}
+              onKeyDown={handleKeyDown}
+              placeholder={placeholder || t("chat.placeholder")}
+              disabled={disabled}
+              rows={1}
+              className="flex-1 bg-transparent text-sm text-slate-200 placeholder:text-slate-500 resize-none outline-none py-1.5 max-h-[200px] disabled:opacity-50"
+            />
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={disabled || !input.trim()}
+              className="flex-shrink-0 w-8 h-8 flex items-center justify-center rounded-lg bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed text-white transition-colors mb-0.5"
+            >
+              {isRunning ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <Send className="w-4 h-4" />
+              )}
+            </button>
+          </div>
         </div>
         <p className="text-[11px] text-slate-600 mt-1.5 text-center">
           {t("chat.hint")}

--- a/frontend/src/components/Composer.tsx
+++ b/frontend/src/components/Composer.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Send, Loader2 } from "lucide-react";
 import type {
@@ -36,7 +36,11 @@ export function Composer({
 }: ComposerProps) {
   const { t } = useTranslation();
   const [input, setInput] = useState("");
+  const [showAgentMenu, setShowAgentMenu] = useState(false);
+  const [showModelMenu, setShowModelMenu] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const agentMenuRef = useRef<HTMLDivElement>(null);
+  const modelMenuRef = useRef<HTMLDivElement>(null);
 
   const configuredProviders = (providers ?? []).filter(
     (provider) => provider.configured,
@@ -55,6 +59,51 @@ export function Composer({
     selectedModel !== "" &&
     configuredProviders.length > 0 &&
     availableModelGroups.length === 0;
+
+  const selectedAgentLabel = useMemo(() => {
+    return (
+      agentPresets?.find((agent) => agent.id === (agentPreset ?? "leader"))
+        ?.label ??
+      agentPreset ??
+      "leader"
+    );
+  }, [agentPreset, agentPresets]);
+
+  const selectedModelLabel = useMemo(() => {
+    for (const { provider, models } of availableModelGroups) {
+      if (models.includes(selectedModel)) {
+        return `${provider.label} / ${displayModelName(selectedModel, provider.name)}`;
+      }
+    }
+    if (showConfiguredModelFallback && selectedModel) {
+      const providerName = settingsProviderOfModel(selectedModel);
+      const providerLabel =
+        configuredProviders.find((provider) => provider.name === providerName)
+          ?.label ?? "Configured";
+      return `${providerLabel} / ${displayModelName(selectedModel, providerName)}`;
+    }
+    return selectedModel || "No models available.";
+  }, [
+    availableModelGroups,
+    configuredProviders,
+    selectedModel,
+    showConfiguredModelFallback,
+  ]);
+
+  useEffect(() => {
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (agentMenuRef.current && !agentMenuRef.current.contains(target)) {
+        setShowAgentMenu(false);
+      }
+      if (modelMenuRef.current && !modelMenuRef.current.contains(target)) {
+        setShowModelMenu(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, []);
 
   const resizeTextarea = useCallback(() => {
     const el = textareaRef.current;
@@ -84,69 +133,20 @@ export function Composer({
     resizeTextarea();
   };
 
+  const handleAgentSelect = (nextAgent: string) => {
+    onAgentPresetChange?.(nextAgent);
+    setShowAgentMenu(false);
+  };
+
+  const handleModelSelect = (nextModel: string) => {
+    onProviderModelChange?.(nextModel);
+    setShowModelMenu(false);
+  };
+
   return (
     <div className="border-t border-slate-800 bg-[#0c0c0e] px-4 py-3">
       <div className="max-w-3xl mx-auto">
         <div className="relative flex flex-col bg-slate-900 border border-slate-700 rounded-xl focus-within:border-indigo-500 focus-within:ring-1 focus-within:ring-indigo-500 transition-colors overflow-hidden">
-          {agentPresets && agentPresets.length > 0 && (
-            <div className="flex items-center gap-2 px-3 py-1.5 border-b border-slate-800/60 bg-slate-900/30 text-xs">
-              <select
-                id="composer-agent"
-                aria-label="Agent"
-                value={agentPreset ?? "leader"}
-                onChange={(event) => onAgentPresetChange?.(event.target.value)}
-                disabled={disabled}
-                className="bg-transparent border-none text-slate-300 font-medium outline-none max-w-[150px] cursor-pointer appearance-none hover:text-white disabled:opacity-50"
-              >
-                {agentPresets.map((agent) => (
-                  <option key={agent.id} value={agent.id}>
-                    {agent.label}
-                  </option>
-                ))}
-              </select>
-
-              <div className="w-px h-3 bg-slate-700" />
-
-              {configuredProviders.length === 0 ? (
-                <div className="text-slate-500 truncate flex-1">
-                  No providers configured.
-                </div>
-              ) : availableModelGroups.length === 0 ? (
-                <div className="text-slate-500 truncate flex-1">
-                  {showConfiguredModelFallback ? (
-                    <>
-                      Configured:{" "}
-                      <span className="font-mono">{selectedModel}</span>
-                    </>
-                  ) : (
-                    <>No models available.</>
-                  )}
-                </div>
-              ) : (
-                <select
-                  id="composer-model"
-                  aria-label="Model"
-                  value={selectedModelAvailable ? selectedModel : ""}
-                  onChange={(event) =>
-                    onProviderModelChange?.(event.target.value)
-                  }
-                  disabled={disabled}
-                  className="bg-transparent border-none text-slate-400 outline-none flex-1 cursor-pointer appearance-none hover:text-slate-200 disabled:opacity-50 truncate"
-                >
-                  {availableModelGroups.map(({ provider, models }) => (
-                    <optgroup key={provider.name} label={provider.label}>
-                      {models.map((model) => (
-                        <option key={model} value={model}>
-                          {model}
-                        </option>
-                      ))}
-                    </optgroup>
-                  ))}
-                </select>
-              )}
-            </div>
-          )}
-
           <div className="flex items-end gap-2 px-3 py-2 bg-transparent">
             <textarea
               ref={textareaRef}
@@ -171,6 +171,111 @@ export function Composer({
               )}
             </button>
           </div>
+
+          {agentPresets && agentPresets.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2 border-t border-slate-800/60 bg-slate-900/30 px-3 py-1.5 text-xs">
+              <div className="relative" ref={agentMenuRef}>
+                <button
+                  id="composer-agent"
+                  aria-label="Agent"
+                  type="button"
+                  onClick={() => {
+                    if (disabled) return;
+                    setShowModelMenu(false);
+                    setShowAgentMenu((open) => !open);
+                  }}
+                  disabled={disabled}
+                  className="max-w-[180px] truncate rounded border border-slate-700 px-2 py-1 text-left text-slate-300 disabled:opacity-50"
+                >
+                  {selectedAgentLabel}
+                </button>
+
+                {showAgentMenu && (
+                  <div className="absolute bottom-full left-0 z-20 mb-2 min-w-[180px] rounded border border-slate-700 bg-[#0c0c0e] py-1 shadow-xl">
+                    {agentPresets.map((agent) => {
+                      const active = agent.id === (agentPreset ?? "leader");
+                      return (
+                        <button
+                          key={agent.id}
+                          type="button"
+                          onClick={() => handleAgentSelect(agent.id)}
+                          className={`block w-full px-3 py-1.5 text-left text-sm ${
+                            active
+                              ? "bg-slate-800 text-slate-100"
+                              : "text-slate-300 hover:bg-slate-800/60"
+                          }`}
+                        >
+                          {agent.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+
+              {configuredProviders.length === 0 ? (
+                <div className="truncate text-slate-500">
+                  No providers configured.
+                </div>
+              ) : availableModelGroups.length === 0 ? (
+                <div className="truncate text-slate-500">
+                  {showConfiguredModelFallback ? (
+                    <>{selectedModelLabel}</>
+                  ) : (
+                    <>No models available.</>
+                  )}
+                </div>
+              ) : (
+                <div className="relative min-w-0 flex-1" ref={modelMenuRef}>
+                  <button
+                    id="composer-model"
+                    aria-label="Model"
+                    type="button"
+                    onClick={() => {
+                      if (disabled) return;
+                      setShowAgentMenu(false);
+                      setShowModelMenu((open) => !open);
+                    }}
+                    disabled={disabled}
+                    className="w-full truncate rounded border border-slate-700 px-2 py-1 text-left text-slate-400 disabled:opacity-50"
+                  >
+                    {selectedModelAvailable
+                      ? selectedModelLabel
+                      : "Select model"}
+                  </button>
+
+                  {showModelMenu && (
+                    <div className="absolute bottom-full left-0 z-20 mb-2 max-h-72 min-w-[260px] max-w-[360px] overflow-y-auto rounded border border-slate-700 bg-[#0c0c0e] py-1 shadow-xl">
+                      {availableModelGroups.map(({ provider, models }) => (
+                        <div key={provider.name} className="py-1">
+                          <div className="px-3 py-1 text-[11px] text-slate-500">
+                            {provider.label}
+                          </div>
+                          {models.map((model) => {
+                            const active = model === selectedModel;
+                            return (
+                              <button
+                                key={model}
+                                type="button"
+                                onClick={() => handleModelSelect(model)}
+                                className={`block w-full px-3 py-1.5 text-left text-sm ${
+                                  active
+                                    ? "bg-slate-800 text-slate-100"
+                                    : "text-slate-300 hover:bg-slate-800/60"
+                                }`}
+                              >
+                                {displayModelName(model, provider.name)}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
         </div>
         <p className="text-[11px] text-slate-600 mt-1.5 text-center">
           {t("chat.hint")}
@@ -178,4 +283,16 @@ export function Composer({
       </div>
     </div>
   );
+}
+
+function settingsProviderOfModel(model: string): string | null {
+  const [provider] = model.split("/");
+  return provider || null;
+}
+
+function displayModelName(model: string, providerName: string | null): string {
+  if (providerName && model.startsWith(`${providerName}/`)) {
+    return model.slice(providerName.length + 1);
+  }
+  return model;
 }

--- a/frontend/src/components/Composer.tsx
+++ b/frontend/src/components/Composer.tsx
@@ -55,10 +55,6 @@ export function Composer({
   const selectedModelAvailable = availableModelGroups.some((group) =>
     group.models.includes(selectedModel),
   );
-  const showConfiguredModelFallback =
-    selectedModel !== "" &&
-    configuredProviders.length > 0 &&
-    availableModelGroups.length === 0;
 
   const selectedAgentLabel = useMemo(() => {
     return (
@@ -75,20 +71,8 @@ export function Composer({
         return `${provider.label} / ${displayModelName(selectedModel, provider.name)}`;
       }
     }
-    if (showConfiguredModelFallback && selectedModel) {
-      const providerName = settingsProviderOfModel(selectedModel);
-      const providerLabel =
-        configuredProviders.find((provider) => provider.name === providerName)
-          ?.label ?? "Configured";
-      return `${providerLabel} / ${displayModelName(selectedModel, providerName)}`;
-    }
-    return selectedModel || "No models available.";
-  }, [
-    availableModelGroups,
-    configuredProviders,
-    selectedModel,
-    showConfiguredModelFallback,
-  ]);
+    return "Select model";
+  }, [availableModelGroups, selectedModel]);
 
   useEffect(() => {
     const handlePointerDown = (event: MouseEvent) => {
@@ -213,19 +197,7 @@ export function Composer({
                 )}
               </div>
 
-              {configuredProviders.length === 0 ? (
-                <div className="truncate text-slate-500">
-                  No providers configured.
-                </div>
-              ) : availableModelGroups.length === 0 ? (
-                <div className="truncate text-slate-500">
-                  {showConfiguredModelFallback ? (
-                    <>{selectedModelLabel}</>
-                  ) : (
-                    <>No models available.</>
-                  )}
-                </div>
-              ) : (
+              {availableModelGroups.length > 0 && (
                 <div className="relative min-w-0 flex-1" ref={modelMenuRef}>
                   <button
                     id="composer-model"
@@ -283,11 +255,6 @@ export function Composer({
       </div>
     </div>
   );
-}
-
-function settingsProviderOfModel(model: string): string | null {
-  const [provider] = model.split("/");
-  return provider || null;
 }
 
 function displayModelName(model: string, providerName: string | null): string {

--- a/frontend/src/components/SessionSidebar.tsx
+++ b/frontend/src/components/SessionSidebar.tsx
@@ -6,6 +6,7 @@ import {
   Code2,
   FolderOpen,
   Plus,
+  Settings,
 } from "lucide-react";
 import type {
   StoredSessionSummary,
@@ -22,6 +23,7 @@ interface SessionSidebarProps {
   isReplayLoading: boolean;
   onSelectSession: (sessionId: string) => void;
   onOpenProjects: () => void;
+  onOpenSettings: () => void;
 }
 
 function formatSessionUpdatedAt(updatedAt: number, now = Date.now()): string {
@@ -54,6 +56,7 @@ export function SessionSidebar({
   isReplayLoading,
   onSelectSession,
   onOpenProjects,
+  onOpenSettings,
 }: SessionSidebarProps) {
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(true);
@@ -279,9 +282,31 @@ export function SessionSidebar({
             >
               <Plus className="w-4 h-4" />
             </button>
+
+            <button
+              type="button"
+              onClick={onOpenSettings}
+              className="w-10 h-10 rounded-xl border border-slate-800 bg-slate-900/50 flex items-center justify-center text-slate-400 hover:bg-slate-800/60 hover:text-slate-200 transition-colors"
+              aria-label={t("nav.settings")}
+            >
+              <Settings className="w-4 h-4" />
+            </button>
           </div>
         )}
       </div>
+
+      {isExpanded && (
+        <div className="hidden border-t border-slate-800 p-3 md:block">
+          <button
+            type="button"
+            onClick={onOpenSettings}
+            className="w-full flex items-center gap-2 rounded-lg px-3 py-2.5 text-sm text-slate-400 transition-colors hover:bg-slate-800/50 hover:text-slate-200"
+          >
+            <Settings className="w-4 h-4" />
+            <span>{t("nav.settings")}</span>
+          </button>
+        </div>
+      )}
     </aside>
   );
 }

--- a/frontend/src/components/SessionSidebar.tsx
+++ b/frontend/src/components/SessionSidebar.tsx
@@ -5,21 +5,12 @@ import {
   ChevronRight,
   Code2,
   FolderOpen,
-  Globe,
   Plus,
-  Settings,
-  Server,
-  Loader2,
-  CheckCircle2,
-  XCircle,
-  GitCompare,
 } from "lucide-react";
 import type {
-  RuntimeStatusSnapshot,
   StoredSessionSummary,
   WorkspaceRegistrySnapshot,
 } from "../lib/runtime/types";
-import { StatusBar } from "./StatusBar";
 
 interface SessionSidebarProps {
   workspaces: WorkspaceRegistrySnapshot | null;
@@ -29,21 +20,8 @@ interface SessionSidebarProps {
   sessionsError: string | null;
   isRunning: boolean;
   isReplayLoading: boolean;
-  language: string;
-  runtimeTestStatus: "idle" | "testing" | "success" | "error";
   onSelectSession: (sessionId: string) => void;
-  onToggleLanguage: () => void;
   onOpenProjects: () => void;
-  onToggleReview: () => void;
-  onOpenSettings: () => void;
-  onTestRuntime: () => void;
-  showReview: boolean;
-  statusSnapshot: RuntimeStatusSnapshot | null;
-  statusStatus: "idle" | "loading" | "success" | "error";
-  statusError: string | null;
-  mcpRetryStatus?: "idle" | "loading" | "success" | "error";
-  mcpRetryError?: string | null;
-  onRetryMcp?: () => void;
 }
 
 function formatSessionUpdatedAt(updatedAt: number, now = Date.now()): string {
@@ -74,21 +52,8 @@ export function SessionSidebar({
   sessionsError,
   isRunning,
   isReplayLoading,
-  language,
-  runtimeTestStatus,
   onSelectSession,
-  onToggleLanguage,
   onOpenProjects,
-  onToggleReview,
-  onOpenSettings,
-  onTestRuntime,
-  showReview,
-  statusSnapshot,
-  statusStatus,
-  statusError,
-  mcpRetryStatus,
-  mcpRetryError,
-  onRetryMcp,
 }: SessionSidebarProps) {
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(true);
@@ -200,27 +165,7 @@ export function SessionSidebar({
                     <Plus className="w-3.5 h-3.5" />
                     {t("project.openTitle")}
                   </button>
-                  <button
-                    type="button"
-                    onClick={onToggleReview}
-                    className={`rounded-lg border px-3 py-2 text-xs font-medium transition-colors ${
-                      showReview
-                        ? "border-indigo-500/30 bg-indigo-500/10 text-indigo-300"
-                        : "border-slate-700 text-slate-400 hover:bg-slate-800/60 hover:text-slate-200"
-                    }`}
-                  >
-                    <GitCompare className="w-3.5 h-3.5" />
-                  </button>
                 </div>
-
-                <StatusBar
-                  snapshot={statusSnapshot}
-                  status={statusStatus}
-                  error={statusError}
-                  mcpRetryStatus={mcpRetryStatus}
-                  mcpRetryError={mcpRetryError}
-                  onRetryMcp={onRetryMcp}
-                />
               </div>
             </div>
 
@@ -336,63 +281,6 @@ export function SessionSidebar({
             </button>
           </div>
         )}
-      </div>
-
-      <div className="p-3 border-t border-slate-800 space-y-1">
-        <button
-          type="button"
-          onClick={onToggleLanguage}
-          aria-label={language === "en" ? t("language.zh") : t("language.en")}
-          className="w-full flex items-center justify-center md:justify-start md:px-3 py-2.5 rounded-lg text-slate-400 hover:bg-slate-800/50 hover:text-slate-200 transition-colors gap-2"
-        >
-          <Globe className="w-5 h-5" />
-          {isExpanded && (
-            <span className="hidden md:block font-medium text-sm">
-              {language === "en" ? t("language.zh") : t("language.en")}
-            </span>
-          )}
-        </button>
-        <button
-          type="button"
-          onClick={onTestRuntime}
-          disabled={runtimeTestStatus === "testing"}
-          aria-label={t("debug.testRuntime")}
-          className="w-full flex items-center justify-center md:justify-start md:px-3 py-2.5 rounded-lg text-slate-400 hover:bg-slate-800/50 hover:text-slate-200 transition-colors gap-2"
-        >
-          {runtimeTestStatus === "testing" ? (
-            <Loader2 className="w-5 h-5 animate-spin text-indigo-400" />
-          ) : runtimeTestStatus === "success" ? (
-            <CheckCircle2 className="w-5 h-5 text-emerald-400" />
-          ) : runtimeTestStatus === "error" ? (
-            <XCircle className="w-5 h-5 text-rose-400" />
-          ) : (
-            <Server className="w-5 h-5" />
-          )}
-          {isExpanded && (
-            <span className="hidden md:block font-medium text-sm">
-              {runtimeTestStatus === "testing"
-                ? t("debug.testing")
-                : runtimeTestStatus === "success"
-                  ? t("debug.success")
-                  : runtimeTestStatus === "error"
-                    ? t("debug.error")
-                    : t("debug.testRuntime")}
-            </span>
-          )}
-        </button>
-        <button
-          type="button"
-          onClick={onOpenSettings}
-          aria-label={t("nav.settings")}
-          className="w-full flex items-center justify-center md:justify-start md:px-3 py-2.5 rounded-lg text-slate-400 hover:bg-slate-800/50 hover:text-slate-200 transition-colors gap-2"
-        >
-          <Settings className="w-5 h-5" />
-          {isExpanded && (
-            <span className="hidden md:block font-medium text-sm">
-              {t("nav.settings")}
-            </span>
-          )}
-        </button>
       </div>
     </aside>
   );

--- a/frontend/src/components/SettingsPanel.test.tsx
+++ b/frontend/src/components/SettingsPanel.test.tsx
@@ -14,6 +14,8 @@ const baseProps = {
   ],
   providersStatus: "success",
   providersError: null,
+  language: "en",
+  onToggleLanguage: vi.fn(),
   onClose: vi.fn(),
   onLoad: vi.fn(),
   onLoadProviders: vi.fn(),
@@ -41,8 +43,8 @@ describe("SettingsPanel", () => {
 
     expect(screen.getByText("GLM")).toBeInTheDocument();
     expect(screen.getByText("OpenAI")).toBeInTheDocument();
-    expect(screen.getByText("Configured")).toBeInTheDocument();
-    expect(screen.getByText("Not configured")).toBeInTheDocument();
+    expect(screen.getByTitle("Configured")).toBeInTheDocument();
+    expect(screen.getByTitle("Not configured")).toBeInTheDocument();
   });
 
   it("shows empty state when no providers are available", () => {

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -15,6 +15,8 @@ interface SettingsPanelProps {
   providers?: ProviderSummary[];
   providersStatus?: string;
   providersError?: string | null;
+  language: string;
+  onToggleLanguage: () => void;
   onClose: () => void;
   onLoad: () => void;
   onLoadProviders?: () => void;
@@ -29,6 +31,8 @@ export function SettingsPanel({
   providers = [],
   providersStatus,
   providersError,
+  language,
+  onToggleLanguage,
   onClose,
   onLoad,
   onLoadProviders,
@@ -60,19 +64,27 @@ export function SettingsPanel({
     });
   };
 
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    handleSave();
+  };
+
   if (!isOpen) return null;
 
   const isLoading = settingsStatus === "loading";
 
   return (
-    <div className="fixed inset-0 z-50 flex justify-end">
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       <button
         type="button"
-        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
         onClick={onClose}
         aria-label={t("common.close")}
       />
-      <div className="relative w-full max-w-md bg-[#0c0c0e] border-l border-slate-800 h-full flex flex-col shadow-2xl">
+      <form
+        className="relative w-full max-w-lg bg-[#0c0c0e] border border-slate-800 rounded-2xl flex flex-col shadow-2xl max-h-[90vh]"
+        onSubmit={handleSubmit}
+      >
         <div className="flex items-center justify-between px-6 h-14 border-b border-slate-800">
           <h2 className="text-base font-semibold text-slate-100">
             {t("settings.title")}
@@ -86,7 +98,7 @@ export function SettingsPanel({
           </button>
         </div>
 
-        <div className="flex-1 overflow-y-auto p-6 space-y-5">
+        <div className="flex-1 overflow-y-auto p-6 space-y-6">
           {settingsError && (
             <div className="flex items-start gap-2 rounded-lg bg-rose-500/10 border border-rose-500/20 p-3 text-sm text-rose-300">
               <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
@@ -102,60 +114,60 @@ export function SettingsPanel({
           )}
 
           <div className="space-y-2">
-            <div className="text-sm font-medium text-slate-300">Providers</div>
+            <div className="text-sm font-medium text-slate-300">
+              {t("language.switch")}
+            </div>
+            <button
+              type="button"
+              onClick={onToggleLanguage}
+              className="inline-flex items-center justify-center rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-200 transition-colors hover:border-slate-600 hover:bg-slate-800"
+            >
+              {language === "en" ? t("language.zh") : t("language.en")}
+            </button>
+          </div>
+
+          <div className="space-y-3">
+            <div className="text-sm font-medium text-slate-300">
+              {t("settings.provider")}
+            </div>
             {providers.length === 0 && providersStatus !== "loading" ? (
               <div className="rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-slate-400">
                 No providers available.
               </div>
             ) : (
-              <div className="space-y-2">
-                {providers.map((provider) => (
-                  <div
-                    key={provider.name}
-                    className="flex items-center justify-between rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-2"
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                {providers.map((p) => (
+                  <button
+                    type="button"
+                    key={p.name}
+                    onClick={() => setProvider(p.name)}
+                    className={`flex flex-col items-start justify-center rounded-xl border p-3 text-left transition-colors ${
+                      provider === p.name
+                        ? "border-indigo-500 bg-indigo-500/10 ring-1 ring-indigo-500/50"
+                        : "border-slate-800 bg-slate-900/40 hover:border-slate-700 hover:bg-slate-800/60"
+                    }`}
                   >
-                    <div>
-                      <div className="text-sm text-slate-200">
-                        {provider.label}
+                    <div className="w-full flex items-center justify-between mb-1">
+                      <div className="text-sm font-medium text-slate-200">
+                        {p.label}
                       </div>
-                      <div className="text-[11px] font-mono text-slate-500">
-                        {provider.name}
-                      </div>
+                      <div
+                        className={`w-2 h-2 rounded-full ${
+                          p.configured ? "bg-emerald-500" : "bg-slate-600"
+                        }`}
+                        title={p.configured ? "Configured" : "Not configured"}
+                      />
                     </div>
-                    <span
-                      className={`rounded-md border px-2 py-0.5 text-[11px] font-medium ${
-                        provider.configured
-                          ? "border-emerald-500/20 bg-emerald-500/10 text-emerald-400"
-                          : "border-slate-700 bg-slate-800 text-slate-400"
-                      }`}
-                    >
-                      {provider.configured ? "Configured" : "Not configured"}
-                    </span>
-                  </div>
+                    <div className="text-[11px] font-mono text-slate-500">
+                      {p.name}
+                    </div>
+                  </button>
                 ))}
               </div>
             )}
           </div>
 
-          <div className="space-y-2">
-            <label
-              htmlFor="settings-provider"
-              className="text-sm font-medium text-slate-300"
-            >
-              {t("settings.provider")}
-            </label>
-            <input
-              id="settings-provider"
-              type="text"
-              value={provider}
-              onChange={(e) => setProvider(e.target.value)}
-              placeholder={t("settings.providerPlaceholder")}
-              disabled={isLoading}
-              className="w-full bg-slate-900 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors disabled:opacity-50"
-            />
-          </div>
-
-          <div className="space-y-2">
+          <div className="space-y-2 pt-2 border-t border-slate-800/50">
             <label
               htmlFor="settings-api-key"
               className="text-sm font-medium text-slate-300"
@@ -165,20 +177,20 @@ export function SettingsPanel({
             <input
               id="settings-api-key"
               type="password"
+              autoComplete="new-password"
               value={apiKey}
               onChange={(e) => setApiKey(e.target.value)}
               placeholder={t("settings.apiKeyPlaceholder")}
               disabled={isLoading}
-              className="w-full bg-slate-900 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors disabled:opacity-50"
+              className="w-full bg-slate-900 border border-slate-700 rounded-lg px-3 py-2.5 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors disabled:opacity-50"
             />
             <p className="text-xs text-slate-500">{t("settings.apiKeyHint")}</p>
           </div>
         </div>
 
-        <div className="p-6 border-t border-slate-800">
+        <div className="p-6 border-t border-slate-800 bg-slate-900/30 rounded-b-2xl">
           <button
-            type="button"
-            onClick={handleSave}
+            type="submit"
             disabled={isLoading}
             className="w-full flex items-center justify-center gap-2 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed text-white px-4 py-2.5 rounded-lg text-sm font-medium transition-colors"
           >
@@ -190,7 +202,7 @@ export function SettingsPanel({
             {t("settings.save")}
           </button>
         </div>
-      </div>
+      </form>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- move shell actions out of the crowded sidebar/header mix so review and runtime status stay in the top chrome while settings moves back to the lower-left sidebar area
- replace manual provider entry with a settings-driven provider picker and move language switching into settings instead of a standalone button
- simplify the composer controls by docking agent/model pickers in the lower-left corner and showing grouped provider model lists with cleaner provider/model text

## Verification
- bun run test:run
- bun run build
- manual Playwright QA for shell layout, settings placement, provider picker behavior, and composer selector behavior