### PR TITLE
feat(runtime): add context window policy config

### DIFF
--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -129,6 +129,30 @@ class RuntimeSkillsConfig:
     paths: tuple[str, ...] = ()
 
 
+def _empty_context_window_tool_limits() -> dict[str, int]:
+    return {}
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeContextWindowConfig:
+    auto_compaction: bool = True
+    max_tool_results: int = 4
+    max_tool_result_tokens: int | None = None
+    max_context_ratio: float | None = None
+    model_context_window_tokens: int | None = None
+    reserved_output_tokens: int | None = None
+    minimum_retained_tool_results: int = 1
+    recent_tool_result_count: int = 1
+    recent_tool_result_tokens: int | None = None
+    default_tool_result_tokens: int | None = None
+    per_tool_result_tokens: Mapping[str, int] = field(
+        default_factory=_empty_context_window_tool_limits
+    )
+    tokenizer_model: str | None = None
+    continuity_preview_items: int = 3
+    continuity_preview_chars: int = 80
+
+
 @dataclass(frozen=True, slots=True)
 class RuntimeLspConfig:
     enabled: bool | None = None
@@ -226,6 +250,7 @@ class RuntimeConfig:
     hooks: RuntimeHooksConfig | None = None
     tools: RuntimeToolsConfig | None = None
     skills: RuntimeSkillsConfig | None = None
+    context_window: RuntimeContextWindowConfig | None = None
     lsp: RuntimeLspConfig | None = None
     acp: RuntimeAcpConfig | None = None
     mcp: RuntimeMcpConfig | None = None
@@ -248,6 +273,7 @@ class RuntimeConfigOverrides:
     hooks: RuntimeHooksConfig | None = None
     tools: RuntimeToolsConfig | None = None
     skills: RuntimeSkillsConfig | None = None
+    context_window: RuntimeContextWindowConfig | None = None
     lsp: RuntimeLspConfig | None = None
     acp: RuntimeAcpConfig | None = None
     mcp: RuntimeMcpConfig | None = None
@@ -394,6 +420,7 @@ def load_runtime_config(
         hooks=repo_local.hooks,
         tools=repo_local.tools,
         skills=repo_local.skills,
+        context_window=repo_local.context_window,
         lsp=resolved_lsp,
         mcp=repo_local.mcp,
         tui=resolved_tui,
@@ -464,6 +491,9 @@ def _load_repo_local_config(
     raw_skills = payload.get("skills")
     skills = _parse_skills_config(raw_skills)
 
+    raw_context_window = payload.get("context_window")
+    context_window = _parse_context_window_config(raw_context_window)
+
     raw_lsp = payload.get("lsp")
     lsp = _parse_lsp_config(raw_lsp)
 
@@ -503,6 +533,7 @@ def _load_repo_local_config(
         hooks=hooks,
         tools=tools,
         skills=skills,
+        context_window=context_window,
         lsp=lsp,
         mcp=mcp,
         tui=tui,
@@ -783,6 +814,170 @@ class _RuntimeSkillsValidationModel(BaseModel):
 
     def to_runtime_config(self) -> RuntimeSkillsConfig:
         return RuntimeSkillsConfig(enabled=self.enabled, paths=self.paths)
+
+
+def _parse_optional_positive_int(value: object, *, field_path: str) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"runtime config field '{field_path}' must be an integer when provided")
+    if value < 1:
+        raise ValueError(f"runtime config field '{field_path}' must be greater than or equal to 1")
+    return value
+
+
+class _RuntimeContextWindowValidationModel(BaseModel):
+    model_config = ConfigDict(validate_default=True)
+
+    auto_compaction: bool = True
+    max_tool_results: int = 4
+    max_tool_result_tokens: int | None = None
+    max_context_ratio: float | None = None
+    model_context_window_tokens: int | None = None
+    reserved_output_tokens: int | None = None
+    minimum_retained_tool_results: int = 1
+    recent_tool_result_count: int = 1
+    recent_tool_result_tokens: int | None = None
+    default_tool_result_tokens: int | None = None
+    per_tool_result_tokens: dict[str, int] = Field(default_factory=dict)
+    tokenizer_model: str | None = None
+    continuity_preview_items: int = 3
+    continuity_preview_chars: int = 80
+
+    @field_validator("auto_compaction", mode="before")
+    @classmethod
+    def _validate_auto_compaction(cls, value: object) -> bool:
+        parsed = _parse_optional_bool(value, field_path="context_window.auto_compaction")
+        return True if parsed is None else parsed
+
+    @field_validator(
+        "max_tool_results",
+        "minimum_retained_tool_results",
+        "recent_tool_result_count",
+        mode="before",
+    )
+    @classmethod
+    def _validate_non_negative_int(cls, value: object, info: ValidationInfo) -> int:
+        field_name = info.field_name or "unknown"
+        field_path = f"context_window.{field_name}"
+        if value is None:
+            defaults = RuntimeContextWindowConfig()
+            return cast(int, getattr(defaults, field_name))
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise ValueError(f"runtime config field '{field_path}' must be an integer")
+        if value < 0:
+            raise ValueError(
+                f"runtime config field '{field_path}' must be greater than or equal to 0"
+            )
+        return value
+
+    @field_validator(
+        "max_tool_result_tokens",
+        "model_context_window_tokens",
+        "recent_tool_result_tokens",
+        "default_tool_result_tokens",
+        "continuity_preview_items",
+        "continuity_preview_chars",
+        mode="before",
+    )
+    @classmethod
+    def _validate_optional_positive_int(cls, value: object, info: ValidationInfo) -> int | None:
+        field_name = info.field_name or "unknown"
+        field_path = f"context_window.{field_name}"
+        parsed = _parse_optional_positive_int(value, field_path=field_path)
+        if parsed is None and field_name in {
+            "continuity_preview_items",
+            "continuity_preview_chars",
+        }:
+            defaults = RuntimeContextWindowConfig()
+            return cast(int, getattr(defaults, field_name))
+        return parsed
+
+    @field_validator("reserved_output_tokens", mode="before")
+    @classmethod
+    def _validate_reserved_output_tokens(cls, value: object) -> int | None:
+        if value is None:
+            return None
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise ValueError(
+                "runtime config field 'context_window.reserved_output_tokens' must be an integer"
+            )
+        if value < 0:
+            raise ValueError(
+                "runtime config field 'context_window.reserved_output_tokens' must be "
+                "greater than or equal to 0"
+            )
+        return value
+
+    @field_validator("max_context_ratio", mode="before")
+    @classmethod
+    def _validate_max_context_ratio(cls, value: object) -> float | None:
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            raise ValueError(
+                "runtime config field 'context_window.max_context_ratio' must be a number"
+            )
+        parsed = float(value)
+        if not 0 < parsed <= 1:
+            raise ValueError(
+                "runtime config field 'context_window.max_context_ratio' must be greater "
+                "than 0 and less than or equal to 1"
+            )
+        return parsed
+
+    @field_validator("per_tool_result_tokens", mode="before")
+    @classmethod
+    def _validate_per_tool_result_tokens(cls, value: object) -> dict[str, int]:
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            raise ValueError(
+                "runtime config field 'context_window.per_tool_result_tokens' must be an object"
+            )
+        parsed: dict[str, int] = {}
+        for raw_key, raw_limit in cast(dict[object, object], value).items():
+            if not isinstance(raw_key, str) or not raw_key:
+                raise ValueError(
+                    "runtime config field 'context_window.per_tool_result_tokens' keys "
+                    "must be non-empty strings"
+                )
+            limit = _parse_optional_positive_int(
+                raw_limit,
+                field_path=f"context_window.per_tool_result_tokens.{raw_key}",
+            )
+            assert limit is not None
+            parsed[raw_key] = limit
+        return parsed
+
+    @field_validator("tokenizer_model", mode="before")
+    @classmethod
+    def _validate_tokenizer_model(cls, value: object) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(
+                "runtime config field 'context_window.tokenizer_model' must be a non-empty string"
+            )
+        return value.strip()
+
+    def to_runtime_config(self) -> RuntimeContextWindowConfig:
+        return RuntimeContextWindowConfig(
+            auto_compaction=self.auto_compaction,
+            max_tool_results=self.max_tool_results,
+            max_tool_result_tokens=self.max_tool_result_tokens,
+            max_context_ratio=self.max_context_ratio,
+            model_context_window_tokens=self.model_context_window_tokens,
+            reserved_output_tokens=self.reserved_output_tokens,
+            minimum_retained_tool_results=self.minimum_retained_tool_results,
+            recent_tool_result_count=self.recent_tool_result_count,
+            recent_tool_result_tokens=self.recent_tool_result_tokens,
+            default_tool_result_tokens=self.default_tool_result_tokens,
+            per_tool_result_tokens=dict(self.per_tool_result_tokens),
+            tokenizer_model=self.tokenizer_model,
+            continuity_preview_items=self.continuity_preview_items,
+            continuity_preview_chars=self.continuity_preview_chars,
+        )
 
 
 def _validation_context_field_path(info: ValidationInfo, *, default: str) -> str:
@@ -1114,6 +1309,23 @@ def _parse_skills_config(raw_skills: object) -> RuntimeSkillsConfig | None:
             skills_payload,
             field_path="skills",
             model_type=_RuntimeSkillsValidationModel,
+        ),
+    )
+
+
+def _parse_context_window_config(raw_context_window: object) -> RuntimeContextWindowConfig | None:
+    if raw_context_window is None:
+        return None
+    if not isinstance(raw_context_window, dict):
+        raise ValueError("runtime config field 'context_window' must be an object when provided")
+
+    context_window_payload = cast(dict[str, object], raw_context_window)
+    return cast(
+        RuntimeContextWindowConfig | None,
+        _parse_runtime_config_section(
+            context_window_payload,
+            field_path="context_window",
+            model_type=_RuntimeContextWindowValidationModel,
         ),
     )
 
@@ -1493,6 +1705,50 @@ def parse_runtime_agents_payload(
         return _parse_agents_config(raw_agents, hooks=hooks)
     except ValueError as exc:
         raise ValueError(f"{source}: {exc}") from exc
+
+
+def parse_runtime_context_window_payload(
+    raw_context_window: object,
+    *,
+    source: str,
+) -> RuntimeContextWindowConfig | None:
+    try:
+        return _parse_context_window_config(raw_context_window)
+    except ValueError as exc:
+        raise ValueError(f"{source}: {exc}") from exc
+
+
+def serialize_runtime_context_window_config(
+    context_window: RuntimeContextWindowConfig | None,
+) -> dict[str, object] | None:
+    if context_window is None:
+        return None
+    payload: dict[str, object] = {
+        "version": 1,
+        "auto_compaction": context_window.auto_compaction,
+        "max_tool_results": context_window.max_tool_results,
+        "minimum_retained_tool_results": context_window.minimum_retained_tool_results,
+        "recent_tool_result_count": context_window.recent_tool_result_count,
+        "continuity_preview_items": context_window.continuity_preview_items,
+        "continuity_preview_chars": context_window.continuity_preview_chars,
+    }
+    if context_window.max_tool_result_tokens is not None:
+        payload["max_tool_result_tokens"] = context_window.max_tool_result_tokens
+    if context_window.max_context_ratio is not None:
+        payload["max_context_ratio"] = context_window.max_context_ratio
+    if context_window.model_context_window_tokens is not None:
+        payload["model_context_window_tokens"] = context_window.model_context_window_tokens
+    if context_window.reserved_output_tokens is not None:
+        payload["reserved_output_tokens"] = context_window.reserved_output_tokens
+    if context_window.recent_tool_result_tokens is not None:
+        payload["recent_tool_result_tokens"] = context_window.recent_tool_result_tokens
+    if context_window.default_tool_result_tokens is not None:
+        payload["default_tool_result_tokens"] = context_window.default_tool_result_tokens
+    if context_window.per_tool_result_tokens:
+        payload["per_tool_result_tokens"] = dict(context_window.per_tool_result_tokens)
+    if context_window.tokenizer_model is not None:
+        payload["tokenizer_model"] = context_window.tokenizer_model
+    return payload
 
 
 def serialize_runtime_plan_config(plan: RuntimePlanConfig | None) -> dict[str, object] | None:

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -5,6 +5,7 @@ import importlib
 import json
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from functools import lru_cache
 from typing import Any, NamedTuple, cast
 
 from ..tools.contracts import ToolResult
@@ -213,17 +214,21 @@ class _TokenEstimate(NamedTuple):
     source: str
 
 
+@lru_cache(maxsize=32)
+def _tiktoken_encoding_for_model(tokenizer_model: str) -> Any:
+    tiktoken = cast(Any, importlib.import_module("tiktoken"))
+    try:
+        return tiktoken.encoding_for_model(tokenizer_model)
+    except KeyError:
+        return tiktoken.get_encoding("cl100k_base")
+
+
 def _estimated_token_count(value: str, *, tokenizer_model: str | None = None) -> _TokenEstimate:
     if not value:
         return _TokenEstimate(0, _UNICODE_TOKEN_ESTIMATE_SOURCE)
     if tokenizer_model is not None:
         try:
-            tiktoken = cast(Any, importlib.import_module("tiktoken"))
-
-            try:
-                encoding = tiktoken.encoding_for_model(tokenizer_model)
-            except KeyError:
-                encoding = tiktoken.get_encoding("cl100k_base")
+            encoding = _tiktoken_encoding_for_model(tokenizer_model)
             return _TokenEstimate(
                 len(encoding.encode(value, disallowed_special=())),
                 f"tiktoken:{tokenizer_model}",

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 import hashlib
+import importlib
 import json
-from dataclasses import dataclass
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, NamedTuple, cast
 
 from ..tools.contracts import ToolResult
+
+
+def _empty_tool_limits() -> dict[str, int]:
+    return {}
 
 
 @dataclass(frozen=True, slots=True)
@@ -47,15 +54,23 @@ class RuntimeContinuityState:
 
 @dataclass(frozen=True, slots=True)
 class ContextWindowPolicy:
+    auto_compaction: bool = True
     max_tool_results: int = 4
     max_tool_result_tokens: int | None = None
     max_context_ratio: float | None = None
     model_context_window_tokens: int | None = None
+    reserved_output_tokens: int | None = None
     minimum_retained_tool_results: int = 1
+    recent_tool_result_count: int = 1
+    recent_tool_result_tokens: int | None = None
+    default_tool_result_tokens: int | None = None
+    per_tool_result_tokens: Mapping[str, int] = field(default_factory=_empty_tool_limits)
+    tokenizer_model: str | None = None
     continuity_preview_items: int = 3
     continuity_preview_chars: int = 80
 
     def __post_init__(self) -> None:
+        object.__setattr__(self, "per_tool_result_tokens", dict(self.per_tool_result_tokens))
         if self.max_tool_results < 0:
             raise ValueError("max_tool_results must be >= 0")
         if self.max_tool_result_tokens is not None and self.max_tool_result_tokens < 1:
@@ -64,12 +79,55 @@ class ContextWindowPolicy:
             raise ValueError("max_context_ratio must be > 0 and <= 1 when provided")
         if self.model_context_window_tokens is not None and self.model_context_window_tokens < 1:
             raise ValueError("model_context_window_tokens must be >= 1 when provided")
+        if self.reserved_output_tokens is not None and self.reserved_output_tokens < 0:
+            raise ValueError("reserved_output_tokens must be >= 0 when provided")
         if self.minimum_retained_tool_results < 0:
             raise ValueError("minimum_retained_tool_results must be >= 0")
+        if self.recent_tool_result_count < 0:
+            raise ValueError("recent_tool_result_count must be >= 0")
+        if self.recent_tool_result_tokens is not None and self.recent_tool_result_tokens < 1:
+            raise ValueError("recent_tool_result_tokens must be >= 1 when provided")
+        if self.default_tool_result_tokens is not None and self.default_tool_result_tokens < 1:
+            raise ValueError("default_tool_result_tokens must be >= 1 when provided")
+        for tool_name, limit in self.per_tool_result_tokens.items():
+            if not tool_name:
+                raise ValueError("per_tool_result_tokens tool names must be non-empty")
+            if limit < 1:
+                raise ValueError("per_tool_result_tokens limits must be >= 1")
+        if self.tokenizer_model is not None and not self.tokenizer_model:
+            raise ValueError("tokenizer_model must be non-empty when provided")
         if self.continuity_preview_items < 1:
             raise ValueError("continuity_preview_items must be >= 1")
         if self.continuity_preview_chars < 1:
             raise ValueError("continuity_preview_chars must be >= 1")
+
+    def metadata_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "version": 1,
+            "auto_compaction": self.auto_compaction,
+            "max_tool_results": self.max_tool_results,
+            "minimum_retained_tool_results": self.minimum_retained_tool_results,
+            "recent_tool_result_count": self.recent_tool_result_count,
+            "continuity_preview_items": self.continuity_preview_items,
+            "continuity_preview_chars": self.continuity_preview_chars,
+        }
+        if self.max_tool_result_tokens is not None:
+            payload["max_tool_result_tokens"] = self.max_tool_result_tokens
+        if self.max_context_ratio is not None:
+            payload["max_context_ratio"] = self.max_context_ratio
+        if self.model_context_window_tokens is not None:
+            payload["model_context_window_tokens"] = self.model_context_window_tokens
+        if self.reserved_output_tokens is not None:
+            payload["reserved_output_tokens"] = self.reserved_output_tokens
+        if self.recent_tool_result_tokens is not None:
+            payload["recent_tool_result_tokens"] = self.recent_tool_result_tokens
+        if self.default_tool_result_tokens is not None:
+            payload["default_tool_result_tokens"] = self.default_tool_result_tokens
+        if self.per_tool_result_tokens:
+            payload["per_tool_result_tokens"] = dict(self.per_tool_result_tokens)
+        if self.tokenizer_model is not None:
+            payload["tokenizer_model"] = self.tokenizer_model
+        return payload
 
 
 @dataclass(frozen=True, slots=True)
@@ -86,6 +144,8 @@ class RuntimeContextWindow:
     dropped_tool_result_tokens: int | None = None
     token_budget: int | None = None
     token_estimate_source: str | None = None
+    reserved_output_tokens: int | None = None
+    truncated_tool_result_count: int = 0
     continuity_state: RuntimeContinuityState | None = None
     summary_anchor: str | None = None
     summary_source: dict[str, int] | None = None
@@ -108,6 +168,10 @@ class RuntimeContextWindow:
             payload["token_budget"] = self.token_budget
         if self.token_estimate_source is not None:
             payload["token_estimate_source"] = self.token_estimate_source
+        if self.reserved_output_tokens is not None:
+            payload["reserved_output_tokens"] = self.reserved_output_tokens
+        if self.truncated_tool_result_count:
+            payload["truncated_tool_result_count"] = self.truncated_tool_result_count
         if self.continuity_state is not None:
             payload["continuity_state"] = self.continuity_state.metadata_payload()
         if self.summary_anchor is not None:
@@ -141,12 +205,31 @@ def _tool_result_preview(result: ToolResult, *, max_preview_chars: int) -> str:
     return " ".join(parts)
 
 
-_TOKEN_ESTIMATE_SOURCE = "unicode_aware_chars"
+_UNICODE_TOKEN_ESTIMATE_SOURCE = "unicode_aware_chars"
 
 
-def _estimated_token_count(value: str) -> int:
+class _TokenEstimate(NamedTuple):
+    tokens: int
+    source: str
+
+
+def _estimated_token_count(value: str, *, tokenizer_model: str | None = None) -> _TokenEstimate:
     if not value:
-        return 0
+        return _TokenEstimate(0, _UNICODE_TOKEN_ESTIMATE_SOURCE)
+    if tokenizer_model is not None:
+        try:
+            tiktoken = cast(Any, importlib.import_module("tiktoken"))
+
+            try:
+                encoding = tiktoken.encoding_for_model(tokenizer_model)
+            except KeyError:
+                encoding = tiktoken.get_encoding("cl100k_base")
+            return _TokenEstimate(
+                len(encoding.encode(value, disallowed_special=())),
+                f"tiktoken:{tokenizer_model}",
+            )
+        except ImportError:
+            pass
     ascii_chars = 0
     non_ascii_chars = 0
     for char in value:
@@ -154,10 +237,15 @@ def _estimated_token_count(value: str) -> int:
             ascii_chars += 1
         else:
             non_ascii_chars += 1
-    return max(1, ((ascii_chars + 3) // 4) + non_ascii_chars)
+    return _TokenEstimate(
+        max(1, ((ascii_chars + 3) // 4) + non_ascii_chars),
+        _UNICODE_TOKEN_ESTIMATE_SOURCE,
+    )
 
 
-def _tool_result_token_estimate(result: ToolResult) -> int:
+def _tool_result_token_estimate(
+    result: ToolResult, *, tokenizer_model: str | None = None
+) -> _TokenEstimate:
     payload = {
         "tool_name": result.tool_name,
         "status": result.status,
@@ -172,15 +260,86 @@ def _tool_result_token_estimate(result: ToolResult) -> int:
         default=str,
         ensure_ascii=False,
     )
-    return _estimated_token_count(serialized)
+    return _estimated_token_count(serialized, tokenizer_model=tokenizer_model)
 
 
 def _policy_token_budget(policy: ContextWindowPolicy) -> int | None:
     if policy.max_tool_result_tokens is not None:
         return policy.max_tool_result_tokens
-    if policy.max_context_ratio is None or policy.model_context_window_tokens is None:
+    if policy.model_context_window_tokens is None:
         return None
-    return max(1, int(policy.model_context_window_tokens * policy.max_context_ratio))
+    available_context = policy.model_context_window_tokens
+    if policy.reserved_output_tokens is not None:
+        available_context = max(1, available_context - policy.reserved_output_tokens)
+    if policy.max_context_ratio is None:
+        return available_context if policy.reserved_output_tokens is not None else None
+    return max(1, int(available_context * policy.max_context_ratio))
+
+
+def _tool_limit_for_result(result: ToolResult, policy: ContextWindowPolicy) -> int | None:
+    return policy.per_tool_result_tokens.get(result.tool_name, policy.default_tool_result_tokens)
+
+
+def _clip_text_to_token_limit(text: str, *, limit: int, tokenizer_model: str | None) -> str:
+    if _estimated_token_count(text, tokenizer_model=tokenizer_model).tokens <= limit:
+        return text
+    clipped: list[str] = []
+    used = 0
+    for char in text:
+        char_tokens = _estimated_token_count(char, tokenizer_model=tokenizer_model).tokens
+        if used + char_tokens > limit:
+            break
+        clipped.append(char)
+        used += char_tokens
+    omitted = len(text) - len(clipped)
+    return (
+        "".join(clipped)
+        + f"\n[Tool output truncated by context window policy; omitted {omitted} chars]"
+    )
+
+
+def _truncate_tool_result_content(
+    result: ToolResult,
+    *,
+    policy: ContextWindowPolicy,
+) -> tuple[ToolResult, bool]:
+    limit = _tool_limit_for_result(result, policy)
+    if limit is None or result.content is None:
+        return result, False
+    original_estimate = _estimated_token_count(
+        result.content, tokenizer_model=policy.tokenizer_model
+    )
+    if original_estimate.tokens <= limit:
+        return result, False
+    clipped = _clip_text_to_token_limit(
+        result.content,
+        limit=limit,
+        tokenizer_model=policy.tokenizer_model,
+    )
+    data = {
+        **result.data,
+        "context_window_truncated": True,
+        "context_window_original_content_tokens": original_estimate.tokens,
+        "context_window_content_token_limit": limit,
+    }
+    return (
+        ToolResult(
+            tool_name=result.tool_name,
+            status=result.status,
+            content=clipped,
+            data=data,
+            error=result.error,
+            truncated=True,
+            partial=True,
+            attachment=result.attachment,
+            timeout_seconds=result.timeout_seconds,
+            source=result.source,
+            fallback_reason=result.fallback_reason,
+            reference=result.reference,
+            error_kind=result.error_kind,
+        ),
+        True,
+    )
 
 
 def _retain_results_within_token_budget(
@@ -188,6 +347,7 @@ def _retain_results_within_token_budget(
     *,
     token_budget: int,
     minimum_retained_results: int,
+    tokenizer_model: str | None,
 ) -> tuple[ToolResult, ...]:
     if not tool_results:
         return ()
@@ -196,13 +356,99 @@ def _retain_results_within_token_budget(
     retained_tokens = 0
     minimum_count = min(minimum_retained_results, len(tool_results))
     for result in reversed(tool_results):
-        estimate = _tool_result_token_estimate(result)
+        estimate = _tool_result_token_estimate(result, tokenizer_model=tokenizer_model).tokens
         must_retain = len(retained_reversed) < minimum_count
         if not must_retain and retained_tokens + estimate > token_budget:
             break
         retained_reversed.append(result)
         retained_tokens += estimate
     return tuple(reversed(retained_reversed))
+
+
+def _token_estimate_source(policy: ContextWindowPolicy, sample: str = "sample") -> str:
+    return _estimated_token_count(sample, tokenizer_model=policy.tokenizer_model).source
+
+
+def _coerce_optional_int(payload: Mapping[str, object], key: str) -> int | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    raise ValueError(f"context window policy field '{key}' must be an integer")
+
+
+def _coerce_int(payload: Mapping[str, object], key: str, *, default: int) -> int:
+    if key not in payload:
+        return default
+    value = _coerce_optional_int(payload, key)
+    if value is None:
+        raise ValueError(f"context window policy field '{key}' must be an integer")
+    return value
+
+
+def context_window_policy_from_payload(raw_payload: object) -> ContextWindowPolicy:
+    if not isinstance(raw_payload, dict):
+        raise ValueError("context window policy payload must be an object")
+    payload = cast(dict[str, object], raw_payload)
+    per_tool_raw = payload.get("per_tool_result_tokens")
+    per_tool: dict[str, int] = {}
+    if per_tool_raw is not None:
+        if not isinstance(per_tool_raw, dict):
+            raise ValueError(
+                "context window policy field 'per_tool_result_tokens' must be an object"
+            )
+        for key, value in cast(dict[object, object], per_tool_raw).items():
+            if not isinstance(key, str) or not key:
+                raise ValueError("context window policy per-tool keys must be non-empty strings")
+            if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+                raise ValueError("context window policy per-tool limits must be positive integers")
+            per_tool[key] = value
+    auto_compaction = payload.get("auto_compaction", True)
+    if not isinstance(auto_compaction, bool):
+        raise ValueError("context window policy field 'auto_compaction' must be a boolean")
+    max_context_ratio = payload.get("max_context_ratio")
+    if max_context_ratio is not None and not isinstance(max_context_ratio, int | float):
+        raise ValueError("context window policy field 'max_context_ratio' must be a number")
+    tokenizer_model = payload.get("tokenizer_model")
+    if tokenizer_model is not None and not isinstance(tokenizer_model, str):
+        raise ValueError("context window policy field 'tokenizer_model' must be a string")
+    return ContextWindowPolicy(
+        auto_compaction=auto_compaction,
+        max_tool_results=_coerce_int(
+            payload,
+            "max_tool_results",
+            default=ContextWindowPolicy().max_tool_results,
+        ),
+        max_tool_result_tokens=_coerce_optional_int(payload, "max_tool_result_tokens"),
+        max_context_ratio=float(max_context_ratio) if max_context_ratio is not None else None,
+        model_context_window_tokens=_coerce_optional_int(payload, "model_context_window_tokens"),
+        reserved_output_tokens=_coerce_optional_int(payload, "reserved_output_tokens"),
+        minimum_retained_tool_results=_coerce_int(
+            payload,
+            "minimum_retained_tool_results",
+            default=ContextWindowPolicy().minimum_retained_tool_results,
+        ),
+        recent_tool_result_count=_coerce_int(
+            payload,
+            "recent_tool_result_count",
+            default=ContextWindowPolicy().recent_tool_result_count,
+        ),
+        recent_tool_result_tokens=_coerce_optional_int(payload, "recent_tool_result_tokens"),
+        default_tool_result_tokens=_coerce_optional_int(payload, "default_tool_result_tokens"),
+        per_tool_result_tokens=per_tool,
+        tokenizer_model=tokenizer_model,
+        continuity_preview_items=_coerce_int(
+            payload,
+            "continuity_preview_items",
+            default=ContextWindowPolicy().continuity_preview_items,
+        ),
+        continuity_preview_chars=_coerce_int(
+            payload,
+            "continuity_preview_chars",
+            default=ContextWindowPolicy().continuity_preview_chars,
+        ),
+    )
 
 
 def normalize_tool_result_content(content: str | None) -> str | None:
@@ -328,16 +574,73 @@ def prepare_provider_context(
     original_count = len(tool_results)
     token_budget = _policy_token_budget(effective_policy)
 
+    if not effective_policy.auto_compaction:
+        retained_results = tool_results
+        retained_count = len(retained_results)
+        original_tokens = None
+        retained_tokens = None
+        if token_budget is not None:
+            original_tokens = sum(
+                _tool_result_token_estimate(
+                    result,
+                    tokenizer_model=effective_policy.tokenizer_model,
+                ).tokens
+                for result in tool_results
+            )
+            retained_tokens = original_tokens
+        return RuntimeContextWindow(
+            prompt=prompt,
+            tool_results=retained_results,
+            compacted=False,
+            compaction_reason=None,
+            original_tool_result_count=original_count,
+            retained_tool_result_count=retained_count,
+            max_tool_result_count=effective_policy.max_tool_results,
+            original_tool_result_tokens=original_tokens,
+            retained_tool_result_tokens=retained_tokens,
+            dropped_tool_result_tokens=0 if token_budget is not None else None,
+            token_budget=token_budget,
+            token_estimate_source=(
+                _token_estimate_source(effective_policy) if token_budget is not None else None
+            ),
+            reserved_output_tokens=effective_policy.reserved_output_tokens,
+        )
+
+    protected_recent_count = max(
+        effective_policy.minimum_retained_tool_results,
+        effective_policy.recent_tool_result_count,
+    )
+    protected_recent_count = min(protected_recent_count, original_count)
+    protected_start = original_count - protected_recent_count
+    truncated_results: list[ToolResult] = []
+    truncated_count = 0
+    for index, result in enumerate(tool_results):
+        if index >= protected_start:
+            truncated_results.append(result)
+            continue
+        truncated_result, was_truncated = _truncate_tool_result_content(
+            result,
+            policy=effective_policy,
+        )
+        truncated_results.append(truncated_result)
+        if was_truncated:
+            truncated_count += 1
+    prepared_results = tuple(truncated_results)
+
     if effective_policy.max_tool_results == 0:
-        count_limited_results: tuple[ToolResult, ...] = ()
+        count_limited_results = (
+            prepared_results[-protected_recent_count:] if protected_recent_count else ()
+        )
     else:
-        count_limited_results = tool_results[-effective_policy.max_tool_results :]
+        count_limit = max(effective_policy.max_tool_results, protected_recent_count)
+        count_limited_results = prepared_results[-count_limit:]
 
     if token_budget is not None:
         retained_results = _retain_results_within_token_budget(
             count_limited_results,
             token_budget=token_budget,
-            minimum_retained_results=effective_policy.minimum_retained_tool_results,
+            minimum_retained_results=protected_recent_count,
+            tokenizer_model=effective_policy.tokenizer_model,
         )
     else:
         retained_results = count_limited_results
@@ -350,10 +653,22 @@ def prepare_provider_context(
     dropped_tokens = None
     token_estimate_source = None
     if token_budget is not None:
-        original_tokens = sum(_tool_result_token_estimate(result) for result in tool_results)
-        retained_tokens = sum(_tool_result_token_estimate(result) for result in retained_results)
+        original_tokens = sum(
+            _tool_result_token_estimate(
+                result,
+                tokenizer_model=effective_policy.tokenizer_model,
+            ).tokens
+            for result in prepared_results
+        )
+        retained_tokens = sum(
+            _tool_result_token_estimate(
+                result,
+                tokenizer_model=effective_policy.tokenizer_model,
+            ).tokens
+            for result in retained_results
+        )
         dropped_tokens = original_tokens - retained_tokens
-        token_estimate_source = _TOKEN_ESTIMATE_SOURCE
+        token_estimate_source = _token_estimate_source(effective_policy)
 
     continuity_state = (
         _build_continuity_state(
@@ -388,6 +703,8 @@ def prepare_provider_context(
         dropped_tool_result_tokens=dropped_tokens,
         token_budget=token_budget,
         token_estimate_source=token_estimate_source,
+        reserved_output_tokens=effective_policy.reserved_output_tokens,
+        truncated_tool_result_count=truncated_count,
         continuity_state=continuity_state,
         summary_anchor=summary_anchor,
         summary_source=summary_source,

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -280,9 +280,7 @@ def _tool_limit_for_result(result: ToolResult, policy: ContextWindowPolicy) -> i
     return policy.per_tool_result_tokens.get(result.tool_name, policy.default_tool_result_tokens)
 
 
-def _clip_text_to_token_limit(text: str, *, limit: int, tokenizer_model: str | None) -> str:
-    if _estimated_token_count(text, tokenizer_model=tokenizer_model).tokens <= limit:
-        return text
+def _clip_plain_text_to_token_limit(text: str, *, limit: int, tokenizer_model: str | None) -> str:
     clipped: list[str] = []
     used = 0
     for char in text:
@@ -291,30 +289,60 @@ def _clip_text_to_token_limit(text: str, *, limit: int, tokenizer_model: str | N
             break
         clipped.append(char)
         used += char_tokens
-    omitted = len(text) - len(clipped)
-    return (
-        "".join(clipped)
-        + f"\n[Tool output truncated by context window policy; omitted {omitted} chars]"
+    candidate = "".join(clipped)
+    while (
+        candidate
+        and _estimated_token_count(candidate, tokenizer_model=tokenizer_model).tokens > limit
+    ):
+        candidate = candidate[:-1]
+    return candidate
+
+
+def _truncation_message(*, omitted_chars: int) -> str:
+    return f"\n[Tool output truncated by context window policy; omitted {omitted_chars} chars]"
+
+
+def _clip_text_to_token_limit(text: str, *, limit: int, tokenizer_model: str | None) -> str:
+    if _estimated_token_count(text, tokenizer_model=tokenizer_model).tokens <= limit:
+        return text
+    clipped = _clip_plain_text_to_token_limit(
+        text,
+        limit=limit,
+        tokenizer_model=tokenizer_model,
     )
+    while True:
+        omitted = len(text) - len(clipped)
+        truncation_message = _truncation_message(omitted_chars=omitted)
+        candidate = f"{clipped}{truncation_message}"
+        if _estimated_token_count(candidate, tokenizer_model=tokenizer_model).tokens <= limit:
+            return candidate
+        if not clipped:
+            return _clip_plain_text_to_token_limit(
+                truncation_message,
+                limit=limit,
+                tokenizer_model=tokenizer_model,
+            )
+        clipped = clipped[:-1]
 
 
 def _truncate_tool_result_content(
     result: ToolResult,
     *,
-    policy: ContextWindowPolicy,
+    limit: int | None,
+    tokenizer_model: str | None,
 ) -> tuple[ToolResult, bool]:
-    limit = _tool_limit_for_result(result, policy)
     if limit is None or result.content is None:
         return result, False
     original_estimate = _estimated_token_count(
-        result.content, tokenizer_model=policy.tokenizer_model
+        result.content,
+        tokenizer_model=tokenizer_model,
     )
     if original_estimate.tokens <= limit:
         return result, False
     clipped = _clip_text_to_token_limit(
         result.content,
         limit=limit,
-        tokenizer_model=policy.tokenizer_model,
+        tokenizer_model=tokenizer_model,
     )
     data = {
         **result.data,
@@ -616,11 +644,13 @@ def prepare_provider_context(
     truncated_count = 0
     for index, result in enumerate(tool_results):
         if index >= protected_start:
-            truncated_results.append(result)
-            continue
+            content_limit = effective_policy.recent_tool_result_tokens
+        else:
+            content_limit = _tool_limit_for_result(result, effective_policy)
         truncated_result, was_truncated = _truncate_tool_result_content(
             result,
-            policy=effective_policy,
+            limit=content_limit,
+            tokenizer_model=effective_policy.tokenizer_model,
         )
         truncated_results.append(truncated_result)
         if was_truncated:

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -83,6 +83,8 @@ class RuntimeRunLoopCoordinator:
                     dropped_tool_result_tokens=base_context.dropped_tool_result_tokens,
                     token_budget=base_context.token_budget,
                     token_estimate_source=base_context.token_estimate_source,
+                    reserved_output_tokens=base_context.reserved_output_tokens,
+                    truncated_tool_result_count=base_context.truncated_tool_result_count,
                     continuity_state=reinjected_continuity,
                     summary_anchor=summary_anchor,
                     summary_source=summary_source,

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -31,6 +31,7 @@ from ..hook.executor import (
 )
 from ..provider.auth import ProviderAuthResolver
 from ..provider.errors import format_invalid_provider_config_error
+from ..provider.model_catalog import infer_model_metadata
 from ..provider.models import (
     ResolvedProviderChain,
     ResolvedProviderConfig,
@@ -62,6 +63,7 @@ from .config import (
     ExecutionEngineName,
     RuntimeAgentConfig,
     RuntimeConfig,
+    RuntimeContextWindowConfig,
     RuntimeHooksConfig,
     RuntimePlanConfig,
     RuntimeProviderFallbackConfig,
@@ -71,10 +73,12 @@ from .config import (
     load_runtime_config,
     parse_provider_fallback_payload,
     parse_runtime_agent_payload,
+    parse_runtime_context_window_payload,
     parse_runtime_plan_payload,
     save_global_web_settings,
     serialize_provider_fallback_config,
     serialize_runtime_agent_config,
+    serialize_runtime_context_window_config,
     serialize_runtime_plan_config,
 )
 from .context_window import (
@@ -403,6 +407,7 @@ class VoidCodeRuntime:
     _plan_contributor: PlanContributor
     _background_task_threads: dict[str, threading.Thread]
     _background_tasks_reconciled: bool
+    _context_window_config_override: RuntimeContextWindowConfig | None
     _run_loop_coordinator: RuntimeRunLoopCoordinator
     _resume_coordinator: RuntimeResumeCoordinator
     _background_task_supervisor: RuntimeBackgroundTaskSupervisor
@@ -489,6 +494,10 @@ class VoidCodeRuntime:
         self._tool_registry = self._base_tool_registry
         self._graph_override = graph
         self._graph_cache = {}
+        self._context_window_config_override = self._context_window_config_from_policy(
+            context_window_policy
+        )
+        initial_context_window = self._context_window_config_override or self._config.context_window
         self._initial_effective_config = EffectiveRuntimeConfig(
             approval_mode=self._config.approval_mode,
             model=initial_model,
@@ -499,6 +508,7 @@ class VoidCodeRuntime:
             plan=self._config.plan,
             resolved_provider=self._resolved_provider_config,
             agent=initial_agent,
+            context_window=initial_context_window,
         )
         self._graph = graph or self._build_graph_for_engine_from_config(
             self._initial_effective_config
@@ -511,7 +521,10 @@ class VoidCodeRuntime:
         self._plan_contributor = build_plan_contributor(self._workspace, self._config.plan)
         self._background_task_threads = {}
         self._background_tasks_reconciled = False
-        self._default_context_window_policy = context_window_policy or ContextWindowPolicy()
+        self._default_context_window_policy = self._context_window_policy_from_config(
+            initial_context_window,
+            resolved_provider=self._resolved_provider_config,
+        )
         self._run_loop_coordinator = RuntimeRunLoopCoordinator(self)
         self._resume_coordinator = RuntimeResumeCoordinator(self)
         self._background_task_supervisor = RuntimeBackgroundTaskSupervisor(self)
@@ -831,6 +844,7 @@ class VoidCodeRuntime:
                 plan=resolved.plan,
                 resolved_provider=resolved.resolved_provider,
                 agent=resolved.agent,
+                context_window=resolved.context_window,
             )
         return resolved
 
@@ -2537,6 +2551,7 @@ class VoidCodeRuntime:
             plan=self._config.plan,
             resolved_provider=self._resolved_provider_config,
             agent=initial_agent,
+            context_window=self._config.context_window,
         )
         self._graph_cache = {}
         self._graph = self._graph_override or self._build_graph_for_engine_from_config(
@@ -3684,6 +3699,62 @@ class VoidCodeRuntime:
         raw_provider_attempt = metadata.get("provider_attempt", 0)
         return raw_provider_attempt if isinstance(raw_provider_attempt, int) else 0
 
+    @staticmethod
+    def _context_window_config_from_policy(
+        policy: ContextWindowPolicy | None,
+    ) -> RuntimeContextWindowConfig | None:
+        if policy is None:
+            return None
+        return RuntimeContextWindowConfig(
+            auto_compaction=policy.auto_compaction,
+            max_tool_results=policy.max_tool_results,
+            max_tool_result_tokens=policy.max_tool_result_tokens,
+            max_context_ratio=policy.max_context_ratio,
+            model_context_window_tokens=policy.model_context_window_tokens,
+            reserved_output_tokens=policy.reserved_output_tokens,
+            minimum_retained_tool_results=policy.minimum_retained_tool_results,
+            recent_tool_result_count=policy.recent_tool_result_count,
+            recent_tool_result_tokens=policy.recent_tool_result_tokens,
+            default_tool_result_tokens=policy.default_tool_result_tokens,
+            per_tool_result_tokens=dict(policy.per_tool_result_tokens),
+            tokenizer_model=policy.tokenizer_model,
+            continuity_preview_items=policy.continuity_preview_items,
+            continuity_preview_chars=policy.continuity_preview_chars,
+        )
+
+    @staticmethod
+    def _context_window_policy_from_config(
+        config: RuntimeContextWindowConfig | None,
+        *,
+        resolved_provider: ResolvedProviderConfig | None,
+    ) -> ContextWindowPolicy:
+        if config is None:
+            return ContextWindowPolicy()
+        model_context_window_tokens = config.model_context_window_tokens
+        if model_context_window_tokens is None and resolved_provider is not None:
+            provider = resolved_provider.active_target.selection.provider
+            model = resolved_provider.active_target.selection.model
+            if provider is not None and model is not None:
+                metadata = infer_model_metadata(provider, model)
+                if metadata is not None:
+                    model_context_window_tokens = metadata.context_window
+        return ContextWindowPolicy(
+            auto_compaction=config.auto_compaction,
+            max_tool_results=config.max_tool_results,
+            max_tool_result_tokens=config.max_tool_result_tokens,
+            max_context_ratio=config.max_context_ratio,
+            model_context_window_tokens=model_context_window_tokens,
+            reserved_output_tokens=config.reserved_output_tokens,
+            minimum_retained_tool_results=config.minimum_retained_tool_results,
+            recent_tool_result_count=config.recent_tool_result_count,
+            recent_tool_result_tokens=config.recent_tool_result_tokens,
+            default_tool_result_tokens=config.default_tool_result_tokens,
+            per_tool_result_tokens=dict(config.per_tool_result_tokens),
+            tokenizer_model=config.tokenizer_model,
+            continuity_preview_items=config.continuity_preview_items,
+            continuity_preview_chars=config.continuity_preview_chars,
+        )
+
     def _prepare_provider_context_window(
         self,
         *,
@@ -3692,6 +3763,12 @@ class VoidCodeRuntime:
         session_metadata: dict[str, object],
         policy: ContextWindowPolicy | None = None,
     ) -> RuntimeContextWindow:
+        if policy is None:
+            effective_config = self._effective_runtime_config_from_metadata(session_metadata)
+            policy = self._context_window_policy_from_config(
+                effective_config.context_window,
+                resolved_provider=effective_config.resolved_provider,
+            )
         return prepare_provider_context(
             prompt=prompt,
             tool_results=tool_results,
@@ -4177,6 +4254,11 @@ class VoidCodeRuntime:
             "resolved_provider": resolved_provider_snapshot(effective_config.resolved_provider),
             "plan": serialize_runtime_plan_config(effective_config.plan),
         }
+        serialized_context_window = serialize_runtime_context_window_config(
+            effective_config.context_window
+        )
+        if serialized_context_window is not None:
+            runtime_config_metadata["context_window"] = serialized_context_window
         if effective_config.model is not None:
             runtime_config_metadata["model"] = effective_config.model
         serialized_agent = serialize_runtime_agent_config(effective_config.agent)
@@ -4290,6 +4372,7 @@ class VoidCodeRuntime:
             plan=resolved.plan,
             resolved_provider=resolved_provider,
             agent=merged_agent,
+            context_window=resolved.context_window,
         )
 
     @staticmethod
@@ -4681,6 +4764,7 @@ class VoidCodeRuntime:
         provider_fallback = self._config.provider_fallback
         plan = self._config.plan
         agent = self._config.agent
+        context_window = self._context_window_config_override or self._config.context_window
         allow_persisted_subagent_presets = False
         if metadata is not None:
             allow_persisted_subagent_presets = (
@@ -4730,6 +4814,7 @@ class VoidCodeRuntime:
                 plan=plan,
                 resolved_provider=resolved_provider,
                 agent=agent,
+                context_window=context_window,
             )
 
         persisted_runtime_config = metadata.get("runtime_config")
@@ -4744,6 +4829,7 @@ class VoidCodeRuntime:
                 plan=plan,
                 resolved_provider=resolved_provider,
                 agent=agent,
+                context_window=context_window,
             )
 
         runtime_config = cast(dict[str, object], persisted_runtime_config)
@@ -4813,6 +4899,19 @@ class VoidCodeRuntime:
                 )
         else:
             agent = None
+        if "context_window" in runtime_config:
+            try:
+                context_window = parse_runtime_context_window_payload(
+                    runtime_config.get("context_window"),
+                    source="persisted runtime_config.context_window",
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    format_invalid_provider_config_error(
+                        "persisted runtime_config.context_window",
+                        str(exc),
+                    )
+                ) from exc
         persisted_execution_engine = runtime_config.get("execution_engine")
         if persisted_execution_engine in ("deterministic", "provider"):
             execution_engine = persisted_execution_engine
@@ -4841,6 +4940,7 @@ class VoidCodeRuntime:
             plan=plan,
             resolved_provider=resolved_provider,
             agent=agent,
+            context_window=context_window,
         )
 
     def _provider_chain_for_session_metadata(
@@ -4863,6 +4963,7 @@ class VoidCodeRuntime:
             and effective_config.provider_fallback
             == self._initial_effective_config.provider_fallback
             and effective_config.agent == self._initial_effective_config.agent
+            and effective_config.context_window == self._initial_effective_config.context_window
         ):
             return self._graph
 
@@ -4935,6 +5036,7 @@ class EffectiveRuntimeConfig:
     plan: RuntimePlanConfig | None = None
     resolved_provider: ResolvedProviderConfig = field(default_factory=ResolvedProviderConfig)
     agent: RuntimeAgentConfig | None = None
+    context_window: RuntimeContextWindowConfig | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -3727,13 +3727,17 @@ class VoidCodeRuntime:
         config: RuntimeContextWindowConfig | None,
         *,
         resolved_provider: ResolvedProviderConfig | None,
+        provider_attempt: int = 0,
     ) -> ContextWindowPolicy:
         if config is None:
             return ContextWindowPolicy()
         model_context_window_tokens = config.model_context_window_tokens
         if model_context_window_tokens is None and resolved_provider is not None:
-            provider = resolved_provider.active_target.selection.provider
-            model = resolved_provider.active_target.selection.model
+            provider_target = resolved_provider.target_chain.target_at(provider_attempt)
+            if provider_target is None:
+                provider_target = resolved_provider.active_target
+            provider = provider_target.selection.provider
+            model = provider_target.selection.model
             if provider is not None and model is not None:
                 metadata = infer_model_metadata(provider, model)
                 if metadata is not None:
@@ -3765,9 +3769,11 @@ class VoidCodeRuntime:
     ) -> RuntimeContextWindow:
         if policy is None:
             effective_config = self._effective_runtime_config_from_metadata(session_metadata)
+            provider_attempt = self._provider_attempt_from_metadata(session_metadata)
             policy = self._context_window_policy_from_config(
                 effective_config.context_window,
                 resolved_provider=effective_config.resolved_provider,
+                provider_attempt=provider_attempt,
             )
         return prepare_provider_context(
             prompt=prompt,

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import sys
+from types import ModuleType
 from typing import Literal
+from unittest.mock import patch
 
 from voidcode.runtime.context_window import (
     ContextWindowPolicy,
@@ -11,6 +14,30 @@ from voidcode.runtime.context_window import (
     prepare_provider_context,
 )
 from voidcode.tools.contracts import ToolResult
+
+
+class _FakeEncoding:
+    def encode(self, value: str, *, disallowed_special: tuple[object, ...]) -> list[str]:
+        _ = disallowed_special
+        return list(value)
+
+
+class _FakeTiktokenModule(ModuleType):
+    def __init__(self) -> None:
+        super().__init__("tiktoken")
+        self.encoding_for_model_calls = 0
+        self.get_encoding_calls = 0
+        self._encoding = _FakeEncoding()
+
+    def encoding_for_model(self, model: str) -> _FakeEncoding:
+        _ = model
+        self.encoding_for_model_calls += 1
+        return self._encoding
+
+    def get_encoding(self, name: str) -> _FakeEncoding:
+        _ = name
+        self.get_encoding_calls += 1
+        return self._encoding
 
 
 def _tool_result(index: int) -> ToolResult:
@@ -331,6 +358,31 @@ def test_prepare_provider_context_applies_recent_tool_result_token_cap() -> None
     assert latest.content is not None
     assert len(latest.content) <= 20
     assert context.truncated_tool_result_count == 1
+
+
+def test_prepare_provider_context_reuses_tokenizer_encoding_when_clipping() -> None:
+    fake_tiktoken = _FakeTiktokenModule()
+    with patch.dict(sys.modules, {"tiktoken": fake_tiktoken}):
+        context = prepare_provider_context(
+            prompt="search",
+            tool_results=(
+                ToolResult(tool_name="grep", status="ok", content="x" * 80, data={"index": 1}),
+            ),
+            session_metadata={},
+            policy=ContextWindowPolicy(
+                max_tool_results=1,
+                minimum_retained_tool_results=0,
+                recent_tool_result_count=0,
+                per_tool_result_tokens={"grep": 20},
+                tokenizer_model="cache-test-model",
+            ),
+        )
+
+    (result,) = context.tool_results
+    assert result.truncated is True
+    assert result.content is not None
+    assert fake_tiktoken.encoding_for_model_calls == 1
+    assert fake_tiktoken.get_encoding_calls == 0
 
 
 def test_prepare_provider_context_preserves_recent_results_over_count_cap() -> None:

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -266,13 +266,13 @@ def test_prepare_provider_context_truncates_old_tool_outputs_by_tool_policy() ->
     context = prepare_provider_context(
         prompt="search",
         tool_results=(
-            ToolResult(tool_name="grep", status="ok", content="x" * 80, data={"index": 1}),
+            ToolResult(tool_name="grep", status="ok", content="x" * 200, data={"index": 1}),
             ToolResult(tool_name="grep", status="ok", content="latest" * 20, data={"index": 2}),
         ),
         session_metadata={},
         policy=ContextWindowPolicy(
             max_tool_results=2,
-            per_tool_result_tokens={"grep": 5},
+            per_tool_result_tokens={"grep": 30},
             recent_tool_result_count=1,
         ),
     )
@@ -286,6 +286,51 @@ def test_prepare_provider_context_truncates_old_tool_outputs_by_tool_policy() ->
     assert latest.content == "latest" * 20
     assert context.truncated_tool_result_count == 1
     assert context.metadata_payload()["truncated_tool_result_count"] == 1
+
+
+def test_prepare_provider_context_keeps_truncation_message_inside_tool_cap() -> None:
+    context = prepare_provider_context(
+        prompt="search",
+        tool_results=(
+            ToolResult(tool_name="grep", status="ok", content="x" * 80, data={"index": 1}),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=1,
+            minimum_retained_tool_results=0,
+            recent_tool_result_count=0,
+            per_tool_result_tokens={"grep": 1},
+        ),
+    )
+
+    (result,) = context.tool_results
+    assert result.truncated is True
+    assert result.content is not None
+    assert len(result.content) <= 4
+
+
+def test_prepare_provider_context_applies_recent_tool_result_token_cap() -> None:
+    context = prepare_provider_context(
+        prompt="search",
+        tool_results=(
+            ToolResult(tool_name="grep", status="ok", content="older", data={"index": 1}),
+            ToolResult(tool_name="grep", status="ok", content="x" * 80, data={"index": 2}),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=1,
+            recent_tool_result_count=1,
+            recent_tool_result_tokens=5,
+            default_tool_result_tokens=None,
+        ),
+    )
+
+    (latest,) = context.tool_results
+    assert latest.data["index"] == 2
+    assert latest.truncated is True
+    assert latest.content is not None
+    assert len(latest.content) <= 20
+    assert context.truncated_tool_result_count == 1
 
 
 def test_prepare_provider_context_preserves_recent_results_over_count_cap() -> None:

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -5,6 +5,7 @@ from typing import Literal
 from voidcode.runtime.context_window import (
     ContextWindowPolicy,
     RuntimeContinuityState,
+    context_window_policy_from_payload,
     continuity_summary_metadata,
     normalize_read_file_output,
     prepare_provider_context,
@@ -239,6 +240,93 @@ def test_prepare_provider_context_keeps_count_policy_when_budget_missing() -> No
     assert tuple(result.data["index"] for result in context.tool_results) == (2, 3)
     assert context.token_budget is None
     assert context.original_tool_result_tokens is None
+
+
+def test_prepare_provider_context_honors_reserved_output_budget() -> None:
+    context = prepare_provider_context(
+        prompt="read sample.txt",
+        tool_results=(
+            _sized_tool_result(1, content_size=240),
+            _sized_tool_result(2, content_size=20),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            model_context_window_tokens=120,
+            reserved_output_tokens=40,
+        ),
+    )
+
+    assert tuple(result.data["index"] for result in context.tool_results) == (2,)
+    assert context.token_budget == 80
+    assert context.reserved_output_tokens == 40
+    assert context.metadata_payload()["reserved_output_tokens"] == 40
+
+
+def test_prepare_provider_context_truncates_old_tool_outputs_by_tool_policy() -> None:
+    context = prepare_provider_context(
+        prompt="search",
+        tool_results=(
+            ToolResult(tool_name="grep", status="ok", content="x" * 80, data={"index": 1}),
+            ToolResult(tool_name="grep", status="ok", content="latest" * 20, data={"index": 2}),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=2,
+            per_tool_result_tokens={"grep": 5},
+            recent_tool_result_count=1,
+        ),
+    )
+
+    first, latest = context.tool_results
+    assert first.truncated is True
+    assert first.partial is True
+    assert first.data["context_window_truncated"] is True
+    assert "Tool output truncated by context window policy" in (first.content or "")
+    assert latest.truncated is False
+    assert latest.content == "latest" * 20
+    assert context.truncated_tool_result_count == 1
+    assert context.metadata_payload()["truncated_tool_result_count"] == 1
+
+
+def test_prepare_provider_context_preserves_recent_results_over_count_cap() -> None:
+    context = prepare_provider_context(
+        prompt="read sample.txt",
+        tool_results=(_tool_result(1), _tool_result(2), _tool_result(3)),
+        session_metadata={},
+        policy=ContextWindowPolicy(max_tool_results=1, recent_tool_result_count=2),
+    )
+
+    assert tuple(result.data["index"] for result in context.tool_results) == (2, 3)
+    assert context.retained_tool_result_count == 2
+
+
+def test_prepare_provider_context_auto_compaction_false_retains_all_results() -> None:
+    context = prepare_provider_context(
+        prompt="read sample.txt",
+        tool_results=(_tool_result(1), _tool_result(2), _tool_result(3)),
+        session_metadata={},
+        policy=ContextWindowPolicy(auto_compaction=False, max_tool_results=1),
+    )
+
+    assert tuple(result.data["index"] for result in context.tool_results) == (1, 2, 3)
+    assert context.compacted is False
+
+
+def test_context_window_policy_metadata_round_trips() -> None:
+    policy = ContextWindowPolicy(
+        auto_compaction=False,
+        max_tool_results=6,
+        max_tool_result_tokens=200,
+        reserved_output_tokens=20,
+        recent_tool_result_count=2,
+        default_tool_result_tokens=30,
+        per_tool_result_tokens={"grep": 10},
+        tokenizer_model="gpt-4o",
+    )
+
+    parsed = context_window_policy_from_payload(policy.metadata_payload())
+
+    assert parsed == policy
 
 
 def test_continuity_summary_metadata_is_derived_from_state() -> None:

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -28,6 +28,7 @@ from voidcode.runtime.config import (
     TOOL_TIMEOUT_ENV_VAR,
     RuntimeAgentConfig,
     RuntimeConfig,
+    RuntimeContextWindowConfig,
     RuntimeFormatterPresetConfig,
     RuntimeHooksConfig,
     RuntimeLspConfig,
@@ -47,12 +48,14 @@ from voidcode.runtime.config import (
     load_runtime_config,
     parse_runtime_agent_payload,
     parse_runtime_agents_payload,
+    parse_runtime_context_window_payload,
     runtime_config_path,
     save_global_tui_preferences,
     save_global_web_settings,
     save_workspace_tui_preferences,
     serialize_runtime_agent_config,
     serialize_runtime_agents_config,
+    serialize_runtime_context_window_config,
     user_runtime_config_path,
 )
 from voidcode.runtime.service import RuntimeRequest, VoidCodeRuntime
@@ -232,6 +235,86 @@ def test_runtime_config_supports_provider_first_opt_in_with_stub_model(
 
     assert config.execution_engine == "provider"
     assert config.model == "opencode/gpt-5.4"
+
+
+def test_runtime_config_loads_context_window_policy_from_repo_file(tmp_path: Path) -> None:
+    config_path = tmp_path / RUNTIME_CONFIG_FILE_NAME
+    config_path.write_text(
+        json.dumps(
+            {
+                "context_window": {
+                    "auto_compaction": False,
+                    "max_tool_results": 6,
+                    "max_tool_result_tokens": 2_000,
+                    "max_context_ratio": 0.25,
+                    "model_context_window_tokens": 128_000,
+                    "reserved_output_tokens": 20_000,
+                    "minimum_retained_tool_results": 2,
+                    "recent_tool_result_count": 3,
+                    "recent_tool_result_tokens": 8_000,
+                    "default_tool_result_tokens": 1_000,
+                    "per_tool_result_tokens": {"grep": 500},
+                    "tokenizer_model": "gpt-4o",
+                    "continuity_preview_items": 4,
+                    "continuity_preview_chars": 120,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.context_window == RuntimeContextWindowConfig(
+        auto_compaction=False,
+        max_tool_results=6,
+        max_tool_result_tokens=2_000,
+        max_context_ratio=0.25,
+        model_context_window_tokens=128_000,
+        reserved_output_tokens=20_000,
+        minimum_retained_tool_results=2,
+        recent_tool_result_count=3,
+        recent_tool_result_tokens=8_000,
+        default_tool_result_tokens=1_000,
+        per_tool_result_tokens={"grep": 500},
+        tokenizer_model="gpt-4o",
+        continuity_preview_items=4,
+        continuity_preview_chars=120,
+    )
+
+
+def test_runtime_context_window_config_serializes_for_session_resume() -> None:
+    config = RuntimeContextWindowConfig(
+        max_tool_results=5,
+        reserved_output_tokens=100,
+        per_tool_result_tokens={"shell_exec": 400},
+    )
+
+    payload = serialize_runtime_context_window_config(config)
+    parsed = parse_runtime_context_window_payload(
+        payload,
+        source="test runtime_config.context_window",
+    )
+
+    assert parsed == config
+
+
+def test_runtime_persists_context_window_config_for_resume(tmp_path: Path) -> None:
+    context_window = RuntimeContextWindowConfig(
+        max_tool_results=5,
+        reserved_output_tokens=100,
+        per_tool_result_tokens={"shell_exec": 400},
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(context_window=context_window),
+    )
+
+    payload = runtime._runtime_config_metadata()
+    restored = runtime._effective_runtime_config_from_metadata({"runtime_config": payload})
+
+    assert payload["context_window"] == serialize_runtime_context_window_config(context_window)
+    assert restored.context_window == context_window
 
 
 def test_runtime_config_uses_environment_when_repo_file_missing(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -37,6 +37,7 @@ from voidcode.runtime.config import (
     RuntimeAcpConfig,
     RuntimeAgentConfig,
     RuntimeConfig,
+    RuntimeContextWindowConfig,
     RuntimeFormatterPresetConfig,
     RuntimeHooksConfig,
     RuntimeLspConfig,
@@ -6730,6 +6731,31 @@ def test_runtime_graph_selection_seam_uses_provider_attempt_target(tmp_path: Pat
     assert selection.provider_target.selection.provider == "fallback"
     assert selection.provider_target.selection.model == "model-b"
     assert created_providers[-1].name == "fallback"
+
+
+def test_runtime_context_window_policy_uses_fallback_attempt_model_metadata(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            provider_fallback=RuntimeProviderFallbackConfig(
+                preferred_model="opencode/gpt-5.4",
+                fallback_models=("kimi/moonshot-v1-8k",),
+            ),
+            context_window=RuntimeContextWindowConfig(max_context_ratio=0.5),
+        ),
+    )
+
+    context_window = runtime._prepare_provider_context_window(  # pyright: ignore[reportPrivateUsage]
+        prompt="read sample.txt",
+        tool_results=(),
+        session_metadata={"provider_attempt": 1},
+    )
+
+    assert context_window.token_budget == 4_000
 
 
 def test_runtime_provider_fallback_seam_returns_next_graph_selection(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Adds runtime-configured context-window policy knobs for auto compaction, reserved output tokens, recent tool-result preservation, per-tool/default tool-result caps, and optional tokenizer-backed estimates with fallback.
- Persists effective context policy in session runtime config while preserving existing applied `context_window` and continuity metadata for stable resume behavior.
- Wires provider/model metadata into policy defaults and adds targeted tests for compaction, truncation, config parsing, and resume metadata stability.

## Verification
- `uv run ruff check .`
- `uv run basedpyright --warnings src`
- `uv run pytest` (1381 passed)
- `bun install && bun run lint && bun run typecheck && bun run test:run` (85 passed)

Closes #257