### PR TITLE
[codex] expose stable agent summaries

### DIFF
--- a/frontend/src/components/Composer.test.tsx
+++ b/frontend/src/components/Composer.test.tsx
@@ -74,6 +74,37 @@ describe("Composer", () => {
     expect(onAgentPresetChange).toHaveBeenCalledWith("leader");
   });
 
+  it("filters non-selectable agents from the agent menu", () => {
+    render(
+      <Composer
+        {...baseProps}
+        agentPresets={[
+          {
+            id: "leader",
+            label: "Leader",
+            description: null,
+            mode: "primary",
+            selectable: true,
+          },
+          {
+            id: "worker",
+            label: "Worker",
+            description: null,
+            mode: "subagent",
+            selectable: false,
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Agent" }));
+
+    expect(screen.getByRole("button", { name: /Leader/ })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Worker/ }),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows empty state when no providers are configured", () => {
     render(
       <Composer

--- a/frontend/src/components/Composer.tsx
+++ b/frontend/src/components/Composer.tsx
@@ -56,21 +56,17 @@ export function Composer({
     group.models.includes(selectedModel),
   );
   const selectableAgentPresets = useMemo(() => {
-    const selectable = (agentPresets ?? []).filter(
-      (agent) => agent.selectable !== false,
-    );
-    return selectable.length > 0 ? selectable : (agentPresets ?? []);
+    return (agentPresets ?? []).filter((agent) => agent.selectable !== false);
   }, [agentPresets]);
 
   const selectedAgentLabel = useMemo(() => {
     return (
-      selectableAgentPresets.find(
-        (agent) => agent.id === (agentPreset ?? "leader"),
-      )?.label ??
+      agentPresets?.find((agent) => agent.id === (agentPreset ?? "leader"))
+        ?.label ??
       agentPreset ??
       "leader"
     );
-  }, [agentPreset, selectableAgentPresets]);
+  }, [agentPreset, agentPresets]);
 
   const selectedModelLabel = useMemo(() => {
     for (const { provider, models } of availableModelGroups) {

--- a/frontend/src/components/Composer.tsx
+++ b/frontend/src/components/Composer.tsx
@@ -55,15 +55,22 @@ export function Composer({
   const selectedModelAvailable = availableModelGroups.some((group) =>
     group.models.includes(selectedModel),
   );
+  const selectableAgentPresets = useMemo(() => {
+    const selectable = (agentPresets ?? []).filter(
+      (agent) => agent.selectable !== false,
+    );
+    return selectable.length > 0 ? selectable : (agentPresets ?? []);
+  }, [agentPresets]);
 
   const selectedAgentLabel = useMemo(() => {
     return (
-      agentPresets?.find((agent) => agent.id === (agentPreset ?? "leader"))
-        ?.label ??
+      selectableAgentPresets.find(
+        (agent) => agent.id === (agentPreset ?? "leader"),
+      )?.label ??
       agentPreset ??
       "leader"
     );
-  }, [agentPreset, agentPresets]);
+  }, [agentPreset, selectableAgentPresets]);
 
   const selectedModelLabel = useMemo(() => {
     for (const { provider, models } of availableModelGroups) {
@@ -156,7 +163,7 @@ export function Composer({
             </button>
           </div>
 
-          {agentPresets && agentPresets.length > 0 && (
+          {selectableAgentPresets.length > 0 && (
             <div className="flex flex-wrap items-center gap-2 border-t border-slate-800/60 bg-slate-900/30 px-3 py-1.5 text-xs">
               <div className="relative" ref={agentMenuRef}>
                 <button
@@ -176,7 +183,7 @@ export function Composer({
 
                 {showAgentMenu && (
                   <div className="absolute bottom-full left-0 z-20 mb-2 min-w-[180px] rounded border border-slate-700 bg-[#0c0c0e] py-1 shadow-xl">
-                    {agentPresets.map((agent) => {
+                    {selectableAgentPresets.map((agent) => {
                       const active = agent.id === (agentPreset ?? "leader");
                       return (
                         <button

--- a/frontend/src/lib/runtime/types.ts
+++ b/frontend/src/lib/runtime/types.ts
@@ -64,6 +64,14 @@ export interface AgentSummary {
   id: string;
   label: string;
   description?: string | null;
+  mode?: string | null;
+  selectable?: boolean;
+  configured?: boolean;
+  execution_engine?: string | null;
+  model?: string | null;
+  model_label?: string | null;
+  model_source?: string | null;
+  provider?: string | null;
 }
 
 export interface GitStatusSnapshot {

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -365,19 +365,15 @@ export const useAppStore = create<AppState>()(
           const selectableAgentPresets = agentPresets.filter(
             (agent) => agent.selectable !== false,
           );
-          const agentSelectionCandidates =
-            selectableAgentPresets.length > 0
-              ? selectableAgentPresets
-              : agentPresets;
           set({
             agentPresets,
             agentsStatus: "success",
             agentsError: null,
-            agentPreset: agentSelectionCandidates.some(
+            agentPreset: selectableAgentPresets.some(
               (agent) => agent.id === get().agentPreset,
             )
               ? get().agentPreset
-              : ((agentSelectionCandidates[0]?.id ?? "leader") as "leader"),
+              : (selectableAgentPresets[0]?.id ?? "leader"),
           });
         } catch (err) {
           set({

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -362,15 +362,22 @@ export const useAppStore = create<AppState>()(
         set({ agentsStatus: "loading", agentsError: null });
         try {
           const agentPresets = await RuntimeClient.listAgents();
+          const selectableAgentPresets = agentPresets.filter(
+            (agent) => agent.selectable !== false,
+          );
+          const agentSelectionCandidates =
+            selectableAgentPresets.length > 0
+              ? selectableAgentPresets
+              : agentPresets;
           set({
             agentPresets,
             agentsStatus: "success",
             agentsError: null,
-            agentPreset: agentPresets.some(
+            agentPreset: agentSelectionCandidates.some(
               (agent) => agent.id === get().agentPreset,
             )
               ? get().agentPreset
-              : ((agentPresets[0]?.id ?? "leader") as "leader"),
+              : ((agentSelectionCandidates[0]?.id ?? "leader") as "leader"),
           });
         } catch (err) {
           set({

--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -498,6 +498,14 @@ class AgentSummary:
     id: str
     label: str
     description: str | None = None
+    mode: str | None = None
+    selectable: bool = True
+    configured: bool = False
+    execution_engine: str | None = None
+    model: str | None = None
+    model_label: str | None = None
+    model_source: str | None = None
+    provider: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/voidcode/runtime/http.py
+++ b/src/voidcode/runtime/http.py
@@ -1609,6 +1609,14 @@ class RuntimeTransportApp:
             "id": summary.id,
             "label": summary.label,
             "description": summary.description,
+            "mode": summary.mode,
+            "selectable": summary.selectable,
+            "configured": summary.configured,
+            "execution_engine": summary.execution_engine,
+            "model": summary.model,
+            "model_label": summary.model_label,
+            "model_source": summary.model_source,
+            "provider": summary.provider,
         }
 
     @staticmethod

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -2132,17 +2132,17 @@ class VoidCodeRuntime:
                 agent_config.execution_engine
                 if agent_config is not None and agent_config.execution_engine is not None
                 else manifest.execution_engine
-                if manifest.execution_engine is not None
+                if agent_config is not None and manifest.execution_engine is not None
                 else self._config.execution_engine
             )
-            configured_model = (
-                agent_config.model
-                if agent_config is not None
-                and agent_config.model is not None
-                and agent_config.model != manifest.model_preference
-                else None
+            agent_model = agent_config.model if agent_config is not None else None
+            model = (
+                agent_model
+                if agent_model is not None
+                else manifest.model_preference
+                if agent_config is not None and manifest.model_preference is not None
+                else self._config.model
             )
-            model = configured_model or manifest.model_preference or self._config.model
             provider_fallback = (
                 agent_config.provider_fallback
                 if agent_config is not None and agent_config.provider_fallback is not None
@@ -2157,9 +2157,9 @@ class VoidCodeRuntime:
             active_selection = resolved_provider.active_target.selection
             model_source = (
                 "configured"
-                if configured_model is not None
+                if agent_model is not None
                 else "builtin"
-                if manifest.model_preference is not None
+                if agent_config is not None and manifest.model_preference is not None
                 else "configured"
                 if self._config.model is not None or provider_fallback is not None
                 else None

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -2117,15 +2117,74 @@ class VoidCodeRuntime:
         )
 
     def list_agent_summaries(self) -> tuple[AgentSummary, ...]:
-        return tuple(
-            AgentSummary(
-                id=manifest.id,
-                label=manifest.name,
-                description=manifest.description,
+        summaries: list[AgentSummary] = []
+        configured_agent = self._config.agent
+        for manifest in list_builtin_agent_manifests():
+            if manifest.mode != "primary":
+                continue
+
+            agent_config = (
+                configured_agent
+                if configured_agent is not None and configured_agent.preset == manifest.id
+                else None
             )
-            for manifest in list_builtin_agent_manifests()
-            if manifest.mode == "primary"
-        )
+            execution_engine = (
+                agent_config.execution_engine
+                if agent_config is not None and agent_config.execution_engine is not None
+                else manifest.execution_engine
+                if manifest.execution_engine is not None
+                else self._config.execution_engine
+            )
+            configured_model = (
+                agent_config.model
+                if agent_config is not None
+                and agent_config.model is not None
+                and agent_config.model != manifest.model_preference
+                else None
+            )
+            model = configured_model or manifest.model_preference or self._config.model
+            provider_fallback = (
+                agent_config.provider_fallback
+                if agent_config is not None and agent_config.provider_fallback is not None
+                else self._config.provider_fallback
+            )
+            resolved_provider = resolve_provider_config(
+                model,
+                provider_fallback,
+                registry=self._model_provider_registry,
+            )
+            resolved_model = resolved_provider.model or model
+            active_selection = resolved_provider.active_target.selection
+            model_source = (
+                "configured"
+                if configured_model is not None
+                else "builtin"
+                if manifest.model_preference is not None
+                else "configured"
+                if self._config.model is not None or provider_fallback is not None
+                else None
+            )
+            configured = (
+                agent_config is not None
+                or self._config.model is not None
+                or provider_fallback is not None
+            )
+            summaries.append(
+                AgentSummary(
+                    id=manifest.id,
+                    label=manifest.name,
+                    description=manifest.description,
+                    mode=manifest.mode,
+                    selectable=manifest.id in _EXECUTABLE_AGENT_PRESETS,
+                    configured=configured,
+                    execution_engine=execution_engine,
+                    model=resolved_model,
+                    model_label=active_selection.model,
+                    model_source=model_source,
+                    provider=active_selection.provider,
+                )
+            )
+        return tuple(summaries)
 
     def current_status(self) -> RuntimeStatusSnapshot:
         git = self._git_status_snapshot()

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -289,6 +289,53 @@ def _run_app(
     )
 
 
+def test_transport_agents_endpoint_serializes_stable_summary_fields() -> None:
+    runtime_http = importlib.import_module("voidcode.runtime.http")
+    runtime_contracts = importlib.import_module("voidcode.runtime.contracts")
+
+    AgentSummary = runtime_contracts.AgentSummary
+    RuntimeTransportApp = runtime_http.RuntimeTransportApp
+
+    class AgentSummaryRuntime:
+        def list_agent_summaries(self) -> tuple[object, ...]:
+            return (
+                AgentSummary(
+                    id="leader",
+                    label="Leader",
+                    description="Primary agent",
+                    mode="primary",
+                    selectable=True,
+                    configured=True,
+                    execution_engine="provider",
+                    model="opencode/gpt-5.4",
+                    model_label="gpt-5.4",
+                    model_source="configured",
+                    provider="opencode",
+                ),
+            )
+
+    app = RuntimeTransportApp(runtime_factory=AgentSummaryRuntime)
+
+    response = _run_app(app, method="GET", path="/api/agents")
+
+    assert response.status == 200
+    assert response.json() == [
+        {
+            "id": "leader",
+            "label": "Leader",
+            "description": "Primary agent",
+            "mode": "primary",
+            "selectable": True,
+            "configured": True,
+            "execution_engine": "provider",
+            "model": "opencode/gpt-5.4",
+            "model_label": "gpt-5.4",
+            "model_source": "configured",
+            "provider": "opencode",
+        }
+    ]
+
+
 def _parse_sse_payloads(response: _TransportResponse) -> list[dict[str, object]]:
     frames = [frame for frame in response.body.decode("utf-8").split("\n\n") if frame]
     payloads: list[dict[str, object]] = []

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -6897,7 +6897,7 @@ def test_runtime_agent_summary_exposes_stable_agent_and_model_fields(tmp_path: P
     assert default_summary[0].mode == "primary"
     assert default_summary[0].selectable is True
     assert default_summary[0].configured is False
-    assert default_summary[0].execution_engine == "provider"
+    assert default_summary[0].execution_engine == "deterministic"
     assert default_summary[0].model is None
     assert default_summary[0].model_label is None
     assert default_summary[0].provider is None
@@ -6910,10 +6910,26 @@ def test_runtime_agent_summary_exposes_stable_agent_and_model_fields(tmp_path: P
     configured_summary = configured_runtime.list_agent_summaries()[0]
 
     assert configured_summary.configured is True
+    assert configured_summary.execution_engine == "deterministic"
     assert configured_summary.model == "opencode/gpt-5.4"
     assert configured_summary.model_label == "gpt-5.4"
     assert configured_summary.model_source == "configured"
     assert configured_summary.provider == "opencode"
+
+    agent_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            model="opencode/gpt-5.4",
+            agent=RuntimeAgentConfig(preset="leader"),
+        ),
+    )
+
+    agent_summary = agent_runtime.list_agent_summaries()[0]
+
+    assert agent_summary.configured is True
+    assert agent_summary.execution_engine == "provider"
+    assert agent_summary.model == "opencode/gpt-5.4"
+    assert agent_summary.model_source == "configured"
 
 
 def test_runtime_provider_compaction_emits_continuity_state_and_persists_metadata(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -6887,6 +6887,35 @@ def test_runtime_classifies_provider_context_limit_failures(tmp_path: Path) -> N
     }
 
 
+def test_runtime_agent_summary_exposes_stable_agent_and_model_fields(tmp_path: Path) -> None:
+    default_runtime = VoidCodeRuntime(workspace=tmp_path, config=RuntimeConfig())
+
+    default_summary = default_runtime.list_agent_summaries()
+
+    assert len(default_summary) == 1
+    assert default_summary[0].id == "leader"
+    assert default_summary[0].mode == "primary"
+    assert default_summary[0].selectable is True
+    assert default_summary[0].configured is False
+    assert default_summary[0].execution_engine == "provider"
+    assert default_summary[0].model is None
+    assert default_summary[0].model_label is None
+    assert default_summary[0].provider is None
+
+    configured_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(model="opencode/gpt-5.4"),
+    )
+
+    configured_summary = configured_runtime.list_agent_summaries()[0]
+
+    assert configured_summary.configured is True
+    assert configured_summary.model == "opencode/gpt-5.4"
+    assert configured_summary.model_label == "gpt-5.4"
+    assert configured_summary.model_source == "configured"
+    assert configured_summary.provider == "opencode"
+
+
 def test_runtime_provider_compaction_emits_continuity_state_and_persists_metadata(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
﻿## Summary
- extend `AgentSummary` with stable agent/model fields for clients
- populate `/api/agents` summaries with mode, selectable, configured, execution engine, model, and provider data
- keep Composer's UI lightweight by filtering non-selectable agents while leaving model display in the existing model picker

## Why
This follows the scoped-down #241 direction: expose reliable runtime summary fields without making Composer render prompt/tool/skill internals. Model details may be empty when no model is configured, and the frontend keeps that state quiet.

## Validation
- `uv run pytest tests/unit/runtime/test_runtime_service_extensions.py -k agent_summary -q`
- `uv run ruff check src/voidcode/runtime/contracts.py src/voidcode/runtime/service.py src/voidcode/runtime/http.py tests/unit/runtime/test_runtime_service_extensions.py`
- `bun run test:run -- Composer`
- `bun run typecheck`
- pre-commit hooks on commit

Closes #241
