### PR TITLE
feat(cli): polish CLI reference client UX

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -31,9 +31,15 @@ uv run voidcode --help
 uv run voidcode run "write hello.txt hello" --workspace . --approval-mode ask
 # 显式进入产品规划模式，用于需求澄清、范围收敛和验收标准
 uv run voidcode run --agent product "shape an issue for improving session replay" --workspace .
+uv run voidcode run --json "read README.md" --workspace .
 uv run voidcode sessions list --workspace .
+uv run voidcode sessions list --json --workspace .
 uv run voidcode sessions resume <session-id> --workspace .
+uv run voidcode commands list --workspace .
+uv run voidcode commands show review --workspace .
 ```
+
+CLI 的默认输出面向人工阅读：`run` 会隐藏原始事件转储，只展示关键进度、最终结果和 session id。需要脚本消费时使用 `--json`；在 JSON 模式下，stdout 仅保留机器可解析的 JSON，进度/诊断信息输出到 stderr。
 
 ## mise 任务
 

--- a/docs/mvp-demo-guide.md
+++ b/docs/mvp-demo-guide.md
@@ -19,16 +19,16 @@
    uv run voidcode run "write hello.txt contents" --workspace . --approval-mode ask
    ```
    *预期结果*：
-   - CLI 打印 `EVENT runtime.approval_requested`。
+   - CLI 打印简洁的审批进度摘要。
    - CLI 弹出类似于 `Approve write_file for write_file hello.txt? [y/N]: ` 的审批提示（具体的 target summary 可能包含工具名和路径）。
-   - 输入 `y` 后，CLI 继续执行并显示写入状态的 `RESULT` 块。
-   - 所有事件（请求接收、工具调用、审批通过等）均通过 `EVENT` 日志实时流式打印。
+   - 输入 `y` 后，CLI 继续执行并显示最终输出和 session id。
+   - 如需完整机器可解析事件流，使用 `uv run voidcode run --json ...`；JSON 模式会把最终结果写到 stdout，并把运行进度保留在 stderr。
 
 2. **会话持久化**：验证会话及其审批状态已记录。
    ```bash
    uv run voidcode sessions list --workspace .
    ```
-   *预期结果*：CLI 打印形如 `SESSION id=<id> status=completed turn=<n> updated_at=<ts> prompt='<prompt>'` 的记录。
+   *预期结果*：CLI 以表格样式列出 session id、状态、turn、更新时间与 prompt；脚本消费可使用 `--json` 输出稳定 JSON 数组。
 
 3. **会话恢复**：在不重新执行工具的情况下重放整个交互过程。
    ```bash

--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -10,6 +10,26 @@ from typing import Protocol, cast
 from . import __version__
 from .acp.stdio import StdioAcpServer
 from .agent.builtin import list_top_level_selectable_agent_manifests
+from .cli_support import (
+    EXIT_APPROVAL_DENIED,
+    EXIT_CONFIG_ERROR,
+    EXIT_GENERAL_ERROR,
+    EXIT_INVALID_COMMAND,
+    EXIT_INVALID_RESOURCE,
+    EXIT_PROVIDER_ERROR,
+    EXIT_RUNTIME_ERROR,
+    EXIT_SUCCESS,
+    RuntimeStreamResult,
+    format_event,
+    print_json,
+    serialize_command_definition,
+    serialize_command_summary,
+    serialize_event,
+    serialize_session_state,
+    serialize_stored_session_summary,
+)
+from .command.loader import load_command_registry
+from .command.registry import CommandRegistry
 from .doctor import (
     CapabilityCheckResult,
     CapabilityCheckStatus,
@@ -60,13 +80,6 @@ class TuiAppProtocol(Protocol):
     def run(self) -> None: ...
 
 
-def _format_event(event_type: str, source: str, data: dict[str, object]) -> str:
-    suffix = " ".join(f"{key}={value}" for key, value in sorted(data.items()))
-    if suffix:
-        return f"EVENT {event_type} source={source} {suffix}"
-    return f"EVENT {event_type} source={source}"
-
-
 def _close_runtime(runtime: object) -> None:
     exit_method = getattr(runtime, "__exit__", None)
     if callable(exit_method):
@@ -76,6 +89,7 @@ def _close_runtime(runtime: object) -> None:
 def _handle_run_command(args: argparse.Namespace) -> int:
     workspace = cast(Path, args.workspace)
     request_text = cast(str, args.request)
+    json_output = cast(bool, getattr(args, "json", False))
     config = load_runtime_config(
         workspace,
         approval_mode=cast(PermissionDecision | None, getattr(args, "approval_mode", None)),
@@ -98,19 +112,28 @@ def _handle_run_command(args: argparse.Namespace) -> int:
         )
         interactive = sys.stdin.isatty() and sys.stderr.isatty()
         try:
-            output = _run_with_inline_approval(
+            result = _run_with_inline_approval(
                 runtime,
                 request,
                 interactive=interactive,
+                emit_events=interactive and not json_output,
             )
         except ValueError as exc:
             raise SystemExit(f"error: {exc}") from None
 
-        if not interactive:
-            _print_runtime_output(output)
+        blocked_event = _pending_blocked_event(result.session, _last_event(result))
+        if json_output:
+            print_json(_runtime_stream_payload(result, workspace=workspace))
+            if not interactive and blocked_event is not None:
+                return _blocked_exit_code(blocked_event)
+        elif not interactive:
+            if blocked_event is not None:
+                _print_noninteractive_blocked(result, blocked_event)
+                return _blocked_exit_code(blocked_event)
+            _print_plain_runtime_output(result.output)
     finally:
         _close_runtime(runtime)
-    return 0
+    return EXIT_SUCCESS
 
 
 def _handle_acp_command(args: argparse.Namespace) -> int:
@@ -132,49 +155,65 @@ def _run_with_inline_approval(
     request: RuntimeRequest,
     *,
     interactive: bool,
-) -> str | None:
-    output, final_session, last_event = _consume_runtime_stream(runtime.run_stream(request))
+    emit_events: bool,
+) -> RuntimeStreamResult:
+    result = _consume_runtime_stream(runtime.run_stream(request), emit_events=emit_events)
 
     while interactive:
-        approval_event = _pending_approval_event(final_session, last_event)
+        approval_event = _pending_approval_event(result.session, _last_event(result))
         if approval_event is None:
             break
-        output, final_session, last_event = _consume_runtime_stream(
+        resumed_result = _consume_runtime_stream(
             runtime.resume_stream(
-                session_id=final_session.session.id,
+                session_id=result.session.session.id,
                 approval_request_id=_approval_request_id(approval_event),
                 approval_decision=_prompt_for_approval(approval_event),
-            )
+            ),
+            emit_events=emit_events,
+        )
+        result = RuntimeStreamResult(
+            output=resumed_result.output,
+            session=resumed_result.session,
+            events=(*result.events, *resumed_result.events),
         )
 
+    if interactive and not emit_events:
+        return result
     if interactive:
-        _print_runtime_output(output)
+        _print_runtime_output(result.output)
 
-    return output
+    return result
 
 
 def _consume_runtime_stream(
     chunks: Iterator[RuntimeStreamChunk],
-) -> tuple[str | None, SessionState, EventEnvelope | None]:
+    *,
+    emit_events: bool,
+) -> RuntimeStreamResult:
     output: str | None = None
     final_session: SessionState | None = None
-    last_event = cast(EventEnvelope | None, None)
+    events: list[EventEnvelope] = []
 
     for chunk in chunks:
         final_session = chunk.session
         if chunk.event is not None:
-            print(
-                _format_event(chunk.event.event_type, chunk.event.source, chunk.event.payload),
-                flush=True,
-            )
-            last_event = chunk.event
+            if emit_events:
+                print(
+                    format_event(chunk.event.event_type, chunk.event.source, chunk.event.payload),
+                    flush=True,
+                )
+            events.append(chunk.event)
         if chunk.kind == "output":
             output = chunk.output
 
     if final_session is None:
         raise ValueError("runtime stream emitted no chunks")
 
-    return output, final_session, last_event
+    return RuntimeStreamResult(output=output, session=final_session, events=tuple(events))
+
+
+def _last_event(result: RuntimeStreamResult) -> EventEnvelope | None:
+    return result.events[-1] if result.events else None
 
 
 def _pending_approval_event(
@@ -186,6 +225,30 @@ def _pending_approval_event(
     if event is None or event.event_type != "runtime.approval_requested":
         return None
     return event
+
+
+def _pending_question_event(
+    session: SessionState,
+    event: EventEnvelope | None,
+) -> EventEnvelope | None:
+    if session.status != "waiting":
+        return None
+    if event is None or event.event_type != "runtime.question_requested":
+        return None
+    return event
+
+
+def _pending_blocked_event(
+    session: SessionState,
+    event: EventEnvelope | None,
+) -> EventEnvelope | None:
+    return _pending_approval_event(session, event) or _pending_question_event(session, event)
+
+
+def _blocked_exit_code(event: EventEnvelope) -> int:
+    if event.event_type == "runtime.approval_requested":
+        return EXIT_APPROVAL_DENIED
+    return EXIT_RUNTIME_ERROR
 
 
 def _approval_request_id(event: EventEnvelope) -> str:
@@ -217,7 +280,7 @@ def _print_runtime_response(
     typed_result = cast("RuntimeResponseLike", result)
 
     for event in typed_result.events[event_offset:]:
-        print(_format_event(event.event_type, event.source, event.payload), flush=True)
+        print(format_event(event.event_type, event.source, event.payload), flush=True)
 
     if include_result:
         _print_runtime_output(typed_result.output)
@@ -231,18 +294,90 @@ def _print_runtime_output(output: str | None) -> None:
         print(flush=True)
 
 
+def _print_plain_runtime_output(output: str | None) -> None:
+    if output is None:
+        return
+    print(output, end="", flush=True)
+    if not output.endswith("\n"):
+        print(flush=True)
+
+
+def _runtime_stream_payload(result: RuntimeStreamResult, *, workspace: Path) -> dict[str, object]:
+    blocked_event = _pending_blocked_event(result.session, _last_event(result))
+    payload: dict[str, object] = {
+        "workspace": str(workspace),
+        "session": serialize_session_state(result.session),
+        "output": result.output,
+        "events": [serialize_event(event) for event in result.events],
+    }
+    if blocked_event is not None:
+        payload["blocked"] = _blocked_payload(result, blocked_event)
+    return payload
+
+
+def _blocked_payload(result: RuntimeStreamResult, event: EventEnvelope) -> dict[str, object]:
+    if event.event_type == "runtime.approval_requested":
+        return {
+            "kind": "approval_required",
+            "session_id": result.session.session.id,
+            "request_id": _approval_request_id(event),
+            "tool": event.payload.get("tool"),
+            "target_summary": event.payload.get("target_summary"),
+        }
+    return {
+        "kind": "question_required",
+        "session_id": result.session.session.id,
+        "request_id": str(event.payload["request_id"]),
+        "tool": event.payload.get("tool"),
+        "question_count": event.payload.get("question_count"),
+        "questions": event.payload.get("questions"),
+    }
+
+
+def _print_noninteractive_blocked(result: RuntimeStreamResult, event: EventEnvelope) -> None:
+    if event.event_type == "runtime.question_requested":
+        print(
+            "error: question response required"
+            f" for {event.payload.get('tool')}; resume session {result.session.session.id} "
+            f"with question request {event.payload.get('request_id')}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return
+    tool = event.payload.get("tool")
+    target_summary = event.payload.get("target_summary")
+    target_suffix = f" for {target_summary}" if isinstance(target_summary, str) else ""
+    print(
+        "error: approval required"
+        f" for {tool}{target_suffix}; resume session {result.session.session.id} "
+        f"with approval request {_approval_request_id(event)}",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
 def _handle_sessions_list_command(args: argparse.Namespace) -> int:
     workspace = cast(Path, args.workspace)
+    json_output = cast(bool, getattr(args, "json", False))
     runtime = VoidCodeRuntime(workspace=workspace)
     try:
         sessions = runtime.list_sessions()
     finally:
         _close_runtime(runtime)
 
+    if json_output:
+        print_json(
+            {
+                "workspace": str(workspace),
+                "sessions": [serialize_stored_session_summary(session) for session in sessions],
+            }
+        )
+        return EXIT_SUCCESS
+
     for session in sessions:
         print(_format_session_summary(session))
 
-    return 0
+    return EXIT_SUCCESS
 
 
 def _format_session_summary(session: StoredSessionSummary) -> str:
@@ -588,26 +723,92 @@ def _handle_config_show_command(args: argparse.Namespace) -> int:
     finally:
         _close_runtime(runtime)
 
-    print(
-        json.dumps(
+    print_json(
+        {
+            "workspace": str(workspace),
+            "session_id": session_id,
+            "approval_mode": effective_config.approval_mode,
+            "model": effective_config.model,
+            "execution_engine": effective_config.execution_engine,
+            "max_steps": effective_config.max_steps,
+            "agent": serialize_runtime_agent_config(getattr(effective_config, "agent", None)),
+            "provider_fallback": serialize_provider_fallback_config(
+                getattr(effective_config, "provider_fallback", None)
+            ),
+            "resolved_provider": resolved_provider_snapshot(
+                getattr(effective_config, "resolved_provider", None)
+            ),
+        }
+    )
+    return EXIT_SUCCESS
+
+
+def _handle_commands_list_command(args: argparse.Namespace) -> int:
+    workspace = cast(Path, args.workspace)
+    registry = _load_cli_command_registry(args, workspace=workspace)
+    commands = registry.list(
+        include_hidden=cast(bool, args.include_hidden),
+        include_disabled=cast(bool, args.include_disabled),
+    )
+
+    if cast(bool, args.json):
+        print_json(
             {
                 "workspace": str(workspace),
-                "session_id": session_id,
-                "approval_mode": effective_config.approval_mode,
-                "model": effective_config.model,
-                "execution_engine": effective_config.execution_engine,
-                "max_steps": effective_config.max_steps,
-                "agent": serialize_runtime_agent_config(getattr(effective_config, "agent", None)),
-                "provider_fallback": serialize_provider_fallback_config(
-                    getattr(effective_config, "provider_fallback", None)
-                ),
-                "resolved_provider": resolved_provider_snapshot(
-                    getattr(effective_config, "resolved_provider", None)
-                ),
+                "commands": [serialize_command_summary(command) for command in commands],
             }
         )
-    )
-    return 0
+        return EXIT_SUCCESS
+
+    for command in commands:
+        print(
+            _format_named_record(
+                "COMMAND",
+                [
+                    ("name", f"/{command.name}"),
+                    ("source", command.source),
+                    ("enabled", command.enabled),
+                    ("description", repr(command.description)),
+                ],
+            )
+        )
+    return EXIT_SUCCESS
+
+
+def _handle_commands_show_command(args: argparse.Namespace) -> int:
+    workspace = cast(Path, args.workspace)
+    registry = _load_cli_command_registry(args, workspace=workspace)
+    command_name = cast(str, args.name)
+    command = registry.get(command_name)
+    if command is None:
+        raise SystemExit(f"error: unknown command: /{command_name.removeprefix('/')}")
+    if command.hidden and not cast(bool, args.include_hidden):
+        raise SystemExit(f"error: unknown command: /{command.name}")
+    if not command.enabled and not cast(bool, args.include_disabled):
+        raise SystemExit(f"error: command is disabled: /{command.name}")
+
+    payload = serialize_command_definition(command)
+    if cast(bool, args.json):
+        print_json(payload)
+        return EXIT_SUCCESS
+
+    print(f"/{command.name}")
+    print(f"Source: {command.source}")
+    print(f"Enabled: {command.enabled}")
+    print(f"Description: {command.description}")
+    if command.path is not None:
+        print(f"Path: {command.path}")
+    print("Template:")
+    print(command.template, end="" if command.template.endswith("\n") else "\n")
+    return EXIT_SUCCESS
+
+
+def _load_cli_command_registry(args: argparse.Namespace, *, workspace: Path) -> CommandRegistry:
+    user_commands_dir = cast(Path | None, getattr(args, "user_commands_dir", None))
+    try:
+        return load_command_registry(workspace=workspace, user_commands_dir=user_commands_dir)
+    except ValueError as exc:
+        raise SystemExit(f"error: {exc}") from None
 
 
 def _handle_config_schema_command(args: argparse.Namespace) -> int:
@@ -882,13 +1083,74 @@ def _handle_doctor_command(args: argparse.Namespace) -> int:
         print(format_report(report, verbose=verbose))
 
     # Return 0 only when healthy and runtime config parsed successfully.
-    return 0 if (report.is_healthy and config_error is None) else 1
+    return EXIT_SUCCESS if (report.is_healthy and config_error is None) else EXIT_RUNTIME_ERROR
+
+
+def _classify_cli_error(message: str) -> int:
+    normalized = message.lower()
+    if "unknown command" in normalized or "command is disabled" in normalized:
+        return EXIT_INVALID_COMMAND
+    if (
+        "unknown session" in normalized
+        or "unknown task" in normalized
+        or "workspace does not exist" in normalized
+    ):
+        return EXIT_INVALID_RESOURCE
+    if "provider" in normalized and (
+        "requires a configured model" in normalized
+        or "not configured" in normalized
+        or "unreachable" in normalized
+    ):
+        return EXIT_PROVIDER_ERROR
+    if (
+        normalized.startswith("error: runtime config")
+        or ".voidcode.json" in normalized
+        or "voidcode/config.json" in normalized
+    ):
+        return EXIT_CONFIG_ERROR
+    return EXIT_RUNTIME_ERROR
+
+
+def _handle_cli_system_exit(exc: SystemExit) -> int:
+    code = exc.code
+    if code is None:
+        return EXIT_SUCCESS
+    if isinstance(code, int):
+        return code
+    message = str(code)
+    print(message, file=sys.stderr)
+    if message.startswith("error:"):
+        return _classify_cli_error(message)
+    return EXIT_GENERAL_ERROR
+
+
+def _add_command_discovery_arguments(parser: argparse.ArgumentParser) -> None:
+    _ = parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd(),
+        help="Workspace root used to discover project-local commands.",
+    )
+    _ = parser.add_argument(
+        "--user-commands-dir",
+        type=Path,
+        help="Optional user command directory to merge before project commands.",
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="voidcode",
         description="Voidcode command-line interface.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  voidcode run 'read README.md' --workspace .\n"
+            "  voidcode run 'read README.md' --json --workspace .\n"
+            "  voidcode sessions list --json --workspace .\n"
+            "  voidcode commands list --workspace .\n"
+            "  voidcode commands show /review --json --workspace ."
+        ),
     )
     _ = parser.add_argument(
         "--version",
@@ -954,6 +1216,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--max-steps",
         type=int,
         help="Optional max graph steps override for this run.",
+    )
+    _ = run_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output a structured JSON payload with session, events, and final output.",
     )
     stream_group = run_parser.add_mutually_exclusive_group()
     _ = stream_group.add_argument(
@@ -1063,6 +1330,11 @@ def build_parser() -> argparse.ArgumentParser:
     provider_parser = subparsers.add_parser("provider", help="Inspect provider metadata.")
     provider_subparsers = provider_parser.add_subparsers(dest="provider_command")
 
+    commands_parser = subparsers.add_parser(
+        "commands", help="Discover prompt commands available to runtime requests."
+    )
+    commands_subparsers = commands_parser.add_subparsers(dest="commands_command")
+
     config_show_parser = config_subparsers.add_parser(
         "show", help="Show effective runtime config for a workspace or session."
     )
@@ -1077,7 +1349,58 @@ def build_parser() -> argparse.ArgumentParser:
         dest="session_id",
         help="Optional persisted session identifier used to show resumed effective config.",
     )
+    _ = config_show_parser.add_argument(
+        "--json",
+        action="store_true",
+        default=True,
+        help="Output JSON effective config (default).",
+    )
     config_show_parser.set_defaults(handler=_handle_config_show_command)
+
+    commands_list_parser = commands_subparsers.add_parser(
+        "list", help="List enabled prompt commands discovered for a workspace."
+    )
+    _add_command_discovery_arguments(commands_list_parser)
+    _ = commands_list_parser.add_argument(
+        "--include-hidden",
+        action="store_true",
+        help="Include commands marked hidden in discovery output.",
+    )
+    _ = commands_list_parser.add_argument(
+        "--include-disabled",
+        action="store_true",
+        help="Include disabled commands in discovery output.",
+    )
+    _ = commands_list_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output discovered commands as JSON.",
+    )
+    commands_list_parser.set_defaults(handler=_handle_commands_list_command)
+
+    commands_show_parser = commands_subparsers.add_parser(
+        "show", help="Show one prompt command definition and rendered template source."
+    )
+    _ = commands_show_parser.add_argument(
+        "name", help="Command name, with or without leading slash."
+    )
+    _add_command_discovery_arguments(commands_show_parser)
+    _ = commands_show_parser.add_argument(
+        "--include-hidden",
+        action="store_true",
+        help="Allow showing hidden commands explicitly by name.",
+    )
+    _ = commands_show_parser.add_argument(
+        "--include-disabled",
+        action="store_true",
+        help="Allow showing disabled commands explicitly by name.",
+    )
+    _ = commands_show_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output the command definition as JSON.",
+    )
+    commands_show_parser.set_defaults(handler=_handle_commands_show_command)
 
     config_schema_parser = config_subparsers.add_parser(
         "schema", help="Print the JSON Schema for .voidcode.json."
@@ -1181,6 +1504,11 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         default=Path.cwd(),
         help="Workspace root used to resolve the local session database.",
+    )
+    _ = list_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output persisted sessions as JSON.",
     )
     list_parser.set_defaults(handler=_handle_sessions_list_command)
 
@@ -1314,5 +1642,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     handler = cast(Handler | None, getattr(args, "handler", None))
     if handler is None:
         parser.print_help()
-        return 0
-    return handler(args)
+        return EXIT_SUCCESS
+    try:
+        return handler(args)
+    except SystemExit as exc:
+        return _handle_cli_system_exit(exc)

--- a/src/voidcode/cli_support.py
+++ b/src/voidcode/cli_support.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from .command.models import CommandDefinition
+from .runtime.events import EventEnvelope
+from .runtime.session import SessionState, StoredSessionSummary
+
+EXIT_SUCCESS = 0
+EXIT_GENERAL_ERROR = 1
+EXIT_USAGE_ERROR = 2
+EXIT_CONFIG_ERROR = 10
+EXIT_PROVIDER_ERROR = 11
+EXIT_RUNTIME_ERROR = 12
+EXIT_APPROVAL_DENIED = 13
+EXIT_CANCELLED = 14
+EXIT_INVALID_COMMAND = 15
+EXIT_INVALID_RESOURCE = 16
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeStreamResult:
+    output: str | None
+    session: SessionState
+    events: tuple[EventEnvelope, ...]
+
+
+def print_json(payload: object) -> None:
+    print(json.dumps(payload, sort_keys=True))
+
+
+def format_event(event_type: str, source: str, data: dict[str, object]) -> str:
+    suffix = " ".join(f"{key}={value}" for key, value in sorted(data.items()))
+    if suffix:
+        return f"EVENT {event_type} source={source} {suffix}"
+    return f"EVENT {event_type} source={source}"
+
+
+def serialize_event(event: EventEnvelope) -> dict[str, object]:
+    return {
+        "event_type": event.event_type,
+        "source": event.source,
+        "payload": event.payload,
+    }
+
+
+def serialize_session_state(session: SessionState) -> dict[str, object]:
+    session_payload: dict[str, object] = {"id": session.session.id}
+    parent_id = getattr(session.session, "parent_id", None)
+    if parent_id is not None:
+        session_payload["parent_id"] = parent_id
+    return {
+        "session": session_payload,
+        "status": session.status,
+        "turn": session.turn,
+        "metadata": session.metadata,
+    }
+
+
+def serialize_stored_session_summary(session: StoredSessionSummary) -> dict[str, object]:
+    return {
+        "id": session.session.id,
+        "parent_id": getattr(session.session, "parent_id", None),
+        "status": session.status,
+        "turn": session.turn,
+        "updated_at": session.updated_at,
+        "prompt": session.prompt,
+    }
+
+
+def serialize_command_definition(command: CommandDefinition) -> dict[str, object]:
+    return {
+        "name": command.name,
+        "description": command.description,
+        "source": command.source,
+        "enabled": command.enabled,
+        "hidden": command.hidden,
+        "agent": command.agent,
+        "model": command.model,
+        "subtask": command.subtask,
+        "path": _serialize_path(command.path),
+        "template": command.template,
+    }
+
+
+def serialize_command_summary(command: CommandDefinition) -> dict[str, object]:
+    return {
+        key: value
+        for key, value in serialize_command_definition(command).items()
+        if key != "template"
+    }
+
+
+def _serialize_path(path: Path | None) -> str | None:
+    return None if path is None else str(path)

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -843,9 +843,10 @@ def test_runtime_skips_hooks_for_nested_hook_launched_runtime_invocations(tmp_pa
     result = runtime.run(runtime_request(prompt=prompt, session_id="outer-hook-recursion-session"))
 
     assert marker_path.read_text(encoding="utf-8") == "1"
-    assert "EVENT runtime.request_received" in nested_output_path.read_text(encoding="utf-8")
-    assert "runtime.tool_hook_pre" not in nested_output_path.read_text(encoding="utf-8")
-    assert "runtime.tool_hook_post" not in nested_output_path.read_text(encoding="utf-8")
+    nested_output = nested_output_path.read_text(encoding="utf-8")
+    assert nested_output == "nested hook read\n"
+    assert "runtime.tool_hook_pre" not in nested_output
+    assert "runtime.tool_hook_post" not in nested_output
     assert [event.event_type for event in result.events].count("runtime.tool_hook_pre") == 1
 
 
@@ -2384,7 +2385,7 @@ def test_runtime_preserves_pending_approval_when_terminal_save_fails(tmp_path: P
     assert cast(str, replay.events[-1].payload["request_id"]) == approval_request_id
 
 
-def test_cli_run_command_prints_events_and_file_contents(tmp_path: Path) -> None:
+def test_cli_run_command_prints_clean_file_contents_by_default(tmp_path: Path) -> None:
     sample_file = tmp_path / "sample.txt"
     _ = sample_file.write_text("slice proof\n", encoding="utf-8")
 
@@ -2408,10 +2409,42 @@ def test_cli_run_command_prints_events_and_file_contents(tmp_path: Path) -> None
     )
 
     assert result.returncode == 0
-    assert "EVENT runtime.request_received" in result.stdout
-    assert "EVENT runtime.tool_completed" in result.stdout
-    assert "RESULT" in result.stdout
-    assert "slice proof" in result.stdout
+    assert result.stdout == "slice proof\n"
+    assert result.stderr == ""
+
+
+def test_cli_run_command_json_outputs_events_and_file_contents(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    _ = sample_file.write_text("slice proof\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "src")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "voidcode",
+            "run",
+            "read sample.txt",
+            "--workspace",
+            str(tmp_path),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    payload = json.loads(result.stdout)
+    event_types = [event["event_type"] for event in payload["events"]]
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert "runtime.request_received" in event_types
+    assert "runtime.tool_completed" in event_types
+    assert payload["output"] == "slice proof"
 
 
 def test_cli_run_command_approval_allow_writes_file_under_tty_and_replays_session(

--- a/tests/unit/interface/test_cli_delegated_parity.py
+++ b/tests/unit/interface/test_cli_delegated_parity.py
@@ -565,10 +565,10 @@ def test_cli_run_non_interactive_skips_approval_loop(capsys: Any) -> None:
                         ["run", "write x.txt hi", "--workspace", "/tmp/demo-workspace"]
                     )
 
-    assert result == 0
+    assert result == 13
     runtime.resume_stream.assert_not_called()
     captured = capsys.readouterr()
-    assert "EVENT runtime.approval_requested" in captured.out
+    assert captured.out == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -195,6 +195,14 @@ def test_serve_command_help_works() -> None:
     assert "transport" in result.stdout.lower()
 
 
+def test_top_level_help_includes_examples() -> None:
+    result = _run_module_cli("--help")
+
+    assert result.returncode == 0
+    assert "Examples:" in result.stdout
+    assert "voidcode commands list" in result.stdout
+
+
 def test_web_command_forwards_runtime_config_and_server_entry() -> None:
     cli = importlib.import_module("voidcode.cli")
     workspace = Path("/tmp/web-workspace")
@@ -381,6 +389,38 @@ def test_sessions_debug_outputs_json_snapshot() -> None:
     assert "Traceback" not in debug_result.stderr
 
 
+def test_sessions_list_outputs_json() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        (workspace / "sample.txt").write_text("sample\n", encoding="utf-8")
+        env = with_src_pythonpath(os.environ.copy())
+
+        setup_result = _run_module_cli(
+            "run",
+            "read sample.txt",
+            "--workspace",
+            str(workspace),
+            "--session-id",
+            "list-json-session",
+            env=env,
+        )
+        list_result = _run_module_cli(
+            "sessions",
+            "list",
+            "--workspace",
+            str(workspace),
+            "--json",
+            env=env,
+        )
+
+    payload = json.loads(list_result.stdout)
+    assert setup_result.returncode == 0
+    assert list_result.returncode == 0
+    assert payload["workspace"] == str(workspace)
+    assert payload["sessions"][0]["id"] == "list-json-session"
+    assert payload["sessions"][0]["prompt"] == "read sample.txt"
+
+
 def test_sessions_debug_missing_session_returns_clean_error() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         workspace = Path(tmp)
@@ -395,7 +435,7 @@ def test_sessions_debug_missing_session_returns_clean_error() -> None:
             env=env,
         )
 
-    assert result.returncode == 1
+    assert result.returncode == 16
     assert result.stdout == ""
     assert "error: unknown session: missing-session" in result.stderr
     assert "Traceback" not in result.stderr
@@ -556,16 +596,21 @@ def test_run_command_prints_request_observability_event(capsys: Any) -> None:
                     "read README.md",
                     "--workspace",
                     str(workspace),
+                    "--json",
                 ]
             )
 
     captured = capsys.readouterr()
+    payload = json.loads(captured.out)
 
     assert result == 0
-    assert (
-        "EVENT runtime.request_received source=runtime "
-        "agent_preset=leader prompt=read README.md" in captured.out
-    )
+    assert payload["events"] == [
+        {
+            "event_type": "runtime.request_received",
+            "source": "runtime",
+            "payload": {"agent_preset": "leader", "prompt": "read README.md"},
+        }
+    ]
 
 
 def test_run_command_real_cli_reports_current_request_truth_without_agent_preset() -> None:
@@ -581,11 +626,30 @@ def test_run_command_real_cli_reports_current_request_truth_without_agent_preset
             env=env,
         )
 
-    assert result.returncode == 1
-    assert "EVENT runtime.request_received source=runtime prompt=read README.md" in result.stdout
-    assert "EVENT runtime.plan_created source=runtime" not in result.stdout
-    assert "read_file target does not exist: README.md" in result.stdout
-    assert result.stderr == "error: read_file target does not exist: README.md\n"
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "EVENT runtime.request_received" not in result.stdout
+    assert "EVENT runtime.plan_created" not in result.stdout
+    assert "read_file target does not exist: README.md" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_run_command_missing_config_named_file_is_runtime_error() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        env = with_src_pythonpath(os.environ.copy())
+
+        result = _run_module_cli(
+            "run",
+            "read config.md",
+            "--workspace",
+            str(workspace),
+            env=env,
+        )
+
+    assert result.returncode == 12
+    assert result.stdout == ""
+    assert "read_file target does not exist: config.md" in result.stderr
     assert "Traceback" not in result.stderr
 
 
@@ -1034,10 +1098,176 @@ def test_run_command_does_not_prompt_or_resume_when_not_interactive(capsys: Any)
 
     captured = capsys.readouterr()
 
-    assert result == 0
+    assert result == 13
     runtime.resume_stream.assert_not_called()
-    assert "EVENT runtime.approval_requested" in captured.out
-    assert captured.out.rstrip().endswith("RESULT")
+    assert captured.out == ""
+    assert stderr.writes == [
+        "error: approval required for write_file for sample.txt; "
+        "resume session demo-session with approval request req-1",
+        "\n",
+    ]
+    assert captured.err == ""
+
+
+def test_run_command_json_reports_non_interactive_approval_block(capsys: Any) -> None:
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/demo-workspace")
+    config = SimpleNamespace(approval_mode="ask")
+    first_stream = (
+        _make_chunk(
+            session_id="demo-session",
+            status="running",
+            event=_runtime_event("runtime.request_received", prompt="write sample.txt hi"),
+        ),
+        _make_chunk(
+            session_id="demo-session",
+            status="waiting",
+            event=_approval_requested_event(),
+        ),
+    )
+    stderr = _StubNonInteractiveStderr()
+
+    with patch.object(cli, "load_runtime_config", autospec=True, return_value=config):
+        with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
+            runtime = runtime_class.return_value
+            runtime.run_stream.return_value = iter(first_stream)
+            with patch.object(cli.sys, "stdin", _StubNonInteractiveInput()):
+                with patch.object(cli.sys, "stderr", stderr):
+                    result = cli.main(
+                        [
+                            "run",
+                            "write sample.txt hi",
+                            "--workspace",
+                            str(workspace),
+                            "--json",
+                        ]
+                    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert result == 13
+    runtime.resume_stream.assert_not_called()
+    assert payload["session"]["status"] == "waiting"
+    assert payload["blocked"] == {
+        "kind": "approval_required",
+        "request_id": "req-1",
+        "session_id": "demo-session",
+        "target_summary": "sample.txt",
+        "tool": "write_file",
+    }
+    assert stderr.writes == []
+    assert captured.err == ""
+
+
+def test_run_command_non_interactive_question_block_returns_failure(capsys: Any) -> None:
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/demo-workspace")
+    config = SimpleNamespace(approval_mode="ask")
+    questions: list[dict[str, object]] = [
+        {
+            "header": "Confirm",
+            "question": "Proceed?",
+            "multiple": False,
+            "options": [],
+        }
+    ]
+    first_stream = (
+        _make_chunk(
+            session_id="question-session",
+            status="running",
+            event=_runtime_event("runtime.request_received", prompt="ask user"),
+        ),
+        _make_chunk(
+            session_id="question-session",
+            status="waiting",
+            event=_runtime_event(
+                "runtime.question_requested",
+                request_id="question-1",
+                tool="question",
+                question_count=1,
+                questions=questions,
+            ),
+        ),
+    )
+    stderr = _StubNonInteractiveStderr()
+
+    with patch.object(cli, "load_runtime_config", autospec=True, return_value=config):
+        with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
+            runtime = runtime_class.return_value
+            runtime.run_stream.return_value = iter(first_stream)
+            with patch.object(cli.sys, "stdin", _StubNonInteractiveInput()):
+                with patch.object(cli.sys, "stderr", stderr):
+                    result = cli.main(["run", "ask user", "--workspace", str(workspace)])
+
+    captured = capsys.readouterr()
+
+    assert result == 12
+    runtime.resume_stream.assert_not_called()
+    assert captured.out == ""
+    assert stderr.writes == [
+        "error: question response required for question; "
+        "resume session question-session with question request question-1",
+        "\n",
+    ]
+    assert captured.err == ""
+
+
+def test_run_command_json_reports_non_interactive_question_block(capsys: Any) -> None:
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/demo-workspace")
+    config = SimpleNamespace(approval_mode="ask")
+    questions: list[dict[str, object]] = [
+        {
+            "header": "Confirm",
+            "question": "Proceed?",
+            "multiple": False,
+            "options": [],
+        }
+    ]
+    question_payload: dict[str, object] = {
+        "request_id": "question-1",
+        "tool": "question",
+        "question_count": 1,
+        "questions": questions,
+    }
+    first_stream = (
+        _make_chunk(
+            session_id="question-session",
+            status="waiting",
+            event=_runtime_event(
+                "runtime.question_requested",
+                request_id="question-1",
+                tool="question",
+                question_count=1,
+                questions=questions,
+            ),
+        ),
+    )
+    stderr = _StubNonInteractiveStderr()
+
+    with patch.object(cli, "load_runtime_config", autospec=True, return_value=config):
+        with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
+            runtime = runtime_class.return_value
+            runtime.run_stream.return_value = iter(first_stream)
+            with patch.object(cli.sys, "stdin", _StubNonInteractiveInput()):
+                with patch.object(cli.sys, "stderr", stderr):
+                    result = cli.main(["run", "ask user", "--workspace", str(workspace), "--json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert result == 12
+    runtime.resume_stream.assert_not_called()
+    assert payload["session"]["status"] == "waiting"
+    assert payload["blocked"] == {
+        "kind": "question_required",
+        "question_count": 1,
+        "questions": question_payload["questions"],
+        "request_id": "question-1",
+        "session_id": "question-session",
+        "tool": "question",
+    }
     assert stderr.writes == []
     assert captured.err == ""
 
@@ -1064,8 +1294,7 @@ def test_run_command_uses_repo_local_config_to_allow_write_request() -> None:
         written = (workspace / "danger.txt").read_text(encoding="utf-8")
 
     assert result.returncode == 0
-    assert "EVENT runtime.approval_resolved" in result.stdout
-    assert "decision=allow" in result.stdout
+    assert "EVENT runtime.approval_resolved" not in result.stdout
     assert written == "config approved"
 
 
@@ -1112,6 +1341,26 @@ def test_config_show_outputs_workspace_effective_config() -> None:
         },
     }
     assert "Traceback" not in result.stderr
+
+
+def test_config_show_accepts_json_flag() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        env = with_src_pythonpath(os.environ.copy())
+
+        result = _run_module_cli(
+            "config",
+            "show",
+            "--workspace",
+            str(workspace),
+            "--json",
+            env=env,
+        )
+
+    payload = json.loads(result.stdout)
+    assert result.returncode == 0
+    assert payload["workspace"] == str(workspace)
+    assert payload["approval_mode"] == "ask"
 
 
 def test_config_show_uses_opencode_go_environment_without_leaking_key() -> None:
@@ -1264,35 +1513,30 @@ def test_config_show_delegates_to_runtime_effective_config(capsys: Any) -> None:
     runtime_class.return_value.effective_runtime_config.assert_called_once_with(
         session_id="config-session"
     )
-    assert captured.out == (
-        json.dumps(
-            {
-                "workspace": str(workspace),
-                "session_id": "config-session",
-                "approval_mode": "allow",
-                "model": "runtime/model",
-                "execution_engine": "deterministic",
-                "max_steps": 9,
-                "agent": None,
-                "provider_fallback": None,
-                "resolved_provider": {
-                    "active_target": {
-                        "raw_model": "runtime/model",
-                        "provider": "runtime",
-                        "model": "model",
-                    },
-                    "targets": [
-                        {
-                            "raw_model": "runtime/model",
-                            "provider": "runtime",
-                            "model": "model",
-                        }
-                    ],
-                },
-            }
-        )
-        + "\n"
-    )
+    assert json.loads(captured.out) == {
+        "workspace": str(workspace),
+        "session_id": "config-session",
+        "approval_mode": "allow",
+        "model": "runtime/model",
+        "execution_engine": "deterministic",
+        "max_steps": 9,
+        "agent": None,
+        "provider_fallback": None,
+        "resolved_provider": {
+            "active_target": {
+                "raw_model": "runtime/model",
+                "provider": "runtime",
+                "model": "model",
+            },
+            "targets": [
+                {
+                    "raw_model": "runtime/model",
+                    "provider": "runtime",
+                    "model": "model",
+                }
+            ],
+        },
+    }
 
 
 def test_config_show_invalid_workspace_returns_error() -> None:
@@ -1495,6 +1739,79 @@ def test_config_migrate_invalid_json_returns_error() -> None:
     assert result.returncode != 0
     assert result.stdout == ""
     assert "must contain valid JSON" in result.stderr
+
+
+def test_commands_list_outputs_discovered_project_commands_json() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        commands_dir = workspace / "commands"
+        commands_dir.mkdir()
+        (commands_dir / "explain.md").write_text(
+            "---\ndescription: Explain a target\n---\nExplain $ARGUMENTS\n",
+            encoding="utf-8",
+        )
+
+        result = _run_module_cli(
+            "commands",
+            "list",
+            "--workspace",
+            str(workspace),
+            "--json",
+        )
+
+    payload = json.loads(result.stdout)
+    command_names = {command["name"] for command in payload["commands"]}
+    assert result.returncode == 0
+    assert payload["workspace"] == str(workspace)
+    assert {"help", "review", "explain"}.issubset(command_names)
+
+
+def test_commands_show_outputs_project_command_json() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        commands_dir = workspace / ".voidcode" / "commands"
+        commands_dir.mkdir(parents=True)
+        (commands_dir / "review.md").write_text(
+            "---\n"
+            "description: Project review override\n"
+            "agent: reviewer\n"
+            "---\n"
+            "Review locally: $ARGUMENTS\n",
+            encoding="utf-8",
+        )
+
+        result = _run_module_cli(
+            "commands",
+            "show",
+            "/review",
+            "--workspace",
+            str(workspace),
+            "--json",
+        )
+
+    payload = json.loads(result.stdout)
+    assert result.returncode == 0
+    assert payload["name"] == "review"
+    assert payload["source"] == "project"
+    assert payload["description"] == "Project review override"
+    assert payload["agent"] == "reviewer"
+    assert payload["template"] == "Review locally: $ARGUMENTS\n"
+
+
+def test_commands_show_missing_command_returns_clean_error() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        result = _run_module_cli(
+            "commands",
+            "show",
+            "missing",
+            "--workspace",
+            tmp,
+        )
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "error: unknown command: /missing" in result.stderr
+    assert "Traceback" not in result.stderr
 
 
 def test_provider_models_command_outputs_refreshed_provider_model_list() -> None:


### PR DESCRIPTION
## Summary
- Polish `voidcode run` default output and add structured `--json` output with session/events/output payloads.
- Add `commands list/show` discovery for prompt commands and JSON contracts for session/config command surfaces.
- Document the updated CLI human-vs-JSON workflow and align unit/integration tests with the new output contract.

Closes #274

## Verification
- `uv run pytest tests/unit/interface/test_cli_smoke.py tests/unit/interface/test_cli_delegated_parity.py`
- `uv run pytest tests/integration/test_read_only_slice.py::test_runtime_skips_hooks_for_nested_hook_launched_runtime_invocations tests/integration/test_read_only_slice.py::test_cli_run_command_prints_clean_file_contents_by_default tests/integration/test_read_only_slice.py::test_cli_run_command_json_outputs_events_and_file_contents`
- `mise run check`