### PR TITLE
feat(runtime): add agents config map

### DIFF
--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import math
 import os
+import re
 from collections.abc import Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -228,6 +229,7 @@ class RuntimeConfig:
     providers: RuntimeProvidersConfig | None = None
     plan: RuntimePlanConfig | None = None
     agent: RuntimeAgentConfig | None = None
+    agents: Mapping[str, RuntimeAgentConfig] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -249,6 +251,7 @@ class RuntimeConfigOverrides:
     providers: RuntimeProvidersConfig | None = None
     plan: RuntimePlanConfig | None = None
     agent: RuntimeAgentConfig | None = None
+    agents: Mapping[str, RuntimeAgentConfig] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -390,6 +393,7 @@ def load_runtime_config(
         providers=resolved_providers,
         plan=repo_local.plan,
         agent=resolved_agent,
+        agents=repo_local.agents,
     )
 
 
@@ -471,6 +475,8 @@ def _load_repo_local_config(
     plan = _parse_plan_config(raw_plan)
     raw_agent = payload.get("agent")
     agent = _parse_agent_config(raw_agent)
+    raw_agents = payload.get("agents")
+    agents = _parse_agents_config(raw_agents)
 
     raw_approval_mode = payload.get("approval_mode")
     parsed_approval_mode = _parse_approval_mode(
@@ -496,6 +502,7 @@ def _load_repo_local_config(
         providers=providers,
         plan=plan,
         agent=agent,
+        agents=agents,
     )
 
 
@@ -1338,6 +1345,66 @@ def _resolve_agent_config(agent: RuntimeAgentConfig | None) -> RuntimeAgentConfi
     return agent
 
 
+_AGENTS_MAP_KEY_PATTERN = re.compile(r"^[a-z][a-z0-9_-]*$")
+
+
+def _parse_agents_config(
+    raw_agents: object,
+) -> Mapping[str, RuntimeAgentConfig] | None:
+    if raw_agents is None:
+        return None
+    if not isinstance(raw_agents, dict):
+        raise ValueError("runtime config field 'agents' must be an object when provided")
+
+    raw_payload = cast(dict[object, object], raw_agents)
+    parsed: dict[str, RuntimeAgentConfig] = {}
+    for key, value in raw_payload.items():
+        if not isinstance(key, str) or not _AGENTS_MAP_KEY_PATTERN.fullmatch(key):
+            raise ValueError("runtime config field 'agents' keys must match '^[a-z][a-z0-9_-]*$'")
+        if not isinstance(value, dict):
+            raise ValueError(f"runtime config field 'agents.{key}' must be an object when provided")
+
+        entry_payload = dict(cast(dict[str, object], value))
+        is_builtin_key = get_builtin_agent_manifest(key) is not None
+        if "preset" not in entry_payload:
+            if is_builtin_key:
+                entry_payload["preset"] = key
+            else:
+                valid_presets = ", ".join(
+                    manifest.id for manifest in list_builtin_agent_manifests()
+                )
+                raise ValueError(
+                    f"runtime config field 'agents.{key}.preset' must be one of: {valid_presets}"
+                )
+
+        try:
+            parsed_entry = _parse_agent_config(entry_payload)
+        except ValueError as exc:
+            message = (
+                str(exc).replace("agent.", f"agents.{key}.").replace("'agent'", f"'agents.{key}'")
+            )
+            raise ValueError(message) from exc
+
+        resolved_entry = _resolve_agent_config(parsed_entry)
+        if resolved_entry is None:
+            raise ValueError(f"runtime config field 'agents.{key}' must resolve to a valid agent")
+        parsed[key] = resolved_entry
+    return parsed
+
+
+def serialize_runtime_agents_config(
+    agents: Mapping[str, RuntimeAgentConfig] | None,
+) -> dict[str, object] | None:
+    if agents is None:
+        return None
+    serialized: dict[str, object] = {}
+    for agent_id, agent in agents.items():
+        entry = serialize_runtime_agent_config(agent)
+        if entry is not None:
+            serialized[agent_id] = entry
+    return serialized
+
+
 def parse_runtime_plan_payload(raw_plan: object, *, source: str) -> RuntimePlanConfig | None:
     try:
         return _parse_plan_config(raw_plan)
@@ -1348,6 +1415,15 @@ def parse_runtime_plan_payload(raw_plan: object, *, source: str) -> RuntimePlanC
 def parse_runtime_agent_payload(raw_agent: object, *, source: str) -> RuntimeAgentConfig | None:
     try:
         return _resolve_agent_config(_parse_agent_config(raw_agent))
+    except ValueError as exc:
+        raise ValueError(f"{source}: {exc}") from exc
+
+
+def parse_runtime_agents_payload(
+    raw_agents: object, *, source: str
+) -> Mapping[str, RuntimeAgentConfig] | None:
+    try:
+        return _parse_agents_config(raw_agents)
     except ValueError as exc:
         raise ValueError(f"{source}: {exc}") from exc
 

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -44,10 +44,12 @@ from voidcode.runtime.config import (
     effective_runtime_tui_preferences,
     load_runtime_config,
     parse_runtime_agent_payload,
+    parse_runtime_agents_payload,
     runtime_config_path,
     save_global_tui_preferences,
     save_workspace_tui_preferences,
     serialize_runtime_agent_config,
+    serialize_runtime_agents_config,
     user_runtime_config_path,
 )
 from voidcode.runtime.service import RuntimeRequest, VoidCodeRuntime
@@ -1019,6 +1021,231 @@ def test_runtime_agent_payload_accepts_future_role_presets_without_execution_map
         prompt_profile="worker",
         execution_engine="provider",
     )
+
+
+def test_runtime_config_parses_agents_map_with_builtin_keys(tmp_path: Path) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps(
+            {
+                "agents": {
+                    "leader": {"model": "opencode/gpt-5.4"},
+                    "worker": {"model": "anthropic/claude-3-5-sonnet"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.agents is not None
+    assert set(config.agents.keys()) == {"leader", "worker"}
+    assert config.agents["leader"] == RuntimeAgentConfig(
+        preset="leader",
+        prompt_profile="leader",
+        model="opencode/gpt-5.4",
+        execution_engine="provider",
+    )
+    assert config.agents["worker"] == RuntimeAgentConfig(
+        preset="worker",
+        prompt_profile="worker",
+        model="anthropic/claude-3-5-sonnet",
+        execution_engine="provider",
+    )
+
+
+def test_runtime_config_parses_agents_map_with_custom_keys(tmp_path: Path) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps(
+            {
+                "agents": {
+                    "my_helper": {
+                        "preset": "advisor",
+                        "model": "anthropic/claude-3-5-sonnet",
+                    },
+                    "code-finder": {"preset": "explore"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.agents is not None
+    assert config.agents["my_helper"] == RuntimeAgentConfig(
+        preset="advisor",
+        prompt_profile="advisor",
+        model="anthropic/claude-3-5-sonnet",
+        execution_engine="provider",
+    )
+    assert config.agents["code-finder"] == RuntimeAgentConfig(
+        preset="explore",
+        prompt_profile="explore",
+        execution_engine="provider",
+    )
+
+
+@pytest.mark.parametrize(
+    "invalid_id",
+    ["Leader", "my agent", "1agent", "_helper", "agent.test", "AGENT"],
+)
+def test_runtime_config_rejects_agents_map_with_invalid_id(tmp_path: Path, invalid_id: str) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps({"agents": {invalid_id: {"preset": "leader"}}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"runtime config field 'agents' keys must match",
+    ):
+        _ = load_runtime_config(tmp_path, env={})
+
+
+def test_runtime_config_rejects_agents_map_when_not_object(tmp_path: Path) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps({"agents": ["leader"]}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"runtime config field 'agents' must be an object when provided",
+    ):
+        _ = load_runtime_config(tmp_path, env={})
+
+
+def test_runtime_config_rejects_agents_entry_when_not_object(tmp_path: Path) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps({"agents": {"leader": "provider"}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"runtime config field 'agents.leader' must be an object when provided",
+    ):
+        _ = load_runtime_config(tmp_path, env={})
+
+
+def test_runtime_config_rejects_agents_custom_key_without_preset(tmp_path: Path) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps({"agents": {"my_helper": {"model": "anthropic/claude-3"}}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"runtime config field 'agents.my_helper.preset' must be one of:",
+    ):
+        _ = load_runtime_config(tmp_path, env={})
+
+
+def test_runtime_config_rejects_agents_custom_key_with_invalid_preset(
+    tmp_path: Path,
+) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps({"agents": {"my_helper": {"preset": "not_a_real_preset"}}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"runtime config field 'agents.my_helper.preset' must be one of:",
+    ):
+        _ = load_runtime_config(tmp_path, env={})
+
+
+def test_runtime_config_rejects_agents_entry_with_malformed_field_type(
+    tmp_path: Path,
+) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps({"agents": {"leader": {"model": 123}}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"runtime config field 'agents.leader.model' must be a non-empty string",
+    ):
+        _ = load_runtime_config(tmp_path, env={})
+
+
+def test_runtime_config_agents_payload_round_trips(tmp_path: Path) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps(
+            {
+                "agents": {
+                    "leader": {"model": "opencode/gpt-5.4"},
+                    "researcher": {"preset": "researcher"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.agents is not None
+    serialized = serialize_runtime_agents_config(config.agents)
+    assert serialized == {
+        "leader": {
+            "preset": "leader",
+            "prompt_profile": "leader",
+            "model": "opencode/gpt-5.4",
+            "execution_engine": "provider",
+        },
+        "researcher": {
+            "preset": "researcher",
+            "prompt_profile": "researcher",
+            "execution_engine": "provider",
+        },
+    }
+
+
+def test_runtime_config_allows_agent_and_agents_to_coexist(tmp_path: Path) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps(
+            {
+                "agent": {"leader": {"model": "opencode/gpt-5.4"}},
+                "agents": {
+                    "advisor": {"model": "anthropic/claude-3-5-sonnet"},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.agent == RuntimeAgentConfig(
+        preset="leader",
+        prompt_profile="leader",
+        model="opencode/gpt-5.4",
+        execution_engine="provider",
+    )
+    assert config.agents is not None
+    assert config.agents["advisor"] == RuntimeAgentConfig(
+        preset="advisor",
+        prompt_profile="advisor",
+        model="anthropic/claude-3-5-sonnet",
+        execution_engine="provider",
+    )
+
+
+def test_runtime_config_parses_agents_payload_via_helper() -> None:
+    parsed = parse_runtime_agents_payload(
+        {
+            "leader": {"model": "opencode/gpt-5.4"},
+            "my_assistant": {"preset": "advisor"},
+        },
+        source="test payload",
+    )
+
+    assert parsed is not None
+    assert parsed["leader"].preset == "leader"
+    assert parsed["my_assistant"].preset == "advisor"
 
 
 def test_runtime_config_parses_repo_local_max_steps(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add repo-local `agents` map parsing alongside the existing single `agent` shortcut.
- Support built-in agent keys plus custom map keys with explicit preset validation.
- Add regression coverage for built-in/custom entries, malformed ids/types, coexistence, helper parsing, and serialization.

## Verification
- LSP diagnostics on modified files: no issues
- `uv run pytest tests/unit/runtime/test_runtime_config.py -q`
- `mise run typecheck`
- `mise run lint`
- Oracle/read-only review: no blocking issues

Closes #239