### PR TITLE
feat(cli): add schema-backed config workflow

### DIFF
--- a/docs/contracts/runtime-config.md
+++ b/docs/contracts/runtime-config.md
@@ -30,6 +30,7 @@
 - hooks 继续保持 runtime-owned，但当前已不再只限 `pre_tool` / `post_tool`，而是同时包含 `session_start`、`session_end`、`session_idle`、`background_task_completed`、`background_task_failed`、`background_task_cancelled` 与 `delegated_result_available` 等已解析的 lifecycle hook phases
 - 显式 / 仓库本地 / 环境 / 默认值这条完整优先级链当前适用于 `approval_mode`、`model`、`execution_engine` 和 `max_steps`
 - 单一可见检查面为 CLI：`voidcode config show --workspace <path> [--session <id>]`
+- 当前 schema-backed 配置 UX 还包含 `voidcode config schema`、`voidcode config init` 与 `voidcode config migrate`
 - 恢复会话的配置覆盖仍存放在 `SessionState.metadata["runtime_config"]`，并继续覆盖新的 runtime 默认值
 
 ## MVP 配置领域
@@ -350,9 +351,12 @@ workspace 本地覆盖路径保持为：
 
 ```bash
 voidcode config show --workspace <path> [--session <id>]
+voidcode config schema
+voidcode config init --workspace <path> [--force] [--print] [--with-examples]
+voidcode config migrate --workspace <path> [--write]
 ```
 
-成功输出必须是 JSON，且当前至少包含：
+`config show` 成功输出必须是 JSON，且当前至少包含：
 
 - `workspace`
 - `session_id`
@@ -362,6 +366,24 @@ voidcode config show --workspace <path> [--session <id>]
 - `max_steps`
 - `provider_fallback`
 - `resolved_provider`
+
+`config schema` 成功输出必须是 JSON Schema 文档，用于描述仓库本地 `.voidcode.json` 的当前公共形状。schema 的稳定 `$id` 为：
+
+```text
+https://voidcode.dev/schemas/runtime-config.schema.json
+```
+
+`config init` 生成不含 secrets 的 starter workspace 配置。默认写入 `<workspace>/.voidcode.json`，并在文件已存在时失败；`--force` 显式覆盖，`--print` 只输出 JSON 而不写入文件，`--with-examples` 会加入最小 `tools` / `skills` 示例块。生成配置默认包含 `$schema` 与 `approval_mode: "ask"`，不会生成 `providers` 或任何 `api_key` / token 字段。
+
+`config migrate` 默认 dry-run，读取 `<workspace>/.voidcode.json` 后输出 JSON：
+
+- `workspace`
+- `config_path`
+- `dry_run`
+- `migrations`
+- `updated_config`
+
+当存在已知重命名或废弃字段时，`updated_config` 表示迁移后的配置；只有传入 `--write` 才会写回磁盘。当前已知迁移为移除已废弃的 `agent.leader_mode`，并提示使用默认 leader execution flow。
 
 失败契约锁定为：
 

--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -19,7 +19,21 @@ from .doctor import (
     format_report_json,
 )
 from .provider.snapshot import resolved_provider_snapshot
-from .runtime.config import RuntimeConfig, load_runtime_config, serialize_provider_fallback_config
+from .runtime.config import (
+    RUNTIME_CONFIG_FILE_NAME,
+    RuntimeConfig,
+    load_runtime_config,
+    serialize_provider_fallback_config,
+)
+from .runtime.config_schema import (
+    apply_config_migrations,
+    detect_config_migrations,
+    format_starter_runtime_config_json,
+    generate_starter_runtime_config,
+    read_runtime_config_payload,
+    runtime_config_json_schema,
+    write_runtime_config_payload,
+)
 from .runtime.contracts import (
     BackgroundTaskResult,
     ProviderInspectResult,
@@ -572,6 +586,83 @@ def _handle_config_show_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def _handle_config_schema_command(args: argparse.Namespace) -> int:
+    _ = args
+    print(json.dumps(runtime_config_json_schema(), indent=2, sort_keys=True))
+    return 0
+
+
+def _handle_config_init_command(args: argparse.Namespace) -> int:
+    workspace = cast(Path, args.workspace)
+    if not workspace.exists() or not workspace.is_dir():
+        raise SystemExit(f"error: workspace does not exist: {workspace}")
+
+    payload = generate_starter_runtime_config(
+        approval_mode=cast(str, args.approval_mode),
+        execution_engine=cast(str | None, getattr(args, "execution_engine", None)),
+        max_steps=cast(int | None, getattr(args, "max_steps", None)),
+        include_examples=cast(bool, args.with_examples),
+    )
+    if cast(bool, args.print):
+        print(format_starter_runtime_config_json(payload), end="")
+        return 0
+
+    config_path = workspace.resolve() / RUNTIME_CONFIG_FILE_NAME
+    if config_path.exists() and not cast(bool, args.force):
+        raise SystemExit(
+            f"error: runtime config already exists: {config_path}; pass --force to overwrite"
+        )
+    written_path = write_runtime_config_payload(workspace, payload)
+    print(json.dumps({"workspace": str(workspace), "config_path": str(written_path)}))
+    return 0
+
+
+def _handle_config_migrate_command(args: argparse.Namespace) -> int:
+    workspace = cast(Path, args.workspace)
+    if not workspace.exists() or not workspace.is_dir():
+        raise SystemExit(f"error: workspace does not exist: {workspace}")
+
+    try:
+        payload = read_runtime_config_payload(workspace)
+    except ValueError as exc:
+        raise SystemExit(f"error: {exc}") from None
+
+    config_path = workspace.resolve() / RUNTIME_CONFIG_FILE_NAME
+    if payload is None:
+        print(
+            json.dumps(
+                {
+                    "workspace": str(workspace),
+                    "config_path": str(config_path),
+                    "dry_run": not cast(bool, args.write),
+                    "migrations": [],
+                    "updated_config": None,
+                }
+            )
+        )
+        return 0
+
+    migrations = detect_config_migrations(payload)
+    updated_payload = apply_config_migrations(payload, migrations)
+    should_write = cast(bool, args.write)
+    if should_write and migrations:
+        write_runtime_config_payload(workspace, updated_payload)
+
+    print(
+        json.dumps(
+            {
+                "workspace": str(workspace),
+                "config_path": str(config_path),
+                "dry_run": not should_write,
+                "migrations": [migration.to_dict() for migration in migrations],
+                "updated_config": updated_payload if migrations else None,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
 def _handle_provider_models_command(args: argparse.Namespace) -> int:
     workspace = cast(Path, args.workspace)
     provider = cast(str, args.provider)
@@ -935,6 +1026,69 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional persisted session identifier used to show resumed effective config.",
     )
     config_show_parser.set_defaults(handler=_handle_config_show_command)
+
+    config_schema_parser = config_subparsers.add_parser(
+        "schema", help="Print the JSON Schema for .voidcode.json."
+    )
+    config_schema_parser.set_defaults(handler=_handle_config_schema_command)
+
+    config_init_parser = config_subparsers.add_parser(
+        "init", help="Generate a starter workspace .voidcode.json."
+    )
+    _ = config_init_parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd(),
+        help="Workspace root where .voidcode.json should be generated.",
+    )
+    _ = config_init_parser.add_argument(
+        "--approval-mode",
+        choices=("allow", "deny", "ask"),
+        default="ask",
+        help="Starter approval mode to write.",
+    )
+    _ = config_init_parser.add_argument(
+        "--execution-engine",
+        choices=("deterministic", "provider"),
+        help="Optional execution engine to include in the generated config.",
+    )
+    _ = config_init_parser.add_argument(
+        "--max-steps",
+        type=int,
+        help="Optional max step budget to include in the generated config.",
+    )
+    _ = config_init_parser.add_argument(
+        "--with-examples",
+        action="store_true",
+        help="Include minimal tools and skills example blocks.",
+    )
+    _ = config_init_parser.add_argument(
+        "--print",
+        action="store_true",
+        help="Print the generated config instead of writing it.",
+    )
+    _ = config_init_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing .voidcode.json.",
+    )
+    config_init_parser.set_defaults(handler=_handle_config_init_command)
+
+    config_migrate_parser = config_subparsers.add_parser(
+        "migrate", help="Detect and optionally apply .voidcode.json migrations."
+    )
+    _ = config_migrate_parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd(),
+        help="Workspace root containing .voidcode.json.",
+    )
+    _ = config_migrate_parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Write migrated config back to .voidcode.json. Defaults to dry-run.",
+    )
+    config_migrate_parser.set_defaults(handler=_handle_config_migrate_command)
 
     provider_models_parser = provider_subparsers.add_parser(
         "models", help="Show or refresh available models for one provider."

--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -597,12 +597,15 @@ def _handle_config_init_command(args: argparse.Namespace) -> int:
     if not workspace.exists() or not workspace.is_dir():
         raise SystemExit(f"error: workspace does not exist: {workspace}")
 
-    payload = generate_starter_runtime_config(
-        approval_mode=cast(str, args.approval_mode),
-        execution_engine=cast(str | None, getattr(args, "execution_engine", None)),
-        max_steps=cast(int | None, getattr(args, "max_steps", None)),
-        include_examples=cast(bool, args.with_examples),
-    )
+    try:
+        payload = generate_starter_runtime_config(
+            approval_mode=cast(str, args.approval_mode),
+            execution_engine=cast(str | None, getattr(args, "execution_engine", None)),
+            max_steps=cast(int | None, getattr(args, "max_steps", None)),
+            include_examples=cast(bool, args.with_examples),
+        )
+    except ValueError as exc:
+        raise SystemExit(f"error: {exc}") from None
     if cast(bool, args.print):
         print(format_starter_runtime_config_json(payload), end="")
         return 0

--- a/src/voidcode/runtime/config_schema.py
+++ b/src/voidcode/runtime/config_schema.py
@@ -1,0 +1,491 @@
+"""Schema-backed config UX for the VoidCode runtime."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, cast
+
+from .config import (
+    APPROVAL_MODE_ENV_VAR,
+    EXECUTION_ENGINE_ENV_VAR,
+    MAX_STEPS_ENV_VAR,
+    MODEL_ENV_VAR,
+    RUNTIME_CONFIG_FILE_NAME,
+    TOOL_TIMEOUT_ENV_VAR,
+    runtime_config_path,
+)
+
+__all__ = [
+    "RUNTIME_CONFIG_SCHEMA_ID",
+    "RUNTIME_CONFIG_SCHEMA_TITLE",
+    "RUNTIME_CONFIG_SCHEMA_URI",
+    "ConfigMigration",
+    "MigrationAction",
+    "apply_config_migrations",
+    "detect_config_migrations",
+    "format_starter_runtime_config_json",
+    "generate_starter_runtime_config",
+    "read_runtime_config_payload",
+    "runtime_config_json_schema",
+    "write_runtime_config_payload",
+]
+
+RUNTIME_CONFIG_SCHEMA_ID = "https://voidcode.dev/schemas/runtime-config.schema.json"
+RUNTIME_CONFIG_SCHEMA_URI = RUNTIME_CONFIG_SCHEMA_ID
+RUNTIME_CONFIG_SCHEMA_TITLE = "VoidCode runtime config"
+_JSON_SCHEMA_DRAFT = "https://json-schema.org/draft/2020-12/schema"
+
+MigrationAction = Literal["remove", "rename"]
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigMigration:
+    field_path: tuple[str, ...]
+    action: MigrationAction
+    reason: str
+    new_field_path: tuple[str, ...] | None = None
+
+    @property
+    def display_path(self) -> str:
+        return ".".join(self.field_path)
+
+    @property
+    def display_new_path(self) -> str | None:
+        if self.new_field_path is None:
+            return None
+        return ".".join(self.new_field_path)
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "field_path": self.display_path,
+            "action": self.action,
+            "reason": self.reason,
+        }
+        if self.new_field_path is not None:
+            payload["new_field_path"] = self.display_new_path
+        return payload
+
+
+def runtime_config_json_schema() -> dict[str, object]:
+    return {
+        "$schema": _JSON_SCHEMA_DRAFT,
+        "$id": RUNTIME_CONFIG_SCHEMA_ID,
+        "title": RUNTIME_CONFIG_SCHEMA_TITLE,
+        "description": (
+            "Workspace-local VoidCode runtime configuration. Stored at "
+            f"`{RUNTIME_CONFIG_FILE_NAME}` in the workspace root. "
+            "Resolves alongside environment variables "
+            f"({APPROVAL_MODE_ENV_VAR}, {MODEL_ENV_VAR}, "
+            f"{EXECUTION_ENGINE_ENV_VAR}, {MAX_STEPS_ENV_VAR}, "
+            f"{TOOL_TIMEOUT_ENV_VAR}) and the user-level "
+            "`~/.config/voidcode/config.json`."
+        ),
+        "type": "object",
+        "additionalProperties": True,
+        "properties": {
+            "$schema": {
+                "type": "string",
+                "description": "JSON Schema reference for editor support.",
+            },
+            "approval_mode": {
+                "type": "string",
+                "enum": ["allow", "deny", "ask"],
+                "description": "Default approval policy for tool execution.",
+            },
+            "model": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Provider/model identifier in `provider/model` form.",
+            },
+            "execution_engine": {
+                "type": "string",
+                "enum": ["deterministic", "provider"],
+                "description": "Execution engine used to advance graph steps.",
+            },
+            "max_steps": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Maximum graph step budget for a single run.",
+            },
+            "tool_timeout_seconds": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Timeout applied to each tool execution.",
+            },
+            "hooks": {
+                "type": "object",
+                "additionalProperties": True,
+                "description": (
+                    "Runtime-managed lifecycle hooks (pre/post tool, session, background)."
+                ),
+                "properties": {
+                    "enabled": {"type": "boolean"},
+                    "timeout_seconds": {"type": "number", "minimum": 1},
+                    "pre_tool": {"$ref": "#/$defs/commandList"},
+                    "post_tool": {"$ref": "#/$defs/commandList"},
+                    "on_session_start": {"$ref": "#/$defs/commandList"},
+                    "on_session_end": {"$ref": "#/$defs/commandList"},
+                    "on_session_idle": {"$ref": "#/$defs/commandList"},
+                    "on_background_task_completed": {"$ref": "#/$defs/commandList"},
+                    "on_background_task_failed": {"$ref": "#/$defs/commandList"},
+                    "on_background_task_cancelled": {"$ref": "#/$defs/commandList"},
+                    "on_delegated_result_available": {"$ref": "#/$defs/commandList"},
+                    "formatter_presets": {
+                        "type": "object",
+                        "additionalProperties": {"type": "object"},
+                    },
+                },
+            },
+            "tools": {"$ref": "#/$defs/toolsConfig"},
+            "skills": {"$ref": "#/$defs/skillsConfig"},
+            "lsp": {
+                "type": "object",
+                "additionalProperties": True,
+                "properties": {
+                    "enabled": {"type": "boolean"},
+                    "servers": {
+                        "type": "object",
+                        "additionalProperties": {"type": "object"},
+                    },
+                },
+            },
+            "mcp": {
+                "type": "object",
+                "additionalProperties": True,
+                "properties": {
+                    "enabled": {"type": "boolean"},
+                    "request_timeout_seconds": {"type": "number", "exclusiveMinimum": 0},
+                    "servers": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": True,
+                            "required": ["command"],
+                            "properties": {
+                                "transport": {"type": "string", "enum": ["stdio"]},
+                                "command": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                    "minItems": 1,
+                                },
+                                "env": {
+                                    "type": "object",
+                                    "additionalProperties": {"type": "string"},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            "tui": {
+                "type": "object",
+                "additionalProperties": True,
+                "properties": {
+                    "leader_key": {"type": "string"},
+                    "keymap": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "enum": [
+                                "command_palette",
+                                "session_new",
+                                "session_resume",
+                            ],
+                        },
+                    },
+                    "preferences": {
+                        "type": "object",
+                        "additionalProperties": True,
+                        "properties": {
+                            "theme": {
+                                "type": "object",
+                                "additionalProperties": True,
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "mode": {
+                                        "type": "string",
+                                        "enum": ["auto", "light", "dark"],
+                                    },
+                                },
+                            },
+                            "reading": {
+                                "type": "object",
+                                "additionalProperties": True,
+                                "properties": {
+                                    "wrap": {"type": "boolean"},
+                                    "sidebar_collapsed": {"type": "boolean"},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            "provider_fallback": {
+                "type": "object",
+                "additionalProperties": True,
+                "description": "Provider fallback chain configuration.",
+            },
+            "providers": {
+                "type": "object",
+                "additionalProperties": True,
+                "description": (
+                    "Provider-level configuration. Credential fields are sensitive; "
+                    "prefer environment variables for secrets."
+                ),
+            },
+            "plan": {
+                "type": "object",
+                "additionalProperties": True,
+                "properties": {
+                    "provider": {"type": "string", "minLength": 1},
+                    "module": {"type": "string", "minLength": 1},
+                    "factory": {"type": "string", "minLength": 1},
+                    "options": {"type": "object", "additionalProperties": True},
+                },
+            },
+            "agent": {"$ref": "#/$defs/agentConfig"},
+            "agents": {
+                "type": "object",
+                "additionalProperties": {"$ref": "#/$defs/agentConfig"},
+                "propertyNames": {"pattern": "^[a-z][a-z0-9_-]*$"},
+            },
+        },
+        "$defs": {
+            "commandList": {
+                "type": "array",
+                "description": "Array of commands; each command is a non-empty array of strings.",
+                "items": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
+                },
+            },
+            "toolsConfig": {
+                "type": "object",
+                "additionalProperties": True,
+                "properties": {
+                    "builtin": {
+                        "type": "object",
+                        "additionalProperties": True,
+                        "properties": {"enabled": {"type": "boolean"}},
+                    },
+                    "paths": {"type": "array", "items": {"type": "string"}},
+                    "allowlist": {"type": "array", "items": {"type": "string"}},
+                    "default": {"type": "array", "items": {"type": "string"}},
+                },
+            },
+            "skillsConfig": {
+                "type": "object",
+                "additionalProperties": True,
+                "properties": {
+                    "enabled": {"type": "boolean"},
+                    "paths": {"type": "array", "items": {"type": "string"}},
+                },
+            },
+            "agentConfig": {
+                "type": "object",
+                "additionalProperties": True,
+                "properties": {
+                    "preset": {
+                        "type": "string",
+                        "enum": [
+                            "leader",
+                            "worker",
+                            "advisor",
+                            "explore",
+                            "researcher",
+                            "product",
+                        ],
+                    },
+                    "prompt_profile": {"type": "string", "minLength": 1},
+                    "prompt_ref": {"type": "string", "minLength": 1},
+                    "prompt_source": {"type": "string", "enum": ["builtin"]},
+                    "hook_refs": {"type": "array", "items": {"type": "string"}},
+                    "model": {"type": "string", "minLength": 1},
+                    "execution_engine": {
+                        "type": "string",
+                        "enum": ["deterministic", "provider"],
+                    },
+                    "tools": {"$ref": "#/$defs/toolsConfig"},
+                    "skills": {"$ref": "#/$defs/skillsConfig"},
+                    "provider_fallback": {
+                        "type": "object",
+                        "additionalProperties": True,
+                    },
+                },
+            },
+        },
+    }
+
+
+def generate_starter_runtime_config(
+    *,
+    approval_mode: str = "ask",
+    execution_engine: str | None = None,
+    max_steps: int | None = None,
+    include_examples: bool = False,
+    include_schema_reference: bool = True,
+) -> dict[str, object]:
+    if approval_mode not in {"allow", "deny", "ask"}:
+        raise ValueError(
+            f"approval_mode must be one of: allow, deny, ask; received {approval_mode!r}"
+        )
+    if execution_engine is not None and execution_engine not in {
+        "deterministic",
+        "provider",
+    }:
+        raise ValueError(
+            "execution_engine must be one of: deterministic, provider; received "
+            f"{execution_engine!r}"
+        )
+    if max_steps is not None and max_steps < 1:
+        raise ValueError("max_steps must be an integer greater than or equal to 1")
+
+    payload: dict[str, object] = {}
+    if include_schema_reference:
+        payload["$schema"] = RUNTIME_CONFIG_SCHEMA_ID
+    payload["approval_mode"] = approval_mode
+    if execution_engine is not None:
+        payload["execution_engine"] = execution_engine
+    if max_steps is not None:
+        payload["max_steps"] = max_steps
+    if include_examples:
+        payload["tools"] = {"builtin": {"enabled": True}}
+        payload["skills"] = {"enabled": True}
+    return payload
+
+
+def format_starter_runtime_config_json(payload: Mapping[str, object]) -> str:
+    return json.dumps(dict(payload), indent=2, ensure_ascii=False) + "\n"
+
+
+def detect_config_migrations(payload: object) -> tuple[ConfigMigration, ...]:
+    if not isinstance(payload, dict):
+        return ()
+    typed_payload = cast(dict[str, object], payload)
+
+    migrations: list[ConfigMigration] = []
+
+    raw_agent = typed_payload.get("agent")
+    if isinstance(raw_agent, dict):
+        agent_payload = cast(dict[str, object], raw_agent)
+        if "leader_mode" in agent_payload:
+            migrations.append(
+                ConfigMigration(
+                    field_path=("agent", "leader_mode"),
+                    action="remove",
+                    reason=(
+                        "agent.leader_mode has been removed; "
+                        "use the default leader execution flow instead"
+                    ),
+                )
+            )
+
+    return tuple(migrations)
+
+
+def apply_config_migrations(
+    payload: Mapping[str, object],
+    migrations: Sequence[ConfigMigration],
+) -> dict[str, object]:
+    new_payload = _clone_payload(payload)
+    for migration in migrations:
+        if migration.action == "remove":
+            _delete_path(new_payload, migration.field_path)
+        elif migration.action == "rename":
+            if migration.new_field_path is None:
+                raise ValueError(
+                    f"rename migration requires a new_field_path; received {migration!r}"
+                )
+            value = _pop_path(new_payload, migration.field_path)
+            if value is _MISSING:
+                continue
+            _set_path(new_payload, migration.new_field_path, value)
+    return new_payload
+
+
+def read_runtime_config_payload(workspace: Path) -> dict[str, object] | None:
+    config_path = runtime_config_path(workspace.resolve())
+    if not config_path.exists():
+        return None
+    raw_text = config_path.read_text(encoding="utf-8")
+    try:
+        raw_payload = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"runtime config file must contain valid JSON: {config_path}") from exc
+    if not isinstance(raw_payload, dict):
+        raise ValueError(f"runtime config file must contain a JSON object: {config_path}")
+    return cast(dict[str, object], raw_payload)
+
+
+def write_runtime_config_payload(
+    workspace: Path,
+    payload: Mapping[str, object],
+    *,
+    create_parents: bool = True,
+) -> Path:
+    config_path = runtime_config_path(workspace.resolve())
+    if create_parents:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        format_starter_runtime_config_json(payload),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+_MISSING: object = object()
+
+
+def _clone_payload(payload: Mapping[str, object]) -> dict[str, object]:
+    return cast(dict[str, object], json.loads(json.dumps(dict(payload))))
+
+
+def _delete_path(payload: dict[str, object], path: Sequence[str]) -> None:
+    if not path:
+        return
+    parent = _resolve_parent(payload, path, create_missing=False)
+    if parent is None:
+        return
+    parent.pop(path[-1], None)
+
+
+def _pop_path(payload: dict[str, object], path: Sequence[str]) -> object:
+    if not path:
+        return _MISSING
+    parent = _resolve_parent(payload, path, create_missing=False)
+    if parent is None or path[-1] not in parent:
+        return _MISSING
+    return parent.pop(path[-1])
+
+
+def _set_path(payload: dict[str, object], path: Sequence[str], value: object) -> None:
+    if not path:
+        raise ValueError("set path requires at least one segment")
+    parent = _resolve_parent(payload, path, create_missing=True)
+    if parent is None:
+        raise ValueError("could not resolve parent path for rename target: " + ".".join(path))
+    parent[path[-1]] = value
+
+
+def _resolve_parent(
+    payload: dict[str, object],
+    path: Sequence[str],
+    *,
+    create_missing: bool,
+) -> dict[str, object] | None:
+    current: dict[str, object] = payload
+    for segment in path[:-1]:
+        nxt = current.get(segment)
+        if isinstance(nxt, dict):
+            current = cast(dict[str, object], nxt)
+            continue
+        if not create_missing:
+            return None
+        new_child: dict[str, object] = {}
+        current[segment] = new_child
+        current = new_child
+    return current

--- a/src/voidcode/runtime/config_schema.py
+++ b/src/voidcode/runtime/config_schema.py
@@ -365,26 +365,7 @@ def format_starter_runtime_config_json(payload: Mapping[str, object]) -> str:
 def detect_config_migrations(payload: object) -> tuple[ConfigMigration, ...]:
     if not isinstance(payload, dict):
         return ()
-    typed_payload = cast(dict[str, object], payload)
-
-    migrations: list[ConfigMigration] = []
-
-    raw_agent = typed_payload.get("agent")
-    if isinstance(raw_agent, dict):
-        agent_payload = cast(dict[str, object], raw_agent)
-        if "leader_mode" in agent_payload:
-            migrations.append(
-                ConfigMigration(
-                    field_path=("agent", "leader_mode"),
-                    action="remove",
-                    reason=(
-                        "agent.leader_mode has been removed; "
-                        "use the default leader execution flow instead"
-                    ),
-                )
-            )
-
-    return tuple(migrations)
+    return ()
 
 
 def apply_config_migrations(

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -1352,6 +1352,132 @@ def test_config_show_session_workspace_mismatch_returns_error() -> None:
     assert "error:" in result.stderr
 
 
+def test_config_schema_outputs_json_schema() -> None:
+    result = _run_module_cli("config", "schema")
+
+    payload = json.loads(result.stdout)
+    assert result.returncode == 0
+    assert payload["$id"] == "https://voidcode.dev/schemas/runtime-config.schema.json"
+    assert payload["properties"]["approval_mode"]["enum"] == ["allow", "deny", "ask"]
+
+
+def test_config_init_prints_starter_config_without_writing() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        result = _run_module_cli(
+            "config",
+            "init",
+            "--workspace",
+            str(workspace),
+            "--approval-mode",
+            "deny",
+            "--execution-engine",
+            "provider",
+            "--max-steps",
+            "8",
+            "--with-examples",
+            "--print",
+        )
+
+        assert not (workspace / ".voidcode.json").exists()
+
+    payload = json.loads(result.stdout)
+    assert result.returncode == 0
+    assert payload == {
+        "$schema": "https://voidcode.dev/schemas/runtime-config.schema.json",
+        "approval_mode": "deny",
+        "execution_engine": "provider",
+        "max_steps": 8,
+        "tools": {"builtin": {"enabled": True}},
+        "skills": {"enabled": True},
+    }
+    assert "api_key" not in result.stdout
+
+
+def test_config_init_writes_starter_config_and_refuses_overwrite() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        first = _run_module_cli("config", "init", "--workspace", str(workspace))
+        second = _run_module_cli("config", "init", "--workspace", str(workspace))
+
+        written_payload = json.loads((workspace / ".voidcode.json").read_text(encoding="utf-8"))
+
+    assert first.returncode == 0
+    assert json.loads(first.stdout)["config_path"].endswith(".voidcode.json")
+    assert written_payload == {
+        "$schema": "https://voidcode.dev/schemas/runtime-config.schema.json",
+        "approval_mode": "ask",
+    }
+    assert second.returncode != 0
+    assert second.stdout == ""
+    assert "already exists" in second.stderr
+
+
+def test_config_migrate_dry_run_reports_removed_agent_field() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        config_path = workspace / ".voidcode.json"
+        config_path.write_text(
+            json.dumps({"agent": {"preset": "leader", "leader_mode": "legacy"}}),
+            encoding="utf-8",
+        )
+
+        result = _run_module_cli("config", "migrate", "--workspace", str(workspace))
+        disk_payload = json.loads(config_path.read_text(encoding="utf-8"))
+
+    payload = json.loads(result.stdout)
+    assert result.returncode == 0
+    assert payload["dry_run"] is True
+    assert payload["migrations"] == [
+        {
+            "action": "remove",
+            "field_path": "agent.leader_mode",
+            "reason": (
+                "agent.leader_mode has been removed; use the default leader execution flow instead"
+            ),
+        }
+    ]
+    assert payload["updated_config"] == {"agent": {"preset": "leader"}}
+    assert disk_payload == {"agent": {"preset": "leader", "leader_mode": "legacy"}}
+
+
+def test_config_migrate_write_updates_config() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        config_path = workspace / ".voidcode.json"
+        config_path.write_text(
+            json.dumps({"agent": {"preset": "leader", "leader_mode": "legacy"}}),
+            encoding="utf-8",
+        )
+
+        result = _run_module_cli(
+            "config",
+            "migrate",
+            "--workspace",
+            str(workspace),
+            "--write",
+        )
+        disk_payload = json.loads(config_path.read_text(encoding="utf-8"))
+
+    payload = json.loads(result.stdout)
+    assert result.returncode == 0
+    assert payload["dry_run"] is False
+    assert payload["updated_config"] == {"agent": {"preset": "leader"}}
+    assert disk_payload == {"agent": {"preset": "leader"}}
+
+
+def test_config_migrate_invalid_json_returns_error() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        (workspace / ".voidcode.json").write_text("{", encoding="utf-8")
+
+        result = _run_module_cli("config", "migrate", "--workspace", str(workspace))
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "must contain valid JSON" in result.stderr
+
+
 def test_provider_models_command_outputs_refreshed_provider_model_list() -> None:
     cli = importlib.import_module("voidcode.cli")
     models = ("alias", "provider/model")

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -1413,12 +1413,30 @@ def test_config_init_writes_starter_config_and_refuses_overwrite() -> None:
     assert "already exists" in second.stderr
 
 
-def test_config_migrate_dry_run_reports_removed_agent_field() -> None:
+def test_config_init_invalid_max_steps_returns_error_without_traceback() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        result = _run_module_cli(
+            "config",
+            "init",
+            "--workspace",
+            str(workspace),
+            "--max-steps",
+            "0",
+        )
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "error: max_steps must be an integer greater than or equal to 1" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_config_migrate_dry_run_reports_no_current_migrations() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         workspace = Path(tmp)
         config_path = workspace / ".voidcode.json"
         config_path.write_text(
-            json.dumps({"agent": {"preset": "leader", "leader_mode": "legacy"}}),
+            json.dumps({"approval_mode": "ask"}),
             encoding="utf-8",
         )
 
@@ -1428,25 +1446,17 @@ def test_config_migrate_dry_run_reports_removed_agent_field() -> None:
     payload = json.loads(result.stdout)
     assert result.returncode == 0
     assert payload["dry_run"] is True
-    assert payload["migrations"] == [
-        {
-            "action": "remove",
-            "field_path": "agent.leader_mode",
-            "reason": (
-                "agent.leader_mode has been removed; use the default leader execution flow instead"
-            ),
-        }
-    ]
-    assert payload["updated_config"] == {"agent": {"preset": "leader"}}
-    assert disk_payload == {"agent": {"preset": "leader", "leader_mode": "legacy"}}
+    assert payload["migrations"] == []
+    assert payload["updated_config"] is None
+    assert disk_payload == {"approval_mode": "ask"}
 
 
-def test_config_migrate_write_updates_config() -> None:
+def test_config_migrate_write_noop_keeps_current_config() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         workspace = Path(tmp)
         config_path = workspace / ".voidcode.json"
         config_path.write_text(
-            json.dumps({"agent": {"preset": "leader", "leader_mode": "legacy"}}),
+            json.dumps({"approval_mode": "deny"}),
             encoding="utf-8",
         )
 
@@ -1462,8 +1472,9 @@ def test_config_migrate_write_updates_config() -> None:
     payload = json.loads(result.stdout)
     assert result.returncode == 0
     assert payload["dry_run"] is False
-    assert payload["updated_config"] == {"agent": {"preset": "leader"}}
-    assert disk_payload == {"agent": {"preset": "leader"}}
+    assert payload["migrations"] == []
+    assert payload["updated_config"] is None
+    assert disk_payload == {"approval_mode": "deny"}
 
 
 def test_config_migrate_invalid_json_returns_error() -> None:

--- a/tests/unit/runtime/test_config_schema.py
+++ b/tests/unit/runtime/test_config_schema.py
@@ -7,6 +7,7 @@ import pytest
 
 from voidcode.runtime.config_schema import (
     RUNTIME_CONFIG_SCHEMA_ID,
+    ConfigMigration,
     apply_config_migrations,
     detect_config_migrations,
     format_starter_runtime_config_json,
@@ -83,38 +84,51 @@ def test_format_starter_runtime_config_json_preserves_order() -> None:
     assert format_starter_runtime_config_json(payload) == '{\n  "approval_mode": "ask"\n}\n'
 
 
-def test_detect_config_migrations_reports_removed_agent_leader_mode() -> None:
+def test_detect_config_migrations_returns_no_current_migrations() -> None:
+    payload: dict[str, object] = {"approval_mode": "ask"}
+
+    assert detect_config_migrations(payload) == ()
+
+
+def test_apply_config_migrations_removes_nested_field_without_mutating_input() -> None:
     payload: dict[str, object] = {
         "approval_mode": "ask",
-        "agent": {"preset": "leader", "leader_mode": "legacy"},
+        "nested": {"keep": True, "deprecated": "value"},
     }
-
-    migrations = detect_config_migrations(payload)
-
-    assert len(migrations) == 1
-    assert migrations[0].to_dict() == {
-        "field_path": "agent.leader_mode",
-        "action": "remove",
-        "reason": (
-            "agent.leader_mode has been removed; use the default leader execution flow instead"
+    migrations = (
+        ConfigMigration(
+            field_path=("nested", "deprecated"),
+            action="remove",
+            reason="nested.deprecated is no longer used",
         ),
-    }
-
-
-def test_apply_config_migrations_removes_legacy_field_without_mutating_input() -> None:
-    payload: dict[str, object] = {
-        "approval_mode": "ask",
-        "agent": {"preset": "leader", "leader_mode": "legacy"},
-    }
-    migrations = detect_config_migrations(payload)
+    )
 
     updated = apply_config_migrations(payload, migrations)
 
-    assert updated == {"approval_mode": "ask", "agent": {"preset": "leader"}}
+    assert updated == {"approval_mode": "ask", "nested": {"keep": True}}
     assert payload == {
         "approval_mode": "ask",
-        "agent": {"preset": "leader", "leader_mode": "legacy"},
+        "nested": {"keep": True, "deprecated": "value"},
     }
+
+
+def test_apply_config_migrations_renames_nested_field() -> None:
+    payload: dict[str, object] = {
+        "approval_mode": "ask",
+        "nested": {"old": "value"},
+    }
+    migrations = (
+        ConfigMigration(
+            field_path=("nested", "old"),
+            action="rename",
+            reason="nested.old was renamed",
+            new_field_path=("nested", "new"),
+        ),
+    )
+
+    updated = apply_config_migrations(payload, migrations)
+
+    assert updated == {"approval_mode": "ask", "nested": {"new": "value"}}
 
 
 def test_detect_config_migrations_ignores_non_object_payload() -> None:

--- a/tests/unit/runtime/test_config_schema.py
+++ b/tests/unit/runtime/test_config_schema.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+from typing import cast
+
+import pytest
+
+from voidcode.runtime.config_schema import (
+    RUNTIME_CONFIG_SCHEMA_ID,
+    apply_config_migrations,
+    detect_config_migrations,
+    format_starter_runtime_config_json,
+    generate_starter_runtime_config,
+    runtime_config_json_schema,
+)
+
+
+def test_runtime_config_json_schema_exposes_core_fields() -> None:
+    schema = runtime_config_json_schema()
+
+    assert schema["$id"] == RUNTIME_CONFIG_SCHEMA_ID
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    properties = schema["properties"]
+    assert isinstance(properties, dict)
+    assert properties["approval_mode"] == {
+        "type": "string",
+        "enum": ["allow", "deny", "ask"],
+        "description": "Default approval policy for tool execution.",
+    }
+    assert properties["agent"] == {"$ref": "#/$defs/agentConfig"}
+    defs = schema["$defs"]
+    assert isinstance(defs, dict)
+    agent_config = cast(dict[str, object], defs["agentConfig"])
+    agent_properties = cast(dict[str, object], agent_config["properties"])
+    preset_property = cast(dict[str, object], agent_properties["preset"])
+    assert preset_property["enum"] == [
+        "leader",
+        "worker",
+        "advisor",
+        "explore",
+        "researcher",
+        "product",
+    ]
+    mcp_schema = cast(dict[str, object], properties["mcp"])
+    mcp_properties = cast(dict[str, object], mcp_schema["properties"])
+    mcp_servers = cast(dict[str, object], mcp_properties["servers"])
+    mcp_server_schema = cast(dict[str, object], mcp_servers["additionalProperties"])
+    assert mcp_server_schema["required"] == ["command"]
+
+
+def test_generate_starter_runtime_config_excludes_secrets() -> None:
+    payload = generate_starter_runtime_config(
+        approval_mode="deny",
+        execution_engine="provider",
+        max_steps=7,
+        include_examples=True,
+    )
+
+    assert payload == {
+        "$schema": RUNTIME_CONFIG_SCHEMA_ID,
+        "approval_mode": "deny",
+        "execution_engine": "provider",
+        "max_steps": 7,
+        "tools": {"builtin": {"enabled": True}},
+        "skills": {"enabled": True},
+    }
+    assert "providers" not in payload
+    assert "api_key" not in json.dumps(payload)
+
+
+def test_generate_starter_runtime_config_validates_inputs() -> None:
+    with pytest.raises(ValueError, match="approval_mode"):
+        generate_starter_runtime_config(approval_mode="always")
+    with pytest.raises(ValueError, match="execution_engine"):
+        generate_starter_runtime_config(execution_engine="remote")
+    with pytest.raises(ValueError, match="max_steps"):
+        generate_starter_runtime_config(max_steps=0)
+
+
+def test_format_starter_runtime_config_json_preserves_order() -> None:
+    payload = generate_starter_runtime_config(include_schema_reference=False)
+
+    assert format_starter_runtime_config_json(payload) == '{\n  "approval_mode": "ask"\n}\n'
+
+
+def test_detect_config_migrations_reports_removed_agent_leader_mode() -> None:
+    payload: dict[str, object] = {
+        "approval_mode": "ask",
+        "agent": {"preset": "leader", "leader_mode": "legacy"},
+    }
+
+    migrations = detect_config_migrations(payload)
+
+    assert len(migrations) == 1
+    assert migrations[0].to_dict() == {
+        "field_path": "agent.leader_mode",
+        "action": "remove",
+        "reason": (
+            "agent.leader_mode has been removed; use the default leader execution flow instead"
+        ),
+    }
+
+
+def test_apply_config_migrations_removes_legacy_field_without_mutating_input() -> None:
+    payload: dict[str, object] = {
+        "approval_mode": "ask",
+        "agent": {"preset": "leader", "leader_mode": "legacy"},
+    }
+    migrations = detect_config_migrations(payload)
+
+    updated = apply_config_migrations(payload, migrations)
+
+    assert updated == {"approval_mode": "ask", "agent": {"preset": "leader"}}
+    assert payload == {
+        "approval_mode": "ask",
+        "agent": {"preset": "leader", "leader_mode": "legacy"},
+    }
+
+
+def test_detect_config_migrations_ignores_non_object_payload() -> None:
+    assert detect_config_migrations([]) == ()


### PR DESCRIPTION
## Summary
- Add a schema-backed runtime config helper surface for `.voidcode.json`, including a JSON Schema export, secrets-free starter config generation, and deprecated-field migration helpers.
- Add `voidcode config schema`, `voidcode config init`, and `voidcode config migrate` CLI workflows with dry-run/write behavior and subprocess coverage.
- Document the schema/init/migrate contract and keep generated config free of provider secrets.

## Verification
- `mise run check`

Closes #254