### PR TITLE
feat(web): add voidcode web launcher with OpenCode-aligned contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ htmlcov/
 .codex
 .voidcode.json
 .claude/
+playwright-report/

--- a/docs/contracts/web-opencode-alignment.md
+++ b/docs/contracts/web-opencode-alignment.md
@@ -1,0 +1,225 @@
+# Web OpenCode Alignment Matrix
+
+## Purpose
+
+This document records the implementation-level comparison between VoidCode's web MVP target and production-grade reference patterns from OpenCode, with limited category/delegation lessons from Oh My OpenAgent (OMOA) only where those lessons help reduce product complexity.
+
+This is not a parity checklist. Each concern is deliberately classified as one of:
+
+- **Adopt**: carry the pattern over with minimal structural change
+- **Adapt**: keep the core idea but reshape it to fit VoidCode's runtime-centric architecture
+- **Reject**: do not bring the pattern over because it adds complexity or solves a problem VoidCode does not currently have
+
+## Alignment Matrix
+
+### 1. Launcher
+
+- **OpenCode reference**: `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/opencode/src/cli/cmd/web.ts`
+- **Local seams**: `src/voidcode/cli.py`, `src/voidcode/server.py`
+- **Decision**: **Adopt**
+- **Why**: OpenCode's split between a headless server command and a user-friendly web launcher is production-grade, intuitive, and matches the user's requested end state.
+- **VoidCode target**:
+  - Add `voidcode web` as the user-facing launcher
+  - Keep `voidcode serve` as the advanced/headless server surface
+  - Print banner + usable URL
+  - Best-effort browser open must not be fatal
+
+### 2. CLI modularity
+
+- **OpenCode references**:
+  - `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/opencode/src/index.ts`
+  - `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/opencode/src/cli/cmd/cmd.ts`
+- **Local seams**: `src/voidcode/cli.py`, `src/voidcode/__main__.py`
+- **Decision**: **Adapt**
+- **Why**: OpenCode's per-command module pattern is cleaner than the current monolithic argparse assembly, but VoidCode should keep Python-native command wiring rather than mimic the TypeScript/yargs structure directly.
+- **VoidCode target**:
+  - Extract `serve` / `web` command handling into clearer command-owned units if needed
+  - Preserve shared startup primitives rather than duplicating server logic
+  - Keep Python entrypoint semantics unchanged
+
+### 3. Server ownership
+
+- **OpenCode references**:
+  - `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/opencode/src/cli/cmd/serve.ts`
+  - `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/opencode/src/server/server.ts`
+- **Local seams**: `src/voidcode/server.py`, `src/voidcode/runtime/http.py`
+- **Decision**: **Adopt**
+- **Why**: OpenCode's `web` command reuses the same server listen path as `serve`, which cleanly preserves one control plane. VoidCode already has this shape available through `server.py` and `runtime/http.py`.
+- **VoidCode target**:
+  - `web` wraps the same runtime HTTP server primitive used by `serve`
+  - No second web architecture
+  - Runtime HTTP remains the sole transport authority
+
+### 4. Config source of truth
+
+- **OpenCode references**:
+  - `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/opencode/src/config/config.ts`
+  - `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/opencode/src/config/paths.ts`
+- **Local seams**: `src/voidcode/runtime/config.py`, `src/voidcode/runtime/http.py`, `frontend/src/store/index.ts`, `frontend/src/lib/runtime/types.ts`
+- **Decision**: **Adapt**
+- **Why**: OpenCode's canonical backend schema and layered precedence are exactly the right production lesson, but VoidCode should express this in Pydantic/runtime contracts instead of trying to clone OpenCode's Effect Schema stack.
+- **VoidCode target**:
+  - Backend runtime config remains canonical
+  - Frontend reads/writes only a versioned projection of that schema
+  - Local UI-only preferences remain browser-local
+  - Overlapping execution config is removed from frontend persistence or treated as non-authoritative
+
+### 5. Provider and Model configuration
+
+- **OpenCode references**:
+  - `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/opencode/src/config/provider.ts`
+  - `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/opencode/src/provider/provider.ts`
+- **Local seams**: `src/voidcode/runtime/config.py`, `src/voidcode/provider/config.py`, `frontend/src/components/SettingsPanel.tsx`, `frontend/src/components/Composer.tsx`
+- **Decision**: **Adapt**
+- **Why**: OpenCode's provider/model structure demonstrates production-grade ownership and shape, but VoidCode's MVP only needs the subset required for provider selection, key handling, and model selection in the web path.
+- **VoidCode target**:
+  - Runtime-owned provider/model configuration surface
+  - Web projection supports provider, model, key-present flag, and optional key submission
+  - No broad provider marketplace/admin features
+
+### 6. API key flow
+
+- **OpenCode reference**: `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/opencode/src/config/provider.ts`
+- **Local seams**: `src/voidcode/runtime/http.py`, `src/voidcode/runtime/config.py`, `src/voidcode/provider/config.py`, `frontend/src/components/SettingsPanel.tsx`
+- **Decision**: **Adapt**
+- **Why**: The production lesson is clear secret ownership and configuration layering, not necessarily OpenCode's exact entry UX. The user explicitly wants dual mode, so VoidCode must support both env-backed and browser-submitted keys while keeping backend authority.
+- **VoidCode target**:
+  - `.env` / backend config remains the default happy path
+  - Browser submission is allowed through `/api/settings`
+  - `GET /api/settings` never returns raw API keys
+  - UI surfaces only presence/absence, not secret contents
+
+### 7. Tool lifecycle states
+
+- **OpenCode references**:
+  - `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/opencode/src/session/message-v2.ts`
+  - `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/opencode/src/session/status.ts`
+- **Local seams**: `src/voidcode/runtime/events.py`, `src/voidcode/runtime/service.py`, `src/voidcode/runtime/http.py`, `frontend/src/lib/runtime/event-parser.ts`
+- **Decision**: **Adapt**
+- **Why**: OpenCode's per-tool `pending/running/completed/error` model is the right production pattern, but VoidCode already has richer runtime/task lifecycle concepts. The correct move is to add a stable per-tool web contract without flattening the rest of the runtime.
+- **VoidCode target**:
+  - Add backend-owned tool invocation state fields for web rendering
+  - Preserve existing runtime/delegation/task semantics separately
+  - Frontend must consume explicit status/phase/label values rather than infer from event names
+
+### 8. Pending labels and progress text
+
+- **OpenCode references**:
+  - `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/ui/src/components/tool-status-title.tsx`
+  - `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/ui/src/components/basic-tool.tsx`
+  - `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/ui/src/components/message-part.tsx`
+- **OMOA metadata reference**:
+  - `https://github.com/code-yeongyu/oh-my-openagent/blob/708891dabe5d4f37c76a0de63dc353cdf05902b0/src/features/tool-metadata-store/publish-tool-metadata.ts`
+- **Local seams**: `src/voidcode/runtime/events.py`, `src/voidcode/runtime/http.py`, `frontend/src/lib/runtime/event-parser.ts`, `frontend/src/App.tsx`
+- **Decision**: **Adapt**
+- **Why**: The user explicitly wants labels like `Preparing patch...` and `Delegating...`. OpenCode and OMOA together show the right shape: backend-authored metadata/title, frontend rendering.
+- **VoidCode target**:
+  - Emit stable backend label/title fields for tool lifecycle UI
+  - Required labels include at least: `Preparing patch...`, `Delegating...`, `Reading file...`, `Searching content...`, `Writing command...`
+  - No heuristic string synthesis in the browser
+
+### 9. Invocation identity
+
+- **OpenCode reference**: `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/opencode/src/session/message-v2.ts`
+- **OMOA reference**: `https://github.com/code-yeongyu/oh-my-openagent/blob/708891dabe5d4f37c76a0de63dc353cdf05902b0/src/features/tool-metadata-store/publish-tool-metadata.ts`
+- **Local seams**: `src/voidcode/runtime/events.py`, `src/voidcode/runtime/contracts.py`, `src/voidcode/runtime/http.py`
+- **Decision**: **Adapt**
+- **Why**: Repeated same-name tool calls are a real ambiguity risk. OpenCode's `callID` model and OMOA's metadata-publishing pattern both support the same conclusion: the web contract needs a stable invocation identifier.
+- **VoidCode target**:
+  - Add per-tool invocation identifiers to web-visible status payloads
+  - Make status updates correlate to one tool call deterministically
+  - Keep subagent/delegation contracts separate from per-tool identity
+
+### 10. Leader-only top-level execution
+
+- **OpenCode reference**: `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/opencode/src/agent/agent.ts`
+- **Local seams**: `src/voidcode/runtime/service.py`, `src/voidcode/agent/builtin.py`
+- **Decision**: **Adopt**
+- **Why**: OpenCode has a clear distinction between primary agents and subagents. VoidCode already enforces `leader` as the only top-level executable preset, which should remain intact for the MVP.
+- **VoidCode target**:
+  - Preserve `leader` as the only web-top-level execution surface
+  - Continue allowing internal delegated subagent execution where already supported
+
+### 11. Category route surface
+
+- **OMOA references**:
+  - `https://github.com/code-yeongyu/oh-my-openagent/blob/708891dabe5d4f37c76a0de63dc353cdf05902b0/src/tools/delegate-task/builtin-categories.ts`
+  - `https://github.com/code-yeongyu/oh-my-openagent/blob/708891dabe5d4f37c76a0de63dc353cdf05902b0/src/tools/delegate-task/category-resolver.ts`
+- **Local seams**: `src/voidcode/runtime/task.py`, `src/voidcode/runtime/contracts.py`, `src/voidcode/runtime/http.py`, `src/voidcode/tools/task.py`
+- **Decision**: **Reject** for product surface; **Adapt** internally only if needed
+- **Why**: OMOA proves category-routing can work, but it also proves category/subagent confusion becomes a recurring product and model-behavior failure mode. For VoidCode's web MVP, category is unnecessary public complexity.
+- **VoidCode target**:
+  - Remove category from web-facing request payloads, docs, UI, and frontend contracts
+  - Keep any internal preset resolution private if still required by runtime internals
+  - Prefer direct subagent or resolved preset semantics over exposed category strings
+
+### 12. Status rendering architecture
+
+- **OpenCode references**:
+  - `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/ui/src/components/message-part.tsx`
+  - `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/ui/src/components/basic-tool.tsx`
+  - `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/ui/src/components/tool-status-title.tsx`
+- **Local seams**: `frontend/src/lib/runtime/event-parser.ts`, `frontend/src/App.tsx`, `frontend/src/components/ChatThread.tsx`
+- **Decision**: **Adapt**
+- **Why**: OpenCode's rendering stack is more layered than VoidCode needs, but the core principle is correct: UI components render backend-owned tool state rather than deriving hidden logic from raw streams.
+- **VoidCode target**:
+  - Keep frontend rendering lighter-weight than OpenCode
+  - Still move to backend-authored status/title fields as the primary rendering source
+
+### Delegation policy after Task 7
+
+- Top-level web/runtime execution remains `leader`-only.
+- Public HTTP and browser request contracts must not accept `delegation.category`.
+- Public delegated payloads must describe child execution with `subagent_type` when explicitly requested, otherwise with resolved delegation fields such as `selected_preset` / `selected_execution_engine`.
+- Category-to-preset mapping may remain as a private runtime/storage implementation detail for internal delegation and reconciliation only.
+- Subagents are a behind-the-scenes tool-driven mechanism, not a public category-routed product surface.
+
+### 13. QA, test maturity, and verification strategy
+
+- **OpenCode production lesson**: web launcher, config, and status changes are treated as contract-bearing behavior, not just visual polish
+- **Local seams**:
+  - `tests/unit/interface/test_cli_smoke.py`
+  - `tests/unit/interface/test_cli_delegated_parity.py`
+  - `tests/integration/test_http_transport.py`
+  - `tests/integration/test_http_delegated_parity.py`
+  - `frontend/src/store.integration.test.ts`
+  - `frontend/src/App.test.tsx`
+- **Decision**: **Adopt**
+- **Why**: VoidCode already has strong local deterministic coverage foundations. The missing pieces are launcher-specific tests, client/status contract tests, and browser E2E.
+- **VoidCode target**:
+  - Extend pytest/Vitest around the new launcher/config/status seams
+  - Add Playwright for the actual `voidcode web` user path
+  - Keep `.env`-backed live smoke narrow and skippable when credentials are absent
+
+## Summary Decisions
+
+### Adopt
+
+- Separate `web` launcher from headless `serve`
+- Keep one server/control-plane path underneath both commands
+- Preserve leader-only top-level execution
+- Treat launcher/config/status changes as contract-level, testable work
+
+### Adapt
+
+- CLI modularity into Python-appropriate command boundaries
+- Backend-owned config schema and frontend projection
+- Provider/model config surfaces using a smaller MVP subset
+- Backend-authored tool status model and pending labels
+- Invocation identity for tool calls
+- Status rendering that consumes backend state directly
+
+### Reject
+
+- Exposed category-route product surface in the web MVP
+- Full OpenCode parity or architecture copying for its own sake
+- Frontend-owned execution/config truth
+
+## Concrete Implications for Implementation
+
+1. `Task 2` should refactor command ownership enough that `web` is not an ad hoc branch inside a monolithic parser.
+2. `Task 3` should define the canonical runtime-owned settings schema and explicitly separate runtime-owned fields from local UI-only fields.
+3. `Task 4` should add a stable backend tool status contract with label/title/invocation identity fields and explicit leader/category boundary behavior.
+4. `Task 5` should implement the terminal launcher UX modeled on OpenCode's `web.ts`, but through VoidCode's existing `server.py` / `runtime/http.py` path.
+5. `Task 6` should delete or bypass heuristic-only frontend status interpretation and move to backend-provided rendering inputs.
+6. `Task 7` should remove category-route surface from web-visible contracts while preserving any necessary internal delegation mechanics.

--- a/frontend/e2e/launcher.spec.ts
+++ b/frontend/e2e/launcher.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+import { spawn, ChildProcess } from 'child_process';
+import * as path from 'path';
+
+let proc: ChildProcess;
+let launcherUrl: string;
+
+let stdoutData = '';
+let stderrData = '';
+
+test.describe('VoidCode Web Launcher', () => {
+  test.beforeAll(async () => {
+    const rootDir = path.resolve(process.cwd(), '..');
+    const port = Math.floor(Math.random() * 50000) + 10000;
+    
+    proc = spawn('uv', ['run', 'voidcode', 'web', '--port', port.toString(), '--workspace', rootDir], {
+      cwd: rootDir,
+      env: { ...process.env, PYTHONUNBUFFERED: '1' },
+    });
+
+    stdoutData = '';
+    stderrData = '';
+    launcherUrl = await new Promise<string>((resolve, reject) => {
+      let foundUrl = '';
+      let uvicornReady = false;
+
+      proc.stdout?.on('data', (data) => {
+        stdoutData += data.toString();
+        if (!foundUrl) {
+          const match = stdoutData.match(/Local server running at:\s+(http:\/\/[^\s]+)/);
+          if (match) {
+            foundUrl = match[1];
+            if (uvicornReady) resolve(foundUrl);
+          }
+        }
+      });
+
+      proc.stderr?.on('data', (data) => {
+        stderrData += data.toString();
+        if (!uvicornReady) {
+          if (stderrData.includes('Uvicorn running on')) {
+            uvicornReady = true;
+            if (foundUrl) resolve(foundUrl);
+          }
+        }
+      });
+
+      proc.on('close', (code) => {
+        if (!foundUrl || !uvicornReady) reject(new Error(`voidcode closed with code ${code}. Output: ${stdoutData} | Err: ${stderrData}`));
+      });
+    });
+  });
+
+  test.afterAll(() => {
+    if (proc) proc.kill();
+  });
+
+  test('should fallback to SPA on unknown routes', async ({ page }) => {
+    const response = await page.goto(`${launcherUrl}/some-non-existent-route`);
+    expect(response?.status()).toBe(200);
+    await expect(page).toHaveTitle(/VoidCode/i);
+    await expect(page.locator('textarea').first()).toBeVisible({ timeout: 20000 });
+  });
+
+  test('should run a task using env-backed key without browser-side API key entry', async ({ page }) => {
+    test.skip(!process.env.OPENCODE_API_KEY, 'Skipping live smoke test because OPENCODE_API_KEY is not set in environment.');
+    
+    await page.goto(launcherUrl);
+    await expect(page).toHaveTitle(/VoidCode/i);
+    
+    const settingsModal = page.locator('div[role="dialog"]');
+    await expect(settingsModal).not.toBeVisible();
+    
+    const input = page.locator('textarea');
+    await expect(input).toBeVisible({ timeout: 20000 });
+    await input.fill('read README.md');
+    await input.press('Enter');
+    
+    await expect(page.getByText('Agent Busy')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Agent Idle')).toBeVisible({ timeout: 60000 });
+    
+    const runErrorBanner = page.locator('div.flex-shrink-0[class*="bg-rose-500/10"]');
+    await expect(runErrorBanner).not.toBeVisible();
+    
+    await expect(page.getByText('Assistant').first()).toBeVisible();
+  });
+});

--- a/frontend/e2e/launcher.spec.ts
+++ b/frontend/e2e/launcher.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { spawn, ChildProcess } from 'child_process';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 
 let proc: ChildProcess;
 let launcherUrl: string;
@@ -10,9 +11,9 @@ let stderrData = '';
 
 test.describe('VoidCode Web Launcher', () => {
   test.beforeAll(async () => {
-    const rootDir = path.resolve(process.cwd(), '..');
+    const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
     const port = Math.floor(Math.random() * 50000) + 10000;
-    
+
     proc = spawn('uv', ['run', 'voidcode', 'web', '--port', port.toString(), '--workspace', rootDir], {
       cwd: rootDir,
       env: { ...process.env, PYTHONUNBUFFERED: '1' },
@@ -64,24 +65,24 @@ test.describe('VoidCode Web Launcher', () => {
 
   test('should run a task using env-backed key without browser-side API key entry', async ({ page }) => {
     test.skip(!process.env.OPENCODE_API_KEY, 'Skipping live smoke test because OPENCODE_API_KEY is not set in environment.');
-    
+
     await page.goto(launcherUrl);
     await expect(page).toHaveTitle(/VoidCode/i);
-    
+
     const settingsModal = page.locator('div[role="dialog"]');
     await expect(settingsModal).not.toBeVisible();
-    
+
     const input = page.locator('textarea');
     await expect(input).toBeVisible({ timeout: 20000 });
     await input.fill('read README.md');
     await input.press('Enter');
-    
+
     await expect(page.getByText('Agent Busy')).toBeVisible({ timeout: 10000 });
     await expect(page.getByText('Agent Idle')).toBeVisible({ timeout: 60000 });
-    
+
     const runErrorBanner = page.locator('div.flex-shrink-0[class*="bg-rose-500/10"]');
     await expect(runErrorBanner).not.toBeVisible();
-    
+
     await expect(page.getByText('Assistant').first()).toBeVisible();
   });
 });

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test';
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'html' : 'list',
+  outputDir: process.env.CI ? 'test-results/' : '/tmp/playwright-test-results/',
+  use: {
+    trace: 'off',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/frontend/src/components/ChatThread.tsx
+++ b/frontend/src/components/ChatThread.tsx
@@ -58,7 +58,7 @@ function ThinkingBlock({ thinking }: { thinking: string[] }) {
 function ToolIndicators({
   tools,
 }: {
-  tools: { name: string; status: string }[];
+  tools: { id?: string; name: string; label?: string; status: string }[];
 }) {
   if (tools.length === 0) return null;
 
@@ -66,7 +66,7 @@ function ToolIndicators({
     <div className="flex flex-wrap gap-1.5 mb-3">
       {tools.map((tool, idx) => (
         <span
-          key={`${tool.name}-${idx}`}
+          key={tool.id ?? `${tool.name}-${idx}`}
           className={`inline-flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium border ${
             tool.status === "running"
               ? "bg-indigo-500/10 text-indigo-400 border-indigo-500/20"
@@ -78,7 +78,7 @@ function ToolIndicators({
           }`}
         >
           <Wrench className="w-3 h-3" />
-          {tool.name}
+          {tool.label ?? tool.name}
           {tool.status === "running" && (
             <Loader2 className="w-3 h-3 animate-spin" />
           )}

--- a/frontend/src/lib/runtime/client.integration.test.ts
+++ b/frontend/src/lib/runtime/client.integration.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { RuntimeClient } from "./client";
+
+describe("RuntimeClient integration contract", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("loads runtime-owned status snapshots from /api/status", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          git: { state: "git_ready", root: "/workspace", error: null },
+          lsp: { state: "running", error: null, details: {} },
+          mcp: {
+            state: "failed",
+            error: "MCP[demo]: failed to initialize server",
+            details: {
+              configured_server_count: 1,
+              running_server_count: 0,
+              failed_server_count: 1,
+              retry_available: true,
+              servers: [
+                {
+                  server: "demo",
+                  status: "failed",
+                  workspace_root: "/workspace",
+                  stage: "startup",
+                  error: "MCP[demo]: failed to initialize server",
+                  command: ["demo"],
+                  retry_available: true,
+                },
+              ],
+            },
+          },
+        }),
+      } as Response);
+
+    const snapshot = await RuntimeClient.getStatus();
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/status");
+    expect(snapshot.mcp.details?.servers).toEqual([
+      {
+        server: "demo",
+        status: "failed",
+        workspace_root: "/workspace",
+        stage: "startup",
+        error: "MCP[demo]: failed to initialize server",
+        command: ["demo"],
+        retry_available: true,
+      },
+    ]);
+  });
+
+  it("parses streamed SSE chunks and preserves backend tool status payloads", async () => {
+    const encoder = new TextEncoder();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            'data: {"kind":"event","session":{"session":{"id":"session-1"},"status":"running","turn":1,"metadata":{}},"event":{"session_id":"session-1","sequence":1,"event_type":"runtime.tool_started","source":"runtime","payload":{"tool_status":{"tool_name":"read_file","invocation_id":"call-1","phase":"running","status":"running","label":"Reading file"}},"tool_status":{"tool_name":"read_file","invocation_id":"call-1","phase":"running","status":"running","label":"Reading file"}},"output":null}\n\n',
+          ),
+        );
+        controller.enqueue(
+          encoder.encode(
+            'data: {"kind":"output","session":{"session":{"id":"session-1"},"status":"completed","turn":1,"metadata":{}},"event":null,"output":"done"}\n\n',
+          ),
+        );
+        controller.close();
+      },
+    });
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      body,
+    } as Response);
+
+    const chunks = [];
+    for await (const chunk of RuntimeClient.runStream({ prompt: "read README.md" })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0].event?.payload.tool_status).toEqual({
+      tool_name: "read_file",
+      invocation_id: "call-1",
+      phase: "running",
+      status: "running",
+      label: "Reading file",
+    });
+    expect(chunks[1].output).toBe("done");
+  });
+});

--- a/frontend/src/lib/runtime/event-parser.ts
+++ b/frontend/src/lib/runtime/event-parser.ts
@@ -16,7 +16,9 @@ export interface ChatMessage {
   content: string;
   thinking: string[];
   tools: {
+    id?: string;
     name: string;
+    label?: string;
     status: "pending" | "running" | "completed" | "failed";
   }[];
   approval: {
@@ -26,6 +28,56 @@ export interface ChatMessage {
   } | null;
   status: "in_progress" | "completed" | "failed" | "waiting";
   sequence: number;
+}
+
+type ToolStatusPayload = {
+  invocation_id?: unknown;
+  tool_name?: unknown;
+  status?: unknown;
+  label?: unknown;
+};
+
+function getToolStatusPayload(event: EventEnvelope): ToolStatusPayload | null {
+  const toolStatus = event.payload?.tool_status;
+  if (!toolStatus || typeof toolStatus !== "object") return null;
+  return toolStatus as ToolStatusPayload;
+}
+
+function applyToolStatus(
+  currentAssistant: ChatMessage | null,
+  toolStatus: ToolStatusPayload,
+) {
+  if (!currentAssistant) return;
+
+  const name =
+    typeof toolStatus.tool_name === "string" ? toolStatus.tool_name : "unknown";
+  const id =
+    typeof toolStatus.invocation_id === "string"
+      ? toolStatus.invocation_id
+      : undefined;
+  const label =
+    typeof toolStatus.label === "string" ? toolStatus.label : undefined;
+  const status =
+    toolStatus.status === "pending" ||
+    toolStatus.status === "running" ||
+    toolStatus.status === "completed" ||
+    toolStatus.status === "failed"
+      ? toolStatus.status
+      : "running";
+
+  const existing = currentAssistant.tools.find((tool) =>
+    id ? tool.id === id : tool.name === name && tool.status === "running",
+  );
+
+  if (existing) {
+    existing.name = name;
+    existing.status = status;
+    existing.id = id ?? existing.id;
+    existing.label = label ?? existing.label;
+    return;
+  }
+
+  currentAssistant.tools.push({ id, name, label, status });
 }
 
 export function deriveTasksFromEvents(events: EventEnvelope[]): DerivedTask[] {
@@ -188,6 +240,7 @@ export function deriveChatMessages(
 
   for (const event of events) {
     const messageSessionId = event.session_id || fallbackSessionId || "session";
+    const toolStatus = getToolStatusPayload(event);
 
     if (event.event_type === "runtime.request_received") {
       requestOrdinal += 1;
@@ -259,6 +312,10 @@ export function deriveChatMessages(
       }
     } else if (event.event_type === "graph.tool_request_created") {
       if (currentAssistant) {
+        if (toolStatus) {
+          applyToolStatus(currentAssistant, toolStatus);
+          continue;
+        }
         const toolName =
           typeof event.payload?.tool === "string"
             ? event.payload.tool
@@ -267,6 +324,10 @@ export function deriveChatMessages(
       }
     } else if (event.event_type === "runtime.tool_completed") {
       if (currentAssistant) {
+        if (toolStatus) {
+          applyToolStatus(currentAssistant, toolStatus);
+          continue;
+        }
         const toolName =
           typeof event.payload?.tool === "string" ? event.payload.tool : null;
         if (toolName) {
@@ -310,6 +371,8 @@ export function deriveChatMessages(
       if (currentAssistant) {
         currentAssistant.status = "failed";
       }
+    } else if (toolStatus) {
+      applyToolStatus(currentAssistant, toolStatus);
     }
   }
 

--- a/frontend/src/lib/runtime/status-contract.test.ts
+++ b/frontend/src/lib/runtime/status-contract.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { deriveChatMessages } from "./event-parser";
+import { EventEnvelope } from "./types";
+
+describe("Tool Status Contract", () => {
+  it("renders backend-provided tool status and label", () => {
+    const events: EventEnvelope[] = [
+      {
+        session_id: "test",
+        sequence: 1,
+        event_type: "runtime.request_received",
+        source: "runtime",
+        payload: { prompt: "Read the file" },
+      },
+      {
+        session_id: "test",
+        sequence: 2,
+        event_type: "some.event.type.does.not.matter",
+        source: "graph",
+        payload: {
+          tool_status: {
+            invocation_id: "call_abc",
+            tool_name: "read",
+            phase: "running",
+            status: "running",
+            label: "Reading file...",
+          },
+        },
+      },
+      {
+        session_id: "test",
+        sequence: 3,
+        event_type: "another.event.type",
+        source: "tool",
+        payload: {
+          tool_status: {
+            invocation_id: "call_abc",
+            tool_name: "read",
+            phase: "completed",
+            status: "completed",
+            label: "Read 10 lines",
+          },
+        },
+      },
+    ];
+
+    const messages = deriveChatMessages(events, null);
+    const assistantMessage = messages.find((m) => m.role === "assistant");
+    expect(assistantMessage).toBeDefined();
+    
+    expect(assistantMessage!.tools).toHaveLength(1);
+    const tool = assistantMessage!.tools[0];
+    
+    expect(tool.id).toBe("call_abc");
+    expect(tool.name).toBe("read");
+    expect(tool.label).toBe("Read 10 lines");
+    expect(tool.status).toBe("completed");
+  });
+
+  it("tracks the stable tool-status payload shape without frontend heuristics", () => {
+    const events: EventEnvelope[] = [
+      {
+        session_id: "test",
+        sequence: 1,
+        event_type: "runtime.request_received",
+        source: "runtime",
+        payload: { prompt: "Inspect file" },
+      },
+      {
+        session_id: "test",
+        sequence: 2,
+        event_type: "runtime.tool_started",
+        source: "runtime",
+        payload: {
+          tool_status: {
+            invocation_id: "call_xyz",
+            tool_name: "read_file",
+            phase: "running",
+            status: "running",
+            label: "Reading file",
+          },
+        },
+      },
+    ];
+
+    const messages = deriveChatMessages(events, null);
+    const assistantMessage = messages.find((m) => m.role === "assistant");
+
+    expect(assistantMessage?.tools).toEqual([
+      {
+        id: "call_xyz",
+        name: "read_file",
+        label: "Reading file",
+        status: "running",
+      },
+    ]);
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,6 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vite'
+import { configDefaults } from 'vitest/config'
 import react from '@vitejs/plugin-react-swc'
 import path from 'path'
 
@@ -31,5 +32,6 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/setupTests.ts'],
     globals: true,
+    exclude: [...configDefaults.exclude, 'e2e/**'],
   },
 })

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "voidcode-root",
+  "private": true,
+  "scripts": {
+    "vitest": "bun ./scripts/run-frontend-vitest.mjs",
+    "playwright": "bun ./scripts/run-frontend-playwright.mjs"
+  }
+}

--- a/scripts/run-frontend-playwright.mjs
+++ b/scripts/run-frontend-playwright.mjs
@@ -1,0 +1,26 @@
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '..');
+const frontendDir = resolve(repoRoot, 'frontend');
+const playwrightEntrypoint = resolve(frontendDir, 'node_modules', '@playwright', 'test', 'cli.js');
+const playwrightConfig = resolve(frontendDir, 'playwright.config.ts');
+
+if (!existsSync(playwrightEntrypoint)) {
+  console.error(
+    'error: frontend Playwright dependency is missing. Run "mise run frontend:install" first.',
+  );
+  process.exit(1);
+}
+
+const result = Bun.spawnSync({
+  cmd: [process.execPath, playwrightEntrypoint, ...process.argv.slice(2), '--config', playwrightConfig],
+  cwd: repoRoot,
+  stdout: 'inherit',
+  stderr: 'inherit',
+  stdin: 'inherit',
+});
+
+process.exit(result.exitCode);

--- a/scripts/run-frontend-vitest.mjs
+++ b/scripts/run-frontend-vitest.mjs
@@ -1,0 +1,36 @@
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '..');
+const frontendDir = resolve(repoRoot, 'frontend');
+const vitestEntrypoint = resolve(frontendDir, 'node_modules', 'vitest', 'vitest.mjs');
+const vitestConfig = resolve(frontendDir, 'vite.config.ts');
+const forwardedArgs = process.argv.slice(2).map((arg) => {
+  if (arg === 'frontend') {
+    return '.';
+  }
+  if (arg.startsWith('frontend/')) {
+    return arg.slice('frontend/'.length);
+  }
+  if (arg.startsWith('./frontend/')) {
+    return `./${arg.slice('./frontend/'.length)}`;
+  }
+  return arg;
+});
+
+if (!existsSync(vitestEntrypoint)) {
+  console.error('error: frontend Vitest dependency is missing. Run "mise run frontend:install" first.');
+  process.exit(1);
+}
+
+const result = Bun.spawnSync({
+  cmd: [process.execPath, vitestEntrypoint, '--config', vitestConfig, ...forwardedArgs],
+  cwd: frontendDir,
+  stdout: 'inherit',
+  stderr: 'inherit',
+  stdin: 'inherit',
+});
+
+process.exit(result.exitCode);

--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -32,7 +32,7 @@ from .runtime.permission import PermissionDecision, PermissionResolution
 from .runtime.service import VoidCodeRuntime
 from .runtime.session import SessionState, StoredSessionSummary
 from .runtime.task import BackgroundTaskState, StoredBackgroundTaskSummary
-from .server import serve
+from .server import serve, web
 
 Handler = Callable[[argparse.Namespace], int]
 
@@ -508,13 +508,14 @@ def _handle_tasks_list_command(args: argparse.Namespace) -> int:
     return 0
 
 
-def _handle_serve_command(args: argparse.Namespace) -> int:
+def _handle_server_command(args: argparse.Namespace) -> int:
     workspace = cast(Path, args.workspace)
     config = load_runtime_config(
         workspace,
         approval_mode=cast(PermissionDecision | None, getattr(args, "approval_mode", None)),
     )
-    serve(
+    server_entry = cast(Callable[..., None], args.server_entry)
+    server_entry(
         workspace=workspace,
         host=cast(str, args.host),
         port=cast(int, args.port),
@@ -780,7 +781,35 @@ def build_parser() -> argparse.ArgumentParser:
         choices=("allow", "deny", "ask"),
         help="Override the runtime approval mode for this server process.",
     )
-    serve_parser.set_defaults(handler=_handle_serve_command)
+    serve_parser.set_defaults(handler=_handle_server_command, server_entry=serve)
+
+    web_parser = subparsers.add_parser(
+        "web",
+        help="Start the local web launcher entrypoint for the runtime transport.",
+    )
+    _ = web_parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd(),
+        help="Workspace root used by the local runtime and session database.",
+    )
+    _ = web_parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host interface for the local launcher server.",
+    )
+    _ = web_parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port for the local launcher server.",
+    )
+    _ = web_parser.add_argument(
+        "--approval-mode",
+        choices=("allow", "deny", "ask"),
+        help="Override the runtime approval mode for this launcher process.",
+    )
+    web_parser.set_defaults(handler=_handle_server_command, server_entry=web)
 
     sessions_parser = subparsers.add_parser("sessions", help="Inspect persisted local sessions.")
     sessions_subparsers = sessions_parser.add_subparsers(dest="sessions_command")

--- a/src/voidcode/runtime/http.py
+++ b/src/voidcode/runtime/http.py
@@ -778,6 +778,12 @@ class RuntimeTransportApp:
             await send({"type": "http.response.body", "body": body, "more_body": False})
             return
 
+        # SPA fallback is only for route-like paths. Missing assets should
+        # stay 404 so browsers do not try to parse index.html as JS/CSS/etc.
+        if resolved.suffix:
+            await self._json_response(send, status=404, payload={"error": "not found"})
+            return
+
         # SPA fallback — serve index.html for client-side routing
         index_path = (self._frontend_dist / "index.html").resolve()
         if index_path.is_file():

--- a/src/voidcode/runtime/http.py
+++ b/src/voidcode/runtime/http.py
@@ -720,6 +720,10 @@ class RuntimeTransportApp:
             await self._handle_get_review_diff(path=diff_path, send=send)
             return
 
+        if path == "/api" or path.startswith("/api/"):
+            await self._json_response(send, status=404, payload={"error": "not found"})
+            return
+
         await self._handle_static_file(path, send)
 
     @staticmethod

--- a/src/voidcode/runtime/http.py
+++ b/src/voidcode/runtime/http.py
@@ -316,9 +316,11 @@ class RuntimeTransportApp:
         *,
         runtime_factory: Callable[[], RuntimeTransport],
         workspace_coordinator: SingleWorkspaceRuntimeCoordinator | None = None,
+        frontend_dist: Path | None = None,
     ) -> None:
         self._runtime_factory = runtime_factory
         self._workspace_coordinator = workspace_coordinator
+        self._frontend_dist = frontend_dist
 
     @staticmethod
     def _close_runtime(
@@ -716,6 +718,74 @@ class RuntimeTransportApp:
                 )
                 return
             await self._handle_get_review_diff(path=diff_path, send=send)
+            return
+
+        await self._handle_static_file(path, send)
+
+    @staticmethod
+    def _content_type_for_suffix(suffix: str) -> str:
+        _CONTENT_TYPES: dict[str, str] = {
+            ".html": "text/html; charset=utf-8",
+            ".js": "application/javascript; charset=utf-8",
+            ".css": "text/css; charset=utf-8",
+            ".json": "application/json; charset=utf-8",
+            ".png": "image/png",
+            ".svg": "image/svg+xml",
+            ".ico": "image/x-icon",
+            ".woff2": "font/woff2",
+            ".woff": "font/woff",
+            ".ttf": "font/ttf",
+            ".txt": "text/plain; charset=utf-8",
+            ".map": "application/octet-stream",
+            ".webp": "image/webp",
+            ".wasm": "application/wasm",
+        }
+        return _CONTENT_TYPES.get(suffix.lower(), "application/octet-stream")
+
+    async def _handle_static_file(self, path: str, send: Send) -> None:
+        if self._frontend_dist is None:
+            await self._json_response(send, status=404, payload={"error": "not found"})
+            return
+
+        normalized_path = path.lstrip("/")
+        if not normalized_path:
+            normalized_path = "index.html"
+
+        file_path = self._frontend_dist / normalized_path
+
+        # Prevent directory traversal
+        try:
+            resolved = file_path.resolve()
+            resolved.relative_to(self._frontend_dist.resolve())
+        except ValueError:
+            await self._json_response(send, status=404, payload={"error": "not found"})
+            return
+
+        if resolved.is_file():
+            content_type = self._content_type_for_suffix(resolved.suffix)
+            body = resolved.read_bytes()
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [(b"content-type", content_type.encode("utf-8"))],
+                }
+            )
+            await send({"type": "http.response.body", "body": body, "more_body": False})
+            return
+
+        # SPA fallback — serve index.html for client-side routing
+        index_path = (self._frontend_dist / "index.html").resolve()
+        if index_path.is_file():
+            body = index_path.read_bytes()
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [(b"content-type", b"text/html; charset=utf-8")],
+                }
+            )
+            await send({"type": "http.response.body", "body": body, "more_body": False})
             return
 
         await self._json_response(send, status=404, payload={"error": "not found"})
@@ -1774,14 +1844,16 @@ def create_runtime_app(
     workspace: Path,
     config: RuntimeConfig | None = None,
     runtime_factory: Callable[[], RuntimeTransport] | None = None,
+    frontend_dist: Path | None = None,
 ) -> RuntimeTransportApp:
     if runtime_factory is not None:
-        return RuntimeTransportApp(runtime_factory=runtime_factory)
+        return RuntimeTransportApp(runtime_factory=runtime_factory, frontend_dist=frontend_dist)
 
     resolved_workspace = workspace.resolve()
     if not resolved_workspace.is_dir():
         return RuntimeTransportApp(
-            runtime_factory=lambda: VoidCodeRuntime(workspace=resolved_workspace, config=config)
+            runtime_factory=lambda: VoidCodeRuntime(workspace=resolved_workspace, config=config),
+            frontend_dist=frontend_dist,
         )
 
     coordinator = SingleWorkspaceRuntimeCoordinator(
@@ -1799,4 +1871,5 @@ def create_runtime_app(
     return RuntimeTransportApp(
         runtime_factory=resolved_factory,
         workspace_coordinator=coordinator,
+        frontend_dist=frontend_dist,
     )

--- a/src/voidcode/server.py
+++ b/src/voidcode/server.py
@@ -48,6 +48,16 @@ _BANNER = """\
 _FRONTEND_DIST = Path(__file__).resolve().parent.parent.parent / "frontend" / "dist"
 
 
+def _resolve_frontend_dist() -> Path:
+    if not _FRONTEND_DIST.is_dir() or not (_FRONTEND_DIST / "index.html").is_file():
+        raise SystemExit(
+            "error: frontend web bundle not found. "
+            "Run `mise run frontend:build` before `voidcode web`, "
+            "or install a package that includes the built frontend assets."
+        )
+    return _FRONTEND_DIST
+
+
 def web(
     *,
     workspace: Path,
@@ -56,12 +66,11 @@ def web(
     config: RuntimeConfig | None = None,
 ) -> None:
     url = f"http://{host}:{port}"
+    frontend_dist = _resolve_frontend_dist()
 
     print(_BANNER)
     print(f"  Local server running at: {url}")
     print()
-
-    frontend_dist = _FRONTEND_DIST if _FRONTEND_DIST.is_dir() else None
 
     try:
         webbrowser.open(url)

--- a/src/voidcode/server.py
+++ b/src/voidcode/server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import webbrowser
 from pathlib import Path
 from typing import Protocol, cast
 
@@ -12,6 +13,19 @@ class UvicornModule(Protocol):
     def run(self, app: object, *, host: str, port: int, lifespan: str) -> None: ...
 
 
+def _run_runtime_server(
+    *,
+    workspace: Path,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    config: RuntimeConfig | None = None,
+    frontend_dist: Path | None = None,
+) -> None:
+    app = create_runtime_app(workspace=workspace, config=config, frontend_dist=frontend_dist)
+    uvicorn = cast(UvicornModule, importlib.import_module("uvicorn"))
+    uvicorn.run(app, host=host, port=port, lifespan="off")
+
+
 def serve(
     *,
     workspace: Path,
@@ -19,6 +33,45 @@ def serve(
     port: int = 8000,
     config: RuntimeConfig | None = None,
 ) -> None:
-    app = create_runtime_app(workspace=workspace, config=config)
-    uvicorn = cast(UvicornModule, importlib.import_module("uvicorn"))
-    uvicorn.run(app, host=host, port=port, lifespan="off")
+    _run_runtime_server(workspace=workspace, host=host, port=port, config=config)
+
+
+_BANNER = """\
+  ╭─────────────────────────────────╮
+  │          VoidCode Web           │
+  │    Local-first Coding Agent     │
+  ╰─────────────────────────────────╯
+"""
+
+# Locate the built frontend dist relative to this package.
+# server.py lives at src/voidcode/server.py; the repo root is 3 levels up.
+_FRONTEND_DIST = Path(__file__).resolve().parent.parent.parent / "frontend" / "dist"
+
+
+def web(
+    *,
+    workspace: Path,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    config: RuntimeConfig | None = None,
+) -> None:
+    url = f"http://{host}:{port}"
+
+    print(_BANNER)
+    print(f"  Local server running at: {url}")
+    print()
+
+    frontend_dist = _FRONTEND_DIST if _FRONTEND_DIST.is_dir() else None
+
+    try:
+        webbrowser.open(url)
+    except Exception:
+        pass
+
+    _run_runtime_server(
+        workspace=workspace,
+        host=host,
+        port=port,
+        config=config,
+        frontend_dist=frontend_dist,
+    )

--- a/tests/integration/test_web_command.py
+++ b/tests/integration/test_web_command.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -176,6 +177,42 @@ def test_frontend_serves_static_assets_when_dist_configured(tmp_path: Path) -> N
         if cast(str, m["type"]) == "http.response.body"
     )
     assert len(body) > 0
+
+
+def test_frontend_does_not_spa_fallback_unknown_api_routes(tmp_path: Path) -> None:
+    """Verify unknown API paths keep JSON 404 semantics with frontend_dist set."""
+    http_module = importlib.import_module("voidcode.runtime.http")
+    rt_app = http_module.RuntimeTransportApp(
+        runtime_factory=Mock(),
+        frontend_dist=write_frontend_dist_fixture(tmp_path),
+    )
+
+    messages: list[dict[str, object]] = [
+        {"type": "http.request", "body": b"", "more_body": False},
+    ]
+    sent: list[dict[str, object]] = []
+
+    async def receive() -> dict[str, object]:
+        if messages:
+            return messages.pop(0)
+        return {"type": "http.disconnect"}
+
+    async def send(message: dict[str, object]) -> None:
+        sent.append(message)
+
+    scope: dict[str, object] = {"type": "http", "method": "GET", "path": "/api/not-real"}
+    asyncio.run(rt_app(scope, receive, send))
+
+    start = cast_start(sent)
+    assert start["status"] == 404
+    headers = decode_headers(start)
+    assert "application/json" in headers.get("content-type", "")
+    body = b"".join(
+        cast(bytes, m.get("body", b""))
+        for m in sent
+        if cast(str, m["type"]) == "http.response.body"
+    )
+    assert json.loads(body.decode("utf-8")) == {"error": "not found"}
 
 
 def test_frontend_returns_404_when_no_dist_configured() -> None:

--- a/tests/integration/test_web_command.py
+++ b/tests/integration/test_web_command.py
@@ -17,6 +17,18 @@ from typing import Any, cast
 from unittest.mock import Mock, patch
 
 
+def write_frontend_dist_fixture(tmp_path: Path) -> Path:
+    frontend_dist = tmp_path / "dist"
+    assets_dir = frontend_dist / "assets"
+    assets_dir.mkdir(parents=True)
+    (frontend_dist / "index.html").write_text(
+        "<!DOCTYPE html><html><head><title>VoidCode</title></head><body></body></html>",
+        encoding="utf-8",
+    )
+    (frontend_dist / "favicon.svg").write_text("<svg></svg>", encoding="utf-8")
+    return frontend_dist
+
+
 def test_web_prints_banner_and_url(capsys: Any) -> None:
     """Verify the web command prints the banner and a usable local URL."""
     server = importlib.import_module("voidcode.server")
@@ -95,12 +107,12 @@ def test_serve_remains_headless_and_uses_shared_runtime_server() -> None:
     )
 
 
-def test_frontend_root_returns_html_when_dist_configured() -> None:
+def test_frontend_root_returns_html_when_dist_configured(tmp_path: Path) -> None:
     """Verify that GET / returns the frontend HTML when frontend_dist is set."""
     http_module = importlib.import_module("voidcode.runtime.http")
     rt_app = http_module.RuntimeTransportApp(
         runtime_factory=Mock(),
-        frontend_dist=Path(__file__).resolve().parent.parent.parent / "frontend" / "dist",
+        frontend_dist=write_frontend_dist_fixture(tmp_path),
     )
 
     messages: list[dict[str, object]] = [
@@ -132,12 +144,12 @@ def test_frontend_root_returns_html_when_dist_configured() -> None:
     assert b"VoidCode" in body
 
 
-def test_frontend_serves_static_assets_when_dist_configured() -> None:
+def test_frontend_serves_static_assets_when_dist_configured(tmp_path: Path) -> None:
     """Verify that static assets under /assets/ are served correctly."""
     http_module = importlib.import_module("voidcode.runtime.http")
     rt_app = http_module.RuntimeTransportApp(
         runtime_factory=Mock(),
-        frontend_dist=Path(__file__).resolve().parent.parent.parent / "frontend" / "dist",
+        frontend_dist=write_frontend_dist_fixture(tmp_path),
     )
 
     messages: list[dict[str, object]] = [

--- a/tests/integration/test_web_command.py
+++ b/tests/integration/test_web_command.py
@@ -17,6 +17,8 @@ from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import Mock, patch
 
+import pytest
+
 
 def write_frontend_dist_fixture(tmp_path: Path) -> Path:
     frontend_dist = tmp_path / "dist"
@@ -30,65 +32,81 @@ def write_frontend_dist_fixture(tmp_path: Path) -> Path:
     return frontend_dist
 
 
-def test_web_prints_banner_and_url(capsys: Any) -> None:
+def test_web_prints_banner_and_url(capsys: Any, tmp_path: Path) -> None:
     """Verify the web command prints the banner and a usable local URL."""
     server = importlib.import_module("voidcode.server")
     workspace = Path("/tmp/web-banner-test")
     config = SimpleNamespace(approval_mode="allow")
+    frontend_dist = write_frontend_dist_fixture(tmp_path)
 
     with patch.object(server, "_run_runtime_server", autospec=True):
-        server.web(workspace=workspace, host="127.0.0.1", port=8080, config=config)
+        with patch.object(server, "_FRONTEND_DIST", frontend_dist):
+            server.web(workspace=workspace, host="127.0.0.1", port=8080, config=config)
 
     captured = capsys.readouterr()
     assert "VoidCode" in captured.out
     assert "http://127.0.0.1:8080" in captured.out
 
 
-def test_web_browser_open_failure_does_not_crash(capsys: Any) -> None:
+def test_web_browser_open_failure_does_not_crash(capsys: Any, tmp_path: Path) -> None:
     """Verify graceful degradation when webbrowser.open raises."""
     server = importlib.import_module("voidcode.server")
     workspace = Path("/tmp/web-browser-fail")
     config = SimpleNamespace(approval_mode="allow")
+    frontend_dist = write_frontend_dist_fixture(tmp_path)
 
     with patch.object(server, "_run_runtime_server", autospec=True):
-        with patch.object(server, "webbrowser", autospec=True) as webbrowser_mock:
-            webbrowser_mock.open.side_effect = RuntimeError("no browser available")
-            server.web(workspace=workspace, host="127.0.0.1", port=8080, config=config)
+        with patch.object(server, "_FRONTEND_DIST", frontend_dist):
+            with patch.object(server, "webbrowser", autospec=True) as webbrowser_mock:
+                webbrowser_mock.open.side_effect = RuntimeError("no browser available")
+                server.web(workspace=workspace, host="127.0.0.1", port=8080, config=config)
 
     captured = capsys.readouterr()
     assert "VoidCode" in captured.out
     assert "http://127.0.0.1:8080" in captured.out
 
 
-def test_web_browser_open_gracefully_handles_false_return() -> None:
+def test_web_browser_open_gracefully_handles_false_return(tmp_path: Path) -> None:
     """Verify graceful degradation when webbrowser.open returns False."""
     server = importlib.import_module("voidcode.server")
     workspace = Path("/tmp/web-browser-false")
     config = SimpleNamespace(approval_mode="allow")
+    frontend_dist = write_frontend_dist_fixture(tmp_path)
 
     with patch.object(server, "_run_runtime_server", autospec=True):
-        with patch.object(server, "webbrowser", autospec=True) as webbrowser_mock:
-            webbrowser_mock.open.return_value = False
-            server.web(workspace=workspace, host="127.0.0.1", port=8080, config=config)
+        with patch.object(server, "_FRONTEND_DIST", frontend_dist):
+            with patch.object(server, "webbrowser", autospec=True) as webbrowser_mock:
+                webbrowser_mock.open.return_value = False
+                server.web(workspace=workspace, host="127.0.0.1", port=8080, config=config)
 
 
-def test_web_delegates_to_shared_runtime_server() -> None:
+def test_web_delegates_to_shared_runtime_server(tmp_path: Path) -> None:
     """Verify the web command delegates to the runtime server primitive."""
     server = importlib.import_module("voidcode.server")
     workspace = Path("/tmp/web-delegate-test")
     config = SimpleNamespace(approval_mode="allow")
-    expected_frontend_dist = server._FRONTEND_DIST if server._FRONTEND_DIST.is_dir() else None
+    frontend_dist = write_frontend_dist_fixture(tmp_path)
 
     with patch.object(server, "_run_runtime_server", autospec=True) as run_mock:
-        server.web(workspace=workspace, host="127.0.0.1", port=8001, config=config)
+        with patch.object(server, "_FRONTEND_DIST", frontend_dist):
+            server.web(workspace=workspace, host="127.0.0.1", port=8001, config=config)
 
     run_mock.assert_called_once_with(
         workspace=workspace,
         host="127.0.0.1",
         port=8001,
         config=config,
-        frontend_dist=expected_frontend_dist,
+        frontend_dist=frontend_dist,
     )
+
+
+def test_web_fails_fast_when_frontend_dist_missing(tmp_path: Path) -> None:
+    """Verify web command does not launch a broken server when dist is absent."""
+    server = importlib.import_module("voidcode.server")
+
+    with patch.object(server, "_FRONTEND_DIST", tmp_path / "missing-dist"):
+        with pytest.raises(SystemExit, match="frontend web bundle not found"):
+            server.web(workspace=tmp_path, host="127.0.0.1", port=8001)
 
 
 def test_serve_remains_headless_and_uses_shared_runtime_server() -> None:
@@ -201,6 +219,42 @@ def test_frontend_does_not_spa_fallback_unknown_api_routes(tmp_path: Path) -> No
         sent.append(message)
 
     scope: dict[str, object] = {"type": "http", "method": "GET", "path": "/api/not-real"}
+    asyncio.run(rt_app(scope, receive, send))
+
+    start = cast_start(sent)
+    assert start["status"] == 404
+    headers = decode_headers(start)
+    assert "application/json" in headers.get("content-type", "")
+    body = b"".join(
+        cast(bytes, m.get("body", b""))
+        for m in sent
+        if cast(str, m["type"]) == "http.response.body"
+    )
+    assert json.loads(body.decode("utf-8")) == {"error": "not found"}
+
+
+def test_frontend_returns_404_for_missing_static_asset(tmp_path: Path) -> None:
+    """Verify missing assets do not receive the SPA index fallback."""
+    http_module = importlib.import_module("voidcode.runtime.http")
+    rt_app = http_module.RuntimeTransportApp(
+        runtime_factory=Mock(),
+        frontend_dist=write_frontend_dist_fixture(tmp_path),
+    )
+
+    messages: list[dict[str, object]] = [
+        {"type": "http.request", "body": b"", "more_body": False},
+    ]
+    sent: list[dict[str, object]] = []
+
+    async def receive() -> dict[str, object]:
+        if messages:
+            return messages.pop(0)
+        return {"type": "http.disconnect"}
+
+    async def send(message: dict[str, object]) -> None:
+        sent.append(message)
+
+    scope: dict[str, object] = {"type": "http", "method": "GET", "path": "/assets/app.js"}
     asyncio.run(rt_app(scope, receive, send))
 
     start = cast_start(sent)

--- a/tests/integration/test_web_command.py
+++ b/tests/integration/test_web_command.py
@@ -1,0 +1,206 @@
+"""Integration tests for the voidcode web launcher command.
+
+These tests verify the user-facing launcher UX that sits on top of the shared
+runtime server primitive. The happy path (banner + URL + delegation) and the
+browser-open failure fallback are both covered here. The underlying server
+startup (_run_runtime_server) is mocked throughout because it is a blocking
+call tested separately in test_server.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import Mock, patch
+
+
+def test_web_prints_banner_and_url(capsys: Any) -> None:
+    """Verify the web command prints the banner and a usable local URL."""
+    server = importlib.import_module("voidcode.server")
+    workspace = Path("/tmp/web-banner-test")
+    config = SimpleNamespace(approval_mode="allow")
+
+    with patch.object(server, "_run_runtime_server", autospec=True):
+        server.web(workspace=workspace, host="127.0.0.1", port=8080, config=config)
+
+    captured = capsys.readouterr()
+    assert "VoidCode" in captured.out
+    assert "http://127.0.0.1:8080" in captured.out
+
+
+def test_web_browser_open_failure_does_not_crash(capsys: Any) -> None:
+    """Verify graceful degradation when webbrowser.open raises."""
+    server = importlib.import_module("voidcode.server")
+    workspace = Path("/tmp/web-browser-fail")
+    config = SimpleNamespace(approval_mode="allow")
+
+    with patch.object(server, "_run_runtime_server", autospec=True):
+        with patch.object(server, "webbrowser", autospec=True) as webbrowser_mock:
+            webbrowser_mock.open.side_effect = RuntimeError("no browser available")
+            server.web(workspace=workspace, host="127.0.0.1", port=8080, config=config)
+
+    captured = capsys.readouterr()
+    assert "VoidCode" in captured.out
+    assert "http://127.0.0.1:8080" in captured.out
+
+
+def test_web_browser_open_gracefully_handles_false_return() -> None:
+    """Verify graceful degradation when webbrowser.open returns False."""
+    server = importlib.import_module("voidcode.server")
+    workspace = Path("/tmp/web-browser-false")
+    config = SimpleNamespace(approval_mode="allow")
+
+    with patch.object(server, "_run_runtime_server", autospec=True):
+        with patch.object(server, "webbrowser", autospec=True) as webbrowser_mock:
+            webbrowser_mock.open.return_value = False
+            server.web(workspace=workspace, host="127.0.0.1", port=8080, config=config)
+
+
+def test_web_delegates_to_shared_runtime_server() -> None:
+    """Verify the web command delegates to the runtime server primitive."""
+    server = importlib.import_module("voidcode.server")
+    workspace = Path("/tmp/web-delegate-test")
+    config = SimpleNamespace(approval_mode="allow")
+    expected_frontend_dist = server._FRONTEND_DIST if server._FRONTEND_DIST.is_dir() else None
+
+    with patch.object(server, "_run_runtime_server", autospec=True) as run_mock:
+        server.web(workspace=workspace, host="127.0.0.1", port=8001, config=config)
+
+    run_mock.assert_called_once_with(
+        workspace=workspace,
+        host="127.0.0.1",
+        port=8001,
+        config=config,
+        frontend_dist=expected_frontend_dist,
+    )
+
+
+def test_serve_remains_headless_and_uses_shared_runtime_server() -> None:
+    """Verify the headless serve command does not inject frontend_dist."""
+    server = importlib.import_module("voidcode.server")
+    workspace = Path("/tmp/serve-headless-test")
+    config = SimpleNamespace(approval_mode="allow")
+
+    with patch.object(server, "_run_runtime_server", autospec=True) as run_mock:
+        server.serve(workspace=workspace, host="127.0.0.1", port=9000, config=config)
+
+    run_mock.assert_called_once_with(
+        workspace=workspace,
+        host="127.0.0.1",
+        port=9000,
+        config=config,
+    )
+
+
+def test_frontend_root_returns_html_when_dist_configured() -> None:
+    """Verify that GET / returns the frontend HTML when frontend_dist is set."""
+    http_module = importlib.import_module("voidcode.runtime.http")
+    rt_app = http_module.RuntimeTransportApp(
+        runtime_factory=Mock(),
+        frontend_dist=Path(__file__).resolve().parent.parent.parent / "frontend" / "dist",
+    )
+
+    messages: list[dict[str, object]] = [
+        {"type": "http.request", "body": b"", "more_body": False},
+    ]
+    sent: list[dict[str, object]] = []
+
+    async def receive() -> dict[str, object]:
+        if messages:
+            return messages.pop(0)
+        return {"type": "http.disconnect"}
+
+    async def send(message: dict[str, object]) -> None:
+        sent.append(message)
+
+    scope: dict[str, object] = {"type": "http", "method": "GET", "path": "/"}
+    asyncio.run(rt_app(scope, receive, send))
+
+    start = cast_start(sent)
+    assert start["status"] == 200
+    headers = decode_headers(start)
+    assert "text/html" in headers.get("content-type", "")
+    body = b"".join(
+        cast(bytes, m.get("body", b""))
+        for m in sent
+        if cast(str, m["type"]) == "http.response.body"
+    )
+    assert b"<!DOCTYPE html>" in body
+    assert b"VoidCode" in body
+
+
+def test_frontend_serves_static_assets_when_dist_configured() -> None:
+    """Verify that static assets under /assets/ are served correctly."""
+    http_module = importlib.import_module("voidcode.runtime.http")
+    rt_app = http_module.RuntimeTransportApp(
+        runtime_factory=Mock(),
+        frontend_dist=Path(__file__).resolve().parent.parent.parent / "frontend" / "dist",
+    )
+
+    messages: list[dict[str, object]] = [
+        {"type": "http.request", "body": b"", "more_body": False},
+    ]
+    sent: list[dict[str, object]] = []
+
+    async def receive() -> dict[str, object]:
+        if messages:
+            return messages.pop(0)
+        return {"type": "http.disconnect"}
+
+    async def send(message: dict[str, object]) -> None:
+        sent.append(message)
+
+    scope: dict[str, object] = {"type": "http", "method": "GET", "path": "/favicon.svg"}
+    asyncio.run(rt_app(scope, receive, send))
+
+    start = cast_start(sent)
+    assert start["status"] == 200
+    body = b"".join(
+        cast(bytes, m.get("body", b""))
+        for m in sent
+        if cast(str, m["type"]) == "http.response.body"
+    )
+    assert len(body) > 0
+
+
+def test_frontend_returns_404_when_no_dist_configured() -> None:
+    """Verify that GET / returns 404 when frontend_dist is None."""
+    http_module = importlib.import_module("voidcode.runtime.http")
+    rt_app = http_module.RuntimeTransportApp(
+        runtime_factory=Mock(),
+        frontend_dist=None,
+    )
+
+    messages: list[dict[str, object]] = [
+        {"type": "http.request", "body": b"", "more_body": False},
+    ]
+    sent: list[dict[str, object]] = []
+
+    async def receive() -> dict[str, object]:
+        if messages:
+            return messages.pop(0)
+        return {"type": "http.disconnect"}
+
+    async def send(message: dict[str, object]) -> None:
+        sent.append(message)
+
+    scope: dict[str, object] = {"type": "http", "method": "GET", "path": "/"}
+    asyncio.run(rt_app(scope, receive, send))
+
+    start = cast_start(sent)
+    assert start["status"] == 404
+
+
+def cast_start(sent: list[dict[str, object]]) -> dict[str, object]:
+    for m in sent:
+        if cast(str, m["type"]) == "http.response.start":
+            return m
+    raise AssertionError("no http.response.start message")
+
+
+def decode_headers(start: dict[str, object]) -> dict[str, str]:
+    raw_headers = cast(list[tuple[bytes, bytes]], start.get("headers", []))
+    return {k.decode("utf-8").lower(): v.decode("utf-8") for k, v in raw_headers}

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -180,6 +180,73 @@ def test_console_script_help_works() -> None:
     assert "usage:" in result.stdout.lower()
 
 
+def test_web_command_help_works() -> None:
+    result = _run_module_cli("web", "--help")
+
+    assert result.returncode == 0
+    assert "launcher" in result.stdout.lower()
+    assert "web" in result.stdout.lower()
+
+
+def test_serve_command_help_works() -> None:
+    result = _run_module_cli("serve", "--help")
+
+    assert result.returncode == 0
+    assert "transport" in result.stdout.lower()
+
+
+def test_web_command_forwards_runtime_config_and_server_entry() -> None:
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/web-workspace")
+    config = SimpleNamespace(approval_mode="allow")
+
+    with patch.object(
+        cli, "load_runtime_config", autospec=True, return_value=config
+    ) as config_mock:
+        with patch.object(cli, "web", autospec=True) as web_mock:
+            result = cli.main([
+                "web",
+                "--workspace", str(workspace),
+                "--host", "127.0.0.1",
+                "--port", "8012",
+            ])
+
+    assert result == 0
+    config_mock.assert_called_once_with(workspace, approval_mode=None)
+    web_mock.assert_called_once_with(
+        workspace=workspace,
+        host="127.0.0.1",
+        port=8012,
+        config=config,
+    )
+
+
+def test_serve_command_forwards_runtime_config_and_server_entry() -> None:
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/serve-workspace")
+    config = SimpleNamespace(approval_mode="allow")
+
+    with patch.object(
+        cli, "load_runtime_config", autospec=True, return_value=config
+    ) as config_mock:
+        with patch.object(cli, "serve", autospec=True) as serve_mock:
+            result = cli.main([
+                "serve",
+                "--workspace", str(workspace),
+                "--host", "127.0.0.1",
+                "--port", "8013",
+            ])
+
+    assert result == 0
+    config_mock.assert_called_once_with(workspace, approval_mode=None)
+    serve_mock.assert_called_once_with(
+        workspace=workspace,
+        host="127.0.0.1",
+        port=8013,
+        config=config,
+    )
+
+
 def test_sessions_resume_rejects_partial_approval_flags() -> None:
     result = _run_module_cli(
         "sessions",

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -204,12 +204,17 @@ def test_web_command_forwards_runtime_config_and_server_entry() -> None:
         cli, "load_runtime_config", autospec=True, return_value=config
     ) as config_mock:
         with patch.object(cli, "web", autospec=True) as web_mock:
-            result = cli.main([
-                "web",
-                "--workspace", str(workspace),
-                "--host", "127.0.0.1",
-                "--port", "8012",
-            ])
+            result = cli.main(
+                [
+                    "web",
+                    "--workspace",
+                    str(workspace),
+                    "--host",
+                    "127.0.0.1",
+                    "--port",
+                    "8012",
+                ]
+            )
 
     assert result == 0
     config_mock.assert_called_once_with(workspace, approval_mode=None)
@@ -230,12 +235,17 @@ def test_serve_command_forwards_runtime_config_and_server_entry() -> None:
         cli, "load_runtime_config", autospec=True, return_value=config
     ) as config_mock:
         with patch.object(cli, "serve", autospec=True) as serve_mock:
-            result = cli.main([
-                "serve",
-                "--workspace", str(workspace),
-                "--host", "127.0.0.1",
-                "--port", "8013",
-            ])
+            result = cli.main(
+                [
+                    "serve",
+                    "--workspace",
+                    str(workspace),
+                    "--host",
+                    "127.0.0.1",
+                    "--port",
+                    "8013",
+                ]
+            )
 
     assert result == 0
     config_mock.assert_called_once_with(workspace, approval_mode=None)

--- a/tests/unit/interface/test_server.py
+++ b/tests/unit/interface/test_server.py
@@ -10,6 +10,13 @@ def _noop_uvicorn_run(app: object, *, host: str, port: int, lifespan: str) -> No
     _ = (app, host, port, lifespan)
 
 
+def _write_frontend_dist_fixture(tmp_path: Path) -> Path:
+    frontend_dist = tmp_path / "dist"
+    frontend_dist.mkdir()
+    (frontend_dist / "index.html").write_text("<!doctype html>", encoding="utf-8")
+    return frontend_dist
+
+
 def test_serve_forwards_runtime_config_to_http_app_factory() -> None:
     server = importlib.import_module("voidcode.server")
     workspace = Path("/tmp/server-workspace")
@@ -42,19 +49,20 @@ def test_serve_delegates_to_shared_runtime_server() -> None:
     )
 
 
-def test_web_delegates_to_shared_runtime_server() -> None:
+def test_web_delegates_to_shared_runtime_server(tmp_path: Path) -> None:
     server = importlib.import_module("voidcode.server")
     workspace = Path("/tmp/server-workspace")
     config = SimpleNamespace(approval_mode="allow")
-    expected_frontend_dist = server._FRONTEND_DIST if server._FRONTEND_DIST.is_dir() else None
+    frontend_dist = _write_frontend_dist_fixture(tmp_path)
 
     with patch.object(server, "_run_runtime_server", autospec=True) as run_mock:
-        server.web(workspace=workspace, host="127.0.0.1", port=8001, config=config)
+        with patch.object(server, "_FRONTEND_DIST", frontend_dist):
+            server.web(workspace=workspace, host="127.0.0.1", port=8001, config=config)
 
     run_mock.assert_called_once_with(
         workspace=workspace,
         host="127.0.0.1",
         port=8001,
         config=config,
-        frontend_dist=expected_frontend_dist,
+        frontend_dist=frontend_dist,
     )

--- a/tests/unit/interface/test_server.py
+++ b/tests/unit/interface/test_server.py
@@ -23,4 +23,38 @@ def test_serve_forwards_runtime_config_to_http_app_factory() -> None:
             import_module_mock.return_value = uvicorn
             server.serve(workspace=workspace, host="127.0.0.1", port=8001, config=config)
 
-    app_mock.assert_called_once_with(workspace=workspace, config=config)
+    app_mock.assert_called_once_with(workspace=workspace, config=config, frontend_dist=None)
+
+
+def test_serve_delegates_to_shared_runtime_server() -> None:
+    server = importlib.import_module("voidcode.server")
+    workspace = Path("/tmp/server-workspace")
+    config = SimpleNamespace(approval_mode="allow")
+
+    with patch.object(server, "_run_runtime_server", autospec=True) as run_mock:
+        server.serve(workspace=workspace, host="127.0.0.1", port=8001, config=config)
+
+    run_mock.assert_called_once_with(
+        workspace=workspace,
+        host="127.0.0.1",
+        port=8001,
+        config=config,
+    )
+
+
+def test_web_delegates_to_shared_runtime_server() -> None:
+    server = importlib.import_module("voidcode.server")
+    workspace = Path("/tmp/server-workspace")
+    config = SimpleNamespace(approval_mode="allow")
+    expected_frontend_dist = server._FRONTEND_DIST if server._FRONTEND_DIST.is_dir() else None
+
+    with patch.object(server, "_run_runtime_server", autospec=True) as run_mock:
+        server.web(workspace=workspace, host="127.0.0.1", port=8001, config=config)
+
+    run_mock.assert_called_once_with(
+        workspace=workspace,
+        host="127.0.0.1",
+        port=8001,
+        config=config,
+        frontend_dist=expected_frontend_dist,
+    )


### PR DESCRIPTION
## Summary

This PR completes the web-integration-alignment plan by introducing a friendly `voidcode web` launcher, moving config/status ownership fully into the runtime, and hardening a leader-only web flow with backend-owned tool-status contracts.

## OpenCode Comparison Decisions

| Concern | Decision | Rationale |
|---------|----------|-----------|
| Launcher UX | **Adopt** | Separate `web` command with banner + URL + best-effort browser open, keeping `serve` as headless/advanced. Matches OpenCode `cli/cmd/web.ts` pattern. |
| CLI Modularity | **Adapt** | `web` and `serve` share `_run_runtime_server` primitive; no second server architecture. |
| Config Schema | **Adopt** | Backend-owned `RuntimeWebSettings` with layered precedence; frontend becomes projection/editor only. |
| API Key Flow | **Adapt** | Dual-mode: env-backed by default, optional browser submission. Raw keys never returned in reads (only `provider_api_key_present` boolean). |
| Tool Status | **Adopt** | Backend-owned `ToolStatusPayload` with phase/status/label/invocation_id. Frontend consumes directly, no heuristic parsing. |
| Leader-Only | **Preserve** | `_EXECUTABLE_AGENT_PRESETS = frozenset({\"leader\"})` enforced at runtime boundary. |
| Category Route | **Reject** | Removed from web MVP surface; web-facing inputs with category are rejected per explicit contract. |

## Key Changes

- **`voidcode web` launcher**: Banner, URL output, best-effort browser open, graceful fallback when browser-open fails
- **Static file serving**: `RuntimeTransportApp` now serves frontend SPA files with proper content-type mapping and SPA fallback to `index.html`
- **Secret-safe settings**: `GET /api/settings` returns only `provider_api_key_present` boolean, never raw key material
- **Tool status contract**: 5 required pending labels (`Preparing patch...`, `Delegating...`, `Reading file...`, `Searching content...`, `Writing command...`) emitted as backend-owned payloads
- **Leader-only enforcement**: Web runtime requests validate against `leader` preset only; category-bearing inputs rejected
- **Playwright E2E**: `frontend/e2e/launcher.spec.ts` covers launcher startup and env-backed key flow

## Verification

- ✅ `uv run pytest tests/integration/test_web_command.py tests/integration/test_http_transport.py tests/integration/test_http_delegated_parity.py -q` — 95 passed
- ✅ `bun run --cwd frontend vitest run --run` — 72 passed (7 files)
- ✅ `uv run basedpyright src/voidcode/server.py src/voidcode/runtime/http.py` — 0 errors
- ✅ `uv run ruff check tests/unit/interface/test_cli_smoke.py` — All passed
- ✅ `uv run voidcode web --help` / `uv run voidcode serve --help` — distinct roles confirmed
- ⚠️ Playwright E2E: 1 passed (launcher startup), 1 flaky (env-backed key test skips gracefully when `OPENCODE_API_KEY` absent)

## Documentation

- `docs/contracts/web-opencode-alignment.md` — Full comparison artifact with Adopt/Adapt/Reject classifications and OpenCode file references

## Commits

- `docs(contracts): add OpenCode alignment record for web MVP`
- `feat(cli): add voidcode web launcher with banner and browser open`