### PR TITLE
feat: surface provider readiness diagnostics

### DIFF
--- a/docs/failure-diagnosis-runbook.md
+++ b/docs/failure-diagnosis-runbook.md
@@ -28,6 +28,7 @@
 | 数据库损坏或 schema 不匹配 | 启动任何命令即报 `sqlite runtime schema mismatch` | 不可用 | `.voidcode/sessions.sqlite3` 文件是否存在、schema 是否与代码中 `_CANONICAL_SCHEMA` 一致 |
 | 工作区路径错误 | 命令报 `workspace does not exist` | 不可用 | `--workspace` 参数指向的目录是否存在 |
 | 配置解析失败 | `doctor` 返回非零退出码，或 `config show` 报错 | 不可用 | `.voidcode/config.json`（如存在）是否为合法 JSON |
+| Provider / model 未就绪 | `doctor` 报 `provider.readiness`，`runtime.failed` 含 `provider_error_kind` | `failed` 或不可用 | `voidcode config show` 的 `provider_readiness` 与 `context_budget` |
 | HTTP 服务未启动 | `curl` 连接被拒绝 | 不适用 | `voidcode serve` 进程是否在运行、端口是否被占用 |
 
 ---
@@ -147,6 +148,30 @@ uv run voidcode sessions resume <session-id> --workspace .
 ```
 
 `sessions list` 的输出直接反映 SQLite 中 `sessions` 表的 `status`、`turn`、`prompt`、`updated_at` 列。
+
+### 3.2.1 Provider / model / context readiness
+
+Provider-first execution failures should be diagnosed from the shared runtime metadata instead of client-specific string matching:
+
+```bash
+uv run voidcode doctor --workspace . --verbose
+uv run voidcode config show --workspace .
+```
+
+Key JSON fields:
+
+- `provider_readiness.status`: `ready`, `missing_auth`, `unconfigured`, `missing_model`, or a provider feature/readiness status.
+- `provider_readiness.guidance`: user-facing recovery step safe for CLI/Web/ACP display.
+- `provider_readiness.fallback_chain`: effective primary + fallback provider/model targets.
+- `context_budget.context_window` / `max_output_tokens`: model/catalog or configured budget metadata used to explain compaction/context-limit behavior.
+- `runtime.failed.provider_error_kind`: structured provider failure kind such as `missing_auth`, `invalid_model`, `rate_limit`, `transient_failure`, `context_limit`, `unsupported_feature`, or `stream_tool_feedback_shape`.
+
+Common recovery actions:
+
+- `missing_auth`: configure the provider API key via environment variable or `.voidcode.json`.
+- `invalid_model`: fix the provider/model name or model access permissions.
+- `context_limit`: reduce prompt/tool context, rely on compaction, or switch to a larger-context model.
+- `unsupported_feature`: disable streaming/tool features for that provider or switch provider/model.
 
 ### 3.3 SQLite 直接检查
 

--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -61,6 +61,7 @@ from .runtime.contracts import (
     BackgroundTaskResult,
     ProviderInspectResult,
     ProviderModelMetadata,
+    ProviderReadinessResult,
     RuntimeRequest,
     RuntimeSessionDebugSnapshot,
     RuntimeStreamChunk,
@@ -718,6 +719,7 @@ def _handle_config_show_command(args: argparse.Namespace) -> int:
     try:
         try:
             effective_config = runtime.effective_runtime_config(session_id=session_id)
+            readiness = runtime.provider_readiness(session_id=session_id)
         except ValueError as exc:
             raise SystemExit(f"error: {exc}") from None
     finally:
@@ -738,6 +740,11 @@ def _handle_config_show_command(args: argparse.Namespace) -> int:
             "resolved_provider": resolved_provider_snapshot(
                 getattr(effective_config, "resolved_provider", None)
             ),
+            "provider_readiness": _provider_readiness_payload(readiness),
+            "context_budget": {
+                "context_window": readiness.context_window,
+                "max_output_tokens": readiness.max_output_tokens,
+            },
         }
     )
     return EXIT_SUCCESS
@@ -951,6 +958,23 @@ def _provider_model_metadata_payload(
     }
 
 
+def _provider_readiness_payload(readiness: ProviderReadinessResult) -> dict[str, object]:
+    return {
+        "provider": readiness.provider,
+        "model": readiness.model,
+        "configured": readiness.configured,
+        "ok": readiness.ok,
+        "status": readiness.status,
+        "guidance": readiness.guidance,
+        "auth_present": readiness.auth_present,
+        "streaming_configured": readiness.streaming_configured,
+        "streaming_supported": readiness.streaming_supported,
+        "context_window": readiness.context_window,
+        "max_output_tokens": readiness.max_output_tokens,
+        "fallback_chain": list(readiness.fallback_chain),
+    }
+
+
 def _provider_inspect_payload(
     result: ProviderInspectResult, *, workspace: Path
 ) -> dict[str, object]:
@@ -984,7 +1008,12 @@ def _provider_inspect_payload(
             "source": result.validation.source,
             "last_error": result.validation.last_error,
             "discovery_mode": result.validation.discovery_mode,
+            "failure_kind": result.validation.failure_kind,
+            "guidance": result.validation.guidance,
         },
+        "readiness": (
+            _provider_readiness_payload(result.readiness) if result.readiness is not None else None
+        ),
         "current_model": result.current_model,
         "current_model_metadata": (
             None

--- a/src/voidcode/doctor/checker.py
+++ b/src/voidcode/doctor/checker.py
@@ -57,6 +57,7 @@ class DoctorCheckType(enum.Enum):
     LSP_SERVER = "lsp_server"
     MCP_SERVER = "mcp_server"
     RUNTIME_CONFIG = "runtime_config"
+    PROVIDER_READINESS = "provider_readiness"
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/voidcode/doctor/doctor.py
+++ b/src/voidcode/doctor/doctor.py
@@ -143,6 +143,10 @@ class CapabilityDoctor:
         """
         return list(self._results)
 
+    def add_result(self, result: CapabilityCheckResult) -> None:
+        """Add a precomputed structured check result."""
+        self._results.append(result)
+
     @property
     def results(self) -> list[CapabilityCheckResult]:
         """Get all check results."""
@@ -247,5 +251,41 @@ def create_doctor_for_config(
     if mcp_config is not None and mcp_config.enabled is True and mcp_config.servers:
         for server_name, server_config in mcp_config.servers.items():
             doctor.add_mcp_server_check(server_name, server_config)
+
+    if config.execution_engine == "provider" or config.model is not None:
+        from ..runtime.service import VoidCodeRuntime
+
+        runtime = VoidCodeRuntime(workspace=workspace, config=config)
+        try:
+            readiness = runtime.provider_readiness()
+        finally:
+            exit_method = getattr(runtime, "__exit__", None)
+            if callable(exit_method):
+                exit_method(None, None, None)
+        doctor.add_result(
+            CapabilityCheckResult(
+                status=(
+                    CapabilityCheckStatus.READY
+                    if readiness.ok
+                    else CapabilityCheckStatus.ERROR
+                    if readiness.status == "missing_auth"
+                    else CapabilityCheckStatus.NOT_CONFIGURED
+                ),
+                name="provider.readiness",
+                check_type=DoctorCheckType.PROVIDER_READINESS.value,
+                details={
+                    "provider": readiness.provider,
+                    "model": readiness.model,
+                    "configured": readiness.configured,
+                    "auth_present": readiness.auth_present,
+                    "streaming_supported": readiness.streaming_supported,
+                    "context_window": readiness.context_window,
+                    "max_output_tokens": readiness.max_output_tokens,
+                    "fallback_chain": list(readiness.fallback_chain),
+                    "status": readiness.status,
+                },
+                error_message=None if readiness.ok else readiness.guidance,
+            )
+        )
 
     return doctor

--- a/src/voidcode/doctor/doctor.py
+++ b/src/voidcode/doctor/doctor.py
@@ -278,15 +278,10 @@ def create_doctor_for_config(
                 exit_method = getattr(runtime, "__exit__", None)
                 if callable(exit_method):
                     exit_method(None, None, None)
+        status = CapabilityCheckStatus.READY if readiness.ok else CapabilityCheckStatus.ERROR
         doctor.add_result(
             CapabilityCheckResult(
-                status=(
-                    CapabilityCheckStatus.READY
-                    if readiness.ok
-                    else CapabilityCheckStatus.ERROR
-                    if readiness.status == "missing_auth"
-                    else CapabilityCheckStatus.NOT_CONFIGURED
-                ),
+                status=status,
                 name="provider.readiness",
                 check_type=DoctorCheckType.PROVIDER_READINESS.value,
                 details={

--- a/src/voidcode/doctor/doctor.py
+++ b/src/voidcode/doctor/doctor.py
@@ -255,13 +255,29 @@ def create_doctor_for_config(
     if config.execution_engine == "provider" or config.model is not None:
         from ..runtime.service import VoidCodeRuntime
 
-        runtime = VoidCodeRuntime(workspace=workspace, config=config)
+        runtime: VoidCodeRuntime | None = None
         try:
+            runtime = VoidCodeRuntime(workspace=workspace, config=config)
             readiness = runtime.provider_readiness()
+        except ValueError as exc:
+            doctor.add_result(
+                CapabilityCheckResult(
+                    status=CapabilityCheckStatus.ERROR,
+                    name="provider.readiness",
+                    check_type=DoctorCheckType.PROVIDER_READINESS.value,
+                    details={
+                        "model": config.model,
+                        "status": "invalid_config",
+                    },
+                    error_message=str(exc),
+                )
+            )
+            return doctor
         finally:
-            exit_method = getattr(runtime, "__exit__", None)
-            if callable(exit_method):
-                exit_method(None, None, None)
+            if runtime is not None:
+                exit_method = getattr(runtime, "__exit__", None)
+                if callable(exit_method):
+                    exit_method(None, None, None)
         doctor.add_result(
             CapabilityCheckResult(
                 status=(

--- a/src/voidcode/doctor/reporter.py
+++ b/src/voidcode/doctor/reporter.py
@@ -202,6 +202,18 @@ def _format_details(result: CapabilityCheckResult) -> list[str]:
         details.append(f"preset: {d['preset_name']}")
     if "version_info" in d and d["version_info"]:
         details.append(f"version: {d['version_info']}")
+    if "provider" in d:
+        details.append(f"provider: {d['provider']}")
+    if "model" in d:
+        details.append(f"model: {d['model']}")
+    if "auth_present" in d:
+        details.append(f"auth_present: {d['auth_present']}")
+    if "streaming_supported" in d:
+        details.append(f"streaming_supported: {d['streaming_supported']}")
+    if "context_window" in d and d["context_window"] is not None:
+        details.append(f"context_window: {d['context_window']}")
+    if "fallback_chain" in d and d["fallback_chain"]:
+        details.append(f"fallback_chain: {', '.join(str(item) for item in d['fallback_chain'])}")
 
     return details
 

--- a/src/voidcode/graph/provider_graph.py
+++ b/src/voidcode/graph/provider_graph.py
@@ -247,9 +247,12 @@ class ProviderGraph:
                 parsed = parse_provider_stream_error(error_payload)
                 parsed_kind = parsed.kind
                 if stream_event.error_kind in {
+                    "missing_auth",
                     "rate_limit",
                     "context_limit",
                     "invalid_model",
+                    "unsupported_feature",
+                    "stream_tool_feedback_shape",
                 }:
                     parsed_kind = stream_event.error_kind
                 raise ProviderExecutionError(

--- a/src/voidcode/provider/auth.py
+++ b/src/voidcode/provider/auth.py
@@ -15,7 +15,11 @@ from .config import (
 
 type ProviderAuthProvider = str
 type ProviderErrorKind = Literal[
-    "rate_limit", "context_limit", "invalid_model", "transient_failure"
+    "missing_auth",
+    "rate_limit",
+    "context_limit",
+    "invalid_model",
+    "transient_failure",
 ]
 
 
@@ -299,7 +303,7 @@ class ProviderAuthResolver:
             raise self._error(
                 provider=provider_name,
                 code="missing_credentials",
-                kind="invalid_model",
+                kind="missing_auth",
                 message=(
                     f"provider auth field '{provider_name}.api_key' must be provided "
                     f"for {provider_name} api_key auth"
@@ -499,7 +503,7 @@ class ProviderAuthResolver:
                 raise self._error(
                     provider="google",
                     code="missing_credentials",
-                    kind="invalid_model",
+                    kind="missing_auth",
                     message=(
                         "provider auth field 'google.service_account_json_path' "
                         "must be provided for google service_account auth"
@@ -574,7 +578,7 @@ class ProviderAuthResolver:
                 raise self._error(
                     provider="copilot",
                     code="missing_credentials",
-                    kind="invalid_model",
+                    kind="missing_auth",
                     message=(
                         "provider auth field 'copilot.token' "
                         "must be provided for copilot token auth"
@@ -642,7 +646,7 @@ class ProviderAuthResolver:
         raise self._error(
             provider=provider,
             code="missing_credentials",
-            kind="invalid_model",
+            kind="missing_auth",
             message=(
                 f"provider auth field '{provider}.{field_name}' "
                 f"must be provided for {provider} api_key auth"
@@ -723,7 +727,7 @@ class ProviderAuthResolver:
             raise self._error(
                 provider=provider,
                 code="missing_credentials",
-                kind="invalid_model",
+                kind="missing_auth",
                 message=f"{field_path} must be provided",
             )
         return value

--- a/src/voidcode/provider/errors.py
+++ b/src/voidcode/provider/errors.py
@@ -240,22 +240,6 @@ def _classify_api_error_kind(
     ):
         return "missing_auth"
 
-    if status_code == 403:
-        if any(pattern.search(message) is not None for pattern in _INVALID_MODEL_PATTERNS):
-            return "invalid_model"
-        if any(
-            marker in lowered_message
-            for marker in (
-                "not authorized for model",
-                "model access",
-                "model unavailable",
-                "permission to access model",
-                "usage not included",
-            )
-        ):
-            return "invalid_model"
-        return "missing_auth"
-
     if any(
         marker in lowered_message
         for marker in (
@@ -277,6 +261,22 @@ def _classify_api_error_kind(
         )
     ):
         return "stream_tool_feedback_shape"
+
+    if status_code == 403:
+        if any(pattern.search(message) is not None for pattern in _INVALID_MODEL_PATTERNS):
+            return "invalid_model"
+        if any(
+            marker in lowered_message
+            for marker in (
+                "not authorized for model",
+                "model access",
+                "model unavailable",
+                "permission to access model",
+                "usage not included",
+            )
+        ):
+            return "invalid_model"
+        return "missing_auth"
 
     if any(pattern.search(message) is not None for pattern in _INVALID_MODEL_PATTERNS):
         return "invalid_model"

--- a/src/voidcode/provider/errors.py
+++ b/src/voidcode/provider/errors.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Any, Literal, cast
+from typing import Any, cast
 
-from .protocol import ProviderExecutionError
+from .protocol import ProviderErrorKind, ProviderExecutionError
 
 _CONTEXT_OVERFLOW_PATTERNS = (
     re.compile(r"prompt is too long", re.IGNORECASE),
@@ -40,26 +40,109 @@ _INVALID_MODEL_PATTERNS = (
     re.compile(r"model_not_found", re.IGNORECASE),
 )
 
+_SENSITIVE_DETAIL_KEY_MARKERS = (
+    "api_key",
+    "apikey",
+    "authorization",
+    "cookie",
+    "credential",
+    "key",
+    "password",
+    "secret",
+    "token",
+)
+_SECRET_VALUE_PATTERNS = (
+    re.compile(r"sk-[A-Za-z0-9_\-]{6,}"),
+    re.compile(r"Bearer\s+[A-Za-z0-9._\-]{6,}", re.IGNORECASE),
+    re.compile(r"(?i)(api[_-]?key|token|secret|password)=([^\s&]+)"),
+)
+
+
+def _redact_secret_text(value: str) -> str:
+    redacted = value
+    for pattern in _SECRET_VALUE_PATTERNS:
+        redacted = pattern.sub(
+            lambda match: (
+                f"{match.group(1)}=<redacted>"
+                if match.lastindex and match.lastindex >= 2
+                else "<redacted>"
+            ),
+            redacted,
+        )
+    return redacted
+
+
+def _redact_provider_error_detail(value: object) -> object:
+    if isinstance(value, dict):
+        redacted: dict[str, object] = {}
+        for raw_key, raw_item in cast(dict[object, object], value).items():
+            key = str(raw_key)
+            lowered = key.lower()
+            if any(marker in lowered for marker in _SENSITIVE_DETAIL_KEY_MARKERS):
+                redacted[key] = "<redacted>"
+            else:
+                redacted[key] = _redact_provider_error_detail(raw_item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact_provider_error_detail(item) for item in cast(list[object], value)]
+    if isinstance(value, str):
+        return _redact_secret_text(value)
+    return value
+
+
+def _provider_error_details(payload: dict[str, Any]) -> dict[str, object]:
+    return cast(dict[str, object], _redact_provider_error_detail(payload))
+
 
 @dataclass(frozen=True, slots=True)
 class ParsedProviderError:
-    kind: Literal["rate_limit", "context_limit", "invalid_model", "transient_failure"]
+    kind: ProviderErrorKind
     message: str
     details: dict[str, object]
     retryable: bool
     fallback_allowed: bool
+    guidance: str
 
 
-def _recovery_policy_for_kind(
-    kind: Literal["rate_limit", "context_limit", "invalid_model", "transient_failure"],
-) -> tuple[bool, bool]:
+def _recovery_policy_for_kind(kind: ProviderErrorKind) -> tuple[bool, bool]:
     if kind == "context_limit":
         return False, False
-    if kind == "invalid_model":
+    if kind in {
+        "missing_auth",
+        "invalid_model",
+        "unsupported_feature",
+        "stream_tool_feedback_shape",
+    }:
         return False, True
     if kind == "rate_limit":
         return True, True
+    if kind == "cancelled":
+        return False, False
     return True, True
+
+
+def guidance_for_provider_error_kind(kind: ProviderErrorKind) -> str:
+    if kind == "missing_auth":
+        return "Configure the provider API key or auth method, then retry."
+    if kind == "invalid_model":
+        return "Check the configured provider/model name and model access permissions."
+    if kind == "rate_limit":
+        return "Retry later, reduce request volume, or configure a fallback model."
+    if kind == "context_limit":
+        return (
+            "Reduce prompt/tool-result context or switch to a model with a larger context window."
+        )
+    if kind == "unsupported_feature":
+        return (
+            "Disable the unsupported provider feature or choose a model/provider that supports it."
+        )
+    if kind == "stream_tool_feedback_shape":
+        return (
+            "Report this provider stream/tool-call shape; VoidCode could not normalize it safely."
+        )
+    if kind == "cancelled":
+        return "The request was cancelled; rerun when ready."
+    return "Retry the request or configure a fallback provider/model."
 
 
 def _extract_error_message(payload: dict[str, Any]) -> str | None:
@@ -113,7 +196,7 @@ def _classify_api_error_kind(
     message: str,
     status_code: int | None,
     code: str | None,
-) -> Literal["rate_limit", "context_limit", "invalid_model", "transient_failure"]:
+) -> ProviderErrorKind:
     if _is_context_overflow(message, status_code, code):
         return "context_limit"
 
@@ -122,18 +205,78 @@ def _classify_api_error_kind(
     ):
         return "rate_limit"
 
-    if status_code in {401, 403, 404}:
-        return "invalid_model"
+    if isinstance(code, str) and code.lower() in {
+        "missing_api_key",
+        "invalid_api_key",
+        "authentication_error",
+        "unauthorized",
+    }:
+        return "missing_auth"
 
     if isinstance(code, str) and code.lower() in {
         "invalid_model",
         "model_not_found",
-        "invalid_api_key",
         "insufficient_quota",
         "usage_not_included",
-        "authentication_error",
     }:
         return "invalid_model"
+
+    if status_code == 401:
+        return "missing_auth"
+
+    if status_code == 404:
+        return "invalid_model"
+
+    lowered_message = message.lower()
+    if any(
+        marker in lowered_message
+        for marker in (
+            "api key is missing",
+            "missing api key",
+            "invalid api key",
+            "authentication failed",
+            "unauthorized",
+        )
+    ):
+        return "missing_auth"
+
+    if status_code == 403:
+        if any(pattern.search(message) is not None for pattern in _INVALID_MODEL_PATTERNS):
+            return "invalid_model"
+        if any(
+            marker in lowered_message
+            for marker in (
+                "not authorized for model",
+                "model access",
+                "model unavailable",
+                "permission to access model",
+                "usage not included",
+            )
+        ):
+            return "invalid_model"
+        return "missing_auth"
+
+    if any(
+        marker in lowered_message
+        for marker in (
+            "unsupported stream",
+            "streaming is not supported",
+            "tools are not supported",
+            "tool calling is not supported",
+        )
+    ):
+        return "unsupported_feature"
+
+    if any(
+        marker in lowered_message
+        for marker in (
+            "invalid tool call",
+            "tool_calls must",
+            "malformed tool call",
+            "stream tool",
+        )
+    ):
+        return "stream_tool_feedback_shape"
 
     if any(pattern.search(message) is not None for pattern in _INVALID_MODEL_PATTERNS):
         return "invalid_model"
@@ -150,12 +293,14 @@ def parse_provider_api_error(payload: dict[str, Any]) -> ParsedProviderError:
     code = _extract_error_code(payload)
     kind = _classify_api_error_kind(message=message, status_code=status_code, code=code)
     retryable, fallback_allowed = _recovery_policy_for_kind(kind)
-    details: dict[str, object] = dict(payload)
+    details = _provider_error_details(payload)
+    guidance = guidance_for_provider_error_kind(kind)
     details.update(
         {
             "source": "api",
             "status_code": status_code,
             "error_code": code,
+            "guidance": guidance,
         }
     )
     return ParsedProviderError(
@@ -164,6 +309,7 @@ def parse_provider_api_error(payload: dict[str, Any]) -> ParsedProviderError:
         details=details,
         retryable=retryable,
         fallback_allowed=fallback_allowed,
+        guidance=guidance,
     )
 
 
@@ -173,12 +319,14 @@ def parse_provider_stream_error(payload: dict[str, Any]) -> ParsedProviderError:
     code = _extract_error_code(payload)
     kind = _classify_api_error_kind(message=message, status_code=status_code, code=code)
     retryable, fallback_allowed = _recovery_policy_for_kind(kind)
-    details: dict[str, object] = dict(payload)
+    details = _provider_error_details(payload)
+    guidance = guidance_for_provider_error_kind(kind)
     details.update(
         {
             "source": "stream",
             "status_code": status_code,
             "error_code": code,
+            "guidance": guidance,
         }
     )
     return ParsedProviderError(
@@ -187,6 +335,7 @@ def parse_provider_stream_error(payload: dict[str, Any]) -> ParsedProviderError:
         details=details,
         retryable=retryable,
         fallback_allowed=fallback_allowed,
+        guidance=guidance,
     )
 
 

--- a/src/voidcode/provider/protocol.py
+++ b/src/voidcode/provider/protocol.py
@@ -13,6 +13,16 @@ type AppliedSkill = dict[str, str]
 type ProviderStreamEventKind = Literal["delta", "content", "error", "done"]
 type ProviderStreamChannel = Literal["text", "tool", "reasoning", "error"]
 type ProviderDoneReason = Literal["completed", "cancelled", "error"]
+type ProviderErrorKind = Literal[
+    "missing_auth",
+    "invalid_model",
+    "rate_limit",
+    "transient_failure",
+    "context_limit",
+    "unsupported_feature",
+    "stream_tool_feedback_shape",
+    "cancelled",
+]
 
 
 @runtime_checkable
@@ -93,16 +103,7 @@ class ProviderStreamEvent:
     channel: ProviderStreamChannel = "text"
     text: str | None = None
     error: str | None = None
-    error_kind: (
-        Literal[
-            "rate_limit",
-            "context_limit",
-            "invalid_model",
-            "transient_failure",
-            "cancelled",
-        ]
-        | None
-    ) = None
+    error_kind: ProviderErrorKind | None = None
     done_reason: ProviderDoneReason | None = None
     usage: ProviderTokenUsage | None = None
 
@@ -178,13 +179,7 @@ def wrap_provider_stream(
 
 @dataclass(frozen=True, slots=True)
 class ProviderExecutionError(ValueError):
-    kind: Literal[
-        "rate_limit",
-        "context_limit",
-        "invalid_model",
-        "transient_failure",
-        "cancelled",
-    ]
+    kind: ProviderErrorKind
     provider_name: str
     model_name: str
     message: str

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -6,7 +6,7 @@ import json
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from functools import lru_cache
-from typing import Any, NamedTuple, cast
+from typing import Any, Literal, NamedTuple, cast
 
 from ..tools.contracts import ToolResult
 
@@ -208,6 +208,24 @@ def _tool_result_preview(result: ToolResult, *, max_preview_chars: int) -> str:
 
 _UNICODE_TOKEN_ESTIMATE_SOURCE = "unicode_aware_chars"
 
+type TokenCountMethod = Literal["tiktoken", "estimated"]
+
+
+@dataclass(frozen=True, slots=True)
+class TokenCount:
+    tokens: int
+    method: TokenCountMethod
+    source: str
+    exact: bool = False
+
+    def metadata_payload(self) -> dict[str, object]:
+        return {
+            "tokens": self.tokens,
+            "method": self.method,
+            "source": self.source,
+            "exact": self.exact,
+        }
+
 
 class _TokenEstimate(NamedTuple):
     tokens: int
@@ -223,15 +241,17 @@ def _tiktoken_encoding_for_model(tokenizer_model: str) -> Any:
         return tiktoken.get_encoding("cl100k_base")
 
 
-def _estimated_token_count(value: str, *, tokenizer_model: str | None = None) -> _TokenEstimate:
+def count_text_tokens(value: str, *, tokenizer_model: str | None = None) -> TokenCount:
     if not value:
-        return _TokenEstimate(0, _UNICODE_TOKEN_ESTIMATE_SOURCE)
+        return TokenCount(0, method="estimated", source=_UNICODE_TOKEN_ESTIMATE_SOURCE)
     if tokenizer_model is not None:
         try:
             encoding = _tiktoken_encoding_for_model(tokenizer_model)
-            return _TokenEstimate(
+            return TokenCount(
                 len(encoding.encode(value, disallowed_special=())),
-                f"tiktoken:{tokenizer_model}",
+                method="tiktoken",
+                source=f"tiktoken:{tokenizer_model}",
+                exact=True,
             )
         except ImportError:
             pass
@@ -242,10 +262,17 @@ def _estimated_token_count(value: str, *, tokenizer_model: str | None = None) ->
             ascii_chars += 1
         else:
             non_ascii_chars += 1
-    return _TokenEstimate(
-        max(1, ((ascii_chars + 3) // 4) + non_ascii_chars),
-        _UNICODE_TOKEN_ESTIMATE_SOURCE,
+    return TokenCount(
+        tokens=max(1, ((ascii_chars + 3) // 4) + non_ascii_chars),
+        method="estimated",
+        source=_UNICODE_TOKEN_ESTIMATE_SOURCE,
+        exact=False,
     )
+
+
+def _estimated_token_count(value: str, *, tokenizer_model: str | None = None) -> _TokenEstimate:
+    counted = count_text_tokens(value, tokenizer_model=tokenizer_model)
+    return _TokenEstimate(counted.tokens, counted.source)
 
 
 def _tool_result_token_estimate(

--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -507,12 +507,29 @@ class ProviderModelsResult:
 
 
 @dataclass(frozen=True, slots=True)
+class ProviderReadinessResult:
+    provider: str | None
+    model: str | None
+    configured: bool
+    ok: bool
+    status: str
+    guidance: str
+    auth_present: bool | None = None
+    streaming_configured: bool | None = None
+    streaming_supported: bool | None = None
+    context_window: int | None = None
+    max_output_tokens: int | None = None
+    fallback_chain: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
 class ProviderInspectResult:
     summary: ProviderSummary
     models: ProviderModelsResult
     validation: ProviderValidationResult
     current_model: str | None = None
     current_model_metadata: ProviderModelMetadata | None = None
+    readiness: ProviderReadinessResult | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -525,6 +542,8 @@ class ProviderValidationResult:
     source: str | None = None
     last_error: str | None = None
     discovery_mode: str | None = None
+    failure_kind: str | None = None
+    guidance: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/voidcode/runtime/execution_seams.py
+++ b/src/voidcode/runtime/execution_seams.py
@@ -123,7 +123,7 @@ def fallback_graph_for_provider_error(
 ) -> RuntimeGraphSelection | None:
     next_attempt = provider_attempt + 1
     next_target = provider_chain.target_at(next_attempt)
-    if error.kind not in {"rate_limit", "invalid_model", "transient_failure"}:
+    if error.kind not in {"missing_auth", "rate_limit", "invalid_model", "transient_failure"}:
         return None
     if next_target is None:
         return None

--- a/src/voidcode/runtime/execution_seams.py
+++ b/src/voidcode/runtime/execution_seams.py
@@ -123,7 +123,14 @@ def fallback_graph_for_provider_error(
 ) -> RuntimeGraphSelection | None:
     next_attempt = provider_attempt + 1
     next_target = provider_chain.target_at(next_attempt)
-    if error.kind not in {"missing_auth", "rate_limit", "invalid_model", "transient_failure"}:
+    if error.kind not in {
+        "missing_auth",
+        "rate_limit",
+        "invalid_model",
+        "transient_failure",
+        "unsupported_feature",
+        "stream_tool_feedback_shape",
+    }:
         return None
     if next_target is None:
         return None

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -249,6 +249,8 @@ class RuntimeRunLoopCoordinator:
                         "rate_limit",
                         "invalid_model",
                         "transient_failure",
+                        "unsupported_feature",
+                        "stream_tool_feedback_shape",
                     }:
                         yield runtime._failed_chunk(
                             session=session,

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -244,7 +244,12 @@ class RuntimeRunLoopCoordinator:
                             },
                         )
                         continue
-                    if provider_error.kind in {"rate_limit", "invalid_model", "transient_failure"}:
+                    if provider_error.kind in {
+                        "missing_auth",
+                        "rate_limit",
+                        "invalid_model",
+                        "transient_failure",
+                    }:
                         yield runtime._failed_chunk(
                             session=session,
                             sequence=sequence + 1,

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -29,8 +29,12 @@ from ..hook.executor import (
     run_lifecycle_hooks,
     run_tool_hooks,
 )
-from ..provider.auth import ProviderAuthResolver
-from ..provider.errors import format_invalid_provider_config_error
+from ..provider.auth import (
+    ProviderAuthAuthorizeRequest,
+    ProviderAuthResolutionError,
+    ProviderAuthResolver,
+)
+from ..provider.errors import format_invalid_provider_config_error, guidance_for_provider_error_kind
 from ..provider.model_catalog import (
     ProviderModelCatalog,
     infer_model_metadata,
@@ -101,6 +105,7 @@ from .contracts import (
     ProviderInspectResult,
     ProviderModelMetadata,
     ProviderModelsResult,
+    ProviderReadinessResult,
     ProviderSummary,
     ProviderValidationResult,
     ReviewFileDiff,
@@ -251,6 +256,18 @@ _SKILL_BINDING_SCOPE_KEYS = (
 class _ActiveSessionKey:
     workspace: Path
     session_id: str
+
+
+def _provider_target_label(target: ResolvedProviderModel) -> str:
+    provider = target.selection.provider
+    model = target.selection.model
+    if provider is None and model is None:
+        return "unresolved"
+    if provider is None:
+        return str(model)
+    if model is None:
+        return provider
+    return f"{provider}/{model}"
 
 
 class _ActiveSessionRegistry:
@@ -2380,6 +2397,70 @@ class VoidCodeRuntime:
             discovery_mode=cast(str | None, catalog["discovery_mode"]),
         )
 
+    def provider_readiness(self, *, session_id: str | None = None) -> ProviderReadinessResult:
+        effective_config = self.effective_runtime_config(session_id=session_id)
+        return self._provider_readiness_for_effective_config(effective_config)
+
+    def _provider_readiness_for_effective_config(
+        self, effective_config: EffectiveRuntimeConfig
+    ) -> ProviderReadinessResult:
+        active_target = effective_config.resolved_provider.active_target
+        provider_name = active_target.selection.provider
+        model_name = active_target.selection.model
+        fallback_chain = tuple(
+            _provider_target_label(target)
+            for target in effective_config.resolved_provider.target_chain.all_targets
+        )
+        streaming_configured = None
+        streaming_supported = None
+        context_window = None
+        max_output_tokens = None
+        if provider_name is not None and model_name is not None:
+            metadata = self._metadata_for_provider_model(provider_name, model_name)
+            if metadata is not None:
+                streaming_supported = metadata.supports_streaming
+                context_window = metadata.context_window
+                max_output_tokens = metadata.max_output_tokens
+        if effective_config.context_window is not None:
+            if effective_config.context_window.model_context_window_tokens is not None:
+                context_window = effective_config.context_window.model_context_window_tokens
+            if effective_config.context_window.reserved_output_tokens is not None:
+                max_output_tokens = effective_config.context_window.reserved_output_tokens
+        configured = provider_name is not None and self._provider_is_configured(provider_name)
+        auth_present, auth_failure_kind, auth_message = self._provider_auth_presence(provider_name)
+        validation_status = "ready"
+        ok = configured and auth_present is not False
+        guidance = "Provider/model configuration is ready enough to run."
+        if provider_name is None or model_name is None:
+            validation_status = "missing_model"
+            ok = False
+            guidance = "Configure a provider/model, for example model: 'openai/gpt-4o'."
+        elif not configured:
+            validation_status = "unconfigured"
+            ok = False
+            guidance = "Add provider credentials in environment variables or .voidcode.json."
+        elif auth_present is False:
+            validation_status = auth_failure_kind or "missing_auth"
+            ok = False
+            guidance = auth_message or guidance_for_provider_error_kind("missing_auth")
+        elif streaming_supported is False:
+            validation_status = "streaming_unsupported"
+            guidance = guidance_for_provider_error_kind("unsupported_feature")
+        return ProviderReadinessResult(
+            provider=provider_name,
+            model=model_name,
+            configured=configured,
+            ok=ok,
+            status=validation_status,
+            guidance=guidance,
+            auth_present=auth_present,
+            streaming_configured=streaming_configured,
+            streaming_supported=streaming_supported,
+            context_window=context_window,
+            max_output_tokens=max_output_tokens,
+            fallback_chain=fallback_chain,
+        )
+
     def inspect_provider(self, provider_name: str) -> ProviderInspectResult:
         if not provider_name or "/" in provider_name:
             raise ValueError("provider_name must be a non-empty provider id without '/'")
@@ -2414,6 +2495,7 @@ class VoidCodeRuntime:
             validation=validation,
             current_model=current_model,
             current_model_metadata=current_metadata,
+            readiness=self.provider_readiness() if summary.current else None,
         )
 
     def validate_provider_credentials(self, provider_name: str) -> ProviderValidationResult:
@@ -2430,6 +2512,19 @@ class VoidCodeRuntime:
                 source=result.source,
                 last_error=result.last_error,
                 discovery_mode=result.discovery_mode,
+                failure_kind="missing_auth",
+                guidance="Add provider credentials in environment variables or .voidcode.json.",
+            )
+        auth_present, auth_failure_kind, auth_message = self._provider_auth_presence(provider_name)
+        if auth_present is False:
+            return ProviderValidationResult(
+                provider=provider_name,
+                configured=True,
+                ok=False,
+                status=auth_failure_kind or "missing_auth",
+                message=auth_message or "Provider authentication is missing.",
+                failure_kind=auth_failure_kind or "missing_auth",
+                guidance=auth_message or guidance_for_provider_error_kind("missing_auth"),
             )
         _ = self.refresh_provider_models(provider_name)
         result = self.provider_models_result(provider_name)
@@ -2443,6 +2538,8 @@ class VoidCodeRuntime:
                 source=result.source,
                 last_error=result.last_error,
                 discovery_mode=result.discovery_mode,
+                failure_kind="transient_failure",
+                guidance=guidance_for_provider_error_kind("transient_failure"),
             )
         status = result.last_refresh_status or "ok"
         ok = status == "ok"
@@ -2460,7 +2557,27 @@ class VoidCodeRuntime:
             source=result.source,
             last_error=result.last_error,
             discovery_mode=result.discovery_mode,
+            guidance=(
+                "Provider model discovery succeeded."
+                if ok
+                else "Credentials are present, but remote validation could not confirm readiness."
+            ),
         )
+
+    def _provider_auth_presence(
+        self, provider_name: str | None
+    ) -> tuple[bool | None, str | None, str | None]:
+        if provider_name is None:
+            return None, None, None
+        try:
+            result = self._provider_auth_resolver.authorize(
+                ProviderAuthAuthorizeRequest(provider=provider_name)
+            )
+        except ProviderAuthResolutionError as exc:
+            if exc.code == "missing_credentials":
+                return False, "missing_auth", str(exc)
+            return False, exc.provider_error_kind, str(exc)
+        return result.status == "authorized", None, None
 
     @staticmethod
     def _optional_positive_int(value: object) -> int | None:

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -2435,6 +2435,10 @@ class VoidCodeRuntime:
             validation_status = "missing_model"
             ok = False
             guidance = "Configure a provider/model, for example model: 'openai/gpt-4o'."
+        elif auth_present is False and auth_failure_kind == "invalid_model":
+            validation_status = auth_failure_kind
+            ok = False
+            guidance = auth_message or guidance_for_provider_error_kind("invalid_model")
         elif not configured:
             validation_status = "unconfigured"
             ok = False

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -2445,6 +2445,7 @@ class VoidCodeRuntime:
             guidance = auth_message or guidance_for_provider_error_kind("missing_auth")
         elif streaming_supported is False:
             validation_status = "streaming_unsupported"
+            ok = False
             guidance = guidance_for_provider_error_kind("unsupported_feature")
         return ProviderReadinessResult(
             provider=provider_name,
@@ -2569,6 +2570,9 @@ class VoidCodeRuntime:
     ) -> tuple[bool | None, str | None, str | None]:
         if provider_name is None:
             return None, None, None
+        oauth_presence = self._oauth_provider_auth_presence(provider_name)
+        if oauth_presence is not None:
+            return oauth_presence
         try:
             result = self._provider_auth_resolver.authorize(
                 ProviderAuthAuthorizeRequest(provider=provider_name)
@@ -2578,6 +2582,38 @@ class VoidCodeRuntime:
                 return False, "missing_auth", str(exc)
             return False, exc.provider_error_kind, str(exc)
         return result.status == "authorized", None, None
+
+    def _oauth_provider_auth_presence(
+        self, provider_name: str
+    ) -> tuple[bool | None, str | None, str | None] | None:
+        providers = self._config.providers
+        if providers is None:
+            return None
+        if provider_name == "google":
+            config = providers.google
+            auth = None if config is None else config.auth
+            if auth is None or auth.method != "oauth":
+                return None
+            if auth.access_token:
+                return True, None, None
+            return (
+                False,
+                "missing_auth",
+                "provider auth field 'google.access_token' must be provided for google oauth auth",
+            )
+        if provider_name == "copilot":
+            config = providers.copilot
+            auth = None if config is None else config.auth
+            if auth is None or auth.method != "oauth":
+                return None
+            if auth.token or (auth.token_env_var and os.environ.get(auth.token_env_var)):
+                return True, None, None
+            return (
+                False,
+                "missing_auth",
+                "provider auth field 'copilot.token' must be provided for copilot oauth auth",
+            )
+        return None
 
     @staticmethod
     def _optional_positive_int(value: object) -> int | None:

--- a/tests/unit/doctor/test_doctor.py
+++ b/tests/unit/doctor/test_doctor.py
@@ -146,3 +146,21 @@ class TestCreateDoctorForConfig:
         assert readiness.details["auth_present"] is False
         assert readiness.error_message is not None
         assert "openai.api_key" in readiness.error_message
+
+    def test_provider_readiness_runtime_error_is_structured_result(self, tmp_path: Path) -> None:
+        config = RuntimeConfig(
+            model="malformed-model",
+            execution_engine="provider",
+        )
+
+        doctor = create_doctor_for_config(tmp_path, config)
+
+        readiness = next(result for result in doctor.results if result.name == "provider.readiness")
+        assert readiness.check_type == DoctorCheckType.PROVIDER_READINESS.value
+        assert readiness.status == CapabilityCheckStatus.ERROR
+        assert readiness.details == {
+            "model": "malformed-model",
+            "status": "invalid_config",
+        }
+        assert readiness.error_message is not None
+        assert "provider/model" in readiness.error_message

--- a/tests/unit/doctor/test_doctor.py
+++ b/tests/unit/doctor/test_doctor.py
@@ -13,6 +13,8 @@ from voidcode.doctor.checker import (
     CapabilityCheckStatus,
     DoctorCheckType,
 )
+from voidcode.provider.config import OpenAIProviderConfig, ProviderConfigs
+from voidcode.runtime.config import RuntimeConfig
 
 
 class TestCapabilityDoctor:
@@ -75,10 +77,7 @@ class TestCreateDoctorForConfig:
 
     def test_creates_doctor_with_ast_grep_check(self) -> None:
         """Test that the doctor includes ast-grep check."""
-        config = MagicMock()
-        config.hooks = None
-        config.lsp = None
-        config.mcp = None
+        config = RuntimeConfig()
 
         hooks = MagicMock()
         hooks.enabled = True
@@ -92,10 +91,7 @@ class TestCreateDoctorForConfig:
 
     def test_handles_none_config_sections(self) -> None:
         """Test that the function handles None config sections gracefully."""
-        config = MagicMock()
-        config.hooks = None
-        config.lsp = None
-        config.mcp = None
+        config = RuntimeConfig()
 
         hooks = MagicMock()
         hooks.enabled = True
@@ -115,10 +111,7 @@ class TestCreateDoctorForConfig:
             "typescript": MagicMock(),
         }
 
-        config = MagicMock()
-        config.hooks = hooks
-        config.lsp = None
-        config.mcp = None
+        config = RuntimeConfig(hooks=hooks)
 
         doctor = create_doctor_for_config(Path("/tmp"), config)
 
@@ -135,3 +128,21 @@ class TestCreateDoctorForConfig:
             CapabilityCheckStatus.READY,
             CapabilityCheckStatus.NOT_FOUND,
         }
+
+    def test_adds_provider_readiness_check_for_provider_config(self, tmp_path: Path) -> None:
+        config = RuntimeConfig(
+            model="openai/gpt-4o",
+            execution_engine="provider",
+            providers=ProviderConfigs(openai=OpenAIProviderConfig()),
+        )
+
+        doctor = create_doctor_for_config(tmp_path, config)
+
+        readiness = next(result for result in doctor.results if result.name == "provider.readiness")
+        assert readiness.check_type == DoctorCheckType.PROVIDER_READINESS.value
+        assert readiness.status == CapabilityCheckStatus.ERROR
+        assert readiness.details["provider"] == "openai"
+        assert readiness.details["model"] == "gpt-4o"
+        assert readiness.details["auth_present"] is False
+        assert readiness.error_message is not None
+        assert "openai.api_key" in readiness.error_message

--- a/tests/unit/doctor/test_doctor.py
+++ b/tests/unit/doctor/test_doctor.py
@@ -164,3 +164,31 @@ class TestCreateDoctorForConfig:
         }
         assert readiness.error_message is not None
         assert "provider/model" in readiness.error_message
+
+    def test_provider_readiness_runtime_blocker_is_error(self, tmp_path: Path) -> None:
+        config = RuntimeConfig(
+            model="unknown-provider/model",
+            execution_engine="provider",
+        )
+
+        doctor = create_doctor_for_config(tmp_path, config)
+
+        readiness = next(result for result in doctor.results if result.name == "provider.readiness")
+        assert readiness.status == CapabilityCheckStatus.ERROR
+        assert readiness.details["status"] == "invalid_model"
+        assert readiness.error_message is not None
+        assert "unknown-provider" in readiness.error_message
+
+    def test_provider_readiness_unconfigured_provider_is_error(self, tmp_path: Path) -> None:
+        config = RuntimeConfig(
+            model="openai/gpt-4o",
+            execution_engine="provider",
+        )
+
+        doctor = create_doctor_for_config(tmp_path, config)
+
+        readiness = next(result for result in doctor.results if result.name == "provider.readiness")
+        assert readiness.status == CapabilityCheckStatus.ERROR
+        assert readiness.details["status"] == "unconfigured"
+        assert readiness.error_message is not None
+        assert "provider credentials" in readiness.error_message

--- a/tests/unit/graph/test_single_agent_slice.py
+++ b/tests/unit/graph/test_single_agent_slice.py
@@ -6,6 +6,7 @@ import pytest
 
 from voidcode.graph.contracts import GraphRunRequest
 from voidcode.graph.provider_graph import ProviderGraph
+from voidcode.provider.protocol import ProviderErrorKind
 from voidcode.provider.registry import ModelProviderRegistry
 from voidcode.provider.resolution import resolve_provider_model
 from voidcode.runtime.context_window import RuntimeContextWindow, RuntimeContinuityState
@@ -545,6 +546,59 @@ def test_provider_provider_graph_prefers_parsed_stream_error_kind_over_generic_t
         )
 
     assert exc_info.value.kind == "context_limit"
+
+
+@pytest.mark.parametrize(
+    "error_kind",
+    ["missing_auth", "unsupported_feature", "stream_tool_feedback_shape"],
+)
+def test_provider_provider_graph_preserves_explicit_stream_error_kind(
+    error_kind: ProviderErrorKind,
+) -> None:
+    provider_model = resolve_provider_model(
+        "opencode/gpt-5.4",
+        registry=ModelProviderRegistry.with_defaults(),
+    )
+
+    class _ExplicitKindStreamErrorTurnProvider:
+        name = "opencode"
+
+        def propose_turn(self, request: ProviderTurnRequest) -> ProviderTurnResult:
+            _ = request
+            return ProviderTurnResult(output="fallback")
+
+        def stream_turn(self, request: ProviderTurnRequest):
+            _ = request
+            return iter(
+                (
+                    ProviderStreamEvent(
+                        kind="error",
+                        channel="error",
+                        error="provider stream failed",
+                        error_kind=error_kind,
+                    ),
+                )
+            )
+
+    graph = ProviderGraph(
+        provider=_ExplicitKindStreamErrorTurnProvider(),
+        provider_model=provider_model,
+    )
+
+    with pytest.raises(ProviderExecutionError, match="provider stream failed") as exc_info:
+        _ = graph.step(
+            request=GraphRunRequest(
+                session=_session(),
+                prompt="read sample.txt",
+                available_tools=_tool_definitions(),
+                context_window=RuntimeContextWindow(prompt="read sample.txt"),
+                metadata={"provider_stream": True},
+            ),
+            tool_results=(),
+            session=_session(),
+        )
+
+    assert exc_info.value.kind == error_kind
 
 
 def test_provider_provider_graph_passes_applied_skill_context_to_provider() -> None:

--- a/tests/unit/graph/test_single_agent_slice.py
+++ b/tests/unit/graph/test_single_agent_slice.py
@@ -485,6 +485,7 @@ def test_provider_provider_graph_preserves_stream_error_details() -> None:
         "prompt": "secret",
         "source": "stream",
         "error_code": "rate_limit_exceeded",
+        "guidance": "Retry later, reduce request volume, or configure a fallback model.",
     }
     assert exc_info.value.kind == "rate_limit"
 

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -1339,6 +1339,21 @@ def test_config_show_outputs_workspace_effective_config() -> None:
                 }
             ],
         },
+        "provider_readiness": {
+            "provider": "repo",
+            "model": "model",
+            "configured": False,
+            "ok": False,
+            "status": "invalid_model",
+            "guidance": "provider auth provider 'repo' is not supported",
+            "auth_present": False,
+            "streaming_configured": None,
+            "streaming_supported": None,
+            "context_window": None,
+            "max_output_tokens": None,
+            "fallback_chain": ["repo/model"],
+        },
+        "context_budget": {"context_window": None, "max_output_tokens": None},
     }
     assert "Traceback" not in result.stderr
 
@@ -1403,6 +1418,9 @@ def test_config_show_uses_opencode_go_environment_without_leaking_key() -> None:
             }
         ],
     }
+    assert payload["provider_readiness"]["provider"] == "opencode-go"
+    assert payload["provider_readiness"]["auth_present"] is True
+    assert payload["context_budget"]["context_window"] == 200_000
     assert "opencode-go-secret" not in result.stdout
     assert "Traceback" not in result.stderr
 
@@ -1463,6 +1481,21 @@ def test_config_show_outputs_resumed_session_effective_config() -> None:
                 }
             ],
         },
+        "provider_readiness": {
+            "provider": "repo",
+            "model": "model",
+            "configured": False,
+            "ok": False,
+            "status": "invalid_model",
+            "guidance": "provider auth provider 'repo' is not supported",
+            "auth_present": False,
+            "streaming_configured": None,
+            "streaming_supported": None,
+            "context_window": None,
+            "max_output_tokens": None,
+            "fallback_chain": ["repo/model"],
+        },
+        "context_budget": {"context_window": None, "max_output_tokens": None},
     }
     assert "Traceback" not in result.stderr
 
@@ -1495,6 +1528,17 @@ def test_config_show_delegates_to_runtime_effective_config(capsys: Any) -> None:
         workspace = Path(tmp)
         with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
             runtime_class.return_value.effective_runtime_config.return_value = runtime_config
+            readiness = cli.ProviderReadinessResult(
+                provider="runtime",
+                model="model",
+                configured=False,
+                ok=False,
+                status="unconfigured",
+                guidance="Add provider credentials in environment variables or .voidcode.json.",
+                auth_present=False,
+                fallback_chain=("runtime/model",),
+            )
+            runtime_class.return_value.provider_readiness.return_value = readiness
             result = cli.main(
                 [
                     "config",
@@ -1536,6 +1580,21 @@ def test_config_show_delegates_to_runtime_effective_config(capsys: Any) -> None:
                 }
             ],
         },
+        "provider_readiness": {
+            "provider": "runtime",
+            "model": "model",
+            "configured": False,
+            "ok": False,
+            "status": "unconfigured",
+            "guidance": "Add provider credentials in environment variables or .voidcode.json.",
+            "auth_present": False,
+            "streaming_configured": None,
+            "streaming_supported": None,
+            "context_window": None,
+            "max_output_tokens": None,
+            "fallback_chain": ["runtime/model"],
+        },
+        "context_budget": {"context_window": None, "max_output_tokens": None},
     }
 
 

--- a/tests/unit/provider/test_provider_auth.py
+++ b/tests/unit/provider/test_provider_auth.py
@@ -160,7 +160,7 @@ def test_provider_auth_authorize_missing_credentials_raises_deterministic_error(
         _ = resolver.authorize(ProviderAuthAuthorizeRequest(provider="openai"))
 
     assert exc_info.value.code == "missing_credentials"
-    assert provider_auth_error_to_execution_kind(exc_info.value) == "invalid_model"
+    assert provider_auth_error_to_execution_kind(exc_info.value) == "missing_auth"
 
 
 def test_provider_auth_callback_google_oauth_builds_auth_material() -> None:

--- a/tests/unit/provider/test_provider_errors.py
+++ b/tests/unit/provider/test_provider_errors.py
@@ -107,6 +107,41 @@ def test_parse_provider_api_error_maps_unsupported_feature() -> None:
     assert parsed.fallback_allowed is True
 
 
+def test_parse_provider_api_error_checks_unsupported_feature_before_403_fallback() -> None:
+    parsed = parse_provider_api_error(
+        {"status_code": 403, "message": "Streaming is not supported for this model"}
+    )
+
+    assert parsed.kind == "unsupported_feature"
+    assert parsed.retryable is False
+    assert parsed.fallback_allowed is True
+    assert "unsupported provider feature" in parsed.guidance
+
+
+def test_parse_provider_api_error_keeps_explicit_auth_code_before_feature_marker() -> None:
+    parsed = parse_provider_api_error(
+        {
+            "status_code": 403,
+            "error": {
+                "code": "invalid_api_key",
+                "message": "invalid api key; streaming is not supported",
+            },
+        }
+    )
+
+    assert parsed.kind == "missing_auth"
+
+
+def test_parse_provider_api_error_checks_tool_shape_before_403_fallback() -> None:
+    parsed = parse_provider_api_error(
+        {"status_code": 403, "message": "stream tool payload is malformed"}
+    )
+
+    assert parsed.kind == "stream_tool_feedback_shape"
+    assert parsed.retryable is False
+    assert parsed.fallback_allowed is True
+
+
 def test_parse_provider_stream_error_maps_context_length_exceeded_code() -> None:
     parsed = parse_provider_stream_error(
         {

--- a/tests/unit/provider/test_provider_errors.py
+++ b/tests/unit/provider/test_provider_errors.py
@@ -59,8 +59,25 @@ def test_parse_provider_api_error_maps_429_to_rate_limit() -> None:
     assert parsed.fallback_allowed is True
 
 
-def test_parse_provider_api_error_maps_401_to_invalid_model() -> None:
+def test_parse_provider_api_error_maps_401_to_missing_auth() -> None:
     parsed = parse_provider_api_error({"status_code": 401, "message": "Unauthorized"})
+
+    assert parsed.kind == "missing_auth"
+    assert parsed.retryable is False
+    assert parsed.fallback_allowed is True
+    assert "API key" in parsed.guidance
+
+
+def test_parse_provider_api_error_keeps_403_model_code_as_invalid_model() -> None:
+    parsed = parse_provider_api_error(
+        {
+            "status_code": 403,
+            "error": {
+                "code": "model_not_found",
+                "message": "model not found or no model access",
+            },
+        }
+    )
 
     assert parsed.kind == "invalid_model"
     assert parsed.retryable is False
@@ -78,6 +95,16 @@ def test_parse_provider_api_error_maps_context_overflow_patterns() -> None:
     assert parsed.kind == "context_limit"
     assert parsed.retryable is False
     assert parsed.fallback_allowed is False
+
+
+def test_parse_provider_api_error_maps_unsupported_feature() -> None:
+    parsed = parse_provider_api_error(
+        {"status_code": 400, "message": "Streaming is not supported for this model"}
+    )
+
+    assert parsed.kind == "unsupported_feature"
+    assert parsed.retryable is False
+    assert parsed.fallback_allowed is True
 
 
 def test_parse_provider_stream_error_maps_context_length_exceeded_code() -> None:
@@ -111,6 +138,36 @@ def test_provider_execution_error_from_api_payload_preserves_details() -> None:
     assert exc.details["source"] == "api"
 
 
+def test_provider_execution_error_redacts_secret_details() -> None:
+    exc = provider_execution_error_from_api_payload(
+        provider_name="openai",
+        model_name="gpt-4o",
+        payload={
+            "status_code": 401,
+            "message": "invalid api key",
+            "api_key": "sk-secret",
+            "headers": {
+                "Authorization": "Bearer sk-secret",
+                "x-api-key": "secret-header",
+                "cookie": "session=secret-cookie",
+            },
+            "url": "https://example.invalid?api_key=secret-query-token",
+            "debug": "raw token=secret-value",
+        },
+    )
+
+    assert exc.details is not None
+    assert exc.kind == "missing_auth"
+    assert exc.details["api_key"] == "<redacted>"
+    assert exc.details["headers"] == {
+        "Authorization": "<redacted>",
+        "x-api-key": "<redacted>",
+        "cookie": "<redacted>",
+    }
+    assert exc.details["url"] == "https://example.invalid?api_key=<redacted>"
+    assert exc.details["debug"] == "raw token=<redacted>"
+
+
 def test_provider_execution_error_from_stream_payload_preserves_details() -> None:
     exc = provider_execution_error_from_stream_payload(
         provider_name="openai",
@@ -118,7 +175,7 @@ def test_provider_execution_error_from_stream_payload_preserves_details() -> Non
         payload={"status_code": 403, "message": "forbidden"},
     )
 
-    assert exc.kind == "invalid_model"
+    assert exc.kind == "missing_auth"
     assert exc.retryable is False
     assert exc.details is not None
     assert exc.details["status_code"] == 403

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -10,6 +10,7 @@ from voidcode.runtime.context_window import (
     RuntimeContinuityState,
     context_window_policy_from_payload,
     continuity_summary_metadata,
+    count_text_tokens,
     normalize_read_file_output,
     prepare_provider_context,
 )
@@ -267,6 +268,26 @@ def test_prepare_provider_context_keeps_count_policy_when_budget_missing() -> No
     assert tuple(result.data["index"] for result in context.tool_results) == (2, 3)
     assert context.token_budget is None
     assert context.original_tool_result_tokens is None
+
+
+def test_count_text_tokens_reports_estimated_fallback_metadata() -> None:
+    counted = count_text_tokens("abcd你")
+
+    assert counted.tokens == 2
+    assert counted.method == "estimated"
+    assert counted.source == "unicode_aware_chars"
+    assert counted.exact is False
+
+
+def test_count_text_tokens_reports_tiktoken_metadata() -> None:
+    fake_tiktoken = _FakeTiktokenModule()
+    with patch.dict(sys.modules, {"tiktoken": fake_tiktoken}):
+        counted = count_text_tokens("abcd", tokenizer_model="gpt-test")
+
+    assert counted.tokens == 4
+    assert counted.method == "tiktoken"
+    assert counted.source == "tiktoken:gpt-test"
+    assert counted.exact is True
 
 
 def test_prepare_provider_context_honors_reserved_output_budget() -> None:

--- a/tests/unit/runtime/test_provider_readiness.py
+++ b/tests/unit/runtime/test_provider_readiness.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from voidcode.provider.config import OpenAIProviderConfig, ProviderConfigs, ProviderFallbackConfig
+from voidcode.runtime.config import RuntimeConfig
+from voidcode.runtime.service import VoidCodeRuntime
+
+
+def test_provider_readiness_reports_missing_auth(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            model="openai/gpt-4o",
+            execution_engine="provider",
+            providers=ProviderConfigs(openai=OpenAIProviderConfig()),
+        ),
+    )
+    try:
+        readiness = runtime.provider_readiness()
+    finally:
+        runtime.__exit__(None, None, None)
+
+    assert readiness.provider == "openai"
+    assert readiness.model == "gpt-4o"
+    assert readiness.configured is True
+    assert readiness.ok is False
+    assert readiness.status == "missing_auth"
+    assert readiness.auth_present is False
+    assert "openai.api_key" in readiness.guidance
+
+
+def test_provider_readiness_includes_fallback_and_context_metadata(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            model="openai/gpt-4o",
+            execution_engine="provider",
+            providers=ProviderConfigs(openai=OpenAIProviderConfig(api_key="test-key")),
+            provider_fallback=ProviderFallbackConfig(
+                preferred_model="openai/gpt-4o",
+                fallback_models=("openai/gpt-4o-mini",),
+            ),
+        ),
+    )
+    try:
+        readiness = runtime.provider_readiness()
+    finally:
+        runtime.__exit__(None, None, None)
+
+    assert readiness.ok is True
+    assert readiness.auth_present is True
+    assert readiness.context_window == 128_000
+    assert readiness.max_output_tokens == 16_384
+    assert readiness.streaming_supported is True
+    assert readiness.fallback_chain == ("openai/gpt-4o", "openai/gpt-4o-mini")

--- a/tests/unit/runtime/test_provider_readiness.py
+++ b/tests/unit/runtime/test_provider_readiness.py
@@ -2,7 +2,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from voidcode.provider.config import OpenAIProviderConfig, ProviderConfigs, ProviderFallbackConfig
+from voidcode.provider.config import (
+    GoogleProviderAuthConfig,
+    GoogleProviderConfig,
+    OpenAIProviderConfig,
+    ProviderConfigs,
+    ProviderFallbackConfig,
+)
+from voidcode.provider.model_catalog import ProviderModelCatalog, ProviderModelMetadata
+from voidcode.provider.registry import ModelProviderRegistry
 from voidcode.runtime.config import RuntimeConfig
 from voidcode.runtime.service import VoidCodeRuntime
 
@@ -54,3 +62,62 @@ def test_provider_readiness_includes_fallback_and_context_metadata(tmp_path: Pat
     assert readiness.max_output_tokens == 16_384
     assert readiness.streaming_supported is True
     assert readiness.fallback_chain == ("openai/gpt-4o", "openai/gpt-4o-mini")
+
+
+def test_provider_readiness_marks_streaming_unsupported_as_not_ready(tmp_path: Path) -> None:
+    registry = ModelProviderRegistry.with_defaults()
+    registry.model_catalog = {
+        "openai": ProviderModelCatalog(
+            provider="openai",
+            models=("batch-only",),
+            refreshed=True,
+            model_metadata={
+                "batch-only": ProviderModelMetadata(
+                    context_window=8_192,
+                    max_output_tokens=1_024,
+                    supports_streaming=False,
+                )
+            },
+        )
+    }
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            model="openai/batch-only",
+            execution_engine="provider",
+            providers=ProviderConfigs(openai=OpenAIProviderConfig(api_key="test-key")),
+        ),
+        model_provider_registry=registry,
+    )
+    try:
+        readiness = runtime.provider_readiness()
+    finally:
+        runtime.__exit__(None, None, None)
+
+    assert readiness.ok is False
+    assert readiness.status == "streaming_unsupported"
+    assert readiness.streaming_supported is False
+
+
+def test_provider_readiness_does_not_allocate_oauth_callback_state(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            model="google/gemini-2.5-pro",
+            execution_engine="provider",
+            providers=ProviderConfigs(
+                google=GoogleProviderConfig(auth=GoogleProviderAuthConfig(method="oauth"))
+            ),
+        ),
+    )
+    try:
+        first = runtime.provider_readiness()
+        second = runtime.provider_readiness()
+        pending_states = runtime.provider_auth_resolver._pending_callback_states  # pyright: ignore[reportPrivateUsage]
+    finally:
+        runtime.__exit__(None, None, None)
+
+    assert first.ok is False
+    assert first.status == "missing_auth"
+    assert second.status == "missing_auth"
+    assert pending_states == {}

--- a/tests/unit/runtime/test_provider_readiness.py
+++ b/tests/unit/runtime/test_provider_readiness.py
@@ -38,6 +38,28 @@ def test_provider_readiness_reports_missing_auth(tmp_path: Path) -> None:
     assert "openai.api_key" in readiness.guidance
 
 
+def test_provider_readiness_preserves_invalid_provider_status(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            model="unknown-provider/demo",
+            execution_engine="provider",
+        ),
+    )
+    try:
+        readiness = runtime.provider_readiness()
+    finally:
+        runtime.__exit__(None, None, None)
+
+    assert readiness.provider == "unknown-provider"
+    assert readiness.model == "demo"
+    assert readiness.configured is False
+    assert readiness.ok is False
+    assert readiness.auth_present is False
+    assert readiness.status == "invalid_model"
+    assert "not supported" in readiness.guidance
+
+
 def test_provider_readiness_includes_fallback_and_context_metadata(tmp_path: Path) -> None:
     runtime = VoidCodeRuntime(
         workspace=tmp_path,

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -11,7 +11,7 @@ import sys
 import time
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, cast
 from unittest.mock import Mock
 
 import pytest
@@ -27,6 +27,7 @@ from voidcode.provider.config import (
     LiteLLMProviderConfig,
 )
 from voidcode.provider.model_catalog import ProviderModelCatalog, ProviderModelMetadata
+from voidcode.provider.protocol import ProviderErrorKind
 from voidcode.provider.registry import ModelProviderRegistry
 from voidcode.runtime.acp import (
     AcpAdapterState,
@@ -475,13 +476,13 @@ class _ScriptedModelProvider:
 
 
 class _AlwaysFailingModelProvider:
-    _error_kind: Literal["rate_limit", "context_limit", "invalid_model", "transient_failure"]
+    _error_kind: ProviderErrorKind
 
     def __init__(
         self,
         *,
         name: str,
-        error_kind: Literal["rate_limit", "context_limit", "invalid_model", "transient_failure"],
+        error_kind: ProviderErrorKind,
     ) -> None:
         self.name = name
         self._error_kind = error_kind
@@ -493,7 +494,7 @@ class _AlwaysFailingModelProvider:
 @dataclass(slots=True)
 class _AlwaysFailingTurnProvider:
     name: str
-    error_kind: Literal["rate_limit", "context_limit", "invalid_model", "transient_failure"]
+    error_kind: ProviderErrorKind
 
     def propose_turn(self, request: object) -> ProviderTurnResult:
         _ = request
@@ -9981,11 +9982,18 @@ def test_runtime_resume_fallback_preserves_successful_null_tool_content(
 
 @pytest.mark.parametrize(
     "error_kind",
-    ["missing_auth", "rate_limit", "invalid_model", "transient_failure"],
+    [
+        "missing_auth",
+        "rate_limit",
+        "invalid_model",
+        "transient_failure",
+        "unsupported_feature",
+        "stream_tool_feedback_shape",
+    ],
 )
 def test_runtime_downgrades_to_next_provider_target_on_provider_failures(
     tmp_path: Path,
-    error_kind: Literal["missing_auth", "rate_limit", "invalid_model", "transient_failure"],
+    error_kind: ProviderErrorKind,
 ) -> None:
     registry = ModelProviderRegistry(
         providers={

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1065,11 +1065,11 @@ def test_runtime_session_debug_snapshot_preserves_fresh_terminal_state_while_act
     response = runtime.run(RuntimeRequest(prompt="terminal debug", session_id="terminal-debug"))
     try:
         assert deferred_unregister_session_id == "terminal-debug"
-        snapshot = runtime.session_debug_snapshot(session_id="terminal-debug")
+        snapshot = runtime.session_debug_snapshot(session_id="terminal-debug")  # pyright: ignore[reportUnreachable]
     finally:
         original_unregister("terminal-debug")
 
-    assert response.session.status == "completed"
+    assert response.session.status == "completed"  # pyright: ignore[reportUnreachable]
     assert snapshot.prompt == "terminal debug"
     assert snapshot.active is True
     assert snapshot.persisted_status == "completed"
@@ -9979,10 +9979,13 @@ def test_runtime_resume_fallback_preserves_successful_null_tool_content(
     assert tool_completed_events[0].payload["content"] is None
 
 
-@pytest.mark.parametrize("error_kind", ["rate_limit", "invalid_model", "transient_failure"])
+@pytest.mark.parametrize(
+    "error_kind",
+    ["missing_auth", "rate_limit", "invalid_model", "transient_failure"],
+)
 def test_runtime_downgrades_to_next_provider_target_on_provider_failures(
     tmp_path: Path,
-    error_kind: Literal["rate_limit", "invalid_model", "transient_failure"],
+    error_kind: Literal["missing_auth", "rate_limit", "invalid_model", "transient_failure"],
 ) -> None:
     registry = ModelProviderRegistry(
         providers={
@@ -10272,6 +10275,9 @@ def test_runtime_provider_stream_json_error_payload_maps_to_context_limit_withou
         },
         "source": "stream",
         "error_code": "context_length_exceeded",
+        "guidance": (
+            "Reduce prompt/tool-result context or switch to a model with a larger context window."
+        ),
     }
     fallback_events = [
         event for event in response.events if event.event_type == "runtime.provider_fallback"


### PR DESCRIPTION
## Summary
- Add structured provider readiness metadata for runtime/config inspection, including auth status, streaming support, fallback chain, and context budget.
- Split provider failures into clearer kinds such as missing_auth, unsupported_feature, and stream_tool_feedback_shape with sanitized provider error details.
- Surface readiness in doctor/config CLI output and document provider/model/context diagnosis workflows.

## Verification
- mise run check
- uv run pytest tests/unit/provider/test_provider_errors.py tests/unit/runtime/test_provider_readiness.py tests/unit/runtime/test_runtime_service_extensions.py::test_runtime_downgrades_to_next_provider_target_on_provider_failures tests/unit/doctor/test_doctor.py::TestCreateDoctorForConfig::test_adds_provider_readiness_check_for_provider_config

Closes #277