### PR TITLE
feat(acp): add stdio runtime facade

### DIFF
--- a/docs/agent-acp-config.md
+++ b/docs/agent-acp-config.md
@@ -95,6 +95,33 @@ The `acp` key in `.voidcode.json` configures the Agent Communication Protocol.
 }
 ```
 
+### External Stdio Facade
+
+VoidCode also exposes a minimal external-facing ACP-compatible stdio facade:
+
+```bash
+voidcode acp --workspace . --approval-mode ask
+```
+
+This command runs a newline-delimited JSON-RPC 2.0 server over stdin/stdout. Each input line must be one JSON-RPC request object, and each stdout line is one JSON-RPC response or notification. Human logs, debug output, and process errors are reserved for stderr so clients can safely parse stdout as protocol data only.
+
+Supported JSON-RPC methods:
+
+| Method | Description |
+|--------|-------------|
+| `initialize` | Returns ACP protocol version `1`, minimal `agentCapabilities`, `agentInfo`, and `authMethods: []`. |
+| `session/new` | Allocates an external ACP session id and records it for later prompts. Non-empty `mcpServers` are rejected because MCP-over-ACP is not implemented. |
+| `session/prompt` | Accepts ACP text prompt blocks, runs `VoidCodeRuntime.run_stream(RuntimeRequest(...))` in a worker thread, maps the ACP session id to the runtime session id emitted by the runtime, emits `session/update` notifications, and returns `stopReason: "end_turn"` on completion. |
+| `session/cancel` | Supports ACP notification style and request style for tests/debugging. It records a best-effort cancel request while the stdio read loop remains active; because the runtime has no public active prompt interrupt hook yet, cancellation is observed between runtime stream chunks and reported as limited in request-style responses. |
+
+Prompt output is emitted as ACP `agent_message_chunk` updates. Runtime tool request/completion events are summarized as `tool_call` and `tool_call_update` with stable per-turn tool call ids; other runtime events are exposed as `agent_thought_chunk` JSON so clients can observe the run without parsing VoidCode's internal stdout. Runtime failures are surfaced as generic `agent_message_chunk` failure text and JSON-RPC errors rather than silent process exits or raw exception leaks.
+
+The facade enforces bounded request lines, prompt text, and in-memory session count to protect the long-running stdio process from accidental client-side floods.
+
+Protocol errors are reported as JSON-RPC errors for malformed JSON, invalid request objects, unknown methods, invalid params, missing params, and unknown ACP session ids. Runtime failures are surfaced as protocol-visible `session/update` failure notifications and JSON-RPC errors; they should not silently terminate stdout framing.
+
+The stdio facade intentionally remains a thin client/protocol layer over the runtime boundary. Runtime configuration is still loaded with the normal `load_runtime_config()` path, `--approval-mode` is honored the same way as `run` and `serve`, and execution still goes through `VoidCodeRuntime`.
+
 ### Supported Fields
 
 | Field | Type | Required | Default | Description |
@@ -119,6 +146,8 @@ The `acp` key in `.voidcode.json` configures the Agent Communication Protocol.
 - Multi-agent routing plane
 - Recoverable delegated execution
 - Supervisor/worker transport
+- Subagent orchestration over stdio ACP
+- MCP-over-ACP, HTTP ACP, auth, full session replay/list/load, or full OpenCode parity
 
 ### Examples
 

--- a/src/voidcode/acp/stdio.py
+++ b/src/voidcode/acp/stdio.py
@@ -95,7 +95,15 @@ class StdioAcpServer:
             )
             return
         payload = cast(dict[object, object], request)
-        request_id = _request_id(payload.get("id"))
+        request_id, invalid_request_id = _request_id(payload.get("id"))
+        if invalid_request_id:
+            self._write_error(
+                None,
+                _ERROR_INVALID_REQUEST,
+                "id must be a string, integer, null, or omitted",
+                respond_without_id=True,
+            )
+            return
         if payload.get("jsonrpc") != JSON_RPC_VERSION:
             self._write_error(request_id, _ERROR_INVALID_REQUEST, "jsonrpc must be '2.0'")
             return
@@ -406,12 +414,12 @@ class StdioAcpServer:
         self.stderr.flush()
 
 
-def _request_id(value: object) -> JsonRpcId:
+def _request_id(value: object) -> tuple[JsonRpcId, bool]:
     if value is None or isinstance(value, str):
-        return value
+        return value, False
     if isinstance(value, int) and not isinstance(value, bool):
-        return value
-    return None
+        return value, False
+    return None, True
 
 
 def _required_string(params: Mapping[str, object], name: str) -> str:

--- a/src/voidcode/acp/stdio.py
+++ b/src/voidcode/acp/stdio.py
@@ -1,0 +1,453 @@
+from __future__ import annotations
+
+import contextlib
+import json
+import sys
+import threading
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol, TextIO, cast
+from uuid import uuid4
+
+from .. import __version__
+from ..runtime.contracts import (
+    RuntimeRequest,
+    RuntimeStreamChunk,
+    validate_runtime_request_metadata,
+)
+
+JSON_RPC_VERSION = "2.0"
+MAX_JSON_RPC_LINE_BYTES = 1_048_576
+MAX_PROMPT_CHARS = 65_536
+MAX_SESSIONS = 128
+
+_ERROR_PARSE = -32700
+_ERROR_INVALID_REQUEST = -32600
+_ERROR_METHOD_NOT_FOUND = -32601
+_ERROR_INVALID_PARAMS = -32602
+_ERROR_INTERNAL = -32603
+
+
+type JsonObject = dict[str, object]
+type JsonRpcId = str | int | None
+
+
+class AcpRuntime(Protocol):
+    def run_stream(self, request: RuntimeRequest) -> Iterator[RuntimeStreamChunk]: ...
+
+
+@dataclass(slots=True)
+class AcpSessionBinding:
+    acp_session_id: str
+    runtime_session_id: str | None = None
+    active: bool = False
+    cancel_requested: bool = False
+    tool_call_ids_by_tool: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class StdioAcpServer:
+    runtime: AcpRuntime
+    workspace: Path
+    stdin: TextIO = field(default_factory=lambda: sys.stdin)
+    stdout: TextIO = field(default_factory=lambda: sys.stdout)
+    stderr: TextIO = field(default_factory=lambda: sys.stderr)
+    _sessions: dict[str, AcpSessionBinding] = field(default_factory=dict, init=False)
+    _prompt_threads: list[threading.Thread] = field(default_factory=list, init=False)
+    _write_lock: threading.Lock = field(default_factory=threading.Lock, init=False)
+    _runtime_lock: threading.Lock = field(default_factory=threading.Lock, init=False)
+    _runtime_prompt_active: bool = field(default=False, init=False)
+
+    def serve(self) -> int:
+        for line in self.stdin:
+            if not line.strip():
+                continue
+            if len(line.encode("utf-8")) > MAX_JSON_RPC_LINE_BYTES:
+                self._write_error(None, _ERROR_INVALID_REQUEST, "request line is too large")
+                continue
+            try:
+                request = json.loads(line)
+            except json.JSONDecodeError as exc:
+                self._write_error(
+                    None,
+                    _ERROR_PARSE,
+                    f"parse error: {exc.msg}",
+                )
+                continue
+            self._handle_loaded_request(request)
+        self._join_all_prompt_threads()
+        return 0
+
+    def _handle_loaded_request(self, request: object) -> None:
+        if not isinstance(request, dict):
+            self._write_error(None, _ERROR_INVALID_REQUEST, "request must be an object")
+            return
+        payload = cast(dict[object, object], request)
+        request_id = _request_id(payload.get("id"))
+        if payload.get("jsonrpc") != JSON_RPC_VERSION:
+            self._write_error(request_id, _ERROR_INVALID_REQUEST, "jsonrpc must be '2.0'")
+            return
+        method = payload.get("method")
+        if not isinstance(method, str) or not method:
+            self._write_error(
+                request_id, _ERROR_INVALID_REQUEST, "method must be a non-empty string"
+            )
+            return
+        params = payload.get("params", {})
+        if params is None:
+            params = {}
+        if not isinstance(params, dict):
+            self._write_error(request_id, _ERROR_INVALID_PARAMS, "params must be an object")
+            return
+        typed_params = cast(dict[str, object], params)
+
+        try:
+            if method == "initialize":
+                self._write_result(request_id, self._initialize_result())
+            elif method == "session/new":
+                self._write_result(request_id, self._new_session_result(typed_params))
+            elif method == "session/prompt":
+                self._start_session_prompt(request_id, typed_params)
+            elif method == "session/cancel":
+                result = self._cancel_result(typed_params)
+                if request_id is not None:
+                    self._write_result(request_id, result)
+            else:
+                self._write_error(request_id, _ERROR_METHOD_NOT_FOUND, f"unknown method: {method}")
+        except ValueError as exc:
+            if request_id is not None or method != "session/cancel":
+                self._write_error(request_id, _ERROR_INVALID_PARAMS, str(exc))
+            else:
+                self.stderr.write(f"ACP session/cancel ignored: {exc}\n")
+                self.stderr.flush()
+        except Exception as exc:
+            self._log_exception("ACP request failed", exc)
+            self._write_error(request_id, _ERROR_INTERNAL, "internal error")
+        self._join_finished_prompt_threads()
+
+    def _join_all_prompt_threads(self) -> None:
+        for thread in tuple(self._prompt_threads):
+            thread.join()
+        self._prompt_threads.clear()
+
+    def _join_finished_prompt_threads(self) -> None:
+        alive_threads: list[threading.Thread] = []
+        for thread in self._prompt_threads:
+            if thread.is_alive():
+                alive_threads.append(thread)
+            else:
+                thread.join()
+        self._prompt_threads = alive_threads
+
+    def _initialize_result(self) -> JsonObject:
+        return {
+            "protocolVersion": 1,
+            "agentCapabilities": {
+                "loadSession": False,
+                "promptCapabilities": {},
+                "mcpCapabilities": {},
+            },
+            "agentInfo": {
+                "name": "voidcode",
+                "title": "VoidCode",
+                "version": __version__,
+            },
+            "authMethods": [],
+        }
+
+    def _start_session_prompt(self, request_id: JsonRpcId, params: Mapping[str, object]) -> None:
+        acp_session_id = _required_string(params, "sessionId")
+        prompt = _prompt_text(params.get("prompt"))
+        binding = self._sessions.get(acp_session_id)
+        if binding is None:
+            raise ValueError(f"unknown ACP session id: {acp_session_id}")
+        if binding.active:
+            raise ValueError(f"ACP session is already running a prompt: {acp_session_id}")
+        with self._runtime_lock:
+            if self._runtime_prompt_active:
+                raise ValueError("another ACP prompt is already running")
+            self._runtime_prompt_active = True
+        binding.active = True
+        binding.cancel_requested = False
+        thread = threading.Thread(
+            target=self._handle_session_prompt,
+            args=(request_id, acp_session_id, prompt, binding),
+            name=f"voidcode-acp-prompt-{acp_session_id}",
+            daemon=False,
+        )
+        self._prompt_threads.append(thread)
+        thread.start()
+
+    def _new_session_result(self, params: Mapping[str, object] | None = None) -> JsonObject:
+        if len(self._sessions) >= MAX_SESSIONS:
+            raise ValueError("maximum ACP session count reached")
+        if params is not None:
+            raw_mcp_servers = params.get("mcpServers", [])
+            if not isinstance(raw_mcp_servers, list):
+                raise ValueError("params.mcpServers must be a list when provided")
+            if raw_mcp_servers:
+                raise ValueError("ACP MCP servers are not supported by the minimal stdio facade")
+        acp_session_id = f"acp-session-{uuid4().hex}"
+        self._sessions[acp_session_id] = AcpSessionBinding(acp_session_id=acp_session_id)
+        return {"sessionId": acp_session_id}
+
+    def _handle_session_prompt(
+        self,
+        request_id: JsonRpcId,
+        acp_session_id: str,
+        prompt: str,
+        binding: AcpSessionBinding,
+    ) -> None:
+        stop_reason = "end_turn"
+        try:
+            request = RuntimeRequest(
+                prompt=prompt,
+                session_id=binding.runtime_session_id,
+                metadata=validate_runtime_request_metadata({"agent": {"preset": "leader"}}),
+                allocate_session_id=binding.runtime_session_id is None,
+            )
+            chunks = self.runtime.run_stream(request)
+            while True:
+                if binding.cancel_requested:
+                    stop_reason = "cancelled"
+                    break
+                try:
+                    with contextlib.redirect_stdout(self.stderr):
+                        chunk = next(chunks)
+                except StopIteration:
+                    break
+                if binding.cancel_requested:
+                    stop_reason = "cancelled"
+                    break
+                if binding.runtime_session_id is None:
+                    binding.runtime_session_id = chunk.session.session.id
+                if chunk.event is not None:
+                    self._write_runtime_event_update(
+                        acp_session_id=acp_session_id,
+                        runtime_session_id=chunk.session.session.id,
+                        binding=binding,
+                        event=chunk.event,
+                    )
+                if chunk.kind == "output":
+                    self._write_session_update(
+                        acp_session_id,
+                        {
+                            "sessionUpdate": "agent_message_chunk",
+                            "content": {"type": "text", "text": chunk.output or ""},
+                        },
+                    )
+            if binding.runtime_session_id is None:
+                raise RuntimeError("runtime stream emitted no chunks")
+            if binding.cancel_requested:
+                stop_reason = "cancelled"
+            self._write_result(
+                request_id,
+                {"stopReason": stop_reason},
+            )
+        except Exception as exc:
+            self._log_exception("ACP prompt failed", exc)
+            self._write_session_update(
+                acp_session_id,
+                {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"type": "text", "text": "Runtime failed."},
+                },
+            )
+            self._write_error(request_id, _ERROR_INTERNAL, "runtime execution failed")
+        finally:
+            binding.active = False
+            with self._runtime_lock:
+                self._runtime_prompt_active = False
+
+    def _cancel_result(self, params: Mapping[str, object]) -> JsonObject:
+        acp_session_id = _required_string(params, "sessionId")
+        binding = self._sessions.get(acp_session_id)
+        if binding is None:
+            raise ValueError(f"unknown ACP session id: {acp_session_id}")
+        binding.cancel_requested = True
+        return {
+            "sessionId": acp_session_id,
+            "runtimeSessionId": binding.runtime_session_id,
+            "cancelled": False,
+            "stopReason": "cancelled" if binding.active else "not_active",
+            "supported": False,
+            "message": (
+                "No active interrupt is available for the minimal stdio ACP facade; "
+                "cancellation is best-effort and currently limited."
+            ),
+        }
+
+    def _write_runtime_event_update(
+        self,
+        *,
+        acp_session_id: str,
+        runtime_session_id: str,
+        binding: AcpSessionBinding,
+        event: object,
+    ) -> None:
+        event_type = _optional_attr(event, "event_type")
+        payload = _mapping_attr(event, "payload")
+        if event_type == "graph.tool_request_created":
+            tool_name = _string_payload(payload, "tool", default="tool")
+            tool_call_id = f"{runtime_session_id}:{tool_name}:{_optional_attr(event, 'sequence')}"
+            binding.tool_call_ids_by_tool[tool_name] = tool_call_id
+            self._write_session_update(
+                acp_session_id,
+                {
+                    "sessionUpdate": "tool_call",
+                    "toolCallId": tool_call_id,
+                    "title": tool_name,
+                    "kind": "other",
+                    "status": "pending",
+                },
+            )
+            return
+        if event_type == "runtime.tool_started":
+            return
+        if event_type == "runtime.tool_completed":
+            tool_name = _string_payload(payload, "tool", default="tool")
+            self._write_session_update(
+                acp_session_id,
+                {
+                    "sessionUpdate": "tool_call_update",
+                    "toolCallId": binding.tool_call_ids_by_tool.get(
+                        tool_name, _tool_call_id(payload, runtime_session_id)
+                    ),
+                    "status": "completed",
+                },
+            )
+            return
+        if event_type == "runtime.failed":
+            self._write_session_update(
+                acp_session_id,
+                {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {
+                        "type": "text",
+                        "text": "Runtime failed.",
+                    },
+                },
+            )
+            return
+        self._write_session_update(
+            acp_session_id,
+            {
+                "sessionUpdate": "agent_thought_chunk",
+                "content": {
+                    "type": "text",
+                    "text": json.dumps(_event_payload(event), separators=(",", ":")),
+                },
+            },
+        )
+
+    def _write_session_update(self, session_id: str, update: JsonObject) -> None:
+        self._write_notification(
+            "session/update",
+            {
+                "sessionId": session_id,
+                "update": update,
+            },
+        )
+
+    def _write_result(self, request_id: JsonRpcId, result: JsonObject) -> None:
+        self._write_json({"jsonrpc": JSON_RPC_VERSION, "id": request_id, "result": result})
+
+    def _write_error(self, request_id: JsonRpcId, code: int, message: str) -> None:
+        self._write_json(
+            {
+                "jsonrpc": JSON_RPC_VERSION,
+                "id": request_id,
+                "error": {"code": code, "message": message},
+            }
+        )
+
+    def _write_notification(self, method: str, params: JsonObject) -> None:
+        self._write_json({"jsonrpc": JSON_RPC_VERSION, "method": method, "params": params})
+
+    def _write_json(self, payload: JsonObject) -> None:
+        with self._write_lock:
+            self.stdout.write(json.dumps(payload, separators=(",", ":")))
+            self.stdout.write("\n")
+            self.stdout.flush()
+
+    def _log_exception(self, message: str, exc: Exception) -> None:
+        self.stderr.write(f"{message}: {exc}\n")
+        self.stderr.flush()
+
+
+def _request_id(value: object) -> JsonRpcId:
+    if value is None or isinstance(value, str):
+        return value
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    return None
+
+
+def _required_string(params: Mapping[str, object], name: str) -> str:
+    value = params.get(name)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"params.{name} must be a non-empty string")
+    return value
+
+
+def _prompt_text(value: object) -> str:
+    if isinstance(value, str) and value:
+        return _validate_prompt_length(value)
+    if isinstance(value, list):
+        parts: list[str] = []
+        for index, item in enumerate(cast(list[object], value)):
+            if not isinstance(item, dict):
+                raise ValueError(f"params.prompt[{index}] must be an object")
+            block = cast(dict[object, object], item)
+            if block.get("type") != "text":
+                raise ValueError("only text prompt blocks are supported")
+            text = block.get("text")
+            if not isinstance(text, str):
+                raise ValueError(f"params.prompt[{index}].text must be a string")
+            parts.append(text)
+        prompt = "\n".join(parts).strip()
+        if prompt:
+            return _validate_prompt_length(prompt)
+    raise ValueError("params.prompt must be a non-empty string or text block array")
+
+
+def _validate_prompt_length(prompt: str) -> str:
+    if len(prompt) > MAX_PROMPT_CHARS:
+        raise ValueError("params.prompt is too large")
+    return prompt
+
+
+def _event_payload(event: object) -> JsonObject:
+    return {
+        "sessionId": _optional_attr(event, "session_id"),
+        "sequence": _optional_attr(event, "sequence"),
+        "type": _optional_attr(event, "event_type"),
+        "source": _optional_attr(event, "source"),
+        "payload": _mapping_attr(event, "payload"),
+    }
+
+
+def _optional_attr(value: object, name: str) -> object:
+    return getattr(value, name, None)
+
+
+def _mapping_attr(value: object, name: str) -> JsonObject:
+    raw = getattr(value, name, {})
+    if isinstance(raw, dict):
+        return cast(JsonObject, raw)
+    return {}
+
+
+def _string_payload(payload: Mapping[str, object], key: str, *, default: str = "") -> str:
+    value = payload.get(key)
+    return value if isinstance(value, str) and value else default
+
+
+def _tool_call_id(payload: Mapping[str, object], runtime_session_id: str) -> str:
+    for key in ("tool_call_id", "call_id", "request_id"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    tool_name = _string_payload(payload, "tool", default="tool")
+    return f"{runtime_session_id}:{tool_name}"

--- a/src/voidcode/acp/stdio.py
+++ b/src/voidcode/acp/stdio.py
@@ -64,7 +64,12 @@ class StdioAcpServer:
             if not line.strip():
                 continue
             if len(line.encode("utf-8")) > MAX_JSON_RPC_LINE_BYTES:
-                self._write_error(None, _ERROR_INVALID_REQUEST, "request line is too large")
+                self._write_error(
+                    None,
+                    _ERROR_INVALID_REQUEST,
+                    "request line is too large",
+                    respond_without_id=True,
+                )
                 continue
             try:
                 request = json.loads(line)
@@ -73,6 +78,7 @@ class StdioAcpServer:
                     None,
                     _ERROR_PARSE,
                     f"parse error: {exc.msg}",
+                    respond_without_id=True,
                 )
                 continue
             self._handle_loaded_request(request)
@@ -81,7 +87,12 @@ class StdioAcpServer:
 
     def _handle_loaded_request(self, request: object) -> None:
         if not isinstance(request, dict):
-            self._write_error(None, _ERROR_INVALID_REQUEST, "request must be an object")
+            self._write_error(
+                None,
+                _ERROR_INVALID_REQUEST,
+                "request must be an object",
+                respond_without_id=True,
+            )
             return
         payload = cast(dict[object, object], request)
         request_id = _request_id(payload.get("id"))
@@ -200,6 +211,8 @@ class StdioAcpServer:
         binding: AcpSessionBinding,
     ) -> None:
         stop_reason = "end_turn"
+        failed_execution = False
+        final_session_status: object = None
         try:
             request = RuntimeRequest(
                 prompt=prompt,
@@ -222,7 +235,10 @@ class StdioAcpServer:
                     break
                 if binding.runtime_session_id is None:
                     binding.runtime_session_id = chunk.session.session.id
+                final_session_status = getattr(chunk.session, "status", None)
                 if chunk.event is not None:
+                    if _optional_attr(chunk.event, "event_type") == "runtime.failed":
+                        failed_execution = True
                     self._write_runtime_event_update(
                         acp_session_id=acp_session_id,
                         runtime_session_id=chunk.session.session.id,
@@ -241,6 +257,9 @@ class StdioAcpServer:
                 raise RuntimeError("runtime stream emitted no chunks")
             if binding.cancel_requested:
                 stop_reason = "cancelled"
+            if failed_execution or final_session_status == "failed":
+                self._write_error(request_id, _ERROR_INTERNAL, "runtime execution failed")
+                return
             self._write_result(
                 request_id,
                 {"stopReason": stop_reason},
@@ -351,9 +370,20 @@ class StdioAcpServer:
         )
 
     def _write_result(self, request_id: JsonRpcId, result: JsonObject) -> None:
+        if request_id is None:
+            return
         self._write_json({"jsonrpc": JSON_RPC_VERSION, "id": request_id, "result": result})
 
-    def _write_error(self, request_id: JsonRpcId, code: int, message: str) -> None:
+    def _write_error(
+        self,
+        request_id: JsonRpcId,
+        code: int,
+        message: str,
+        *,
+        respond_without_id: bool = False,
+    ) -> None:
+        if request_id is None and not respond_without_id:
+            return
         self._write_json(
             {
                 "jsonrpc": JSON_RPC_VERSION,

--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Protocol, cast
 
 from . import __version__
+from .acp.stdio import StdioAcpServer
 from .doctor import (
     CapabilityCheckResult,
     CapabilityCheckStatus,
@@ -102,6 +103,20 @@ def _handle_run_command(args: argparse.Namespace) -> int:
     finally:
         _close_runtime(runtime)
     return 0
+
+
+def _handle_acp_command(args: argparse.Namespace) -> int:
+    workspace = cast(Path, args.workspace)
+    config = load_runtime_config(
+        workspace,
+        approval_mode=cast(PermissionDecision | None, getattr(args, "approval_mode", None)),
+    )
+    runtime = VoidCodeRuntime(workspace=workspace, config=config)
+    try:
+        server = StdioAcpServer(runtime=runtime, workspace=workspace)
+        return server.serve()
+    finally:
+        _close_runtime(runtime)
 
 
 def _run_with_inline_approval(
@@ -938,6 +953,23 @@ def build_parser() -> argparse.ArgumentParser:
     )
     run_parser.set_defaults(provider_stream=None)
     run_parser.set_defaults(handler=_handle_run_command)
+
+    acp_parser = subparsers.add_parser(
+        "acp",
+        help="Run the minimal external-facing ACP stdio JSON-RPC facade.",
+    )
+    _ = acp_parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd(),
+        help="Workspace root used by the ACP-backed runtime session database.",
+    )
+    _ = acp_parser.add_argument(
+        "--approval-mode",
+        choices=("allow", "deny", "ask"),
+        help="Override the runtime approval mode for this ACP process.",
+    )
+    acp_parser.set_defaults(handler=_handle_acp_command)
 
     serve_parser = subparsers.add_parser(
         "serve",

--- a/tests/unit/acp/test_stdio.py
+++ b/tests/unit/acp/test_stdio.py
@@ -305,6 +305,29 @@ def test_notification_style_requests_write_no_result_or_error() -> None:
     assert messages == []
 
 
+def test_malformed_request_id_is_rejected_without_side_effects() -> None:
+    runtime = _StubRuntime()
+    messages, _ = _run_server(
+        runtime,
+        json.dumps({"jsonrpc": "2.0", "id": True, "method": "session/new", "params": {}}),
+        _request("session/prompt", 1, {"sessionId": "acp-session-any", "prompt": "hello"}),
+    )
+
+    assert messages[0] == {
+        "jsonrpc": "2.0",
+        "id": None,
+        "error": {
+            "code": -32600,
+            "message": "id must be a string, integer, null, or omitted",
+        },
+    }
+    assert messages[1]["error"] == {
+        "code": -32602,
+        "message": "unknown ACP session id: acp-session-any",
+    }
+    assert runtime.requests == []
+
+
 def test_cancel_request_during_prompt_returns_cancelled_stop_reason() -> None:
     with patch("voidcode.acp.stdio.uuid4", return_value=SimpleNamespace(hex="abc")):
         messages, _ = _run_server(

--- a/tests/unit/acp/test_stdio.py
+++ b/tests/unit/acp/test_stdio.py
@@ -86,6 +86,13 @@ def _request(method: str, request_id: int, params: dict[str, object] | None = No
     return json.dumps(payload)
 
 
+def _notification(method: str, params: dict[str, object] | None = None) -> str:
+    payload: dict[str, object] = {"jsonrpc": "2.0", "method": method}
+    if params is not None:
+        payload["params"] = params
+    return json.dumps(payload)
+
+
 def _run_server(runtime: Any, *lines: str) -> tuple[list[dict[str, Any]], str]:
     stdout = io.StringIO()
     stderr = io.StringIO()
@@ -207,6 +214,48 @@ def test_prompt_failure_emits_failure_notification_and_json_rpc_error() -> None:
     assert messages[2]["error"] == {"code": -32603, "message": "runtime execution failed"}
 
 
+def test_prompt_runtime_failed_event_returns_json_rpc_error() -> None:
+    runtime = _StubRuntime(
+        [
+            _StubChunk(
+                kind="event",
+                session=_StubSession(_StubSessionRef("runtime-1")),
+                event=_StubEvent(
+                    session_id="runtime-1",
+                    sequence=1,
+                    event_type="runtime.request_received",
+                    source="runtime",
+                    payload={"prompt": "hello"},
+                ),
+            ),
+            _StubChunk(
+                kind="event",
+                session=_StubSession(_StubSessionRef("runtime-1"), status="failed"),
+                event=_StubEvent(
+                    session_id="runtime-1",
+                    sequence=2,
+                    event_type="runtime.failed",
+                    source="runtime",
+                    payload={"error": "permission denied for tool: write_file"},
+                ),
+            ),
+        ]
+    )
+    with patch("voidcode.acp.stdio.uuid4", return_value=SimpleNamespace(hex="abc")):
+        messages, _ = _run_server(
+            runtime,
+            _request("session/new", 1),
+            _request("session/prompt", 2, {"sessionId": "acp-session-abc", "prompt": "hello"}),
+        )
+
+    assert messages[-1] == {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "error": {"code": -32603, "message": "runtime execution failed"},
+    }
+    assert not any(message.get("result") == {"stopReason": "end_turn"} for message in messages)
+
+
 def test_cancel_returns_limited_success_without_crashing() -> None:
     messages, _ = _run_server(
         _StubRuntime(),
@@ -243,6 +292,17 @@ def test_cancel_notification_writes_no_response() -> None:
 
     assert len(messages) == 1
     assert messages[0]["result"]["sessionId"] == "acp-session-abc"
+
+
+def test_notification_style_requests_write_no_result_or_error() -> None:
+    messages, _ = _run_server(
+        _StubRuntime(),
+        _notification("initialize"),
+        _notification("session/new"),
+        _notification("unknown"),
+    )
+
+    assert messages == []
 
 
 def test_cancel_request_during_prompt_returns_cancelled_stop_reason() -> None:

--- a/tests/unit/acp/test_stdio.py
+++ b/tests/unit/acp/test_stdio.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import importlib
+import io
+import json
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+from voidcode.acp.stdio import StdioAcpServer
+from voidcode.runtime.contracts import RuntimeRequest
+
+
+@dataclass(frozen=True, slots=True)
+class _StubEvent:
+    session_id: str
+    sequence: int
+    event_type: str
+    source: str
+    payload: dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class _StubSessionRef:
+    id: str
+
+
+@dataclass(frozen=True, slots=True)
+class _StubSession:
+    session: _StubSessionRef
+    status: str = "running"
+
+
+@dataclass(frozen=True, slots=True)
+class _StubChunk:
+    kind: str
+    session: _StubSession
+    event: _StubEvent | None = None
+    output: str | None = None
+
+
+class _StubRuntime:
+    def __init__(self, chunks: list[_StubChunk] | None = None, *, fail: bool = False) -> None:
+        self.chunks = chunks or []
+        self.fail = fail
+        self.requests: list[RuntimeRequest] = []
+
+    def run_stream(self, request: RuntimeRequest) -> Iterator[Any]:
+        self.requests.append(request)
+        if self.fail:
+            raise RuntimeError("runtime exploded")
+        print("runtime debug should go to stderr")
+        yield from self.chunks
+
+
+class _SlowRuntime:
+    def run_stream(self, request: RuntimeRequest) -> Iterator[Any]:
+        _ = request
+        yield _StubChunk(
+            kind="event",
+            session=_StubSession(_StubSessionRef("runtime-1")),
+            event=_StubEvent(
+                session_id="runtime-1",
+                sequence=1,
+                event_type="runtime.request_received",
+                source="runtime",
+                payload={"prompt": "hello"},
+            ),
+        )
+        time.sleep(0.05)
+        yield _StubChunk(
+            kind="output",
+            session=_StubSession(_StubSessionRef("runtime-1"), status="completed"),
+            output="late output",
+        )
+
+
+def _request(method: str, request_id: int, params: dict[str, object] | None = None) -> str:
+    payload: dict[str, object] = {"jsonrpc": "2.0", "id": request_id, "method": method}
+    if params is not None:
+        payload["params"] = params
+    return json.dumps(payload)
+
+
+def _run_server(runtime: Any, *lines: str) -> tuple[list[dict[str, Any]], str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    server = StdioAcpServer(
+        runtime=runtime,
+        workspace=Path("/tmp/workspace"),
+        stdin=io.StringIO("\n".join(lines) + "\n"),
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    assert server.serve() == 0
+
+    return [json.loads(line) for line in stdout.getvalue().splitlines()], stderr.getvalue()
+
+
+def test_initialize_returns_capabilities_and_agent_metadata() -> None:
+    messages, _ = _run_server(_StubRuntime(), _request("initialize", 1))
+
+    assert messages == [
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "protocolVersion": 1,
+                "agentCapabilities": {
+                    "loadSession": False,
+                    "promptCapabilities": {},
+                    "mcpCapabilities": {},
+                },
+                "agentInfo": {
+                    "name": "voidcode",
+                    "title": "VoidCode",
+                    "version": messages[0]["result"]["agentInfo"]["version"],
+                },
+                "authMethods": [],
+            },
+        }
+    ]
+
+
+def test_session_new_returns_external_session_id() -> None:
+    with patch("voidcode.acp.stdio.uuid4", return_value=SimpleNamespace(hex="abc")):
+        messages, _ = _run_server(_StubRuntime(), _request("session/new", 1))
+
+    result = messages[0]["result"]
+    assert result["sessionId"] == "acp-session-abc"
+
+
+def test_prompt_happy_path_emits_event_output_and_result() -> None:
+    runtime = _StubRuntime(
+        [
+            _StubChunk(
+                kind="event",
+                session=_StubSession(_StubSessionRef("runtime-1")),
+                event=_StubEvent(
+                    session_id="runtime-1",
+                    sequence=1,
+                    event_type="runtime.request_received",
+                    source="runtime",
+                    payload={"prompt": "hello"},
+                ),
+            ),
+            _StubChunk(
+                kind="output",
+                session=_StubSession(_StubSessionRef("runtime-1"), status="completed"),
+                output="done",
+            ),
+        ]
+    )
+    with patch("voidcode.acp.stdio.uuid4", return_value=SimpleNamespace(hex="abc")):
+        messages, stderr = _run_server(
+            runtime,
+            _request("session/new", 1),
+            _request(
+                "session/prompt",
+                2,
+                {"sessionId": "acp-session-abc", "prompt": [{"type": "text", "text": "hello"}]},
+            ),
+        )
+
+    assert messages[1]["method"] == "session/update"
+    assert messages[1]["params"]["sessionId"] == messages[0]["result"]["sessionId"]
+    assert messages[1]["params"]["update"]["sessionUpdate"] == "agent_thought_chunk"
+    assert messages[2]["params"] == {
+        "sessionId": messages[0]["result"]["sessionId"],
+        "update": {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "done"},
+        },
+    }
+    assert messages[3]["result"] == {"stopReason": "end_turn"}
+    assert runtime.requests[-1].prompt == "hello"
+    assert runtime.requests[-1].allocate_session_id is True
+    assert "runtime debug should go to stderr" in stderr
+
+
+def test_prompt_failure_emits_failure_notification_and_json_rpc_error() -> None:
+    messages, _ = _run_server(
+        _StubRuntime(fail=True),
+        _request("session/new", 1),
+        _request("session/prompt", 2, {"sessionId": "acp-session-missing", "prompt": "hello"}),
+    )
+
+    assert messages[1]["error"]["code"] == -32602
+
+    with patch("voidcode.acp.stdio.uuid4", return_value=SimpleNamespace(hex="abc")):
+        messages, _ = _run_server(
+            _StubRuntime(fail=True),
+            _request("session/new", 1),
+            _request("session/prompt", 2, {"sessionId": "acp-session-abc", "prompt": "hello"}),
+        )
+
+    assert messages[1]["method"] == "session/update"
+    assert messages[1]["params"]["update"] == {
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "Runtime failed."},
+    }
+    assert messages[2]["error"] == {"code": -32603, "message": "runtime execution failed"}
+
+
+def test_cancel_returns_limited_success_without_crashing() -> None:
+    messages, _ = _run_server(
+        _StubRuntime(),
+        _request("session/new", 1),
+        _request("session/cancel", 2, {"sessionId": "unknown"}),
+    )
+    assert messages[1]["error"]["code"] == -32602
+
+    with patch("voidcode.acp.stdio.uuid4", return_value=SimpleNamespace(hex="abc")):
+        messages, _ = _run_server(
+            _StubRuntime(),
+            _request("session/new", 1),
+            _request("session/cancel", 2, {"sessionId": "acp-session-abc"}),
+        )
+    assert messages[1]["result"]["cancelled"] is False
+    assert messages[1]["result"]["stopReason"] == "not_active"
+    assert messages[1]["result"]["supported"] is False
+    assert "limited" in messages[1]["result"]["message"]
+
+
+def test_cancel_notification_writes_no_response() -> None:
+    with patch("voidcode.acp.stdio.uuid4", return_value=SimpleNamespace(hex="abc")):
+        messages, _ = _run_server(
+            _StubRuntime(),
+            _request("session/new", 1),
+            json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "session/cancel",
+                    "params": {"sessionId": "acp-session-abc"},
+                }
+            ),
+        )
+
+    assert len(messages) == 1
+    assert messages[0]["result"]["sessionId"] == "acp-session-abc"
+
+
+def test_cancel_request_during_prompt_returns_cancelled_stop_reason() -> None:
+    with patch("voidcode.acp.stdio.uuid4", return_value=SimpleNamespace(hex="abc")):
+        messages, _ = _run_server(
+            _SlowRuntime(),
+            _request("session/new", 1),
+            _request(
+                "session/prompt",
+                2,
+                {"sessionId": "acp-session-abc", "prompt": [{"type": "text", "text": "hello"}]},
+            ),
+            _request("session/cancel", 3, {"sessionId": "acp-session-abc"}),
+        )
+
+    results = [message["result"] for message in messages if isinstance(message.get("result"), dict)]
+    assert {result["stopReason"] for result in results if "stopReason" in result} == {"cancelled"}
+    assert not any(
+        message.get("params", {}).get("update", {}).get("content", {}).get("text") == "late output"
+        for message in messages
+    )
+
+
+def test_rejects_concurrent_prompt_across_sessions() -> None:
+    uuid_values = [SimpleNamespace(hex="abc"), SimpleNamespace(hex="def")]
+    with patch("voidcode.acp.stdio.uuid4", side_effect=uuid_values):
+        messages, _ = _run_server(
+            _SlowRuntime(),
+            _request("session/new", 1),
+            _request("session/new", 2),
+            _request("session/prompt", 3, {"sessionId": "acp-session-abc", "prompt": "first"}),
+            _request("session/prompt", 4, {"sessionId": "acp-session-def", "prompt": "second"}),
+            _request("session/cancel", 5, {"sessionId": "acp-session-abc"}),
+        )
+
+    assert any(
+        message.get("id") == 4
+        and message.get("error")
+        == {
+            "code": -32602,
+            "message": "another ACP prompt is already running",
+        }
+        for message in messages
+    )
+
+
+def test_tool_call_update_reuses_created_tool_call_id() -> None:
+    runtime = _StubRuntime(
+        [
+            _StubChunk(
+                kind="event",
+                session=_StubSession(_StubSessionRef("runtime-1")),
+                event=_StubEvent(
+                    session_id="runtime-1",
+                    sequence=4,
+                    event_type="graph.tool_request_created",
+                    source="graph",
+                    payload={"tool": "read", "arguments": {"path": "README.md"}},
+                ),
+            ),
+            _StubChunk(
+                kind="event",
+                session=_StubSession(_StubSessionRef("runtime-1")),
+                event=_StubEvent(
+                    session_id="runtime-1",
+                    sequence=5,
+                    event_type="runtime.tool_started",
+                    source="runtime",
+                    payload={"tool": "read"},
+                ),
+            ),
+            _StubChunk(
+                kind="event",
+                session=_StubSession(_StubSessionRef("runtime-1")),
+                event=_StubEvent(
+                    session_id="runtime-1",
+                    sequence=6,
+                    event_type="runtime.tool_completed",
+                    source="tool",
+                    payload={"tool": "read", "path": "README.md"},
+                ),
+            ),
+        ]
+    )
+    with patch("voidcode.acp.stdio.uuid4", return_value=SimpleNamespace(hex="abc")):
+        messages, _ = _run_server(
+            runtime,
+            _request("session/new", 1),
+            _request("session/prompt", 2, {"sessionId": "acp-session-abc", "prompt": "hello"}),
+        )
+
+    updates = [message["params"]["update"] for message in messages if "params" in message]
+    tool_call = next(update for update in updates if update["sessionUpdate"] == "tool_call")
+    tool_update = next(
+        update for update in updates if update["sessionUpdate"] == "tool_call_update"
+    )
+    assert tool_update["toolCallId"] == tool_call["toolCallId"]
+
+
+def test_rejects_oversized_line_and_prompt() -> None:
+    messages, _ = _run_server(_StubRuntime(), "x" * 1_048_577)
+    assert messages[0]["error"]["code"] == -32600
+
+    with patch("voidcode.acp.stdio.uuid4", return_value=SimpleNamespace(hex="abc")):
+        messages, _ = _run_server(
+            _StubRuntime(),
+            _request("session/new", 1),
+            _request("session/prompt", 2, {"sessionId": "acp-session-abc", "prompt": "x" * 65_537}),
+        )
+    assert messages[1]["error"] == {"code": -32602, "message": "params.prompt is too large"}
+
+
+def test_invalid_protocol_inputs_return_json_rpc_errors() -> None:
+    messages, _ = _run_server(
+        _StubRuntime(),
+        "not-json",
+        "[]",
+        json.dumps({"jsonrpc": "2.0", "id": 1, "method": "missing", "params": []}),
+        _request("unknown", 2),
+    )
+
+    assert [message["error"]["code"] for message in messages] == [-32700, -32600, -32602, -32601]
+
+
+def test_cli_acp_loads_config_constructs_runtime_and_keeps_stdout_protocol_clean() -> None:
+    cli = importlib.import_module("voidcode.cli")
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    stdin = io.StringIO(_request("initialize", 1) + "\n")
+    workspace = Path("/tmp/acp-workspace")
+    config = SimpleNamespace(approval_mode="deny")
+    runtime = _StubRuntime()
+
+    with patch.object(
+        cli, "load_runtime_config", autospec=True, return_value=config
+    ) as config_mock:
+        with patch.object(
+            cli, "VoidCodeRuntime", autospec=True, return_value=runtime
+        ) as runtime_mock:
+            with (
+                patch.object(cli.sys, "stdin", stdin),
+                patch.object(cli.sys, "stdout", stdout),
+                patch.object(cli.sys, "stderr", stderr),
+            ):
+                result = cli.main(
+                    [
+                        "acp",
+                        "--workspace",
+                        str(workspace),
+                        "--approval-mode",
+                        "deny",
+                    ]
+                )
+
+    assert result == 0
+    config_mock.assert_called_once_with(workspace, approval_mode="deny")
+    runtime_mock.assert_called_once_with(workspace=workspace, config=config)
+    assert [json.loads(line)["jsonrpc"] for line in stdout.getvalue().splitlines()] == ["2.0"]
+    assert "EVENT" not in stdout.getvalue()


### PR DESCRIPTION
## Summary
- Add `voidcode acp` as a newline-delimited JSON-RPC stdio facade over `VoidCodeRuntime.run_stream`.
- Support minimal ACP lifecycle methods: `initialize`, `session/new`, `session/prompt`, and best-effort `session/cancel` with protocol-clean stdout.
- Document supported methods, limitations, and unsupported MCP/auth/replay scope.

## Verification
- `uv run pytest tests/unit/acp/test_stdio.py tests/unit/acp/test_acp.py tests/unit/runtime/test_acp.py -q` (31 passed)
- `uv run ruff check .`
- `uv run basedpyright --warnings src`
- `uv run pytest tests/unit --ignore=tests/unit/tools/fuzz --ignore=tests/unit/runtime/test_http_question_payload_fuzz.py --ignore=tests/unit/runtime/test_runtime_service_extensions.py -q` (1033 passed)
- `uv build`
- Manual `python -m voidcode acp` subprocess smoke checks for initialize/session/new and prompt failure termination

Closes #276