### PR TITLE
feat(agent): add model-aware manifest metadata

### DIFF
--- a/src/voidcode/agent/README.md
+++ b/src/voidcode/agent/README.md
@@ -64,6 +64,10 @@
 
 当前 builtin preset 都有 agent-owned prompt profile；active / delegated agent 的 manifest allowlist 会收窄 provider 可见的 `available_tools`，并且同一边界也会约束实际 tool lookup / invocation。builtin `prompt_profile` 由 `src/voidcode/agent/` 统一 materialize 后进入 provider system message，`model_preference` / `execution_engine` 会作为 manifest live defaults 被 runtime 解析，manifest `skill_refs` 会作为默认 skill selection 进入 runtime skill application，`agent.skills` 会覆盖本次运行使用的 runtime-managed skill discovery / application policy。
 
+`prompt_materialization` 是 prompt 审计元数据：它声明 builtin prompt profile、materialization version、source/format，以及可选的 `model_family_overrides`。当前 builtin agents 仍共享各自默认 profile，但这个结构允许后续在不改变执行拓扑的前提下，为特定模型族选择不同 profile。profile 选择规则属于 agent declaration 层；最终 provider system message 的组装仍由 runtime/provider 路径负责。
+
+`top_level_selectable` 显式声明一个 manifest 是否允许作为顶层 active agent 被选择。当前只有 `leader` 为 `true`；`worker`、`advisor`、`explore`、`researcher`、`product` 都是 delegated/internal presets，不能作为任意顶层 active agent 选择。runtime 仍通过自己的 `_EXECUTABLE_AGENT_PRESETS` 做执行时 enforcement，测试会校验该 allowlist 与 manifest 声明保持一致。
+
 此外，builtin prompt 文本 ownership 现在明确归属 `src/voidcode/agent/`：agent 层负责 builtin prompt 内容、profile materialization 与 manifest 校验，provider 层只负责 message assembly 和模型调用，不再持有 role-specific persona 源码副本。
 
 ## 与 runtime 的边界
@@ -72,7 +76,7 @@
 
 当前 agent manifest 内部也区分了两类语义：
 
-- **live defaults**：`prompt_profile`、`execution_engine`、`model_preference`、`tool_allowlist`、`skill_refs`。这些字段要么已经被 runtime 直接消费，要么作为 active agent 的默认值进入 runtime config truth。
+- **live defaults**：`prompt_profile`、`prompt_materialization`、`top_level_selectable`、`execution_engine`、`model_preference`、`tool_allowlist`、`skill_refs`。这些字段要么已经被 runtime 直接消费，要么作为 active agent 的默认值进入 runtime config truth。`top_level_selectable` 是 declaration，runtime enforcement 仍由 `_EXECUTABLE_AGENT_PRESETS` 持有；`prompt_materialization` 是 declaration，runtime/provider materialization 仍使用 agent 层导出的 prompt rendering helper。
 - **intent metadata**：`routing_hints`。它仍属于声明层元数据，不是 runtime execution governance truth。
 
 最终的执行真相仍然由 `voidcode.runtime` 持有。

--- a/src/voidcode/agent/__init__.py
+++ b/src/voidcode/agent/__init__.py
@@ -6,7 +6,9 @@ from .builtin import (
     RESEARCHER_AGENT_MANIFEST,
     WORKER_AGENT_MANIFEST,
     get_builtin_agent_manifest,
+    is_agent_top_level_selectable,
     list_builtin_agent_manifests,
+    list_top_level_selectable_agent_manifests,
     validate_builtin_agent_manifests,
 )
 from .leader import render_leader_prompt
@@ -16,8 +18,16 @@ from .models import (
     AgentManifestFieldSemantic,
     AgentManifestId,
     AgentMode,
+    AgentPromptFormat,
+    AgentPromptMaterialization,
+    AgentPromptSource,
 )
-from .prompts import is_builtin_prompt_profile, render_agent_prompt, render_builtin_prompt_profile
+from .prompts import (
+    is_builtin_prompt_profile,
+    render_agent_prompt,
+    render_builtin_prompt_profile,
+    select_prompt_profile_for_manifest,
+)
 
 __all__ = [
     "AgentExecutionEngineName",
@@ -25,6 +35,9 @@ __all__ = [
     "AgentManifestFieldSemantic",
     "AgentManifestId",
     "AgentMode",
+    "AgentPromptFormat",
+    "AgentPromptMaterialization",
+    "AgentPromptSource",
     "ADVISOR_AGENT_MANIFEST",
     "EXPLORE_AGENT_MANIFEST",
     "LEADER_AGENT_MANIFEST",
@@ -32,10 +45,13 @@ __all__ = [
     "RESEARCHER_AGENT_MANIFEST",
     "WORKER_AGENT_MANIFEST",
     "get_builtin_agent_manifest",
+    "is_agent_top_level_selectable",
     "is_builtin_prompt_profile",
     "list_builtin_agent_manifests",
+    "list_top_level_selectable_agent_manifests",
     "validate_builtin_agent_manifests",
     "render_agent_prompt",
     "render_builtin_prompt_profile",
     "render_leader_prompt",
+    "select_prompt_profile_for_manifest",
 ]

--- a/src/voidcode/agent/builtin.py
+++ b/src/voidcode/agent/builtin.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from .models import AgentManifest, AgentManifestId
+from types import MappingProxyType
+
+from .models import AgentManifest, AgentManifestId, AgentPromptMaterialization
 from .prompts import render_builtin_prompt_profile
 
 _READ_ONLY_WORKSPACE_TOOLS = (
@@ -34,6 +36,8 @@ _LEADER_TOOL_ALLOWLIST = (
     "mcp/*",
 )
 
+_BUILTIN_PROMPT_MATERIALIZATION_VERSION = 1
+
 LEADER_AGENT_MANIFEST = AgentManifest(
     id="leader",
     name="Leader",
@@ -42,6 +46,14 @@ LEADER_AGENT_MANIFEST = AgentManifest(
     prompt_profile="leader",
     execution_engine="provider",
     tool_allowlist=_LEADER_TOOL_ALLOWLIST,
+    top_level_selectable=True,
+    prompt_materialization=AgentPromptMaterialization(
+        profile="leader",
+        version=_BUILTIN_PROMPT_MATERIALIZATION_VERSION,
+        source="builtin",
+        format="text",
+        model_family_overrides=MappingProxyType({}),
+    ),
 )
 
 WORKER_AGENT_MANIFEST = AgentManifest(
@@ -61,6 +73,14 @@ WORKER_AGENT_MANIFEST = AgentManifest(
         "format_file",
         "task",
     ),
+    top_level_selectable=False,
+    prompt_materialization=AgentPromptMaterialization(
+        profile="worker",
+        version=_BUILTIN_PROMPT_MATERIALIZATION_VERSION,
+        source="builtin",
+        format="text",
+        model_family_overrides=MappingProxyType({}),
+    ),
 )
 
 ADVISOR_AGENT_MANIFEST = AgentManifest(
@@ -71,6 +91,14 @@ ADVISOR_AGENT_MANIFEST = AgentManifest(
     prompt_profile="advisor",
     execution_engine="provider",
     tool_allowlist=_READ_ONLY_WORKSPACE_TOOLS,
+    top_level_selectable=False,
+    prompt_materialization=AgentPromptMaterialization(
+        profile="advisor",
+        version=_BUILTIN_PROMPT_MATERIALIZATION_VERSION,
+        source="builtin",
+        format="text",
+        model_family_overrides=MappingProxyType({}),
+    ),
 )
 
 EXPLORE_AGENT_MANIFEST = AgentManifest(
@@ -83,6 +111,14 @@ EXPLORE_AGENT_MANIFEST = AgentManifest(
     prompt_profile="explore",
     execution_engine="provider",
     tool_allowlist=_READ_ONLY_WORKSPACE_TOOLS,
+    top_level_selectable=False,
+    prompt_materialization=AgentPromptMaterialization(
+        profile="explore",
+        version=_BUILTIN_PROMPT_MATERIALIZATION_VERSION,
+        source="builtin",
+        format="text",
+        model_family_overrides=MappingProxyType({}),
+    ),
 )
 
 RESEARCHER_AGENT_MANIFEST = AgentManifest(
@@ -95,6 +131,14 @@ RESEARCHER_AGENT_MANIFEST = AgentManifest(
     prompt_profile="researcher",
     execution_engine="provider",
     tool_allowlist=("web_search", "web_fetch", "code_search"),
+    top_level_selectable=False,
+    prompt_materialization=AgentPromptMaterialization(
+        profile="researcher",
+        version=_BUILTIN_PROMPT_MATERIALIZATION_VERSION,
+        source="builtin",
+        format="text",
+        model_family_overrides=MappingProxyType({}),
+    ),
 )
 
 PRODUCT_AGENT_MANIFEST = AgentManifest(
@@ -105,6 +149,14 @@ PRODUCT_AGENT_MANIFEST = AgentManifest(
     prompt_profile="product",
     execution_engine="provider",
     tool_allowlist=("read_file", "list", "glob", "grep"),
+    top_level_selectable=False,
+    prompt_materialization=AgentPromptMaterialization(
+        profile="product",
+        version=_BUILTIN_PROMPT_MATERIALIZATION_VERSION,
+        source="builtin",
+        format="text",
+        model_family_overrides=MappingProxyType({}),
+    ),
 )
 
 
@@ -141,6 +193,39 @@ def validate_builtin_agent_manifests(
             raise ValueError(
                 f"builtin agent manifest '{manifest.id}' must not contain duplicate tool patterns"
             )
+        if manifest.mode == "primary" and not manifest.top_level_selectable:
+            raise ValueError(
+                f"builtin agent manifest '{manifest.id}' has mode='primary' but is not "
+                "marked top_level_selectable"
+            )
+        if manifest.mode == "subagent" and manifest.top_level_selectable:
+            raise ValueError(
+                f"builtin agent manifest '{manifest.id}' has mode='subagent' but is marked "
+                "top_level_selectable; subagent presets must not be top-level selectable"
+            )
+        if manifest.prompt_materialization is None:
+            raise ValueError(
+                f"builtin agent manifest '{manifest.id}' must declare prompt_materialization"
+            )
+        materialization = manifest.prompt_materialization
+        if render_builtin_prompt_profile(materialization.profile) is None:
+            raise ValueError(
+                f"builtin agent manifest '{manifest.id}' prompt_materialization.profile "
+                f"references unknown prompt profile '{materialization.profile}'"
+            )
+        if materialization.profile != manifest.prompt_profile:
+            raise ValueError(
+                f"builtin agent manifest '{manifest.id}' prompt_materialization.profile "
+                f"'{materialization.profile}' must match prompt_profile "
+                f"'{manifest.prompt_profile}'"
+            )
+        for family, override_profile in materialization.model_family_overrides.items():
+            if render_builtin_prompt_profile(override_profile) is None:
+                raise ValueError(
+                    f"builtin agent manifest '{manifest.id}' prompt_materialization "
+                    f"model_family_overrides[{family!r}] references unknown prompt profile "
+                    f"'{override_profile}'"
+                )
     return manifests
 
 
@@ -168,3 +253,16 @@ def get_builtin_agent_manifest(agent_id: str) -> AgentManifest | None:
 
 def list_builtin_agent_manifests() -> tuple[AgentManifest, ...]:
     return tuple(_BUILTIN_AGENT_MANIFESTS.values())
+
+
+def is_agent_top_level_selectable(agent_id: str) -> bool:
+    manifest = get_builtin_agent_manifest(agent_id)
+    if manifest is None:
+        return False
+    return manifest.top_level_selectable
+
+
+def list_top_level_selectable_agent_manifests() -> tuple[AgentManifest, ...]:
+    return tuple(
+        manifest for manifest in _BUILTIN_AGENT_MANIFESTS.values() if manifest.top_level_selectable
+    )

--- a/src/voidcode/agent/models.py
+++ b/src/voidcode/agent/models.py
@@ -78,9 +78,9 @@ class AgentPromptMaterialization:
             return self.profile
         return self.model_family_overrides.get(normalized, self.profile)
 
-    def to_payload(self) -> dict[str, object]:
+    def to_payload(self, *, profile: str | None = None) -> dict[str, object]:
         payload: dict[str, object] = {
-            "profile": self.profile,
+            "profile": self.profile if profile is None else profile,
             "version": self.version,
             "source": self.source,
             "format": self.format,

--- a/src/voidcode/agent/models.py
+++ b/src/voidcode/agent/models.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import Literal
 
 type AgentManifestId = Literal[
@@ -14,6 +16,78 @@ type AgentManifestId = Literal[
 type AgentMode = Literal["primary", "subagent", "all"]
 type AgentExecutionEngineName = Literal["deterministic", "provider"]
 type AgentManifestFieldSemantic = Literal["live_default", "intent"]
+type AgentPromptSource = Literal["builtin"]
+type AgentPromptFormat = Literal["text"]
+
+
+_EMPTY_MODEL_FAMILY_OVERRIDES: Mapping[str, str] = MappingProxyType({})
+
+
+@dataclass(frozen=True, slots=True)
+class AgentPromptMaterialization:
+    """Stable, audit-friendly description of how a manifest's prompt is rendered.
+
+    The fields are intentionally narrow today: every builtin manifest renders a
+    static text profile owned by `src/voidcode/agent/<profile>/base.txt`. The
+    `version` integer is bumped whenever the persona text or its materialization
+    semantics change so external consumers can compare prompts deterministically.
+
+    `model_family_overrides` declares an optional mapping from a model-family
+    hint (for example `"opencode"` or `"anthropic"`) to a builtin prompt
+    profile name. Runtime callers may pass a model-family hint into
+    `select_prompt_profile_for_manifest` to pick a family-tuned profile while
+    still falling back to the default profile when no override is declared.
+    """
+
+    profile: str
+    version: int = 1
+    source: AgentPromptSource = "builtin"
+    format: AgentPromptFormat = "text"
+    model_family_overrides: Mapping[str, str] = field(
+        default_factory=lambda: _EMPTY_MODEL_FAMILY_OVERRIDES,
+    )
+
+    def __post_init__(self) -> None:
+        if not self.profile.strip():
+            raise ValueError("AgentPromptMaterialization.profile must be a non-empty string")
+        if self.version < 1:
+            raise ValueError("AgentPromptMaterialization.version must be >= 1")
+        for family, override_profile in self.model_family_overrides.items():
+            if not family.strip():
+                raise ValueError(
+                    "AgentPromptMaterialization.model_family_overrides keys "
+                    "must be non-empty strings"
+                )
+            if not override_profile.strip():
+                raise ValueError(
+                    "AgentPromptMaterialization.model_family_overrides values "
+                    "must be non-empty strings"
+                )
+
+    def select_profile(self, model_family: str | None = None) -> str:
+        """Return the profile to materialize for the given model family hint.
+
+        Falls back to the default `profile` when `model_family` is `None` or
+        when no override is declared for that family.
+        """
+
+        if model_family is None:
+            return self.profile
+        normalized = model_family.strip()
+        if not normalized:
+            return self.profile
+        return self.model_family_overrides.get(normalized, self.profile)
+
+    def to_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "profile": self.profile,
+            "version": self.version,
+            "source": self.source,
+            "format": self.format,
+        }
+        if self.model_family_overrides:
+            payload["model_family_overrides"] = dict(self.model_family_overrides)
+        return payload
 
 
 @dataclass(frozen=True, slots=True)
@@ -28,6 +102,8 @@ class AgentManifest:
     tool_allowlist: tuple[str, ...] = ()
     skill_refs: tuple[str, ...] = ()
     routing_hints: dict[str, object] = field(default_factory=dict)
+    top_level_selectable: bool = False
+    prompt_materialization: AgentPromptMaterialization | None = None
 
     @property
     def live_default_fields(self) -> tuple[str, ...]:
@@ -42,6 +118,9 @@ class AgentManifest:
             fields.append("tool_allowlist")
         if self.skill_refs:
             fields.append("skill_refs")
+        fields.append("top_level_selectable")
+        if self.prompt_materialization is not None:
+            fields.append("prompt_materialization")
         return tuple(fields)
 
     @property

--- a/src/voidcode/agent/prompts.py
+++ b/src/voidcode/agent/prompts.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from collections.abc import Mapping
 from functools import cache
 from pathlib import Path
+from typing import cast
+
+from .models import AgentManifest, AgentPromptMaterialization
 
 _AGENT_DIR = Path(__file__).resolve().parent
 _PROMPT_FILE_NAME = "base.txt"
@@ -42,19 +45,62 @@ def render_builtin_prompt_profile(prompt_profile: str) -> str | None:
     return _render_known_builtin_prompt_profile(normalized_prompt_profile)
 
 
-def render_agent_prompt(agent_preset: Mapping[str, object] | None = None) -> str | None:
+def select_prompt_profile_for_manifest(
+    manifest: AgentManifest,
+    model_family: str | None = None,
+) -> str | None:
+    materialization = manifest.prompt_materialization
+    if materialization is not None:
+        return materialization.select_profile(model_family)
+    return manifest.prompt_profile
+
+
+def _select_profile_from_materialization_payload(
+    materialization: Mapping[str, object],
+    model_family: str | None,
+) -> str | None:
+    profile = materialization.get("profile")
+    if not isinstance(profile, str) or not profile.strip():
+        return None
+    if model_family is None or not model_family.strip():
+        return profile.strip()
+    raw_overrides = materialization.get("model_family_overrides")
+    if not isinstance(raw_overrides, Mapping):
+        return profile.strip()
+    overrides = cast(Mapping[object, object], raw_overrides)
+    override_profile = overrides.get(model_family.strip())
+    if not isinstance(override_profile, str) or not override_profile.strip():
+        return profile.strip()
+    return override_profile.strip()
+
+
+def render_agent_prompt(
+    agent_preset: Mapping[str, object] | None = None,
+    *,
+    model_family: str | None = None,
+) -> str | None:
     if agent_preset is None:
         return None
-    prompt_profile = agent_preset.get("prompt_profile")
-    if not isinstance(prompt_profile, str) or not prompt_profile.strip():
-        return None
-    normalized_prompt_profile = prompt_profile.strip()
-    builtin_prompt = render_builtin_prompt_profile(normalized_prompt_profile)
+    materialization = agent_preset.get("prompt_materialization")
+    selected_profile: str | None = None
+    if isinstance(materialization, AgentPromptMaterialization):
+        selected_profile = materialization.select_profile(model_family)
+    elif isinstance(materialization, Mapping):
+        selected_profile = _select_profile_from_materialization_payload(
+            cast(Mapping[str, object], materialization),
+            model_family,
+        )
+    if selected_profile is None:
+        prompt_profile = agent_preset.get("prompt_profile")
+        if not isinstance(prompt_profile, str) or not prompt_profile.strip():
+            return None
+        selected_profile = prompt_profile.strip()
+    builtin_prompt = render_builtin_prompt_profile(selected_profile)
     if builtin_prompt is not None:
         return builtin_prompt
     return (
         "Runtime-selected VoidCode agent prompt profile: "
-        f"{normalized_prompt_profile}. Treat this as the active agent role profile "
+        f"{selected_profile}. Treat this as the active agent role profile "
         "for this single-agent turn while still following the runtime-provided tool "
         "and skill boundaries."
     )
@@ -65,4 +111,5 @@ __all__ = [
     "is_builtin_prompt_profile",
     "render_agent_prompt",
     "render_builtin_prompt_profile",
+    "select_prompt_profile_for_manifest",
 ]

--- a/src/voidcode/provider/litellm_backend.py
+++ b/src/voidcode/provider/litellm_backend.py
@@ -164,7 +164,19 @@ class LiteLLMBackendSingleAgentProvider:
 
     @classmethod
     def _agent_profile_system_message(cls, request: ProviderTurnRequest) -> str | None:
-        return render_agent_prompt(request.agent_preset)
+        return render_agent_prompt(
+            request.agent_preset,
+            model_family=cls._model_family_hint(request),
+        )
+
+    @staticmethod
+    def _model_family_hint(request: ProviderTurnRequest) -> str | None:
+        if request.provider_name is not None and request.provider_name.strip():
+            return request.provider_name.strip()
+        if request.raw_model is None or "/" not in request.raw_model:
+            return None
+        provider_name, _model_name = request.raw_model.split("/", 1)
+        return provider_name.strip() or None
 
     @staticmethod
     def _continuity_system_message(request: ProviderTurnRequest) -> str | None:

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -1514,8 +1514,11 @@ def serialize_runtime_agent_config(agent: RuntimeAgentConfig | None) -> dict[str
     if agent is None:
         return None
     payload: dict[str, object] = {"preset": agent.preset}
+    manifest = get_builtin_agent_manifest(agent.preset)
     if agent.prompt_profile is not None:
         payload["prompt_profile"] = agent.prompt_profile
+    if manifest is not None and manifest.prompt_materialization is not None:
+        payload["prompt_materialization"] = manifest.prompt_materialization.to_payload()
     if agent.prompt_ref is not None:
         payload["prompt_ref"] = agent.prompt_ref
     if agent.prompt_source is not None:

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -1518,7 +1518,12 @@ def serialize_runtime_agent_config(agent: RuntimeAgentConfig | None) -> dict[str
     if agent.prompt_profile is not None:
         payload["prompt_profile"] = agent.prompt_profile
     if manifest is not None and manifest.prompt_materialization is not None:
-        payload["prompt_materialization"] = manifest.prompt_materialization.to_payload()
+        prompt_materialization_profile = (
+            agent.prompt_profile or manifest.prompt_materialization.profile
+        )
+        payload["prompt_materialization"] = manifest.prompt_materialization.to_payload(
+            profile=prompt_materialization_profile,
+        )
     if agent.prompt_ref is not None:
         payload["prompt_ref"] = agent.prompt_ref
     if agent.prompt_source is not None:

--- a/tests/unit/agent/test_builtin.py
+++ b/tests/unit/agent/test_builtin.py
@@ -5,14 +5,18 @@ from typing import Protocol, cast
 import pytest
 
 from voidcode.agent import (
+    get_builtin_agent_manifest,
+    is_agent_top_level_selectable,
     is_builtin_prompt_profile,
     list_builtin_agent_manifests,
+    list_top_level_selectable_agent_manifests,
     render_agent_prompt,
     render_builtin_prompt_profile,
+    select_prompt_profile_for_manifest,
 )
 from voidcode.agent import prompts as prompt_module
 from voidcode.agent.builtin import validate_builtin_agent_manifests
-from voidcode.agent.models import AgentManifest
+from voidcode.agent.models import AgentManifest, AgentPromptMaterialization
 
 
 class _PromptCacheInfo(Protocol):
@@ -34,10 +38,74 @@ def test_builtin_agent_manifests_have_materialized_prompt_profiles_and_execution
     assert manifests
     for manifest in manifests:
         assert manifest.prompt_profile is not None
+        assert manifest.prompt_materialization is not None
+        assert manifest.prompt_materialization.profile == manifest.prompt_profile
+        assert manifest.prompt_materialization.source == "builtin"
+        assert manifest.prompt_materialization.format == "text"
+        assert manifest.prompt_materialization.version >= 1
         assert manifest.execution_engine == "provider"
         prompt = render_builtin_prompt_profile(manifest.prompt_profile)
         assert prompt is not None
         assert prompt
+
+
+def test_builtin_agent_manifests_declare_top_level_selectability() -> None:
+    manifests = list_builtin_agent_manifests()
+
+    assert [manifest.id for manifest in manifests if manifest.top_level_selectable] == ["leader"]
+    assert is_agent_top_level_selectable("leader") is True
+    assert is_agent_top_level_selectable("worker") is False
+    assert is_agent_top_level_selectable("advisor") is False
+    assert is_agent_top_level_selectable("explore") is False
+    assert is_agent_top_level_selectable("researcher") is False
+    assert is_agent_top_level_selectable("product") is False
+    assert is_agent_top_level_selectable("missing") is False
+    assert tuple(manifest.id for manifest in list_top_level_selectable_agent_manifests()) == (
+        "leader",
+    )
+
+
+def test_prompt_profile_selection_uses_materialization_fallback() -> None:
+    manifest = get_builtin_agent_manifest("leader")
+
+    assert manifest is not None
+    assert select_prompt_profile_for_manifest(manifest) == "leader"
+    assert select_prompt_profile_for_manifest(manifest, model_family="unknown") == "leader"
+
+
+def test_prompt_profile_selection_supports_model_family_overrides() -> None:
+    manifest = AgentManifest(
+        id="leader",
+        name="Leader",
+        mode="primary",
+        description="Primary preset",
+        prompt_profile="leader",
+        execution_engine="provider",
+        prompt_materialization=AgentPromptMaterialization(
+            profile="leader",
+            model_family_overrides={"compact": "worker"},
+        ),
+    )
+
+    assert select_prompt_profile_for_manifest(manifest, model_family="compact") == "worker"
+    assert select_prompt_profile_for_manifest(manifest, model_family="unknown") == "leader"
+
+
+def test_render_agent_prompt_uses_model_family_materialization_override() -> None:
+    prompt = render_agent_prompt(
+        {
+            "preset": "leader",
+            "prompt_profile": "leader",
+            "prompt_materialization": AgentPromptMaterialization(
+                profile="leader",
+                model_family_overrides={"compact": "worker"},
+            ),
+        },
+        model_family="compact",
+    )
+
+    assert prompt is not None
+    assert "VoidCode's worker agent" in prompt
 
 
 @pytest.mark.parametrize(
@@ -108,6 +176,8 @@ def test_agent_manifest_exposes_live_default_vs_intent_field_semantics() -> None
         tool_allowlist=("read_file",),
         skill_refs=("demo",),
         routing_hints={"tier": "primary"},
+        top_level_selectable=True,
+        prompt_materialization=AgentPromptMaterialization(profile="leader"),
     )
 
     assert manifest.live_default_fields == (
@@ -116,9 +186,13 @@ def test_agent_manifest_exposes_live_default_vs_intent_field_semantics() -> None
         "model_preference",
         "tool_allowlist",
         "skill_refs",
+        "top_level_selectable",
+        "prompt_materialization",
     )
     assert manifest.intent_fields == ("routing_hints",)
     assert manifest.field_semantic("prompt_profile") == "live_default"
+    assert manifest.field_semantic("top_level_selectable") == "live_default"
+    assert manifest.field_semantic("prompt_materialization") == "live_default"
     assert manifest.field_semantic("routing_hints") == "intent"
 
 
@@ -133,6 +207,63 @@ def test_validate_builtin_agent_manifests_rejects_unknown_prompt_profile() -> No
                     description="Primary preset",
                     prompt_profile="missing-profile",
                     execution_engine="provider",
+                ),
+            )
+        )
+
+
+def test_validate_builtin_agent_manifests_rejects_top_level_subagent() -> None:
+    with pytest.raises(ValueError, match="subagent.*top_level_selectable"):
+        _ = validate_builtin_agent_manifests(
+            (
+                AgentManifest(
+                    id="worker",
+                    name="Worker",
+                    mode="subagent",
+                    description="Worker preset",
+                    prompt_profile="worker",
+                    execution_engine="provider",
+                    top_level_selectable=True,
+                    prompt_materialization=AgentPromptMaterialization(profile="worker"),
+                ),
+            )
+        )
+
+
+def test_validate_builtin_agent_manifests_rejects_unknown_materialized_profile() -> None:
+    with pytest.raises(ValueError, match="prompt_materialization.profile"):
+        _ = validate_builtin_agent_manifests(
+            (
+                AgentManifest(
+                    id="leader",
+                    name="Leader",
+                    mode="primary",
+                    description="Primary preset",
+                    prompt_profile="leader",
+                    execution_engine="provider",
+                    top_level_selectable=True,
+                    prompt_materialization=AgentPromptMaterialization(profile="missing-profile"),
+                ),
+            )
+        )
+
+
+def test_validate_builtin_agent_manifests_rejects_unknown_model_family_override() -> None:
+    with pytest.raises(ValueError, match="model_family_overrides"):
+        _ = validate_builtin_agent_manifests(
+            (
+                AgentManifest(
+                    id="leader",
+                    name="Leader",
+                    mode="primary",
+                    description="Primary preset",
+                    prompt_profile="leader",
+                    execution_engine="provider",
+                    top_level_selectable=True,
+                    prompt_materialization=AgentPromptMaterialization(
+                        profile="leader",
+                        model_family_overrides={"unknown": "missing-profile"},
+                    ),
                 ),
             )
         )

--- a/tests/unit/provider/test_provider_adapters.py
+++ b/tests/unit/provider/test_provider_adapters.py
@@ -68,6 +68,22 @@ def _build_turn_request(*, model_name: str) -> ProviderTurnRequest:
     )
 
 
+def _prompt_materialization_payload(
+    profile: str,
+    *,
+    model_family_overrides: dict[str, str] | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "profile": profile,
+        "version": 1,
+        "source": "builtin",
+        "format": "text",
+    }
+    if model_family_overrides is not None:
+        payload["model_family_overrides"] = model_family_overrides
+    return payload
+
+
 def _build_turn_request_with_skill(*, model_name: str) -> ProviderTurnRequest:
     tool_results = (ToolResult(tool_name="read_file", status="ok", content="hello world"),)
     return ProviderTurnRequest(
@@ -611,6 +627,7 @@ def test_provider_adapter_omits_continuity_message_without_summary_text(
             {
                 "preset": "leader",
                 "prompt_profile": "leader",
+                "prompt_materialization": _prompt_materialization_payload("leader"),
                 "model": "openai/demo",
                 "execution_engine": "provider",
             },
@@ -620,6 +637,7 @@ def test_provider_adapter_omits_continuity_message_without_summary_text(
             {
                 "preset": "worker",
                 "prompt_profile": "worker",
+                "prompt_materialization": _prompt_materialization_payload("worker"),
                 "model": "openai/demo",
                 "execution_engine": "provider",
             },
@@ -664,6 +682,53 @@ def test_provider_adapter_materializes_builtin_agent_prompt_profiles(
     messages = cast(list[dict[str, str]], messages_obj)
     assert messages[0]["role"] == "system"
     assert expected_fragment in messages[0]["content"]
+    assert messages[1] == {"role": "user", "content": "read sample.txt"}
+
+
+def test_provider_adapter_applies_serialized_model_family_prompt_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = OpenAIModelProvider()
+    provider = provider.turn_provider()
+    request = _build_turn_request(model_name="openai")
+    request = ProviderTurnRequest(
+        prompt=request.prompt,
+        available_tools=request.available_tools,
+        tool_results=request.tool_results,
+        context_window=request.context_window,
+        applied_skills=request.applied_skills,
+        raw_model=request.raw_model,
+        provider_name=request.provider_name,
+        model_name=request.model_name,
+        agent_preset={
+            "preset": "leader",
+            "prompt_profile": "leader",
+            "prompt_materialization": _prompt_materialization_payload(
+                "leader",
+                model_family_overrides={"openai": "worker"},
+            ),
+            "model": "openai/demo",
+            "execution_engine": "provider",
+        },
+        attempt=request.attempt,
+        abort_signal=request.abort_signal,
+    )
+    _patch_litellm_completion(
+        monkeypatch,
+        mode="completion",
+        completion_content="hello world",
+    )
+
+    _ = provider.propose_turn(request)
+
+    payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
+    assert isinstance(payload_obj, dict)
+    payload = cast(dict[str, object], payload_obj)
+    messages_obj = payload.get("messages")
+    assert isinstance(messages_obj, list)
+    messages = cast(list[dict[str, str]], messages_obj)
+    assert messages[0]["role"] == "system"
+    assert "VoidCode's worker agent" in messages[0]["content"]
     assert messages[1] == {"role": "user", "content": "read sample.txt"}
 
 

--- a/tests/unit/provider/test_provider_adapters.py
+++ b/tests/unit/provider/test_provider_adapters.py
@@ -732,6 +732,50 @@ def test_provider_adapter_applies_serialized_model_family_prompt_override(
     assert messages[1] == {"role": "user", "content": "read sample.txt"}
 
 
+def test_provider_adapter_preserves_serialized_prompt_profile_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = OpenAIModelProvider()
+    provider = provider.turn_provider()
+    request = _build_turn_request(model_name="openai")
+    request = ProviderTurnRequest(
+        prompt=request.prompt,
+        available_tools=request.available_tools,
+        tool_results=request.tool_results,
+        context_window=request.context_window,
+        applied_skills=request.applied_skills,
+        raw_model=request.raw_model,
+        provider_name=request.provider_name,
+        model_name=request.model_name,
+        agent_preset={
+            "preset": "leader",
+            "prompt_profile": "researcher",
+            "prompt_materialization": _prompt_materialization_payload("researcher"),
+            "model": "openai/demo",
+            "execution_engine": "provider",
+        },
+        attempt=request.attempt,
+        abort_signal=request.abort_signal,
+    )
+    _patch_litellm_completion(
+        monkeypatch,
+        mode="completion",
+        completion_content="hello world",
+    )
+
+    _ = provider.propose_turn(request)
+
+    payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
+    assert isinstance(payload_obj, dict)
+    payload = cast(dict[str, object], payload_obj)
+    messages_obj = payload.get("messages")
+    assert isinstance(messages_obj, list)
+    messages = cast(list[dict[str, str]], messages_obj)
+    assert messages[0]["role"] == "system"
+    assert "VoidCode's researcher agent" in messages[0]["content"]
+    assert messages[1] == {"role": "user", "content": "read sample.txt"}
+
+
 def test_provider_adapter_falls_back_for_unknown_agent_prompt_profile(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -995,6 +995,27 @@ def test_runtime_agent_payload_round_trips_through_serialization() -> None:
     }
 
 
+def test_runtime_agent_serialization_materialization_preserves_prompt_profile_override() -> None:
+    agent = parse_runtime_agent_payload(
+        {
+            "preset": "leader",
+            "prompt_ref": "researcher",
+            "prompt_source": "builtin",
+        },
+        source="test payload",
+    )
+
+    assert agent is not None
+    assert serialize_runtime_agent_config(agent) == {
+        "preset": "leader",
+        "prompt_profile": "researcher",
+        "prompt_materialization": _prompt_materialization_payload("researcher"),
+        "prompt_ref": "researcher",
+        "prompt_source": "builtin",
+        "execution_engine": "provider",
+    }
+
+
 def test_runtime_agent_payload_round_trips_explicit_empty_tool_boundaries() -> None:
     agent = parse_runtime_agent_payload(
         {

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -75,6 +75,11 @@ PRETTIER_ROOT_MARKERS = (
     "prettier.config.mjs",
 )
 
+
+def _prompt_materialization_payload(profile: str) -> dict[str, object]:
+    return {"profile": profile, "version": 1, "source": "builtin", "format": "text"}
+
+
 PRETTIER_FALLBACK_COMMANDS = (
     ("bunx", "prettier", "--write"),
     ("pnpm", "exec", "prettier", "--write"),
@@ -977,6 +982,7 @@ def test_runtime_agent_payload_round_trips_through_serialization() -> None:
     assert serialize_runtime_agent_config(agent) == {
         "preset": "leader",
         "prompt_profile": "leader",
+        "prompt_materialization": _prompt_materialization_payload("leader"),
         "model": "opencode/gpt-5.4",
         "execution_engine": "provider",
         "tools": {
@@ -1010,6 +1016,7 @@ def test_runtime_agent_payload_round_trips_explicit_empty_tool_boundaries() -> N
     assert serialize_runtime_agent_config(agent) == {
         "preset": "leader",
         "prompt_profile": "leader",
+        "prompt_materialization": _prompt_materialization_payload("leader"),
         "execution_engine": "provider",
         "tools": {"allowlist": [], "default": []},
     }
@@ -1322,6 +1329,7 @@ def test_runtime_config_agents_payload_round_trips(tmp_path: Path) -> None:
         "leader": {
             "preset": "leader",
             "prompt_profile": "leader",
+            "prompt_materialization": _prompt_materialization_payload("leader"),
             "prompt_ref": "leader",
             "prompt_source": "builtin",
             "hook_refs": ["python"],
@@ -1331,6 +1339,7 @@ def test_runtime_config_agents_payload_round_trips(tmp_path: Path) -> None:
         "researcher": {
             "preset": "researcher",
             "prompt_profile": "researcher",
+            "prompt_materialization": _prompt_materialization_payload("researcher"),
             "execution_engine": "provider",
         },
     }

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -104,6 +104,24 @@ from voidcode.tools import ToolCall
 from voidcode.tools.contracts import ToolDefinition, ToolResult
 
 
+def test_runtime_top_level_agent_allowlist_matches_manifest_selectability() -> None:
+    top_level_manifest_ids = {
+        manifest.id
+        for manifest in runtime_service_module.list_builtin_agent_manifests()
+        if manifest.top_level_selectable
+    }
+    executable_agent_presets = cast(
+        frozenset[str],
+        _private_attr(runtime_service_module, "_EXECUTABLE_AGENT_PRESETS"),
+    )
+
+    assert top_level_manifest_ids == executable_agent_presets
+
+
+def _prompt_materialization_payload(profile: str) -> dict[str, object]:
+    return {"profile": profile, "version": 1, "source": "builtin", "format": "text"}
+
+
 def _private_attr(instance: object, name: str) -> Any:
     return getattr(instance, name)
 
@@ -1044,6 +1062,7 @@ def test_runtime_task_tool_starts_background_task_with_skill_metadata(tmp_path: 
         "agent": {
             "preset": "worker",
             "prompt_profile": "worker",
+            "prompt_materialization": _prompt_materialization_payload("worker"),
             "execution_engine": "provider",
         },
     }
@@ -1081,6 +1100,7 @@ def test_runtime_constructs_with_custom_agent_hook_refs(tmp_path: Path) -> None:
     assert runtime_config["agent"] == {
         "preset": "leader",
         "prompt_profile": "researcher",
+        "prompt_materialization": _prompt_materialization_payload("leader"),
         "prompt_ref": "researcher",
         "prompt_source": "builtin",
         "hook_refs": ["customfmt"],
@@ -1124,6 +1144,7 @@ def test_runtime_category_routing_resolves_real_child_agent_and_persists_identit
         "agent": {
             "preset": "worker",
             "prompt_profile": "worker",
+            "prompt_materialization": _prompt_materialization_payload("worker"),
             "execution_engine": "provider",
         },
     }
@@ -1131,6 +1152,7 @@ def test_runtime_category_routing_resolves_real_child_agent_and_persists_identit
     assert runtime_config["agent"] == {
         "preset": "worker",
         "prompt_profile": "worker",
+        "prompt_materialization": _prompt_materialization_payload("worker"),
         "execution_engine": "provider",
     }
     assert result.routing is not None
@@ -1162,6 +1184,7 @@ def test_runtime_subagent_type_routing_resolves_real_child_agent_and_persists_id
     assert runtime_config["agent"] == {
         "preset": "explore",
         "prompt_profile": "explore",
+        "prompt_materialization": _prompt_materialization_payload("explore"),
         "execution_engine": "provider",
     }
     assert response.session.metadata["delegation"] == {
@@ -1225,6 +1248,7 @@ def test_runtime_background_delegation_executes_on_real_provider_child_path(
     assert created_providers[1].requests[0].agent_preset == {
         "preset": "worker",
         "prompt_profile": "worker",
+        "prompt_materialization": _prompt_materialization_payload("worker"),
         "model": "opencode/gpt-5.4",
         "execution_engine": "provider",
     }
@@ -7346,6 +7370,7 @@ def test_runtime_agent_config_selects_provider_graph_and_persists_agent_metadata
     assert created_providers[0].requests[0].agent_preset == {
         "preset": "leader",
         "prompt_profile": "leader",
+        "prompt_materialization": _prompt_materialization_payload("leader"),
         "model": "opencode/gpt-5.4",
         "execution_engine": "provider",
     }
@@ -7353,6 +7378,7 @@ def test_runtime_agent_config_selects_provider_graph_and_persists_agent_metadata
     assert runtime_config["agent"] == {
         "preset": "leader",
         "prompt_profile": "leader",
+        "prompt_materialization": _prompt_materialization_payload("leader"),
         "model": "opencode/gpt-5.4",
         "execution_engine": "provider",
     }
@@ -7407,6 +7433,7 @@ def test_runtime_request_metadata_agent_override_persists_and_restores_agent_con
     assert created_providers[0].requests[0].agent_preset == {
         "preset": "leader",
         "prompt_profile": "leader",
+        "prompt_materialization": _prompt_materialization_payload("leader"),
         "model": "opencode/gpt-5.4",
         "execution_engine": "provider",
     }
@@ -7468,6 +7495,7 @@ def test_runtime_partial_request_agent_override_preserves_inherited_agent_fields
     assert created_providers[0].requests[0].agent_preset == {
         "preset": "leader",
         "prompt_profile": "leader",
+        "prompt_materialization": _prompt_materialization_payload("leader"),
         "model": "opencode/gpt-5.4",
         "execution_engine": "provider",
         "provider_fallback": {
@@ -7479,6 +7507,7 @@ def test_runtime_partial_request_agent_override_preserves_inherited_agent_fields
     assert runtime_config["agent"] == {
         "preset": "leader",
         "prompt_profile": "leader",
+        "prompt_materialization": _prompt_materialization_payload("leader"),
         "model": "opencode/gpt-5.4",
         "execution_engine": "provider",
         "provider_fallback": {
@@ -7561,6 +7590,7 @@ def test_runtime_agent_tool_allowlist_limits_provider_visible_tools(tmp_path: Pa
     assert runtime_config["agent"] == {
         "preset": "leader",
         "prompt_profile": "leader",
+        "prompt_materialization": _prompt_materialization_payload("leader"),
         "model": "opencode/gpt-5.4",
         "execution_engine": "provider",
         "tools": {"allowlist": ["read_file"]},
@@ -7704,6 +7734,7 @@ def test_runtime_agent_builtin_tools_disabled_exposes_no_builtin_tools(tmp_path:
     assert runtime_config["agent"] == {
         "preset": "leader",
         "prompt_profile": "leader",
+        "prompt_materialization": _prompt_materialization_payload("leader"),
         "model": "opencode/gpt-5.4",
         "execution_engine": "provider",
         "tools": {"builtin": {"enabled": False}},
@@ -7854,6 +7885,7 @@ def test_runtime_agent_skills_config_loads_and_persists_runtime_skills(
     assert runtime_config["agent"] == {
         "preset": "leader",
         "prompt_profile": "leader",
+        "prompt_materialization": _prompt_materialization_payload("leader"),
         "execution_engine": "provider",
         "skills": {"enabled": True, "paths": ["agent-skills"]},
     }

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1100,7 +1100,7 @@ def test_runtime_constructs_with_custom_agent_hook_refs(tmp_path: Path) -> None:
     assert runtime_config["agent"] == {
         "preset": "leader",
         "prompt_profile": "researcher",
-        "prompt_materialization": _prompt_materialization_payload("leader"),
+        "prompt_materialization": _prompt_materialization_payload("researcher"),
         "prompt_ref": "researcher",
         "prompt_source": "builtin",
         "hook_refs": ["customfmt"],


### PR DESCRIPTION
## Summary
- Extend builtin agent manifests with stable prompt materialization metadata and explicit top-level selectability.
- Serialize materialization metadata into runtime/provider agent presets so model-family prompt overrides affect real provider system messages.
- Add tests for hidden/delegated agents, model-family prompt selection, runtime executable allowlist parity, and document declaration-only vs runtime-enforced fields.

## Verification
- `mise run check`

Closes #256