### PR TITLE
test: parallelize python test tiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: uv run basedpyright --warnings src
 
       - name: Run tests with coverage
-        run: uv run pytest --cov=voidcode --cov-report=xml
+        run: uv run pytest -n auto --cov=voidcode --cov-report=xml
 
       - name: Build package
         run: uv build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,9 @@ Run the standard checks with `mise`:
 mise run lint
 mise run format
 mise run typecheck
+mise run test:fast
 mise run test
+mise run test:coverage
 mise run build
 mise run frontend:lint
 mise run frontend:typecheck
@@ -59,7 +61,8 @@ When needed, you can also invoke the Python tooling directly:
 uv run ruff check .
 uv run ruff format .
 uv run basedpyright --warnings src
-uv run pytest
+uv run pytest -n auto
+uv run pytest -n auto --cov=voidcode --cov-report=term-missing
 uv run pre-commit run --all-files
 ```
 
@@ -68,6 +71,7 @@ uv run pre-commit run --all-files
 Please add or update tests when behavior changes.
 
 - Run the relevant local checks before opening a pull request.
+- Prefer `mise run test:fast` while iterating, then run the relevant full or coverage-bearing task before asking for review.
 - Keep linting and type checking clean.
 - If you change CLI, runtime, graph, tool, or transport behavior, add test coverage where an existing test surface already exists.
 - For frontend changes, run the relevant Bun-based checks as well.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ Common tasks from `mise.toml`:
 mise run lint
 mise run format
 mise run typecheck
+mise run test:fast
 mise run test
+mise run test:coverage
 mise run build
 
 # Frontend
@@ -133,7 +135,7 @@ mise run pre-commit
 uv run pre-commit install
 ```
 
-`mise` orchestrates tasks and loads the local virtual environment. `uv` remains the source of truth for Python dependency management and execution.
+`mise` orchestrates tasks and loads the local virtual environment. `uv` remains the source of truth for Python dependency management and execution. Use `mise run test:fast` for the tight local feedback loop, `mise run test` for parallel full pytest without coverage, and `mise run test:coverage` for coverage-bearing validation.
 Bun scripts are owned by `frontend/package.json`; the repository root intentionally has no `package.json` so root-level automation goes through `mise.toml`.
 
 ## Documentation map

--- a/docs/development.md
+++ b/docs/development.md
@@ -42,10 +42,14 @@ uv run voidcode sessions resume <session-id> --workspace .
 - `mise run lint` → `uv run ruff check .`
 - `mise run format` → `uv run ruff format .`
 - `mise run typecheck` → `uv run basedpyright --warnings src`
-- `mise run test` → `uv run pytest`
+- `mise run test:fast` → 并行运行主要 unit tests，跳过 integration、fuzz-style tests 和大型 runtime extension 回归文件
+- `mise run test` → `uv run pytest -n auto`
+- `mise run test:coverage` → `uv run pytest -n auto --cov=voidcode --cov-report=term-missing`
 - `mise run build` → `uv build`
 
 Python 测试现在同时包含示例型测试和一小批基于 Hypothesis 的 property tests。当前这类覆盖刻意保持在 helper 层，主要用于验证像 `apply_patch`、`edit`、`todo_write`、`glob` 这类确定性字符串/patch/summary/路径规范化逻辑，而不是直接对 runtime 主循环做随机化测试。为了让 CI 行为稳定，这批测试使用有界 strategy，并通过 Hypothesis 设置保持可重复的 deterministic 运行。
+
+默认本地 Python 测试不再自动启用 coverage：`mise run test:fast` 用于高频迭代，跳过 integration、fuzz-style 单测和大型 runtime extension 回归文件；`mise run test` 使用 `pytest-xdist` 并行运行完整 pytest；`mise run test:coverage` 与 CI 的 Python 测试路径保持 coverage-bearing 验证。
 
 ### 前端 任务
 
@@ -61,7 +65,7 @@ Python 测试现在同时包含示例型测试和一小批基于 Hypothesis 的 
 
 - `mise run check` → 运行所有 Python 和前端静态/单元检查
 - `mise run frontend:check:e2e` → 运行前端静态/单元检查后再运行 Playwright E2E
-- `mise run ci` → 运行 `mise run check`，随后构建 Python 包和前端生产包，用于合并前的 CI parity 验证
+- `mise run ci` → 运行 Python lint/typecheck、coverage-bearing pytest、Python 构建、前端检查和前端生产构建，用于合并前的 CI parity 验证
 - `mise run pre-commit` → `uv run pre-commit run --all-files`
 
 当前 pre-commit 会直接执行仓库约定的 Python 质量门禁：`ruff check --fix` 会自动修复可安全修复的问题，`ruff format` 会直接格式化文件，随后再运行 `basedpyright` 做类型检查。

--- a/mise.toml
+++ b/mise.toml
@@ -55,7 +55,13 @@ run = "uv run ruff format ."
 run = "uv run basedpyright --warnings src"
 
 [tasks.test]
-run = "uv run pytest"
+run = "uv run pytest -n auto"
+
+[tasks."test:fast"]
+run = "uv run pytest -n auto tests/unit --ignore=tests/unit/tools/fuzz --ignore=tests/unit/runtime/test_http_question_payload_fuzz.py --ignore=tests/unit/runtime/test_runtime_service_extensions.py"
+
+[tasks."test:coverage"]
+run = "uv run pytest -n auto --cov=voidcode --cov-report=term-missing"
 
 [tasks.build]
 run = "uv build"
@@ -64,7 +70,7 @@ run = "uv build"
 run = "mise run lint && mise run typecheck && mise run test && mise run frontend:check"
 
 [tasks.ci]
-run = "mise run check && mise run build && mise run frontend:build"
+run = "mise run lint && mise run typecheck && mise run test:coverage && mise run build && mise run frontend:check && mise run frontend:build"
 
 [tasks.pre-commit]
 run = "uv run pre-commit run --all-files"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
   "pre-commit",
   "pytest",
   "pytest-cov",
+  "pytest-xdist>=3.8.0",
   "ruff",
 ]
 
@@ -87,7 +88,12 @@ root = "."
 extraPaths = ["src"]
 
 [tool.pytest.ini_options]
-addopts = "--cov=src --cov-report=term-missing"
+addopts = ""
+markers = [
+  "slow: tests that are useful locally but too slow for the fast feedback loop",
+  "integration: tests that exercise cross-module/runtime integration paths",
+  "fuzz: property-based or fuzz-style tests that can be more expensive than example tests",
+]
 pythonpath = ["src"]
 testpaths = ["tests"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import tempfile
+
+os.environ["XDG_CONFIG_HOME"] = tempfile.mkdtemp(prefix="voidcode-pytest-config-")

--- a/uv.lock
+++ b/uv.lock
@@ -318,6 +318,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastuuid"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1187,6 +1196,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-discovery"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1722,6 +1744,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -1741,6 +1764,7 @@ requires-dist = [
     { name = "pydantic-settings" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.8.0" },
     { name = "rapidfuzz", specifier = ">=3.14.5" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "textual" },


### PR DESCRIPTION
## Summary
- Add `pytest-xdist` and split Python test commands into fast, full, and coverage-bearing tiers.
- Remove default pytest coverage from `pyproject.toml` so local `pytest`/`mise run test` gives faster feedback while CI and `test:coverage` still collect coverage explicitly.
- Run Python CI coverage tests with `pytest -n auto`, isolate pytest from user `XDG_CONFIG_HOME`, and document the new workflow.

## Verification
- `mise run test:fast` — 933 passed in 2:23
- `mise run test` — 1377 passed in 2:53
- `env -u VIRTUAL_ENV uv run pytest -n auto --cov=voidcode --cov-report=xml` — 1377 passed in 3:07
- `env -u VIRTUAL_ENV uv run ruff check .`
- `env -u VIRTUAL_ENV uv run ruff format --check .`
- `env -u VIRTUAL_ENV uv run basedpyright --warnings src`
- `env -u VIRTUAL_ENV uv build`