### PR TITLE
feat(runtime): add token-budget tool retention

### DIFF
--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from dataclasses import dataclass
 
 from ..tools.contracts import ToolResult
@@ -12,6 +13,11 @@ class RuntimeContinuityState:
     dropped_tool_result_count: int = 0
     retained_tool_result_count: int = 0
     source: str = "tool_result_window"
+    original_tool_result_tokens: int | None = None
+    retained_tool_result_tokens: int | None = None
+    dropped_tool_result_tokens: int | None = None
+    token_budget: int | None = None
+    token_estimate_source: str | None = None
     # Lightweight versioning for continuity state to aid reinjection/refresh
     # semantics. This is incremented when the shape evolves and is included
     # in the serialized payload so consumers can decide how to handle newer
@@ -19,24 +25,47 @@ class RuntimeContinuityState:
     version: int = 1
 
     def metadata_payload(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "summary_text": self.summary_text,
             "dropped_tool_result_count": self.dropped_tool_result_count,
             "retained_tool_result_count": self.retained_tool_result_count,
             "source": self.source,
             "version": self.version,
         }
+        if self.original_tool_result_tokens is not None:
+            payload["original_tool_result_tokens"] = self.original_tool_result_tokens
+        if self.retained_tool_result_tokens is not None:
+            payload["retained_tool_result_tokens"] = self.retained_tool_result_tokens
+        if self.dropped_tool_result_tokens is not None:
+            payload["dropped_tool_result_tokens"] = self.dropped_tool_result_tokens
+        if self.token_budget is not None:
+            payload["token_budget"] = self.token_budget
+        if self.token_estimate_source is not None:
+            payload["token_estimate_source"] = self.token_estimate_source
+        return payload
 
 
 @dataclass(frozen=True, slots=True)
 class ContextWindowPolicy:
     max_tool_results: int = 4
+    max_tool_result_tokens: int | None = None
+    max_context_ratio: float | None = None
+    model_context_window_tokens: int | None = None
+    minimum_retained_tool_results: int = 1
     continuity_preview_items: int = 3
     continuity_preview_chars: int = 80
 
     def __post_init__(self) -> None:
         if self.max_tool_results < 0:
             raise ValueError("max_tool_results must be >= 0")
+        if self.max_tool_result_tokens is not None and self.max_tool_result_tokens < 1:
+            raise ValueError("max_tool_result_tokens must be >= 1 when provided")
+        if self.max_context_ratio is not None and not 0 < self.max_context_ratio <= 1:
+            raise ValueError("max_context_ratio must be > 0 and <= 1 when provided")
+        if self.model_context_window_tokens is not None and self.model_context_window_tokens < 1:
+            raise ValueError("model_context_window_tokens must be >= 1 when provided")
+        if self.minimum_retained_tool_results < 0:
+            raise ValueError("minimum_retained_tool_results must be >= 0")
         if self.continuity_preview_items < 1:
             raise ValueError("continuity_preview_items must be >= 1")
         if self.continuity_preview_chars < 1:
@@ -52,6 +81,11 @@ class RuntimeContextWindow:
     original_tool_result_count: int = 0
     retained_tool_result_count: int = 0
     max_tool_result_count: int = 0
+    original_tool_result_tokens: int | None = None
+    retained_tool_result_tokens: int | None = None
+    dropped_tool_result_tokens: int | None = None
+    token_budget: int | None = None
+    token_estimate_source: str | None = None
     continuity_state: RuntimeContinuityState | None = None
     summary_anchor: str | None = None
     summary_source: dict[str, int] | None = None
@@ -64,6 +98,16 @@ class RuntimeContextWindow:
             "retained_tool_result_count": self.retained_tool_result_count,
             "max_tool_result_count": self.max_tool_result_count,
         }
+        if self.original_tool_result_tokens is not None:
+            payload["original_tool_result_tokens"] = self.original_tool_result_tokens
+        if self.retained_tool_result_tokens is not None:
+            payload["retained_tool_result_tokens"] = self.retained_tool_result_tokens
+        if self.dropped_tool_result_tokens is not None:
+            payload["dropped_tool_result_tokens"] = self.dropped_tool_result_tokens
+        if self.token_budget is not None:
+            payload["token_budget"] = self.token_budget
+        if self.token_estimate_source is not None:
+            payload["token_estimate_source"] = self.token_estimate_source
         if self.continuity_state is not None:
             payload["continuity_state"] = self.continuity_state.metadata_payload()
         if self.summary_anchor is not None:
@@ -95,6 +139,57 @@ def _tool_result_preview(result: ToolResult, *, max_preview_chars: int) -> str:
         preview_label = "content_preview" if content else "error_preview"
         parts.append(f'{preview_label}="{clipped}"')
     return " ".join(parts)
+
+
+_TOKEN_ESTIMATE_SOURCE = "approx_chars_per_4"
+
+
+def _estimated_token_count(value: str) -> int:
+    if not value:
+        return 0
+    return max(1, (len(value) + 3) // 4)
+
+
+def _tool_result_token_estimate(result: ToolResult) -> int:
+    payload = {
+        "tool_name": result.tool_name,
+        "status": result.status,
+        "content": normalize_tool_result_content(result.content),
+        "error": result.error,
+        "data": result.data,
+    }
+    serialized = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return _estimated_token_count(serialized)
+
+
+def _policy_token_budget(policy: ContextWindowPolicy) -> int | None:
+    if policy.max_tool_result_tokens is not None:
+        return policy.max_tool_result_tokens
+    if policy.max_context_ratio is None or policy.model_context_window_tokens is None:
+        return None
+    return max(1, int(policy.model_context_window_tokens * policy.max_context_ratio))
+
+
+def _retain_results_within_token_budget(
+    tool_results: tuple[ToolResult, ...],
+    *,
+    token_budget: int,
+    minimum_retained_results: int,
+) -> tuple[ToolResult, ...]:
+    if not tool_results:
+        return ()
+
+    retained_reversed: list[ToolResult] = []
+    retained_tokens = 0
+    minimum_count = min(minimum_retained_results, len(tool_results))
+    for result in reversed(tool_results):
+        estimate = _tool_result_token_estimate(result)
+        must_retain = len(retained_reversed) < minimum_count
+        if not must_retain and retained_tokens + estimate > token_budget:
+            break
+        retained_reversed.append(result)
+        retained_tokens += estimate
+    return tuple(reversed(retained_reversed))
 
 
 def normalize_tool_result_content(content: str | None) -> str | None:
@@ -138,10 +233,22 @@ def _build_continuity_state(
     retained_count: int,
     preview_item_limit: int,
     preview_char_limit: int,
+    original_tokens: int | None = None,
+    retained_tokens: int | None = None,
+    dropped_tokens: int | None = None,
+    token_budget: int | None = None,
+    token_estimate_source: str | None = None,
 ) -> RuntimeContinuityState:
     dropped_count = len(dropped_results)
     if dropped_count == 0:
-        return RuntimeContinuityState(retained_tool_result_count=retained_count)
+        return RuntimeContinuityState(
+            retained_tool_result_count=retained_count,
+            original_tool_result_tokens=original_tokens,
+            retained_tool_result_tokens=retained_tokens,
+            dropped_tool_result_tokens=dropped_tokens,
+            token_budget=token_budget,
+            token_estimate_source=token_estimate_source,
+        )
 
     preview_count = min(preview_item_limit, dropped_count)
     lines = [f"Compacted {dropped_count} earlier tool results:"]
@@ -158,6 +265,11 @@ def _build_continuity_state(
         dropped_tool_result_count=dropped_count,
         retained_tool_result_count=retained_count,
         source="tool_result_window",
+        original_tool_result_tokens=original_tokens,
+        retained_tool_result_tokens=retained_tokens,
+        dropped_tool_result_tokens=dropped_tokens,
+        token_budget=token_budget,
+        token_estimate_source=token_estimate_source,
     )
 
 
@@ -201,8 +313,15 @@ def prepare_provider_context(
     _ = session_metadata
     effective_policy = policy or ContextWindowPolicy()
     original_count = len(tool_results)
+    token_budget = _policy_token_budget(effective_policy)
 
-    if effective_policy.max_tool_results == 0:
+    if token_budget is not None:
+        retained_results = _retain_results_within_token_budget(
+            tool_results,
+            token_budget=token_budget,
+            minimum_retained_results=effective_policy.minimum_retained_tool_results,
+        )
+    elif effective_policy.max_tool_results == 0:
         retained_results: tuple[ToolResult, ...] = ()
     else:
         retained_results = tool_results[-effective_policy.max_tool_results :]
@@ -210,6 +329,15 @@ def prepare_provider_context(
     retained_count = len(retained_results)
     compacted = retained_count < original_count
     dropped_results = tool_results[: original_count - retained_count]
+    original_tokens = None
+    retained_tokens = None
+    dropped_tokens = None
+    token_estimate_source = None
+    if token_budget is not None:
+        original_tokens = sum(_tool_result_token_estimate(result) for result in tool_results)
+        retained_tokens = sum(_tool_result_token_estimate(result) for result in retained_results)
+        dropped_tokens = original_tokens - retained_tokens
+        token_estimate_source = _TOKEN_ESTIMATE_SOURCE
 
     continuity_state = (
         _build_continuity_state(
@@ -217,6 +345,11 @@ def prepare_provider_context(
             retained_count=retained_count,
             preview_item_limit=effective_policy.continuity_preview_items,
             preview_char_limit=effective_policy.continuity_preview_chars,
+            original_tokens=original_tokens,
+            retained_tokens=retained_tokens,
+            dropped_tokens=dropped_tokens,
+            token_budget=token_budget,
+            token_estimate_source=token_estimate_source,
         )
         if compacted
         else None
@@ -234,6 +367,11 @@ def prepare_provider_context(
         original_tool_result_count=original_count,
         retained_tool_result_count=retained_count,
         max_tool_result_count=effective_policy.max_tool_results,
+        original_tool_result_tokens=original_tokens,
+        retained_tool_result_tokens=retained_tokens,
+        dropped_tool_result_tokens=dropped_tokens,
+        token_budget=token_budget,
+        token_estimate_source=token_estimate_source,
         continuity_state=continuity_state,
         summary_anchor=summary_anchor,
         summary_source=summary_source,

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -78,6 +78,11 @@ class RuntimeRunLoopCoordinator:
                     original_tool_result_count=base_context.original_tool_result_count,
                     retained_tool_result_count=base_context.retained_tool_result_count,
                     max_tool_result_count=base_context.max_tool_result_count,
+                    original_tool_result_tokens=base_context.original_tool_result_tokens,
+                    retained_tool_result_tokens=base_context.retained_tool_result_tokens,
+                    dropped_tool_result_tokens=base_context.dropped_tool_result_tokens,
+                    token_budget=base_context.token_budget,
+                    token_estimate_source=base_context.token_estimate_source,
                     continuity_state=reinjected_continuity,
                     summary_anchor=summary_anchor,
                     summary_source=summary_source,
@@ -96,6 +101,15 @@ class RuntimeRunLoopCoordinator:
                 metadata=graph_request.metadata,
             )
             if context_window.compacted and reinjected_continuity is None:
+                token_metadata: dict[str, object] = {}
+                if context_window.token_budget is not None:
+                    token_metadata = {
+                        "original_tool_result_tokens": (context_window.original_tool_result_tokens),
+                        "retained_tool_result_tokens": (context_window.retained_tool_result_tokens),
+                        "dropped_tool_result_tokens": context_window.dropped_tool_result_tokens,
+                        "token_budget": context_window.token_budget,
+                        "token_estimate_source": context_window.token_estimate_source,
+                    }
                 sequence += 1
                 yield RuntimeStreamChunk(
                     kind="event",
@@ -109,6 +123,7 @@ class RuntimeRunLoopCoordinator:
                             "reason": context_window.compaction_reason,
                             "original_tool_result_count": context_window.original_tool_result_count,
                             "retained_tool_result_count": context_window.retained_tool_result_count,
+                            **token_metadata,
                             "compacted": True,
                             "summary_anchor": context_window.summary_anchor,
                             "summary_source": context_window.summary_source,

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -3657,6 +3657,11 @@ class VoidCodeRuntime:
         dropped = continuity_payload.get("dropped_tool_result_count")
         retained = continuity_payload.get("retained_tool_result_count")
         source = continuity_payload.get("source")
+        original_tokens = continuity_payload.get("original_tool_result_tokens")
+        retained_tokens = continuity_payload.get("retained_tool_result_tokens")
+        dropped_tokens = continuity_payload.get("dropped_tool_result_tokens")
+        token_budget = continuity_payload.get("token_budget")
+        token_estimate_source = continuity_payload.get("token_estimate_source")
         if summary_text is not None and not isinstance(summary_text, str):
             return None
         if not isinstance(dropped, int) or isinstance(dropped, bool):
@@ -3668,11 +3673,33 @@ class VoidCodeRuntime:
         version = continuity_payload.get("version")
         if version is not None and (not isinstance(version, int) or isinstance(version, bool)):
             return None
+
+        def _optional_int(value: object) -> int | None:
+            if value is None:
+                return None
+            if isinstance(value, int) and not isinstance(value, bool):
+                return value
+            raise ValueError
+
+        try:
+            original_token_count = _optional_int(original_tokens)
+            retained_token_count = _optional_int(retained_tokens)
+            dropped_token_count = _optional_int(dropped_tokens)
+            resolved_token_budget = _optional_int(token_budget)
+        except ValueError:
+            return None
+        if token_estimate_source is not None and not isinstance(token_estimate_source, str):
+            return None
         return RuntimeContinuityState(
             summary_text=summary_text,
             dropped_tool_result_count=dropped,
             retained_tool_result_count=retained,
             source=source,
+            original_tool_result_tokens=original_token_count,
+            retained_tool_result_tokens=retained_token_count,
+            dropped_tool_result_tokens=dropped_token_count,
+            token_budget=resolved_token_budget,
+            token_estimate_source=token_estimate_source,
             version=version if version is not None else 1,
         )
 

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -21,6 +21,15 @@ def _tool_result(index: int) -> ToolResult:
     )
 
 
+def _sized_tool_result(index: int, *, content_size: int) -> ToolResult:
+    return ToolResult(
+        tool_name="read_file",
+        content=f"content-{index}-" + ("x" * content_size),
+        status="ok",
+        data={"index": index, "path": f"sample-{index}.txt"},
+    )
+
+
 def test_prepare_provider_context_keeps_results_within_limit() -> None:
     context = prepare_provider_context(
         prompt="read sample.txt",
@@ -93,6 +102,87 @@ def test_prepare_provider_context_uses_explicit_continuity_preview_policy() -> N
         '1. read_file ok content_preview="conte..."\n'
         "... and 2 more"
     )
+
+
+def test_prepare_provider_context_compacts_by_absolute_token_budget() -> None:
+    context = prepare_provider_context(
+        prompt="read sample.txt",
+        tool_results=(
+            _sized_tool_result(1, content_size=240),
+            _sized_tool_result(2, content_size=40),
+            _sized_tool_result(3, content_size=40),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(max_tool_result_tokens=90),
+    )
+
+    assert tuple(result.data["index"] for result in context.tool_results) == (2, 3)
+    assert context.compacted is True
+    assert context.compaction_reason == "tool_result_window"
+    assert context.token_budget == 90
+    assert context.token_estimate_source == "approx_chars_per_4"
+    assert context.original_tool_result_tokens is not None
+    assert context.retained_tool_result_tokens is not None
+    assert context.dropped_tool_result_tokens is not None
+    assert context.retained_tool_result_tokens <= 90
+    assert context.dropped_tool_result_tokens > 0
+    assert context.continuity_state is not None
+    assert (
+        context.continuity_state.original_tool_result_tokens == context.original_tool_result_tokens
+    )
+    assert (
+        context.continuity_state.retained_tool_result_tokens == context.retained_tool_result_tokens
+    )
+    assert context.continuity_state.dropped_tool_result_tokens == context.dropped_tool_result_tokens
+    assert context.continuity_state.token_budget == 90
+    assert context.metadata_payload()["token_budget"] == 90
+
+
+def test_prepare_provider_context_derives_budget_from_context_ratio() -> None:
+    context = prepare_provider_context(
+        prompt="read sample.txt",
+        tool_results=(
+            _sized_tool_result(1, content_size=160),
+            _sized_tool_result(2, content_size=32),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_context_ratio=0.1,
+            model_context_window_tokens=500,
+        ),
+    )
+
+    assert tuple(result.data["index"] for result in context.tool_results) == (2,)
+    assert context.token_budget == 50
+    assert context.retained_tool_result_tokens is not None
+    assert context.retained_tool_result_tokens <= 50
+
+
+def test_prepare_provider_context_preserves_latest_result_over_budget() -> None:
+    context = prepare_provider_context(
+        prompt="read sample.txt",
+        tool_results=(_sized_tool_result(1, content_size=400),),
+        session_metadata={},
+        policy=ContextWindowPolicy(max_tool_result_tokens=1),
+    )
+
+    assert tuple(result.data["index"] for result in context.tool_results) == (1,)
+    assert context.compacted is False
+    assert context.retained_tool_result_tokens is not None
+    assert context.retained_tool_result_tokens > 1
+
+
+def test_prepare_provider_context_keeps_count_policy_when_budget_missing() -> None:
+    context = prepare_provider_context(
+        prompt="read sample.txt",
+        tool_results=(_tool_result(1), _tool_result(2), _tool_result(3)),
+        session_metadata={},
+        policy=ContextWindowPolicy(max_tool_results=2),
+    )
+
+    assert tuple(result.data["index"] for result in context.tool_results) == (2, 3)
+    assert context.token_budget is None
+    assert context.original_tool_result_tokens is None
 
 
 def test_continuity_summary_metadata_is_derived_from_state() -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -6090,6 +6090,87 @@ def test_runtime_approval_resume_preserves_canonical_continuity_state(tmp_path: 
     assert (tmp_path / "beta.txt").read_text(encoding="utf-8") == "2"
 
 
+def test_runtime_approval_resume_preserves_token_budget_context_metadata(
+    tmp_path: Path,
+) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("x" * 300, encoding="utf-8")
+    created_providers: list[_ScriptedTurnProvider] = []
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderTurnResult(tool_call=ToolCall("read_file", {"filePath": "sample.txt"})),
+                    ProviderTurnResult(tool_call=ToolCall("read_file", {"filePath": "sample.txt"})),
+                    ProviderTurnResult(
+                        tool_call=ToolCall(
+                            "write_file",
+                            {"path": "beta.txt", "content": "2"},
+                        )
+                    ),
+                    ProviderTurnResult(output="done"),
+                ),
+                created_providers=created_providers,
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            approval_mode="ask",
+        ),
+        permission_policy=PermissionPolicy(mode="ask"),
+        model_provider_registry=registry,
+        context_window_policy=ContextWindowPolicy(max_tool_result_tokens=1),
+    )
+
+    waiting = runtime.run(
+        RuntimeRequest(
+            prompt="read sample.txt\nread sample.txt\nwrite beta.txt 2",
+            session_id="token-continuity-approval",
+        )
+    )
+    approval_request_id = str(waiting.events[-1].payload["request_id"])
+    resumed = runtime.resume(
+        session_id="token-continuity-approval",
+        approval_request_id=approval_request_id,
+        approval_decision="allow",
+    )
+
+    resumed_runtime_state = cast(dict[str, object], resumed.session.metadata["runtime_state"])
+    resumed_continuity = cast(dict[str, object], resumed_runtime_state["continuity"])
+    persisted_context_window = cast(dict[str, object], resumed.session.metadata["context_window"])
+    context_window = cast(RuntimeContextWindow, created_providers[-1].requests[-1].context_window)
+
+    assert context_window.token_budget == 1
+    assert context_window.token_estimate_source == "approx_chars_per_4"
+    assert context_window.original_tool_result_tokens is not None
+    assert context_window.retained_tool_result_tokens is not None
+    assert context_window.dropped_tool_result_tokens is not None
+    assert resumed_continuity["token_budget"] == context_window.token_budget
+    assert resumed_continuity["token_estimate_source"] == context_window.token_estimate_source
+    assert isinstance(resumed_continuity["original_tool_result_tokens"], int)
+    assert isinstance(resumed_continuity["retained_tool_result_tokens"], int)
+    assert isinstance(resumed_continuity["dropped_tool_result_tokens"], int)
+    assert (
+        persisted_context_window["original_tool_result_tokens"]
+        == context_window.original_tool_result_tokens
+    )
+    assert (
+        persisted_context_window["retained_tool_result_tokens"]
+        == context_window.retained_tool_result_tokens
+    )
+    assert (
+        persisted_context_window["dropped_tool_result_tokens"]
+        == context_window.dropped_tool_result_tokens
+    )
+    assert persisted_context_window["token_budget"] == context_window.token_budget
+    assert persisted_context_window["token_estimate_source"] == context_window.token_estimate_source
+
+
 def test_runtime_resume_falls_back_to_fresh_policy_for_legacy_sessions_without_runtime_config(
     tmp_path: Path,
 ) -> None:
@@ -6158,6 +6239,64 @@ def test_runtime_rejects_boolean_continuity_version_in_session_metadata() -> Non
                     "retained_tool_result_count": 1,
                     "source": "tool_result_window",
                     "version": True,
+                }
+            }
+        }
+    )
+
+    assert continuity is None
+
+
+def test_runtime_restores_token_budget_continuity_metadata() -> None:
+    continuity_from_metadata = _private_attr(
+        VoidCodeRuntime, "_continuity_state_from_session_metadata"
+    )
+    continuity = continuity_from_metadata(
+        {
+            "runtime_state": {
+                "continuity": {
+                    "summary_text": "summary",
+                    "dropped_tool_result_count": 2,
+                    "retained_tool_result_count": 1,
+                    "source": "tool_result_window",
+                    "version": 1,
+                    "original_tool_result_tokens": 300,
+                    "retained_tool_result_tokens": 80,
+                    "dropped_tool_result_tokens": 220,
+                    "token_budget": 100,
+                    "token_estimate_source": "approx_chars_per_4",
+                }
+            }
+        }
+    )
+
+    assert continuity == RuntimeContinuityState(
+        summary_text="summary",
+        dropped_tool_result_count=2,
+        retained_tool_result_count=1,
+        source="tool_result_window",
+        original_tool_result_tokens=300,
+        retained_tool_result_tokens=80,
+        dropped_tool_result_tokens=220,
+        token_budget=100,
+        token_estimate_source="approx_chars_per_4",
+        version=1,
+    )
+
+
+def test_runtime_rejects_invalid_token_budget_continuity_metadata() -> None:
+    continuity_from_metadata = _private_attr(
+        VoidCodeRuntime, "_continuity_state_from_session_metadata"
+    )
+    continuity = continuity_from_metadata(
+        {
+            "runtime_state": {
+                "continuity": {
+                    "summary_text": "summary",
+                    "dropped_tool_result_count": 2,
+                    "retained_tool_result_count": 1,
+                    "source": "tool_result_window",
+                    "token_budget": True,
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Add token-budget based tool-result retention with conservative approximate token estimates.
- Preserve token retention metadata in context-window payloads, memory refresh events, and resume continuity paths.
- Cover absolute budgets, context-ratio budgets, fallback count policy behavior, metadata restore validation, and approval-resume reinjection.

## Verification
- `uv run ruff check src tests`
- `uv run basedpyright src tests`
- `uv run pytest tests/unit/runtime/test_context_window.py tests/unit/runtime/test_runtime_service_extensions.py -q`
- `uv run pytest -q`
- `mise run build`
- Manual `prepare_provider_context(..., ContextWindowPolicy(max_tool_result_tokens=90))` token-budget check

close #246 