### PR TITLE
feat(provider): add provider capability inspection

### DIFF
--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -22,6 +22,8 @@ from .provider.snapshot import resolved_provider_snapshot
 from .runtime.config import RuntimeConfig, load_runtime_config, serialize_provider_fallback_config
 from .runtime.contracts import (
     BackgroundTaskResult,
+    ProviderInspectResult,
+    ProviderModelMetadata,
     RuntimeRequest,
     RuntimeSessionDebugSnapshot,
     RuntimeStreamChunk,
@@ -577,37 +579,115 @@ def _handle_provider_models_command(args: argparse.Namespace) -> int:
     runtime = VoidCodeRuntime(workspace=workspace)
     try:
         try:
-            models = (
-                runtime.refresh_provider_models(provider)
-                if refresh
-                else runtime.provider_models(provider)
-            )
+            if refresh:
+                _ = runtime.refresh_provider_models(provider)
+            result = runtime.provider_models_result(provider)
         except ValueError as exc:
             raise SystemExit(f"error: {exc}") from None
     finally:
         _close_runtime(runtime)
 
-    catalog = runtime.provider_model_catalog(provider)
     payload: dict[str, object] = {
         "workspace": str(workspace),
         "provider": provider,
         "refreshed": refresh,
-        "models": list(models),
+        "models": list(result.models),
+        "model_metadata": {
+            model: _provider_model_metadata_payload(metadata)
+            for model, metadata in result.model_metadata.items()
+        },
+        "source": result.source,
+        "last_refresh_status": result.last_refresh_status,
+        "last_error": result.last_error,
+        "discovery_mode": result.discovery_mode,
     }
-    if catalog is not None:
-        payload["source"] = catalog.get("source")
-        payload["last_refresh_status"] = catalog.get("last_refresh_status")
-        payload["last_error"] = catalog.get("last_error")
-        if refresh and catalog.get("source") == "fallback":
-            refresh_error = catalog.get("last_error")
-            print(
-                "WARN provider.models.refresh "
-                f"provider={provider} source=fallback reason={refresh_error}",
-                file=sys.stderr,
-                flush=True,
-            )
+    if refresh and result.source == "fallback":
+        print(
+            "WARN provider.models.refresh "
+            f"provider={provider} source=fallback reason={result.last_error}",
+            file=sys.stderr,
+            flush=True,
+        )
 
     print(json.dumps(payload))
+    return 0
+
+
+def _provider_model_metadata_payload(
+    metadata: ProviderModelMetadata,
+) -> dict[str, object]:
+    return {
+        key: value
+        for key, value in {
+            "context_window": metadata.context_window,
+            "max_input_tokens": metadata.max_input_tokens,
+            "max_output_tokens": metadata.max_output_tokens,
+            "supports_tools": metadata.supports_tools,
+            "supports_vision": metadata.supports_vision,
+            "supports_streaming": metadata.supports_streaming,
+            "supports_reasoning": metadata.supports_reasoning,
+            "supports_json_mode": metadata.supports_json_mode,
+        }.items()
+        if value is not None
+    }
+
+
+def _provider_inspect_payload(
+    result: ProviderInspectResult, *, workspace: Path
+) -> dict[str, object]:
+    return {
+        "workspace": str(workspace),
+        "provider": {
+            "name": result.summary.name,
+            "label": result.summary.label,
+            "configured": result.summary.configured,
+            "current": result.summary.current,
+        },
+        "models": {
+            "provider": result.models.provider,
+            "configured": result.models.configured,
+            "models": list(result.models.models),
+            "model_metadata": {
+                model: _provider_model_metadata_payload(metadata)
+                for model, metadata in result.models.model_metadata.items()
+            },
+            "source": result.models.source,
+            "last_refresh_status": result.models.last_refresh_status,
+            "last_error": result.models.last_error,
+            "discovery_mode": result.models.discovery_mode,
+        },
+        "validation": {
+            "provider": result.validation.provider,
+            "configured": result.validation.configured,
+            "ok": result.validation.ok,
+            "status": result.validation.status,
+            "message": result.validation.message,
+            "source": result.validation.source,
+            "last_error": result.validation.last_error,
+            "discovery_mode": result.validation.discovery_mode,
+        },
+        "current_model": result.current_model,
+        "current_model_metadata": (
+            None
+            if result.current_model_metadata is None
+            else _provider_model_metadata_payload(result.current_model_metadata)
+        ),
+    }
+
+
+def _handle_provider_inspect_command(args: argparse.Namespace) -> int:
+    workspace = cast(Path, args.workspace)
+    provider = cast(str, args.provider)
+    runtime = VoidCodeRuntime(workspace=workspace)
+    try:
+        try:
+            result = runtime.inspect_provider(provider)
+        except ValueError as exc:
+            raise SystemExit(f"error: {exc}") from None
+    finally:
+        _close_runtime(runtime)
+
+    print(json.dumps(_provider_inspect_payload(result, workspace=workspace), sort_keys=True))
     return 0
 
 
@@ -874,6 +954,20 @@ def build_parser() -> argparse.ArgumentParser:
         help="Refresh model list from provider endpoint before printing.",
     )
     provider_models_parser.set_defaults(handler=_handle_provider_models_command)
+
+    provider_inspect_parser = provider_subparsers.add_parser(
+        "inspect", help="Show configured status, model limits, and model capabilities."
+    )
+    _ = provider_inspect_parser.add_argument(
+        "provider", help="Provider name, e.g. openai or litellm."
+    )
+    _ = provider_inspect_parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd(),
+        help="Workspace root used to resolve runtime config.",
+    )
+    provider_inspect_parser.set_defaults(handler=_handle_provider_inspect_command)
 
     list_parser = sessions_subparsers.add_parser("list", help="List persisted sessions.")
     _ = list_parser.add_argument(

--- a/src/voidcode/provider/model_catalog.py
+++ b/src/voidcode/provider/model_catalog.py
@@ -17,14 +17,44 @@ from .config import LiteLLMProviderConfig
 @dataclass(frozen=True, slots=True)
 class ProviderModelMetadata:
     context_window: int | None = None
+    max_input_tokens: int | None = None
     max_output_tokens: int | None = None
+    supports_tools: bool | None = None
+    supports_vision: bool | None = None
+    supports_streaming: bool | None = None
+    supports_reasoning: bool | None = None
+    supports_json_mode: bool | None = None
 
-    def payload(self) -> dict[str, int]:
-        payload: dict[str, int] = {}
+    def __post_init__(self) -> None:
+        if self.max_input_tokens is not None or self.context_window is None:
+            return
+        if self.max_output_tokens is None:
+            object.__setattr__(self, "max_input_tokens", self.context_window)
+            return
+        object.__setattr__(
+            self,
+            "max_input_tokens",
+            max(1, self.context_window - self.max_output_tokens),
+        )
+
+    def payload(self) -> dict[str, int | bool]:
+        payload: dict[str, int | bool] = {}
         if self.context_window is not None:
             payload["context_window"] = self.context_window
+        if self.max_input_tokens is not None:
+            payload["max_input_tokens"] = self.max_input_tokens
         if self.max_output_tokens is not None:
             payload["max_output_tokens"] = self.max_output_tokens
+        if self.supports_tools is not None:
+            payload["supports_tools"] = self.supports_tools
+        if self.supports_vision is not None:
+            payload["supports_vision"] = self.supports_vision
+        if self.supports_streaming is not None:
+            payload["supports_streaming"] = self.supports_streaming
+        if self.supports_reasoning is not None:
+            payload["supports_reasoning"] = self.supports_reasoning
+        if self.supports_json_mode is not None:
+            payload["supports_json_mode"] = self.supports_json_mode
         return payload
 
 
@@ -168,76 +198,185 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
     if not model:
         return None
     if provider == "openai" or model.startswith(("gpt-5", "gpt-4.1", "gpt-4o", "o1", "o3", "o4")):
+        common_openai = {
+            "supports_tools": True,
+            "supports_vision": not model.startswith(("o1", "o3-mini")),
+            "supports_streaming": True,
+            "supports_reasoning": model.startswith(("gpt-5", "o1", "o3", "o4")),
+            "supports_json_mode": True,
+        }
         if model.startswith(("gpt-5.5", "gpt-5.4")) and not model.startswith(
             ("gpt-5.4-mini", "gpt-5.4-nano")
         ):
-            return ProviderModelMetadata(context_window=1_000_000, max_output_tokens=128_000)
+            return ProviderModelMetadata(
+                context_window=1_000_000, max_output_tokens=128_000, **common_openai
+            )
         if model.startswith(("gpt-5.4-mini", "gpt-5.4-nano")):
-            return ProviderModelMetadata(context_window=400_000, max_output_tokens=128_000)
+            return ProviderModelMetadata(
+                context_window=400_000, max_output_tokens=128_000, **common_openai
+            )
         if model.startswith("gpt-5"):
-            return ProviderModelMetadata(context_window=400_000, max_output_tokens=128_000)
+            return ProviderModelMetadata(
+                context_window=400_000, max_output_tokens=128_000, **common_openai
+            )
         if model.startswith("gpt-4o-mini"):
-            return ProviderModelMetadata(context_window=128_000, max_output_tokens=16_384)
+            return ProviderModelMetadata(
+                context_window=128_000, max_output_tokens=16_384, **common_openai
+            )
         if model.startswith("gpt-4o"):
-            return ProviderModelMetadata(context_window=128_000, max_output_tokens=16_384)
+            return ProviderModelMetadata(
+                context_window=128_000, max_output_tokens=16_384, **common_openai
+            )
         if model.startswith("gpt-4.1"):
-            return ProviderModelMetadata(context_window=1_047_576, max_output_tokens=32_768)
+            return ProviderModelMetadata(
+                context_window=1_047_576, max_output_tokens=32_768, **common_openai
+            )
         if model.startswith(("o1", "o3", "o4")):
-            return ProviderModelMetadata(context_window=200_000, max_output_tokens=100_000)
+            return ProviderModelMetadata(
+                context_window=200_000, max_output_tokens=100_000, **common_openai
+            )
     if provider == "anthropic" or model.startswith("claude-"):
+        common_anthropic = {
+            "supports_tools": True,
+            "supports_vision": "haiku" not in model,
+            "supports_streaming": True,
+            "supports_reasoning": model.startswith(("claude-opus-4", "claude-sonnet-4")),
+            "supports_json_mode": False,
+        }
         if model.startswith(("claude-opus-4-7", "claude-sonnet-4-6")):
-            return ProviderModelMetadata(context_window=1_000_000, max_output_tokens=64_000)
+            return ProviderModelMetadata(
+                context_window=1_000_000, max_output_tokens=64_000, **common_anthropic
+            )
         if model.startswith("claude-haiku-4-5"):
-            return ProviderModelMetadata(context_window=200_000, max_output_tokens=64_000)
-        return ProviderModelMetadata(context_window=200_000, max_output_tokens=8_192)
+            return ProviderModelMetadata(
+                context_window=200_000, max_output_tokens=64_000, **common_anthropic
+            )
+        return ProviderModelMetadata(
+            context_window=200_000, max_output_tokens=8_192, **common_anthropic
+        )
     if provider == "google" or model.startswith("gemini-"):
+        common_google = {
+            "supports_tools": True,
+            "supports_vision": True,
+            "supports_streaming": True,
+            "supports_reasoning": model.startswith(("gemini-2.5", "gemini-3")),
+            "supports_json_mode": True,
+        }
         if model.startswith(("gemini-3-pro-preview", "gemini-3-flash-preview")):
-            return ProviderModelMetadata(context_window=1_048_576, max_output_tokens=65_536)
+            return ProviderModelMetadata(
+                context_window=1_048_576, max_output_tokens=65_536, **common_google
+            )
         if model.startswith("gemini-3"):
-            return ProviderModelMetadata(context_window=1_000_000, max_output_tokens=65_536)
+            return ProviderModelMetadata(
+                context_window=1_000_000, max_output_tokens=65_536, **common_google
+            )
         if model.startswith("gemini-2.5"):
-            return ProviderModelMetadata(context_window=1_000_000, max_output_tokens=65_536)
-        return ProviderModelMetadata(context_window=1_000_000, max_output_tokens=8_192)
+            return ProviderModelMetadata(
+                context_window=1_000_000, max_output_tokens=65_536, **common_google
+            )
+        return ProviderModelMetadata(
+            context_window=1_000_000, max_output_tokens=8_192, **common_google
+        )
     if provider == "deepseek" or model.startswith("deepseek-"):
+        common_deepseek = {
+            "supports_tools": True,
+            "supports_vision": False,
+            "supports_streaming": True,
+            "supports_reasoning": "reasoner" in model or model.startswith("deepseek-v4"),
+            "supports_json_mode": True,
+        }
         if model.startswith("deepseek-v4"):
-            return ProviderModelMetadata(context_window=1_000_000, max_output_tokens=384_000)
+            return ProviderModelMetadata(
+                context_window=1_000_000, max_output_tokens=384_000, **common_deepseek
+            )
         if model in {"deepseek-chat", "deepseek-reasoner"}:
-            return ProviderModelMetadata(context_window=1_000_000, max_output_tokens=384_000)
+            return ProviderModelMetadata(
+                context_window=1_000_000, max_output_tokens=384_000, **common_deepseek
+            )
     if provider in {"qwen", "opencode-go"} or model.startswith(("qwen", "qwq", "qvq")):
+        common_qwen = {
+            "supports_tools": True,
+            "supports_vision": model.startswith(("qvq",)) or "vl" in model,
+            "supports_streaming": True,
+            "supports_reasoning": model.startswith(("qwq", "qvq", "qwen3")),
+            "supports_json_mode": True,
+        }
         if model.startswith(("qwen3.6-plus", "qwen3.6-flash", "qwen3.5-plus", "qwen3.5-flash")):
-            return ProviderModelMetadata(context_window=1_000_000, max_output_tokens=64_000)
+            return ProviderModelMetadata(
+                context_window=1_000_000, max_output_tokens=64_000, **common_qwen
+            )
         if model.startswith("qwen3.6-max-preview"):
-            return ProviderModelMetadata(context_window=256_000, max_output_tokens=64_000)
+            return ProviderModelMetadata(
+                context_window=256_000, max_output_tokens=64_000, **common_qwen
+            )
         if model.startswith("qwen3.5-"):
-            return ProviderModelMetadata(context_window=256_000, max_output_tokens=64_000)
+            return ProviderModelMetadata(
+                context_window=256_000, max_output_tokens=64_000, **common_qwen
+            )
         if model in {"qwen-plus-us", "qwen-flash-us"}:
-            return ProviderModelMetadata(context_window=1_000_000)
+            return ProviderModelMetadata(context_window=1_000_000, **common_qwen)
     if provider in {"glm", "opencode-go"} or model.startswith("glm-"):
+        common_glm = {
+            "supports_tools": True,
+            "supports_vision": model.startswith("glm-4v") or "vision" in model,
+            "supports_streaming": True,
+            "supports_reasoning": model.startswith(("glm-5", "glm-z1")),
+            "supports_json_mode": True,
+        }
         if model.startswith("glm-5.1"):
-            return ProviderModelMetadata(context_window=198_000, max_output_tokens=128_000)
+            return ProviderModelMetadata(
+                context_window=198_000, max_output_tokens=128_000, **common_glm
+            )
         if model.startswith("glm-5"):
-            return ProviderModelMetadata(context_window=200_000)
+            return ProviderModelMetadata(context_window=200_000, **common_glm)
     if provider in {"kimi", "opencode-go"} or model.startswith(("kimi-", "moonshot-")):
+        common_kimi = {
+            "supports_tools": True,
+            "supports_vision": False,
+            "supports_streaming": True,
+            "supports_reasoning": "thinking" in model,
+            "supports_json_mode": True,
+        }
         if model.startswith(("kimi-k2.6", "kimi-k2.5", "kimi-k2-0905")):
-            return ProviderModelMetadata(context_window=256_000, max_output_tokens=96_000)
+            return ProviderModelMetadata(
+                context_window=256_000, max_output_tokens=96_000, **common_kimi
+            )
         if model.startswith(("kimi-k2-thinking", "kimi-k2-turbo")):
-            return ProviderModelMetadata(context_window=256_000)
+            return ProviderModelMetadata(context_window=256_000, **common_kimi)
         if model.startswith("kimi-k2-0711"):
-            return ProviderModelMetadata(context_window=128_000)
+            return ProviderModelMetadata(context_window=128_000, **common_kimi)
         if model.startswith("moonshot-v1-128k"):
-            return ProviderModelMetadata(context_window=128_000)
+            return ProviderModelMetadata(context_window=128_000, **common_kimi)
         if model.startswith("moonshot-v1-32k"):
-            return ProviderModelMetadata(context_window=32_000)
+            return ProviderModelMetadata(context_window=32_000, **common_kimi)
         if model.startswith("moonshot-v1-8k"):
-            return ProviderModelMetadata(context_window=8_000)
+            return ProviderModelMetadata(context_window=8_000, **common_kimi)
     if provider in {"minimax", "opencode-go"} or model.startswith(("minimax-", "mimo-")):
+        common_minimax = {
+            "supports_tools": True,
+            "supports_vision": model.startswith("mimo-v2-omni"),
+            "supports_streaming": True,
+            "supports_reasoning": model.startswith(("minimax-m2", "mimo-v2.5")),
+            "supports_json_mode": True,
+        }
         if model.startswith("minimax-m2.5"):
-            return ProviderModelMetadata(context_window=192_000, max_output_tokens=32_000)
+            return ProviderModelMetadata(
+                context_window=192_000, max_output_tokens=32_000, **common_minimax
+            )
         if model.startswith("minimax-m2"):
-            return ProviderModelMetadata(context_window=204_800)
+            return ProviderModelMetadata(context_window=204_800, **common_minimax)
     if provider == "grok" or model.startswith("grok-"):
+        common_grok = {
+            "supports_tools": True,
+            "supports_vision": True,
+            "supports_streaming": True,
+            "supports_reasoning": "reasoning" in model or model.startswith("grok-4"),
+            "supports_json_mode": True,
+        }
         if model.startswith(("grok-4-1-fast", "grok-4-fast")):
-            return ProviderModelMetadata(context_window=2_000_000, max_output_tokens=30_000)
+            return ProviderModelMetadata(
+                context_window=2_000_000, max_output_tokens=30_000, **common_grok
+            )
     return None
 
 

--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -485,7 +485,13 @@ class ProviderSummary:
 @dataclass(frozen=True, slots=True)
 class ProviderModelMetadata:
     context_window: int | None = None
+    max_input_tokens: int | None = None
     max_output_tokens: int | None = None
+    supports_tools: bool | None = None
+    supports_vision: bool | None = None
+    supports_streaming: bool | None = None
+    supports_reasoning: bool | None = None
+    supports_json_mode: bool | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -498,6 +504,15 @@ class ProviderModelsResult:
     last_refresh_status: str | None = None
     last_error: str | None = None
     discovery_mode: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderInspectResult:
+    summary: ProviderSummary
+    models: ProviderModelsResult
+    validation: ProviderValidationResult
+    current_model: str | None = None
+    current_model_metadata: ProviderModelMetadata | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/voidcode/runtime/http.py
+++ b/src/voidcode/runtime/http.py
@@ -19,6 +19,7 @@ from .contracts import (
     CapabilityStatusSnapshot,
     GitStatusSnapshot,
     NoPendingQuestionError,
+    ProviderInspectResult,
     ProviderModelsResult,
     ProviderSummary,
     ProviderValidationResult,
@@ -89,6 +90,8 @@ class RuntimeTransport(Protocol):
     def list_provider_summaries(self) -> tuple[ProviderSummary, ...]: ...
 
     def provider_models_result(self, provider_name: str) -> ProviderModelsResult: ...
+
+    def inspect_provider(self, provider_name: str) -> ProviderInspectResult: ...
 
     def validate_provider_credentials(self, provider_name: str) -> ProviderValidationResult: ...
 
@@ -691,19 +694,22 @@ class RuntimeTransportApp:
         if path.startswith(provider_prefix):
             provider_path = path.removeprefix(provider_prefix)
             is_models_route = provider_path.endswith("/models")
+            is_inspect_route = provider_path.endswith("/inspect")
             is_validate_route = provider_path.endswith("/validate")
-            if not is_models_route and not is_validate_route:
+            if not is_models_route and not is_inspect_route and not is_validate_route:
                 await self._json_response(send, status=404, payload={"error": "not found"})
                 return
             provider_name = (
                 provider_path.removesuffix("/models")
                 if is_models_route
+                else provider_path.removesuffix("/inspect")
+                if is_inspect_route
                 else provider_path.removesuffix("/validate")
             )
             if not provider_name:
                 await self._json_response(send, status=404, payload={"error": "not found"})
                 return
-            expected_method = "GET" if is_models_route else "POST"
+            expected_method = "POST" if is_validate_route else "GET"
             if method != expected_method:
                 await self._json_response(
                     send,
@@ -713,6 +719,8 @@ class RuntimeTransportApp:
                 return
             if is_models_route:
                 await self._handle_provider_models(provider_name=provider_name, send=send)
+            elif is_inspect_route:
+                await self._handle_provider_inspect(provider_name=provider_name, send=send)
             else:
                 await self._handle_provider_validation(provider_name=provider_name, send=send)
             return
@@ -1121,6 +1129,21 @@ class RuntimeTransportApp:
         status = 200 if result.configured else 409
         await self._json_response(
             send, status=status, payload=self._serialize_provider_models_result(result)
+        )
+
+    async def _handle_provider_inspect(self, *, provider_name: str, send: Send) -> None:
+        with self._active_request_scope():
+            runtime = self._runtime_factory()
+            try:
+                result = runtime.inspect_provider(provider_name)
+            except ValueError as exc:
+                await self._json_response(send, status=400, payload={"error": str(exc)})
+                return
+            finally:
+                self._close_runtime(runtime, workspace_coordinator=self._workspace_coordinator)
+        status = 200 if result.summary.configured else 409
+        await self._json_response(
+            send, status=status, payload=self._serialize_provider_inspect_result(result)
         )
 
     async def _handle_provider_validation(self, *, provider_name: str, send: Send) -> None:
@@ -1710,7 +1733,13 @@ class RuntimeTransportApp:
                     key: value
                     for key, value in {
                         "context_window": metadata.context_window,
+                        "max_input_tokens": metadata.max_input_tokens,
                         "max_output_tokens": metadata.max_output_tokens,
+                        "supports_tools": metadata.supports_tools,
+                        "supports_vision": metadata.supports_vision,
+                        "supports_streaming": metadata.supports_streaming,
+                        "supports_reasoning": metadata.supports_reasoning,
+                        "supports_json_mode": metadata.supports_json_mode,
                     }.items()
                     if value is not None
                 }
@@ -1720,6 +1749,35 @@ class RuntimeTransportApp:
             "last_refresh_status": result.last_refresh_status,
             "last_error": result.last_error,
             "discovery_mode": result.discovery_mode,
+        }
+
+    @staticmethod
+    def _serialize_provider_inspect_result(result: ProviderInspectResult) -> dict[str, object]:
+        return {
+            "provider": RuntimeTransportApp._serialize_provider_summary(result.summary),
+            "models": RuntimeTransportApp._serialize_provider_models_result(result.models),
+            "validation": RuntimeTransportApp._serialize_provider_validation_result(
+                result.validation
+            ),
+            "current_model": result.current_model,
+            "current_model_metadata": (
+                None
+                if result.current_model_metadata is None
+                else {
+                    key: value
+                    for key, value in {
+                        "context_window": result.current_model_metadata.context_window,
+                        "max_input_tokens": result.current_model_metadata.max_input_tokens,
+                        "max_output_tokens": result.current_model_metadata.max_output_tokens,
+                        "supports_tools": result.current_model_metadata.supports_tools,
+                        "supports_vision": result.current_model_metadata.supports_vision,
+                        "supports_streaming": result.current_model_metadata.supports_streaming,
+                        "supports_reasoning": result.current_model_metadata.supports_reasoning,
+                        "supports_json_mode": result.current_model_metadata.supports_json_mode,
+                    }.items()
+                    if value is not None
+                }
+            ),
         }
 
     @staticmethod

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -2387,8 +2387,8 @@ class VoidCodeRuntime:
                 current=provider_name == self._current_provider_name(),
             ),
         )
-        models = self.provider_models_result(provider_name)
         validation = self.validate_provider_credentials(provider_name)
+        models = self.provider_models_result(provider_name)
         current_model = (
             self._provider_model.selection.model
             if self._provider_model.selection.provider == provider_name
@@ -2410,8 +2410,8 @@ class VoidCodeRuntime:
     def validate_provider_credentials(self, provider_name: str) -> ProviderValidationResult:
         if not provider_name or "/" in provider_name:
             raise ValueError("provider_name must be a non-empty provider id without '/'")
-        result = self.provider_models_result(provider_name)
-        if not result.configured:
+        if not self._provider_is_configured(provider_name):
+            result = self.provider_models_result(provider_name)
             return ProviderValidationResult(
                 provider=provider_name,
                 configured=False,
@@ -2422,6 +2422,8 @@ class VoidCodeRuntime:
                 last_error=result.last_error,
                 discovery_mode=result.discovery_mode,
             )
+        _ = self.refresh_provider_models(provider_name)
+        result = self.provider_models_result(provider_name)
         if result.last_refresh_status == "failed":
             return ProviderValidationResult(
                 provider=provider_name,

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -31,7 +31,13 @@ from ..hook.executor import (
 )
 from ..provider.auth import ProviderAuthResolver
 from ..provider.errors import format_invalid_provider_config_error
-from ..provider.model_catalog import infer_model_metadata
+from ..provider.model_catalog import (
+    ProviderModelCatalog,
+    infer_model_metadata,
+)
+from ..provider.model_catalog import (
+    ProviderModelMetadata as CatalogProviderModelMetadata,
+)
 from ..provider.models import (
     ResolvedProviderChain,
     ResolvedProviderConfig,
@@ -92,6 +98,7 @@ from .contracts import (
     BackgroundTaskResult,
     CapabilityStatusSnapshot,
     GitStatusSnapshot,
+    ProviderInspectResult,
     ProviderModelMetadata,
     ProviderModelsResult,
     ProviderSummary,
@@ -436,6 +443,7 @@ class VoidCodeRuntime:
             model_provider_registry
             or ModelProviderRegistry.with_defaults(provider_configs=self._config.providers)
         )
+        self._hydrate_provider_model_catalog_cache()
         initial_agent = self._config.agent
         if initial_agent is not None:
             initial_agent = parse_runtime_agent_payload(
@@ -521,9 +529,11 @@ class VoidCodeRuntime:
         self._plan_contributor = build_plan_contributor(self._workspace, self._config.plan)
         self._background_task_threads = {}
         self._background_tasks_reconciled = False
-        self._default_context_window_policy = self._context_window_policy_from_config(
-            initial_context_window,
-            resolved_provider=self._resolved_provider_config,
+        self._default_context_window_policy = self._context_window_policy_for_active_model(
+            self._context_window_policy_from_config(
+                initial_context_window,
+                resolved_provider=self._resolved_provider_config,
+            )
         )
         self._run_loop_coordinator = RuntimeRunLoopCoordinator(self)
         self._resume_coordinator = RuntimeResumeCoordinator(self)
@@ -2077,7 +2087,9 @@ class VoidCodeRuntime:
         if not provider_name or "/" in provider_name:
             raise ValueError("provider_name must be a non-empty provider id without '/'")
         _ = self._model_provider_registry.resolve(provider_name)
-        return self._model_provider_registry.refresh_available_models(provider_name)
+        models = self._model_provider_registry.refresh_available_models(provider_name)
+        self._persist_provider_model_catalog_cache()
+        return models
 
     def provider_models(self, provider_name: str) -> tuple[str, ...]:
         if not provider_name or "/" in provider_name:
@@ -2102,6 +2114,196 @@ class VoidCodeRuntime:
             "last_error": catalog.last_error,
             "discovery_mode": catalog.discovery_mode,
         }
+
+    def _provider_model_catalog_cache_path(self) -> Path:
+        return self._workspace / ".voidcode" / "provider-model-catalog.json"
+
+    def _hydrate_provider_model_catalog_cache(self) -> None:
+        catalog = self._model_provider_registry.model_catalog
+        if catalog is None or catalog:
+            return
+        cache_path = self._provider_model_catalog_cache_path()
+        try:
+            raw_payload = json.loads(cache_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            return
+        if not isinstance(raw_payload, dict):
+            return
+        payload = cast(dict[str, object], raw_payload)
+        raw_providers = payload.get("providers")
+        if not isinstance(raw_providers, dict):
+            return
+
+        hydrated: dict[str, ProviderModelCatalog] = {}
+        for provider_name, raw_catalog in cast(dict[object, object], raw_providers).items():
+            if not isinstance(provider_name, str) or not provider_name or "/" in provider_name:
+                continue
+            if not isinstance(raw_catalog, dict):
+                continue
+            catalog_payload = cast(dict[str, object], raw_catalog)
+            raw_models = catalog_payload.get("models", [])
+            if not isinstance(raw_models, list):
+                continue
+            models = tuple(
+                raw_model
+                for raw_model in cast(list[object], raw_models)
+                if isinstance(raw_model, str) and raw_model
+            )
+            raw_metadata = catalog_payload.get("model_metadata", {})
+            metadata_payloads: dict[object, object] = (
+                cast(dict[object, object], raw_metadata) if isinstance(raw_metadata, dict) else {}
+            )
+            model_metadata = {
+                model: CatalogProviderModelMetadata(
+                    context_window=VoidCodeRuntime._optional_positive_int(
+                        payload.get("context_window")
+                    ),
+                    max_input_tokens=VoidCodeRuntime._optional_positive_int(
+                        payload.get("max_input_tokens")
+                    ),
+                    max_output_tokens=VoidCodeRuntime._optional_positive_int(
+                        payload.get("max_output_tokens")
+                    ),
+                    supports_tools=VoidCodeRuntime._optional_bool(payload.get("supports_tools")),
+                    supports_vision=VoidCodeRuntime._optional_bool(payload.get("supports_vision")),
+                    supports_streaming=VoidCodeRuntime._optional_bool(
+                        payload.get("supports_streaming")
+                    ),
+                    supports_reasoning=VoidCodeRuntime._optional_bool(
+                        payload.get("supports_reasoning")
+                    ),
+                    supports_json_mode=VoidCodeRuntime._optional_bool(
+                        payload.get("supports_json_mode")
+                    ),
+                )
+                for model, raw_payload in metadata_payloads.items()
+                if isinstance(model, str) and isinstance(raw_payload, dict)
+                for payload in (cast(dict[str, object], raw_payload),)
+            }
+            raw_source = catalog_payload.get("source")
+            source = raw_source if isinstance(raw_source, str) else "remote"
+            raw_status = catalog_payload.get("last_refresh_status")
+            last_refresh_status = raw_status if isinstance(raw_status, str) else "ok"
+            raw_discovery_mode = catalog_payload.get("discovery_mode")
+            discovery_mode = (
+                cast(
+                    Literal[
+                        "configured_endpoint",
+                        "configured_base_url",
+                        "disabled",
+                        "unavailable",
+                    ],
+                    raw_discovery_mode,
+                )
+                if raw_discovery_mode
+                in {"configured_endpoint", "configured_base_url", "disabled", "unavailable"}
+                else "unavailable"
+            )
+            hydrated[provider_name] = ProviderModelCatalog(
+                provider=provider_name,
+                models=models,
+                refreshed=bool(catalog_payload.get("refreshed", False)),
+                model_metadata=model_metadata,
+                source=source,
+                last_refresh_status=last_refresh_status,
+                last_error=(
+                    cast(str, catalog_payload["last_error"])
+                    if isinstance(catalog_payload.get("last_error"), str)
+                    else None
+                ),
+                discovery_mode=discovery_mode,
+            )
+        catalog.update(hydrated)
+
+    def _persist_provider_model_catalog_cache(self) -> None:
+        catalog = self._model_provider_registry.model_catalog
+        if catalog is None:
+            return
+        cache_path = self._provider_model_catalog_cache_path()
+        payload = {
+            "version": 1,
+            "providers": {
+                provider_name: {
+                    "provider": entry.provider,
+                    "models": list(entry.models),
+                    "model_metadata": {
+                        model: metadata.payload()
+                        for model, metadata in entry.model_metadata.items()
+                    },
+                    "refreshed": entry.refreshed,
+                    "source": entry.source,
+                    "last_refresh_status": entry.last_refresh_status,
+                    "last_error": entry.last_error,
+                    "discovery_mode": entry.discovery_mode,
+                }
+                for provider_name, entry in sorted(catalog.items())
+            },
+        }
+        try:
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            cache_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+        except OSError:
+            logger.debug("failed to persist provider model catalog cache", exc_info=True)
+
+    def _metadata_for_provider_model(
+        self, provider_name: str, model_name: str
+    ) -> ProviderModelMetadata | None:
+        catalog = self.provider_model_catalog(provider_name)
+        raw_metadata = None if catalog is None else catalog.get("model_metadata")
+        if isinstance(raw_metadata, dict):
+            metadata_payloads = cast(dict[str, object], raw_metadata)
+            raw_payload = metadata_payloads.get(model_name)
+            if isinstance(raw_payload, dict):
+                payload = cast(dict[str, object], raw_payload)
+                return ProviderModelMetadata(
+                    context_window=VoidCodeRuntime._optional_positive_int(
+                        payload.get("context_window")
+                    ),
+                    max_input_tokens=VoidCodeRuntime._optional_positive_int(
+                        payload.get("max_input_tokens")
+                    ),
+                    max_output_tokens=VoidCodeRuntime._optional_positive_int(
+                        payload.get("max_output_tokens")
+                    ),
+                    supports_tools=VoidCodeRuntime._optional_bool(payload.get("supports_tools")),
+                    supports_vision=VoidCodeRuntime._optional_bool(payload.get("supports_vision")),
+                    supports_streaming=VoidCodeRuntime._optional_bool(
+                        payload.get("supports_streaming")
+                    ),
+                    supports_reasoning=VoidCodeRuntime._optional_bool(
+                        payload.get("supports_reasoning")
+                    ),
+                    supports_json_mode=VoidCodeRuntime._optional_bool(
+                        payload.get("supports_json_mode")
+                    ),
+                )
+        inferred = infer_model_metadata(provider_name, model_name)
+        if inferred is None:
+            return None
+        return ProviderModelMetadata(
+            context_window=inferred.context_window,
+            max_input_tokens=inferred.max_input_tokens,
+            max_output_tokens=inferred.max_output_tokens,
+            supports_tools=inferred.supports_tools,
+            supports_vision=inferred.supports_vision,
+            supports_streaming=inferred.supports_streaming,
+            supports_reasoning=inferred.supports_reasoning,
+            supports_json_mode=inferred.supports_json_mode,
+        )
+
+    def _context_window_policy_for_active_model(
+        self, policy: ContextWindowPolicy
+    ) -> ContextWindowPolicy:
+        if policy.model_context_window_tokens is not None:
+            return policy
+        provider_name = self._provider_model.selection.provider
+        model_name = self._provider_model.selection.model
+        if provider_name is None or model_name is None:
+            return policy
+        metadata = self._metadata_for_provider_model(provider_name, model_name)
+        if metadata is None or metadata.context_window is None:
+            return policy
+        return replace(policy, model_context_window_tokens=metadata.context_window)
 
     def list_provider_summaries(self) -> tuple[ProviderSummary, ...]:
         current_provider = self._current_provider_name()
@@ -2139,8 +2341,22 @@ class VoidCodeRuntime:
                     context_window=VoidCodeRuntime._optional_positive_int(
                         payload.get("context_window")
                     ),
+                    max_input_tokens=VoidCodeRuntime._optional_positive_int(
+                        payload.get("max_input_tokens")
+                    ),
                     max_output_tokens=VoidCodeRuntime._optional_positive_int(
                         payload.get("max_output_tokens")
+                    ),
+                    supports_tools=VoidCodeRuntime._optional_bool(payload.get("supports_tools")),
+                    supports_vision=VoidCodeRuntime._optional_bool(payload.get("supports_vision")),
+                    supports_streaming=VoidCodeRuntime._optional_bool(
+                        payload.get("supports_streaming")
+                    ),
+                    supports_reasoning=VoidCodeRuntime._optional_bool(
+                        payload.get("supports_reasoning")
+                    ),
+                    supports_json_mode=VoidCodeRuntime._optional_bool(
+                        payload.get("supports_json_mode")
                     ),
                 )
                 for model, raw_payload in cast(
@@ -2153,6 +2369,42 @@ class VoidCodeRuntime:
             last_refresh_status=cast(str | None, catalog["last_refresh_status"]),
             last_error=cast(str | None, catalog["last_error"]),
             discovery_mode=cast(str | None, catalog["discovery_mode"]),
+        )
+
+    def inspect_provider(self, provider_name: str) -> ProviderInspectResult:
+        if not provider_name or "/" in provider_name:
+            raise ValueError("provider_name must be a non-empty provider id without '/'")
+        summary = next(
+            (
+                provider
+                for provider in self.list_provider_summaries()
+                if provider.name == provider_name
+            ),
+            ProviderSummary(
+                name=provider_name,
+                label=self._provider_label(provider_name),
+                configured=self._provider_is_configured(provider_name),
+                current=provider_name == self._current_provider_name(),
+            ),
+        )
+        models = self.provider_models_result(provider_name)
+        validation = self.validate_provider_credentials(provider_name)
+        current_model = (
+            self._provider_model.selection.model
+            if self._provider_model.selection.provider == provider_name
+            else None
+        )
+        current_metadata = (
+            self._metadata_for_provider_model(provider_name, current_model)
+            if current_model is not None
+            else None
+        )
+        return ProviderInspectResult(
+            summary=summary,
+            models=models,
+            validation=validation,
+            current_model=current_model,
+            current_model_metadata=current_metadata,
         )
 
     def validate_provider_credentials(self, provider_name: str) -> ProviderValidationResult:
@@ -2204,6 +2456,10 @@ class VoidCodeRuntime:
         if isinstance(value, bool) or not isinstance(value, int):
             return None
         return value if value > 0 else None
+
+    @staticmethod
+    def _optional_bool(value: object) -> bool | None:
+        return value if isinstance(value, bool) else None
 
     def list_agent_summaries(self) -> tuple[AgentSummary, ...]:
         summaries: list[AgentSummary] = []

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -529,11 +529,9 @@ class VoidCodeRuntime:
         self._plan_contributor = build_plan_contributor(self._workspace, self._config.plan)
         self._background_task_threads = {}
         self._background_tasks_reconciled = False
-        self._default_context_window_policy = self._context_window_policy_for_active_model(
-            self._context_window_policy_from_config(
-                initial_context_window,
-                resolved_provider=self._resolved_provider_config,
-            )
+        self._default_context_window_policy = self._context_window_policy_from_config(
+            initial_context_window,
+            resolved_provider=None,
         )
         self._run_loop_coordinator = RuntimeRunLoopCoordinator(self)
         self._resume_coordinator = RuntimeResumeCoordinator(self)
@@ -2291,13 +2289,22 @@ class VoidCodeRuntime:
             supports_json_mode=inferred.supports_json_mode,
         )
 
-    def _context_window_policy_for_active_model(
-        self, policy: ContextWindowPolicy
+    def _context_window_policy_for_provider_attempt(
+        self,
+        policy: ContextWindowPolicy,
+        *,
+        resolved_provider: ResolvedProviderConfig | None,
+        provider_attempt: int,
     ) -> ContextWindowPolicy:
         if policy.model_context_window_tokens is not None:
             return policy
-        provider_name = self._provider_model.selection.provider
-        model_name = self._provider_model.selection.model
+        if resolved_provider is None:
+            return policy
+        provider_target = resolved_provider.target_chain.target_at(provider_attempt)
+        if provider_target is None:
+            provider_target = resolved_provider.active_target
+        provider_name = provider_target.selection.provider
+        model_name = provider_target.selection.model
         if provider_name is None or model_name is None:
             return policy
         metadata = self._metadata_for_provider_model(provider_name, model_name)
@@ -4025,14 +4032,19 @@ class VoidCodeRuntime:
         session_metadata: dict[str, object],
         policy: ContextWindowPolicy | None = None,
     ) -> RuntimeContextWindow:
+        effective_config = self._effective_runtime_config_from_metadata(session_metadata)
+        provider_attempt = self._provider_attempt_from_metadata(session_metadata)
         if policy is None:
-            effective_config = self._effective_runtime_config_from_metadata(session_metadata)
-            provider_attempt = self._provider_attempt_from_metadata(session_metadata)
             policy = self._context_window_policy_from_config(
                 effective_config.context_window,
-                resolved_provider=effective_config.resolved_provider,
+                resolved_provider=None,
                 provider_attempt=provider_attempt,
             )
+        policy = self._context_window_policy_for_provider_attempt(
+            policy,
+            resolved_provider=effective_config.resolved_provider,
+            provider_attempt=provider_attempt,
+        )
         return prepare_provider_context(
             prompt=prompt,
             tool_results=tool_results,

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -526,6 +526,42 @@ def test_transport_reports_configured_opencode_go_validation_unavailable(
     }
 
 
+def test_transport_provider_inspect_exposes_model_capabilities(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "global-config"))
+    create_runtime_app = _load_transport_app_factory()
+    app = create_runtime_app(workspace=tmp_path)
+
+    _ = _run_app(
+        app,
+        method="POST",
+        path="/api/settings",
+        body=json.dumps(
+            {
+                "provider": "opencode-go",
+                "provider_api_key": "secret-key",
+                "model": "opencode-go/glm-5.1",
+            }
+        ).encode("utf-8"),
+    )
+    response = _run_app(app, method="GET", path="/api/providers/opencode-go/inspect")
+    payload = cast(dict[str, object], response.json())
+
+    assert response.status == 200
+    provider = cast(dict[str, object], payload["provider"])
+    models = cast(dict[str, object], payload["models"])
+    model_metadata = cast(dict[str, object], models["model_metadata"])
+    glm_metadata = cast(dict[str, object], model_metadata["glm-5.1"])
+    current_metadata = cast(dict[str, object], payload["current_model_metadata"])
+    assert provider["configured"] is True
+    assert payload["current_model"] == "glm-5.1"
+    assert glm_metadata["context_window"] == 198_000
+    assert glm_metadata["max_input_tokens"] == 70_000
+    assert glm_metadata["supports_tools"] is True
+    assert current_metadata["supports_reasoning"] is True
+
+
 def test_transport_lists_only_explicit_provider_configs_as_configured(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -1360,14 +1360,24 @@ def test_provider_models_command_outputs_refreshed_provider_model_list() -> None
         workspace = Path(tmp)
         with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
             runtime_class.return_value.refresh_provider_models.return_value = models
-            runtime_class.return_value.provider_model_catalog.return_value = {
-                "provider": "litellm",
-                "models": list(models),
-                "refreshed": True,
-                "source": "remote",
-                "last_refresh_status": "ok",
-                "last_error": None,
-            }
+            contracts = importlib.import_module("voidcode.runtime.contracts")
+            runtime_class.return_value.provider_models_result.return_value = (
+                contracts.ProviderModelsResult(
+                    provider="litellm",
+                    configured=True,
+                    models=models,
+                    model_metadata={
+                        "provider/model": contracts.ProviderModelMetadata(
+                            context_window=128_000,
+                            max_input_tokens=111_616,
+                            max_output_tokens=16_384,
+                            supports_tools=True,
+                        )
+                    },
+                    source="remote",
+                    last_refresh_status="ok",
+                )
+            )
             result = cli.main(
                 [
                     "provider",
@@ -1382,4 +1392,72 @@ def test_provider_models_command_outputs_refreshed_provider_model_list() -> None
     assert result == 0
     runtime_class.assert_called_once_with(workspace=workspace)
     runtime_class.return_value.refresh_provider_models.assert_called_once_with("litellm")
-    runtime_class.return_value.provider_model_catalog.assert_called_once_with("litellm")
+    runtime_class.return_value.provider_models_result.assert_called_once_with("litellm")
+
+
+def test_provider_inspect_command_outputs_provider_capabilities() -> None:
+    cli = importlib.import_module("voidcode.cli")
+    contracts = importlib.import_module("voidcode.runtime.contracts")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        inspect_result = contracts.ProviderInspectResult(
+            summary=contracts.ProviderSummary(
+                name="openai", label="OpenAI", configured=True, current=True
+            ),
+            models=contracts.ProviderModelsResult(
+                provider="openai",
+                configured=True,
+                models=("gpt-4o",),
+                model_metadata={
+                    "gpt-4o": contracts.ProviderModelMetadata(
+                        context_window=128_000,
+                        max_input_tokens=111_616,
+                        max_output_tokens=16_384,
+                        supports_tools=True,
+                        supports_vision=True,
+                    )
+                },
+                source="remote",
+                last_refresh_status="ok",
+                discovery_mode="configured_endpoint",
+            ),
+            validation=contracts.ProviderValidationResult(
+                provider="openai",
+                configured=True,
+                ok=True,
+                status="ok",
+                message="Remote provider validation succeeded.",
+                source="remote",
+                discovery_mode="configured_endpoint",
+            ),
+            current_model="gpt-4o",
+            current_model_metadata=contracts.ProviderModelMetadata(
+                context_window=128_000,
+                max_input_tokens=111_616,
+                max_output_tokens=16_384,
+                supports_tools=True,
+                supports_vision=True,
+            ),
+        )
+        with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
+            runtime_class.return_value.inspect_provider.return_value = inspect_result
+            with patch.object(cli, "print") as print_fn:
+                result = cli.main(
+                    [
+                        "provider",
+                        "inspect",
+                        "openai",
+                        "--workspace",
+                        str(workspace),
+                    ]
+                )
+
+    assert result == 0
+    runtime_class.assert_called_once_with(workspace=workspace)
+    runtime_class.return_value.inspect_provider.assert_called_once_with("openai")
+    payload = json.loads(print_fn.call_args.args[0])
+    assert payload["provider"]["name"] == "openai"
+    assert payload["current_model"] == "gpt-4o"
+    assert payload["current_model_metadata"]["max_input_tokens"] == 111_616
+    assert payload["current_model_metadata"]["supports_tools"] is True

--- a/tests/unit/provider/test_model_catalog.py
+++ b/tests/unit/provider/test_model_catalog.py
@@ -72,10 +72,12 @@ def test_discover_available_models_includes_known_model_budget_metadata() -> Non
         fetcher=lambda _request: ("gpt-4o", "unknown-model"),
     )
 
-    assert result.model_metadata["gpt-4o"] == ProviderModelMetadata(
-        context_window=128_000,
-        max_output_tokens=16_384,
-    )
+    metadata = result.model_metadata["gpt-4o"]
+    assert metadata.context_window == 128_000
+    assert metadata.max_input_tokens == 111_616
+    assert metadata.max_output_tokens == 16_384
+    assert metadata.supports_tools is True
+    assert metadata.supports_vision is True
     assert "unknown-model" not in result.model_metadata
 
 
@@ -99,10 +101,50 @@ def test_infer_model_metadata_covers_current_frontier_provider_models(
     context_window: int,
     max_output_tokens: int,
 ) -> None:
-    assert infer_model_metadata(provider, model) == ProviderModelMetadata(
+    metadata = infer_model_metadata(provider, model)
+    assert metadata is not None
+    assert metadata == ProviderModelMetadata(
         context_window=context_window,
         max_output_tokens=max_output_tokens,
+        supports_tools=metadata.supports_tools,
+        supports_vision=metadata.supports_vision,
+        supports_streaming=metadata.supports_streaming,
+        supports_reasoning=metadata.supports_reasoning,
+        supports_json_mode=metadata.supports_json_mode,
     )
+
+
+def test_infer_model_metadata_exposes_model_capability_flags() -> None:
+    metadata = infer_model_metadata("anthropic", "claude-sonnet-4-6")
+
+    assert metadata == ProviderModelMetadata(
+        context_window=1_000_000,
+        max_output_tokens=64_000,
+        supports_tools=True,
+        supports_vision=True,
+        supports_streaming=True,
+        supports_reasoning=True,
+        supports_json_mode=False,
+    )
+
+
+def test_provider_model_metadata_payload_includes_limits_and_capabilities() -> None:
+    payload = ProviderModelMetadata(
+        context_window=128_000,
+        max_output_tokens=16_384,
+        supports_tools=True,
+        supports_vision=False,
+        supports_streaming=True,
+    ).payload()
+
+    assert payload == {
+        "context_window": 128_000,
+        "max_input_tokens": 111_616,
+        "max_output_tokens": 16_384,
+        "supports_tools": True,
+        "supports_vision": False,
+        "supports_streaming": True,
+    }
 
 
 def test_infer_model_metadata_returns_none_for_unknown_models() -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -10358,6 +10358,52 @@ def test_runtime_persists_provider_model_catalog_cache(tmp_path: Path) -> None:
     assert result.model_metadata["gpt-4o"].max_input_tokens == 111_616
 
 
+def test_runtime_provider_validation_refreshes_past_persisted_catalog_cache(
+    tmp_path: Path,
+) -> None:
+    cache_dir = tmp_path / ".voidcode"
+    cache_dir.mkdir()
+    (cache_dir / "provider-model-catalog.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {
+                    "litellm": {
+                        "provider": "litellm",
+                        "models": ["stale"],
+                        "model_metadata": {},
+                        "refreshed": True,
+                        "source": "fallback",
+                        "last_refresh_status": "failed",
+                        "last_error": "stale credential failure",
+                        "discovery_mode": "configured_endpoint",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    config = RuntimeConfig(
+        providers=RuntimeProvidersConfig(
+            litellm=LiteLLMProviderConfig(
+                discovery_base_url="",
+                auth_scheme="none",
+                model_map={"alias": "gpt-4o"},
+            )
+        )
+    )
+    runtime = VoidCodeRuntime(workspace=tmp_path, config=config)
+
+    validation = runtime.validate_provider_credentials("litellm")
+    inspect = runtime.inspect_provider("litellm")
+
+    assert validation.status == "skipped"
+    assert validation.last_error == "provider model discovery disabled by config"
+    assert inspect.models.models == ("alias", "gpt-4o")
+    assert inspect.models.last_refresh_status == "skipped"
+    assert inspect.models.last_error == "provider model discovery disabled by config"
+
+
 def test_runtime_provider_models_result_exposes_capability_metadata(tmp_path: Path) -> None:
     registry = ModelProviderRegistry.with_defaults()
     registry.model_catalog = {

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -26,6 +26,7 @@ from voidcode.provider.config import (
     CopilotProviderConfig,
     LiteLLMProviderConfig,
 )
+from voidcode.provider.model_catalog import ProviderModelCatalog, ProviderModelMetadata
 from voidcode.provider.registry import ModelProviderRegistry
 from voidcode.runtime.acp import (
     AcpAdapterState,
@@ -10332,6 +10333,95 @@ def test_runtime_refresh_provider_models_returns_catalog_with_model_map_fallback
     assert models[0] == "alias"
     assert "openrouter/openai/gpt-4o" in models
     assert runtime.provider_models("litellm") == models
+
+
+def test_runtime_persists_provider_model_catalog_cache(tmp_path: Path) -> None:
+    config = RuntimeConfig(
+        providers=RuntimeProvidersConfig(
+            litellm=LiteLLMProviderConfig(
+                discovery_base_url="",
+                auth_scheme="none",
+                model_map={"alias": "gpt-4o"},
+            )
+        )
+    )
+    first_runtime = VoidCodeRuntime(workspace=tmp_path, config=config)
+
+    models = first_runtime.refresh_provider_models("litellm")
+    second_runtime = VoidCodeRuntime(workspace=tmp_path, config=config)
+    result = second_runtime.provider_models_result("litellm")
+
+    assert (tmp_path / ".voidcode" / "provider-model-catalog.json").is_file()
+    assert result.models == models
+    assert result.source == "fallback"
+    assert result.last_refresh_status == "skipped"
+    assert result.model_metadata["gpt-4o"].max_input_tokens == 111_616
+
+
+def test_runtime_provider_models_result_exposes_capability_metadata(tmp_path: Path) -> None:
+    registry = ModelProviderRegistry.with_defaults()
+    registry.model_catalog = {
+        "openai": ProviderModelCatalog(
+            provider="openai",
+            models=("gpt-4o",),
+            refreshed=True,
+            model_metadata={
+                "gpt-4o": ProviderModelMetadata(
+                    context_window=128_000,
+                    max_output_tokens=16_384,
+                    supports_tools=True,
+                    supports_vision=True,
+                    supports_streaming=True,
+                    supports_reasoning=False,
+                    supports_json_mode=True,
+                )
+            },
+        )
+    }
+    runtime = VoidCodeRuntime(workspace=tmp_path, model_provider_registry=registry)
+
+    result = runtime.provider_models_result("openai")
+
+    assert result.model_metadata["gpt-4o"].context_window == 128_000
+    assert result.model_metadata["gpt-4o"].max_input_tokens == 111_616
+    assert result.model_metadata["gpt-4o"].supports_tools is True
+    assert result.model_metadata["gpt-4o"].supports_vision is True
+    assert result.model_metadata["gpt-4o"].supports_json_mode is True
+
+
+def test_runtime_inspect_provider_combines_status_models_and_validation(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(model="openai/gpt-4o"),
+    )
+
+    result = runtime.inspect_provider("openai")
+
+    assert result.summary.name == "openai"
+    assert result.summary.current is True
+    assert result.models.configured is False
+    assert result.validation.status == "unconfigured"
+    assert result.current_model == "gpt-4o"
+    assert result.current_model_metadata is not None
+    assert result.current_model_metadata.context_window == 128_000
+    assert result.current_model_metadata.max_input_tokens == 111_616
+    assert result.current_model_metadata.supports_tools is True
+
+
+def test_runtime_context_window_policy_uses_active_model_limit(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(model="openai/gpt-4o"),
+        context_window_policy=ContextWindowPolicy(max_context_ratio=0.01),
+    )
+
+    context = runtime._prepare_provider_context_window(
+        prompt="read sample.txt",
+        tool_results=(),
+        session_metadata={},
+    )
+
+    assert context.token_budget == 1_280
 
 
 def test_runtime_rejects_malformed_model_reference_during_initialization(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -6783,6 +6783,32 @@ def test_runtime_context_window_policy_uses_fallback_attempt_model_metadata(
     assert context_window.token_budget == 4_000
 
 
+def test_runtime_context_window_policy_recomputes_default_for_fallback_attempt(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            provider_fallback=RuntimeProviderFallbackConfig(
+                preferred_model="opencode/gpt-5.4",
+                fallback_models=("kimi/moonshot-v1-8k",),
+            ),
+            context_window=RuntimeContextWindowConfig(max_context_ratio=0.5),
+        ),
+    )
+
+    context_window = runtime._prepare_provider_context_window(  # pyright: ignore[reportPrivateUsage]
+        prompt="read sample.txt",
+        tool_results=(),
+        session_metadata={"provider_attempt": 1},
+        policy=runtime._default_context_window_policy,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    assert context_window.token_budget == 4_000
+
+
 def test_runtime_provider_fallback_seam_returns_next_graph_selection(tmp_path: Path) -> None:
     created_providers: list[_ScriptedTurnProvider] = []
     registry = ModelProviderRegistry(


### PR DESCRIPTION
## Summary
- Adds provider/model capability metadata with context/input/output limits and feature flags.
- Persists refreshed provider model catalogs under workspace `.voidcode/` and reuses them across runtime instances.
- Exposes capabilities via CLI `provider models`, new CLI `provider inspect`, and HTTP `GET /api/providers/{provider}/inspect` without leaking secrets.

Closes #255.

## Verification
- `uv run ruff check .`
- `uv run basedpyright --warnings src`
- `uv run pytest` (`1383 passed`)
- `bun run lint && bun run typecheck && bun run test:run` (`85 passed`)

## Notes
- `mise run check` was not used because the new worktree's `mise.toml` was blocked by mise trust; equivalent backend/frontend commands above passed directly.