### PR TITLE
feat(provider): harden model metadata for routing

### DIFF
--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -954,6 +954,20 @@ def _provider_model_metadata_payload(
             "supports_streaming": metadata.supports_streaming,
             "supports_reasoning": metadata.supports_reasoning,
             "supports_json_mode": metadata.supports_json_mode,
+            "cost_per_input_token": metadata.cost_per_input_token,
+            "cost_per_output_token": metadata.cost_per_output_token,
+            "cost_per_cache_read_token": metadata.cost_per_cache_read_token,
+            "cost_per_cache_write_token": metadata.cost_per_cache_write_token,
+            "supports_reasoning_effort": metadata.supports_reasoning_effort,
+            "default_reasoning_effort": metadata.default_reasoning_effort,
+            "supports_interleaved_reasoning": metadata.supports_interleaved_reasoning,
+            "modalities_input": list(metadata.modalities_input)
+            if metadata.modalities_input is not None
+            else None,
+            "modalities_output": list(metadata.modalities_output)
+            if metadata.modalities_output is not None
+            else None,
+            "model_status": metadata.model_status,
         }.items()
         if value is not None
     }

--- a/src/voidcode/provider/model_catalog.py
+++ b/src/voidcode/provider/model_catalog.py
@@ -298,10 +298,10 @@ def _metadata(
         supports_streaming=_optional_bool(values.get("supports_streaming")),
         supports_reasoning=_optional_bool(values.get("supports_reasoning")),
         supports_json_mode=_optional_bool(values.get("supports_json_mode")),
-        cost_per_input_token=_positive_float(values.get("cost_per_input_token")),
-        cost_per_output_token=_positive_float(values.get("cost_per_output_token")),
-        cost_per_cache_read_token=_positive_float(values.get("cost_per_cache_read_token")),
-        cost_per_cache_write_token=_positive_float(values.get("cost_per_cache_write_token")),
+        cost_per_input_token=_non_negative_float(values.get("cost_per_input_token")),
+        cost_per_output_token=_non_negative_float(values.get("cost_per_output_token")),
+        cost_per_cache_read_token=_non_negative_float(values.get("cost_per_cache_read_token")),
+        cost_per_cache_write_token=_non_negative_float(values.get("cost_per_cache_write_token")),
         supports_reasoning_effort=_optional_bool(values.get("supports_reasoning_effort")),
         default_reasoning_effort=_optional_str(values.get("default_reasoning_effort")),
         supports_interleaved_reasoning=_optional_bool(values.get("supports_interleaved_reasoning")),
@@ -768,8 +768,8 @@ def _positive_int(value: object) -> int | None:
     return None
 
 
-def _positive_float(value: object) -> float | None:
-    if isinstance(value, int | float) and not isinstance(value, bool) and value > 0:
+def _non_negative_float(value: object) -> float | None:
+    if isinstance(value, int | float) and not isinstance(value, bool) and value >= 0:
         return float(value)
     return None
 
@@ -812,10 +812,10 @@ def _metadata_from_discovery_item(
         supports_streaming=_optional_bool(raw.get("supports_streaming")),
         supports_reasoning=_optional_bool(raw.get("supports_reasoning")),
         supports_json_mode=_optional_bool(raw.get("supports_json_mode")),
-        cost_per_input_token=_positive_float(raw.get("input_cost_per_token")),
-        cost_per_output_token=_positive_float(raw.get("output_cost_per_token")),
-        cost_per_cache_read_token=_positive_float(raw.get("cache_read_input_token_cost")),
-        cost_per_cache_write_token=_positive_float(raw.get("cache_creation_input_token_cost")),
+        cost_per_input_token=_non_negative_float(raw.get("input_cost_per_token")),
+        cost_per_output_token=_non_negative_float(raw.get("output_cost_per_token")),
+        cost_per_cache_read_token=_non_negative_float(raw.get("cache_read_input_token_cost")),
+        cost_per_cache_write_token=_non_negative_float(raw.get("cache_creation_input_token_cost")),
         supports_reasoning_effort=_optional_bool(raw.get("supports_reasoning_effort")),
         default_reasoning_effort=_optional_str(raw.get("default_reasoning_effort")),
         supports_interleaved_reasoning=_optional_bool(raw.get("supports_interleaved_reasoning")),
@@ -846,8 +846,6 @@ def _metadata_from_google_item(
             else None
         ),
         supports_json_mode=True,
-        modalities_input=("text", "image"),
-        modalities_output=("text",),
         model_status="preview" if "preview" in model_name.lower() else "active",
     )
     return metadata if metadata.payload() else None

--- a/src/voidcode/provider/model_catalog.py
+++ b/src/voidcode/provider/model_catalog.py
@@ -326,6 +326,8 @@ def _override_max_input_tokens(
     override: ProviderModelMetadata,
 ) -> int | None:
     if override.max_input_tokens is None:
+        if override.max_output_tokens is not None:
+            return None
         return None if inferred is None else inferred.max_input_tokens
     if (
         override.context_window is not None

--- a/src/voidcode/provider/model_catalog.py
+++ b/src/voidcode/provider/model_catalog.py
@@ -34,18 +34,21 @@ class ProviderModelMetadata:
     modalities_input: tuple[str, ...] | None = None
     modalities_output: tuple[str, ...] | None = None
     model_status: str | None = None
+    derived_max_input_tokens: bool = field(default=False, init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         if self.max_input_tokens is not None or self.context_window is None:
             return
         if self.max_output_tokens is None:
             object.__setattr__(self, "max_input_tokens", self.context_window)
+            object.__setattr__(self, "derived_max_input_tokens", True)
             return
         object.__setattr__(
             self,
             "max_input_tokens",
             max(1, self.context_window - self.max_output_tokens),
         )
+        object.__setattr__(self, "derived_max_input_tokens", True)
 
     def payload(self) -> dict[str, int | float | bool | str | list[str]]:
         payload: dict[str, int | float | bool | str | list[str]] = {}
@@ -333,6 +336,7 @@ def _override_max_input_tokens(
         override.context_window is not None
         and override.max_input_tokens == override.context_window
         and override.max_output_tokens is None
+        and override.derived_max_input_tokens
     ):
         if inferred is not None and override.context_window != inferred.context_window:
             return None
@@ -527,9 +531,7 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             "supports_reasoning": "reasoner" in model or model.startswith("deepseek-v4"),
             "supports_json_mode": True,
             "supports_reasoning_effort": False,
-            "default_reasoning_effort": "medium"
-            if "reasoner" in model or model.startswith("deepseek-v4")
-            else None,
+            "default_reasoning_effort": None,
             "supports_interleaved_reasoning": False,
             "modalities_input": ("text",),
             "modalities_output": ("text",),

--- a/src/voidcode/provider/model_catalog.py
+++ b/src/voidcode/provider/model_catalog.py
@@ -332,6 +332,8 @@ def _override_max_input_tokens(
         and override.max_input_tokens == override.context_window
         and override.max_output_tokens is None
     ):
+        if inferred is not None and override.context_window != inferred.context_window:
+            return None
         return None if inferred is None else inferred.max_input_tokens
     return override.max_input_tokens
 
@@ -820,7 +822,9 @@ def _metadata_from_discovery_item(
     return metadata if metadata.payload() else None
 
 
-def _metadata_from_google_item(item: _GoogleModelItem) -> ProviderModelMetadata | None:
+def _metadata_from_google_item(
+    item: _GoogleModelItem, *, model_name: str
+) -> ProviderModelMetadata | None:
     context_window = item.inputTokenLimit
     metadata = ProviderModelMetadata(
         context_window=context_window,
@@ -840,7 +844,7 @@ def _metadata_from_google_item(item: _GoogleModelItem) -> ProviderModelMetadata 
         supports_json_mode=True,
         modalities_input=("text", "image"),
         modalities_output=("text",),
-        model_status="active",
+        model_status="preview" if "preview" in model_name.lower() else "active",
     )
     return metadata if metadata.payload() else None
 
@@ -900,7 +904,7 @@ def _parse_google_discovery_payload(payload: object) -> ModelDiscoveryFetchResul
         if isinstance(raw_name, str) and raw_name:
             normalized = raw_name[len("models/") :] if raw_name.startswith("models/") else raw_name
             model_ids.append(normalized)
-            metadata = _metadata_from_google_item(item)
+            metadata = _metadata_from_google_item(item, model_name=normalized)
             if metadata is not None:
                 model_metadata[normalized] = metadata
     return ModelDiscoveryFetchResult(models=tuple(model_ids), model_metadata=model_metadata)

--- a/src/voidcode/provider/model_catalog.py
+++ b/src/voidcode/provider/model_catalog.py
@@ -246,7 +246,10 @@ def discover_available_models(
 
     model_metadata: dict[str, ProviderModelMetadata] = {}
     for model in deduped:
-        metadata = discovered_metadata.get(model) or infer_model_metadata(provider_name, model)
+        metadata = _merge_model_metadata(
+            inferred=infer_model_metadata(provider_name, model),
+            override=discovered_metadata.get(model),
+        )
         if metadata is not None:
             model_metadata[model] = metadata
 
@@ -311,6 +314,78 @@ def _modalities_tuple(value: object) -> tuple[str, ...] | None:
     raw_items = cast(Iterable[object], value)
     modalities = tuple(item for item in raw_items if isinstance(item, str) and item)
     return modalities or None
+
+
+def _override_value[T](inferred: T | None, override: T | None) -> T | None:
+    return override if override is not None else inferred
+
+
+def _override_max_input_tokens(
+    *,
+    inferred: ProviderModelMetadata | None,
+    override: ProviderModelMetadata,
+) -> int | None:
+    if override.max_input_tokens is None:
+        return None if inferred is None else inferred.max_input_tokens
+    if (
+        override.context_window is not None
+        and override.max_input_tokens == override.context_window
+        and override.max_output_tokens is None
+    ):
+        return None if inferred is None else inferred.max_input_tokens
+    return override.max_input_tokens
+
+
+def _merge_model_metadata(
+    *,
+    inferred: ProviderModelMetadata | None,
+    override: ProviderModelMetadata | None,
+) -> ProviderModelMetadata | None:
+    if inferred is None:
+        return override
+    if override is None:
+        return inferred
+    return ProviderModelMetadata(
+        context_window=_override_value(inferred.context_window, override.context_window),
+        max_input_tokens=_override_max_input_tokens(inferred=inferred, override=override),
+        max_output_tokens=_override_value(inferred.max_output_tokens, override.max_output_tokens),
+        supports_tools=_override_value(inferred.supports_tools, override.supports_tools),
+        supports_vision=_override_value(inferred.supports_vision, override.supports_vision),
+        supports_streaming=_override_value(
+            inferred.supports_streaming, override.supports_streaming
+        ),
+        supports_reasoning=_override_value(
+            inferred.supports_reasoning, override.supports_reasoning
+        ),
+        supports_json_mode=_override_value(
+            inferred.supports_json_mode, override.supports_json_mode
+        ),
+        cost_per_input_token=_override_value(
+            inferred.cost_per_input_token, override.cost_per_input_token
+        ),
+        cost_per_output_token=_override_value(
+            inferred.cost_per_output_token, override.cost_per_output_token
+        ),
+        cost_per_cache_read_token=_override_value(
+            inferred.cost_per_cache_read_token, override.cost_per_cache_read_token
+        ),
+        cost_per_cache_write_token=_override_value(
+            inferred.cost_per_cache_write_token, override.cost_per_cache_write_token
+        ),
+        supports_reasoning_effort=_override_value(
+            inferred.supports_reasoning_effort, override.supports_reasoning_effort
+        ),
+        default_reasoning_effort=_override_value(
+            inferred.default_reasoning_effort, override.default_reasoning_effort
+        ),
+        supports_interleaved_reasoning=_override_value(
+            inferred.supports_interleaved_reasoning,
+            override.supports_interleaved_reasoning,
+        ),
+        modalities_input=_override_value(inferred.modalities_input, override.modalities_input),
+        modalities_output=_override_value(inferred.modalities_output, override.modalities_output),
+        model_status=_override_value(inferred.model_status, override.model_status),
+    )
 
 
 def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMetadata | None:

--- a/src/voidcode/provider/model_catalog.py
+++ b/src/voidcode/provider/model_catalog.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Literal, cast
 from urllib.error import URLError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
@@ -24,6 +24,16 @@ class ProviderModelMetadata:
     supports_streaming: bool | None = None
     supports_reasoning: bool | None = None
     supports_json_mode: bool | None = None
+    cost_per_input_token: float | None = None
+    cost_per_output_token: float | None = None
+    cost_per_cache_read_token: float | None = None
+    cost_per_cache_write_token: float | None = None
+    supports_reasoning_effort: bool | None = None
+    default_reasoning_effort: str | None = None
+    supports_interleaved_reasoning: bool | None = None
+    modalities_input: tuple[str, ...] | None = None
+    modalities_output: tuple[str, ...] | None = None
+    model_status: str | None = None
 
     def __post_init__(self) -> None:
         if self.max_input_tokens is not None or self.context_window is None:
@@ -37,8 +47,8 @@ class ProviderModelMetadata:
             max(1, self.context_window - self.max_output_tokens),
         )
 
-    def payload(self) -> dict[str, int | bool]:
-        payload: dict[str, int | bool] = {}
+    def payload(self) -> dict[str, int | float | bool | str | list[str]]:
+        payload: dict[str, int | float | bool | str | list[str]] = {}
         if self.context_window is not None:
             payload["context_window"] = self.context_window
         if self.max_input_tokens is not None:
@@ -55,6 +65,26 @@ class ProviderModelMetadata:
             payload["supports_reasoning"] = self.supports_reasoning
         if self.supports_json_mode is not None:
             payload["supports_json_mode"] = self.supports_json_mode
+        if self.cost_per_input_token is not None:
+            payload["cost_per_input_token"] = self.cost_per_input_token
+        if self.cost_per_output_token is not None:
+            payload["cost_per_output_token"] = self.cost_per_output_token
+        if self.cost_per_cache_read_token is not None:
+            payload["cost_per_cache_read_token"] = self.cost_per_cache_read_token
+        if self.cost_per_cache_write_token is not None:
+            payload["cost_per_cache_write_token"] = self.cost_per_cache_write_token
+        if self.supports_reasoning_effort is not None:
+            payload["supports_reasoning_effort"] = self.supports_reasoning_effort
+        if self.default_reasoning_effort is not None:
+            payload["default_reasoning_effort"] = self.default_reasoning_effort
+        if self.supports_interleaved_reasoning is not None:
+            payload["supports_interleaved_reasoning"] = self.supports_interleaved_reasoning
+        if self.modalities_input is not None:
+            payload["modalities_input"] = list(self.modalities_input)
+        if self.modalities_output is not None:
+            payload["modalities_output"] = list(self.modalities_output)
+        if self.model_status is not None:
+            payload["model_status"] = self.model_status
         return payload
 
 
@@ -67,7 +97,13 @@ class DiscoveryRequest:
     api_key: str | None
 
 
-type ModelCatalogFetcher = Callable[[DiscoveryRequest], tuple[str, ...]]
+@dataclass(frozen=True, slots=True)
+class ModelDiscoveryFetchResult:
+    models: tuple[str, ...]
+    model_metadata: dict[str, ProviderModelMetadata] = field(default_factory=dict)
+
+
+type ModelCatalogFetcher = Callable[[DiscoveryRequest], tuple[str, ...] | ModelDiscoveryFetchResult]
 
 
 @dataclass(frozen=True, slots=True)
@@ -120,6 +156,27 @@ class _DiscoveryPayloadModel(BaseModel):
 
 class _OpenAICompatibleModelItem(_DiscoveryPayloadModel):
     id: str | None = None
+    context_window: int | None = None
+    context_length: int | None = None
+    max_context_length: int | None = None
+    max_input_tokens: int | None = None
+    max_output_tokens: int | None = None
+    input_cost_per_token: float | None = None
+    output_cost_per_token: float | None = None
+    cache_read_input_token_cost: float | None = None
+    cache_creation_input_token_cost: float | None = None
+    supports_tools: bool | None = None
+    supports_vision: bool | None = None
+    supports_streaming: bool | None = None
+    supports_reasoning: bool | None = None
+    supports_json_mode: bool | None = None
+    supports_reasoning_effort: bool | None = None
+    default_reasoning_effort: str | None = None
+    supports_interleaved_reasoning: bool | None = None
+    modalities: list[str] | None = None
+    input_modalities: list[str] | None = None
+    output_modalities: list[str] | None = None
+    status: str | None = None
 
 
 class _OpenAICompatibleDiscoveryPayload(_DiscoveryPayloadModel):
@@ -132,6 +189,9 @@ class _AnthropicDiscoveryPayload(_DiscoveryPayloadModel):
 
 class _GoogleModelItem(_DiscoveryPayloadModel):
     name: str | None = None
+    inputTokenLimit: int | None = None
+    outputTokenLimit: int | None = None
+    supportedGenerationMethods: list[str] | None = None
 
 
 class _GoogleDiscoveryPayload(_DiscoveryPayloadModel):
@@ -152,9 +212,16 @@ def discover_available_models(
     if discovery_plan.request is not None:
         active_fetcher = _fetch_models if fetcher is None else fetcher
         try:
-            discovered = active_fetcher(discovery_plan.request)
+            fetch_result = active_fetcher(discovery_plan.request)
+            if isinstance(fetch_result, ModelDiscoveryFetchResult):
+                discovered = fetch_result.models
+                discovered_metadata = fetch_result.model_metadata
+            else:
+                discovered = fetch_result
+                discovered_metadata = {}
         except (ValueError, OSError, TimeoutError, URLError):
             discovered = ()
+            discovered_metadata = {}
             source = "fallback"
             refresh_status = "failed"
             error_message = "remote model discovery failed"
@@ -162,6 +229,7 @@ def discover_available_models(
         source = "fallback"
         refresh_status = "skipped"
         error_message = discovery_plan.skip_reason
+        discovered_metadata = {}
 
     mapped_aliases = tuple(config.model_map.keys()) if config is not None else ()
     mapped_targets = tuple(config.model_map.values()) if config is not None else ()
@@ -176,11 +244,11 @@ def discover_available_models(
     if source == "remote" and not discovered and deduped:
         source = "mixed"
 
-    model_metadata = {
-        model: metadata
-        for model in deduped
-        if (metadata := infer_model_metadata(provider_name, model)) is not None
-    }
+    model_metadata: dict[str, ProviderModelMetadata] = {}
+    for model in deduped:
+        metadata = discovered_metadata.get(model) or infer_model_metadata(provider_name, model)
+        if metadata is not None:
+            model_metadata[model] = metadata
 
     return ModelDiscoveryResult(
         models=tuple(deduped),
@@ -190,6 +258,59 @@ def discover_available_models(
         last_error=error_message,
         discovery_mode=discovery_plan.discovery_mode,
     )
+
+
+def _cost(
+    *,
+    input_per_million: float,
+    output_per_million: float,
+    cache_read_per_million: float | None = None,
+    cache_write_per_million: float | None = None,
+) -> dict[str, float]:
+    cost = {
+        "cost_per_input_token": input_per_million / 1_000_000,
+        "cost_per_output_token": output_per_million / 1_000_000,
+    }
+    if cache_read_per_million is not None:
+        cost["cost_per_cache_read_token"] = cache_read_per_million / 1_000_000
+    if cache_write_per_million is not None:
+        cost["cost_per_cache_write_token"] = cache_write_per_million / 1_000_000
+    return cost
+
+
+def _metadata(
+    *,
+    context_window: int,
+    max_output_tokens: int | None = None,
+    values: Mapping[str, object],
+) -> ProviderModelMetadata:
+    return ProviderModelMetadata(
+        context_window=context_window,
+        max_output_tokens=max_output_tokens,
+        supports_tools=_optional_bool(values.get("supports_tools")),
+        supports_vision=_optional_bool(values.get("supports_vision")),
+        supports_streaming=_optional_bool(values.get("supports_streaming")),
+        supports_reasoning=_optional_bool(values.get("supports_reasoning")),
+        supports_json_mode=_optional_bool(values.get("supports_json_mode")),
+        cost_per_input_token=_positive_float(values.get("cost_per_input_token")),
+        cost_per_output_token=_positive_float(values.get("cost_per_output_token")),
+        cost_per_cache_read_token=_positive_float(values.get("cost_per_cache_read_token")),
+        cost_per_cache_write_token=_positive_float(values.get("cost_per_cache_write_token")),
+        supports_reasoning_effort=_optional_bool(values.get("supports_reasoning_effort")),
+        default_reasoning_effort=_optional_str(values.get("default_reasoning_effort")),
+        supports_interleaved_reasoning=_optional_bool(values.get("supports_interleaved_reasoning")),
+        modalities_input=_modalities_tuple(values.get("modalities_input")),
+        modalities_output=_modalities_tuple(values.get("modalities_output")),
+        model_status=_optional_str(values.get("model_status")),
+    )
+
+
+def _modalities_tuple(value: object) -> tuple[str, ...] | None:
+    if not isinstance(value, tuple):
+        return None
+    raw_items = cast(Iterable[object], value)
+    modalities = tuple(item for item in raw_items if isinstance(item, str) and item)
+    return modalities or None
 
 
 def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMetadata | None:
@@ -204,36 +325,54 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             "supports_streaming": True,
             "supports_reasoning": model.startswith(("gpt-5", "o1", "o3", "o4")),
             "supports_json_mode": True,
+            "supports_reasoning_effort": model.startswith(("gpt-5", "o1", "o3", "o4")),
+            "default_reasoning_effort": "medium"
+            if model.startswith(("gpt-5", "o1", "o3", "o4"))
+            else None,
+            "supports_interleaved_reasoning": model.startswith(("gpt-5", "o3", "o4")),
+            "modalities_input": ("text", "image")
+            if not model.startswith(("o1", "o3-mini"))
+            else ("text",),
+            "modalities_output": ("text",),
+            "model_status": "active",
         }
+        if model.startswith(("gpt-5.4", "gpt-5.5")):
+            common_openai |= _cost(input_per_million=1.25, output_per_million=10.0)
+        elif model.startswith("gpt-5"):
+            common_openai |= _cost(input_per_million=1.25, output_per_million=10.0)
+        elif model.startswith("gpt-4.1"):
+            common_openai |= _cost(input_per_million=2.0, output_per_million=8.0)
+        elif model.startswith("gpt-4o-mini"):
+            common_openai |= _cost(input_per_million=0.15, output_per_million=0.60)
+        elif model.startswith("gpt-4o"):
+            common_openai |= _cost(input_per_million=2.5, output_per_million=10.0)
+        elif model.startswith(("o1", "o3", "o4")):
+            common_openai |= _cost(input_per_million=2.0, output_per_million=8.0)
         if model.startswith(("gpt-5.5", "gpt-5.4")) and not model.startswith(
             ("gpt-5.4-mini", "gpt-5.4-nano")
         ):
-            return ProviderModelMetadata(
-                context_window=1_000_000, max_output_tokens=128_000, **common_openai
+            return _metadata(
+                context_window=1_000_000, max_output_tokens=128_000, values=common_openai
             )
         if model.startswith(("gpt-5.4-mini", "gpt-5.4-nano")):
-            return ProviderModelMetadata(
-                context_window=400_000, max_output_tokens=128_000, **common_openai
+            return _metadata(
+                context_window=400_000, max_output_tokens=128_000, values=common_openai
             )
         if model.startswith("gpt-5"):
-            return ProviderModelMetadata(
-                context_window=400_000, max_output_tokens=128_000, **common_openai
+            return _metadata(
+                context_window=400_000, max_output_tokens=128_000, values=common_openai
             )
         if model.startswith("gpt-4o-mini"):
-            return ProviderModelMetadata(
-                context_window=128_000, max_output_tokens=16_384, **common_openai
-            )
+            return _metadata(context_window=128_000, max_output_tokens=16_384, values=common_openai)
         if model.startswith("gpt-4o"):
-            return ProviderModelMetadata(
-                context_window=128_000, max_output_tokens=16_384, **common_openai
-            )
+            return _metadata(context_window=128_000, max_output_tokens=16_384, values=common_openai)
         if model.startswith("gpt-4.1"):
-            return ProviderModelMetadata(
-                context_window=1_047_576, max_output_tokens=32_768, **common_openai
+            return _metadata(
+                context_window=1_047_576, max_output_tokens=32_768, values=common_openai
             )
         if model.startswith(("o1", "o3", "o4")):
-            return ProviderModelMetadata(
-                context_window=200_000, max_output_tokens=100_000, **common_openai
+            return _metadata(
+                context_window=200_000, max_output_tokens=100_000, values=common_openai
             )
     if provider == "anthropic" or model.startswith("claude-"):
         common_anthropic = {
@@ -242,18 +381,32 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             "supports_streaming": True,
             "supports_reasoning": model.startswith(("claude-opus-4", "claude-sonnet-4")),
             "supports_json_mode": False,
+            "supports_reasoning_effort": model.startswith(("claude-opus-4", "claude-sonnet-4")),
+            "default_reasoning_effort": "medium"
+            if model.startswith(("claude-opus-4", "claude-sonnet-4"))
+            else None,
+            "supports_interleaved_reasoning": model.startswith(
+                ("claude-opus-4", "claude-sonnet-4")
+            ),
+            "modalities_input": ("text", "image") if "haiku" not in model else ("text",),
+            "modalities_output": ("text",),
+            "model_status": "active",
         }
+        if "opus" in model:
+            common_anthropic |= _cost(input_per_million=15.0, output_per_million=75.0)
+        elif "haiku" in model:
+            common_anthropic |= _cost(input_per_million=0.8, output_per_million=4.0)
+        else:
+            common_anthropic |= _cost(input_per_million=3.0, output_per_million=15.0)
         if model.startswith(("claude-opus-4-7", "claude-sonnet-4-6")):
-            return ProviderModelMetadata(
-                context_window=1_000_000, max_output_tokens=64_000, **common_anthropic
+            return _metadata(
+                context_window=1_000_000, max_output_tokens=64_000, values=common_anthropic
             )
         if model.startswith("claude-haiku-4-5"):
-            return ProviderModelMetadata(
-                context_window=200_000, max_output_tokens=64_000, **common_anthropic
+            return _metadata(
+                context_window=200_000, max_output_tokens=64_000, values=common_anthropic
             )
-        return ProviderModelMetadata(
-            context_window=200_000, max_output_tokens=8_192, **common_anthropic
-        )
+        return _metadata(context_window=200_000, max_output_tokens=8_192, values=common_anthropic)
     if provider == "google" or model.startswith("gemini-"):
         common_google = {
             "supports_tools": True,
@@ -261,22 +414,32 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             "supports_streaming": True,
             "supports_reasoning": model.startswith(("gemini-2.5", "gemini-3")),
             "supports_json_mode": True,
+            "supports_reasoning_effort": model.startswith(("gemini-2.5", "gemini-3")),
+            "default_reasoning_effort": "medium"
+            if model.startswith(("gemini-2.5", "gemini-3"))
+            else None,
+            "supports_interleaved_reasoning": False,
+            "modalities_input": ("text", "image", "audio", "video"),
+            "modalities_output": ("text",),
+            "model_status": "preview" if "preview" in model else "active",
         }
+        if "flash" in model:
+            common_google |= _cost(input_per_million=0.30, output_per_million=2.50)
+        else:
+            common_google |= _cost(input_per_million=1.25, output_per_million=10.0)
         if model.startswith(("gemini-3-pro-preview", "gemini-3-flash-preview")):
-            return ProviderModelMetadata(
-                context_window=1_048_576, max_output_tokens=65_536, **common_google
+            return _metadata(
+                context_window=1_048_576, max_output_tokens=65_536, values=common_google
             )
         if model.startswith("gemini-3"):
-            return ProviderModelMetadata(
-                context_window=1_000_000, max_output_tokens=65_536, **common_google
+            return _metadata(
+                context_window=1_000_000, max_output_tokens=65_536, values=common_google
             )
         if model.startswith("gemini-2.5"):
-            return ProviderModelMetadata(
-                context_window=1_000_000, max_output_tokens=65_536, **common_google
+            return _metadata(
+                context_window=1_000_000, max_output_tokens=65_536, values=common_google
             )
-        return ProviderModelMetadata(
-            context_window=1_000_000, max_output_tokens=8_192, **common_google
-        )
+        return _metadata(context_window=1_000_000, max_output_tokens=8_192, values=common_google)
     if provider == "deepseek" or model.startswith("deepseek-"):
         common_deepseek = {
             "supports_tools": True,
@@ -284,14 +447,23 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             "supports_streaming": True,
             "supports_reasoning": "reasoner" in model or model.startswith("deepseek-v4"),
             "supports_json_mode": True,
+            "supports_reasoning_effort": False,
+            "default_reasoning_effort": "medium"
+            if "reasoner" in model or model.startswith("deepseek-v4")
+            else None,
+            "supports_interleaved_reasoning": False,
+            "modalities_input": ("text",),
+            "modalities_output": ("text",),
+            "model_status": "active",
+            **_cost(input_per_million=0.27, output_per_million=1.10),
         }
         if model.startswith("deepseek-v4"):
-            return ProviderModelMetadata(
-                context_window=1_000_000, max_output_tokens=384_000, **common_deepseek
+            return _metadata(
+                context_window=1_000_000, max_output_tokens=384_000, values=common_deepseek
             )
         if model in {"deepseek-chat", "deepseek-reasoner"}:
-            return ProviderModelMetadata(
-                context_window=1_000_000, max_output_tokens=384_000, **common_deepseek
+            return _metadata(
+                context_window=1_000_000, max_output_tokens=384_000, values=common_deepseek
             )
     if provider in {"qwen", "opencode-go"} or model.startswith(("qwen", "qwq", "qvq")):
         common_qwen = {
@@ -300,21 +472,26 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             "supports_streaming": True,
             "supports_reasoning": model.startswith(("qwq", "qvq", "qwen3")),
             "supports_json_mode": True,
+            "supports_reasoning_effort": model.startswith(("qwq", "qvq", "qwen3")),
+            "default_reasoning_effort": "medium"
+            if model.startswith(("qwq", "qvq", "qwen3"))
+            else None,
+            "supports_interleaved_reasoning": False,
+            "modalities_input": ("text", "image")
+            if model.startswith(("qvq",)) or "vl" in model
+            else ("text",),
+            "modalities_output": ("text",),
+            "model_status": "preview" if "preview" in model else "active",
+            **_cost(input_per_million=0.40, output_per_million=1.20),
         }
         if model.startswith(("qwen3.6-plus", "qwen3.6-flash", "qwen3.5-plus", "qwen3.5-flash")):
-            return ProviderModelMetadata(
-                context_window=1_000_000, max_output_tokens=64_000, **common_qwen
-            )
+            return _metadata(context_window=1_000_000, max_output_tokens=64_000, values=common_qwen)
         if model.startswith("qwen3.6-max-preview"):
-            return ProviderModelMetadata(
-                context_window=256_000, max_output_tokens=64_000, **common_qwen
-            )
+            return _metadata(context_window=256_000, max_output_tokens=64_000, values=common_qwen)
         if model.startswith("qwen3.5-"):
-            return ProviderModelMetadata(
-                context_window=256_000, max_output_tokens=64_000, **common_qwen
-            )
+            return _metadata(context_window=256_000, max_output_tokens=64_000, values=common_qwen)
         if model in {"qwen-plus-us", "qwen-flash-us"}:
-            return ProviderModelMetadata(context_window=1_000_000, **common_qwen)
+            return _metadata(context_window=1_000_000, values=common_qwen)
     if provider in {"glm", "opencode-go"} or model.startswith("glm-"):
         common_glm = {
             "supports_tools": True,
@@ -322,13 +499,20 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             "supports_streaming": True,
             "supports_reasoning": model.startswith(("glm-5", "glm-z1")),
             "supports_json_mode": True,
+            "supports_reasoning_effort": model.startswith(("glm-5", "glm-z1")),
+            "default_reasoning_effort": "medium" if model.startswith(("glm-5", "glm-z1")) else None,
+            "supports_interleaved_reasoning": False,
+            "modalities_input": ("text", "image")
+            if model.startswith("glm-4v") or "vision" in model
+            else ("text",),
+            "modalities_output": ("text",),
+            "model_status": "active",
+            **_cost(input_per_million=0.60, output_per_million=2.20),
         }
         if model.startswith("glm-5.1"):
-            return ProviderModelMetadata(
-                context_window=198_000, max_output_tokens=128_000, **common_glm
-            )
+            return _metadata(context_window=198_000, max_output_tokens=128_000, values=common_glm)
         if model.startswith("glm-5"):
-            return ProviderModelMetadata(context_window=200_000, **common_glm)
+            return _metadata(context_window=200_000, values=common_glm)
     if provider in {"kimi", "opencode-go"} or model.startswith(("kimi-", "moonshot-")):
         common_kimi = {
             "supports_tools": True,
@@ -336,21 +520,26 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             "supports_streaming": True,
             "supports_reasoning": "thinking" in model,
             "supports_json_mode": True,
+            "supports_reasoning_effort": "thinking" in model,
+            "default_reasoning_effort": "medium" if "thinking" in model else None,
+            "supports_interleaved_reasoning": False,
+            "modalities_input": ("text",),
+            "modalities_output": ("text",),
+            "model_status": "active",
+            **_cost(input_per_million=0.60, output_per_million=2.50),
         }
         if model.startswith(("kimi-k2.6", "kimi-k2.5", "kimi-k2-0905")):
-            return ProviderModelMetadata(
-                context_window=256_000, max_output_tokens=96_000, **common_kimi
-            )
+            return _metadata(context_window=256_000, max_output_tokens=96_000, values=common_kimi)
         if model.startswith(("kimi-k2-thinking", "kimi-k2-turbo")):
-            return ProviderModelMetadata(context_window=256_000, **common_kimi)
+            return _metadata(context_window=256_000, values=common_kimi)
         if model.startswith("kimi-k2-0711"):
-            return ProviderModelMetadata(context_window=128_000, **common_kimi)
+            return _metadata(context_window=128_000, values=common_kimi)
         if model.startswith("moonshot-v1-128k"):
-            return ProviderModelMetadata(context_window=128_000, **common_kimi)
+            return _metadata(context_window=128_000, values=common_kimi)
         if model.startswith("moonshot-v1-32k"):
-            return ProviderModelMetadata(context_window=32_000, **common_kimi)
+            return _metadata(context_window=32_000, values=common_kimi)
         if model.startswith("moonshot-v1-8k"):
-            return ProviderModelMetadata(context_window=8_000, **common_kimi)
+            return _metadata(context_window=8_000, values=common_kimi)
     if provider in {"minimax", "opencode-go"} or model.startswith(("minimax-", "mimo-")):
         common_minimax = {
             "supports_tools": True,
@@ -358,13 +547,24 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             "supports_streaming": True,
             "supports_reasoning": model.startswith(("minimax-m2", "mimo-v2.5")),
             "supports_json_mode": True,
+            "supports_reasoning_effort": model.startswith(("minimax-m2", "mimo-v2.5")),
+            "default_reasoning_effort": "medium"
+            if model.startswith(("minimax-m2", "mimo-v2.5"))
+            else None,
+            "supports_interleaved_reasoning": False,
+            "modalities_input": ("text", "image")
+            if model.startswith("mimo-v2-omni")
+            else ("text",),
+            "modalities_output": ("text",),
+            "model_status": "active",
+            **_cost(input_per_million=0.50, output_per_million=2.00),
         }
         if model.startswith("minimax-m2.5"):
-            return ProviderModelMetadata(
-                context_window=192_000, max_output_tokens=32_000, **common_minimax
+            return _metadata(
+                context_window=192_000, max_output_tokens=32_000, values=common_minimax
             )
         if model.startswith("minimax-m2"):
-            return ProviderModelMetadata(context_window=204_800, **common_minimax)
+            return _metadata(context_window=204_800, values=common_minimax)
     if provider == "grok" or model.startswith("grok-"):
         common_grok = {
             "supports_tools": True,
@@ -372,11 +572,18 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             "supports_streaming": True,
             "supports_reasoning": "reasoning" in model or model.startswith("grok-4"),
             "supports_json_mode": True,
+            "supports_reasoning_effort": "reasoning" in model or model.startswith("grok-4"),
+            "default_reasoning_effort": "medium"
+            if "reasoning" in model or model.startswith("grok-4")
+            else None,
+            "supports_interleaved_reasoning": False,
+            "modalities_input": ("text", "image"),
+            "modalities_output": ("text",),
+            "model_status": "active",
+            **_cost(input_per_million=0.20, output_per_million=0.50),
         }
         if model.startswith(("grok-4-1-fast", "grok-4-fast")):
-            return ProviderModelMetadata(
-                context_window=2_000_000, max_output_tokens=30_000, **common_grok
-            )
+            return _metadata(context_window=2_000_000, max_output_tokens=30_000, values=common_grok)
     return None
 
 
@@ -466,7 +673,7 @@ def _discovery_plan_from_base_url(
     )
 
 
-def _fetch_models(request: DiscoveryRequest) -> tuple[str, ...]:
+def _fetch_models(request: DiscoveryRequest) -> ModelDiscoveryFetchResult:
     if request.provider == "google":
         return _fetch_google_models(request)
     if request.provider == "anthropic":
@@ -474,53 +681,159 @@ def _fetch_models(request: DiscoveryRequest) -> tuple[str, ...]:
     return _fetch_openai_compatible_models(request)
 
 
-def _parse_openai_compatible_discovery_payload(payload: object) -> tuple[str, ...]:
+def _positive_int(value: object) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return value
+    return None
+
+
+def _positive_float(value: object) -> float | None:
+    if isinstance(value, int | float) and not isinstance(value, bool) and value > 0:
+        return float(value)
+    return None
+
+
+def _optional_bool(value: object) -> bool | None:
+    return value if isinstance(value, bool) else None
+
+
+def _optional_str(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _modalities(value: object) -> tuple[str, ...] | None:
+    if not isinstance(value, list):
+        return None
+    raw_items = cast(Iterable[object], value)
+    modalities = tuple(item for item in raw_items if isinstance(item, str) and item)
+    return modalities or None
+
+
+def _metadata_from_discovery_item(
+    item: _OpenAICompatibleModelItem,
+) -> ProviderModelMetadata | None:
+    raw = item.model_dump()
+    context_window = (
+        _positive_int(raw.get("context_window"))
+        or _positive_int(raw.get("context_length"))
+        or _positive_int(raw.get("max_context_length"))
+    )
+    input_modalities = _modalities(raw.get("input_modalities")) or _modalities(
+        raw.get("modalities")
+    )
+    output_modalities = _modalities(raw.get("output_modalities"))
+    metadata = ProviderModelMetadata(
+        context_window=context_window,
+        max_input_tokens=_positive_int(raw.get("max_input_tokens")),
+        max_output_tokens=_positive_int(raw.get("max_output_tokens")),
+        supports_tools=_optional_bool(raw.get("supports_tools")),
+        supports_vision=_optional_bool(raw.get("supports_vision")),
+        supports_streaming=_optional_bool(raw.get("supports_streaming")),
+        supports_reasoning=_optional_bool(raw.get("supports_reasoning")),
+        supports_json_mode=_optional_bool(raw.get("supports_json_mode")),
+        cost_per_input_token=_positive_float(raw.get("input_cost_per_token")),
+        cost_per_output_token=_positive_float(raw.get("output_cost_per_token")),
+        cost_per_cache_read_token=_positive_float(raw.get("cache_read_input_token_cost")),
+        cost_per_cache_write_token=_positive_float(raw.get("cache_creation_input_token_cost")),
+        supports_reasoning_effort=_optional_bool(raw.get("supports_reasoning_effort")),
+        default_reasoning_effort=_optional_str(raw.get("default_reasoning_effort")),
+        supports_interleaved_reasoning=_optional_bool(raw.get("supports_interleaved_reasoning")),
+        modalities_input=input_modalities,
+        modalities_output=output_modalities,
+        model_status=_optional_str(raw.get("status")),
+    )
+    return metadata if metadata.payload() else None
+
+
+def _metadata_from_google_item(item: _GoogleModelItem) -> ProviderModelMetadata | None:
+    context_window = item.inputTokenLimit
+    metadata = ProviderModelMetadata(
+        context_window=context_window,
+        max_input_tokens=item.inputTokenLimit,
+        max_output_tokens=item.outputTokenLimit,
+        supports_tools=(
+            "generateContent" in item.supportedGenerationMethods
+            if item.supportedGenerationMethods is not None
+            else None
+        ),
+        supports_vision=True,
+        supports_streaming=(
+            "streamGenerateContent" in item.supportedGenerationMethods
+            if item.supportedGenerationMethods is not None
+            else None
+        ),
+        supports_json_mode=True,
+        modalities_input=("text", "image"),
+        modalities_output=("text",),
+        model_status="active",
+    )
+    return metadata if metadata.payload() else None
+
+
+def _parse_openai_compatible_discovery_payload(payload: object) -> ModelDiscoveryFetchResult:
     try:
         parsed = _OpenAICompatibleDiscoveryPayload.model_validate(payload)
     except ValidationError as exc:
         raise ValueError("provider model discovery response must be an object") from exc
     if parsed.data is None:
-        return ()
+        return ModelDiscoveryFetchResult(models=())
     model_ids: list[str] = []
+    model_metadata: dict[str, ProviderModelMetadata] = {}
     for item in parsed.data:
         if isinstance(item, str) and item:
             model_ids.append(item)
             continue
         if isinstance(item, _OpenAICompatibleModelItem) and item.id:
             model_ids.append(item.id)
-    return tuple(model_ids)
+            metadata = _metadata_from_discovery_item(item)
+            if metadata is not None:
+                model_metadata[item.id] = metadata
+    return ModelDiscoveryFetchResult(models=tuple(model_ids), model_metadata=model_metadata)
 
 
-def _parse_anthropic_discovery_payload(payload: object) -> tuple[str, ...]:
+def _parse_anthropic_discovery_payload(payload: object) -> ModelDiscoveryFetchResult:
     try:
         parsed = _AnthropicDiscoveryPayload.model_validate(payload)
     except ValidationError:
-        return ()
+        return ModelDiscoveryFetchResult(models=())
     if parsed.data is None:
-        return ()
-    return tuple(item.id for item in parsed.data if item.id)
+        return ModelDiscoveryFetchResult(models=())
+    model_ids: list[str] = []
+    model_metadata: dict[str, ProviderModelMetadata] = {}
+    for item in parsed.data:
+        if not item.id:
+            continue
+        model_ids.append(item.id)
+        metadata = _metadata_from_discovery_item(item)
+        if metadata is not None:
+            model_metadata[item.id] = metadata
+    return ModelDiscoveryFetchResult(models=tuple(model_ids), model_metadata=model_metadata)
 
 
-def _parse_google_discovery_payload(payload: object) -> tuple[str, ...]:
+def _parse_google_discovery_payload(payload: object) -> ModelDiscoveryFetchResult:
     try:
         parsed = _GoogleDiscoveryPayload.model_validate(payload)
     except ValidationError:
-        return ()
+        return ModelDiscoveryFetchResult(models=())
     if parsed.models is None:
-        return ()
+        return ModelDiscoveryFetchResult(models=())
 
     model_ids: list[str] = []
+    model_metadata: dict[str, ProviderModelMetadata] = {}
     for item in parsed.models:
         raw_name = item.name
         if isinstance(raw_name, str) and raw_name:
             normalized = raw_name[len("models/") :] if raw_name.startswith("models/") else raw_name
             model_ids.append(normalized)
-    return tuple(model_ids)
+            metadata = _metadata_from_google_item(item)
+            if metadata is not None:
+                model_metadata[normalized] = metadata
+    return ModelDiscoveryFetchResult(models=tuple(model_ids), model_metadata=model_metadata)
 
 
 def _fetch_openai_compatible_models(
     request: DiscoveryRequest,
-) -> tuple[str, ...]:
+) -> ModelDiscoveryFetchResult:
     base_url = request.base_url.rstrip("/")
     if base_url.endswith("/v1/models"):
         models_url = base_url
@@ -538,7 +851,7 @@ def _fetch_openai_compatible_models(
     return _parse_openai_compatible_discovery_payload(payload)
 
 
-def _fetch_anthropic_models(request: DiscoveryRequest) -> tuple[str, ...]:
+def _fetch_anthropic_models(request: DiscoveryRequest) -> ModelDiscoveryFetchResult:
     base_url = request.base_url.rstrip("/")
     models_url = f"{base_url}/models" if base_url.endswith("/v1") else f"{base_url}/v1/models"
     http_request = Request(url=models_url, headers=request.headers, method="GET")
@@ -548,7 +861,7 @@ def _fetch_anthropic_models(request: DiscoveryRequest) -> tuple[str, ...]:
     return _parse_anthropic_discovery_payload(payload)
 
 
-def _fetch_google_models(request: DiscoveryRequest) -> tuple[str, ...]:
+def _fetch_google_models(request: DiscoveryRequest) -> ModelDiscoveryFetchResult:
     base_url = request.base_url.rstrip("/")
     if base_url.endswith("/v1beta/models"):
         models_url = base_url

--- a/src/voidcode/provider/models.py
+++ b/src/voidcode/provider/models.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 from .config import ProviderFallbackConfig
+from .model_catalog import ProviderModelMetadata
 from .protocol import ModelTurnProvider
 
 type ProviderResolutionSource = Literal["builtin", "custom", "default_litellm"]
@@ -27,6 +28,7 @@ class ResolvedProviderModel:
     selection: ProviderModelSelection = ProviderModelSelection()
     provider: ModelTurnProvider | None = None
     resolution: ProviderResolutionMetadata = ProviderResolutionMetadata()
+    metadata: ProviderModelMetadata | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/voidcode/provider/registry.py
+++ b/src/voidcode/provider/registry.py
@@ -19,7 +19,12 @@ from .grok import GrokModelProvider
 from .kimi import KimiModelProvider
 from .litellm import LiteLLMModelProvider
 from .minimax import MiniMaxModelProvider
-from .model_catalog import ProviderModelCatalog, discover_available_models
+from .model_catalog import (
+    ProviderModelCatalog,
+    ProviderModelMetadata,
+    discover_available_models,
+    infer_model_metadata,
+)
 from .models import ProviderResolutionSource
 from .openai import OpenAIModelProvider
 from .opencode_go import OpenCodeGoModelProvider
@@ -327,6 +332,17 @@ class ModelProviderRegistry:
                 discovery_mode=discovery.discovery_mode,
             )
         return discovery.models
+
+    def model_metadata_for_model(
+        self, provider_name: str, model_name: str
+    ) -> ProviderModelMetadata | None:
+        if self.model_catalog is not None:
+            catalog = self.model_catalog.get(provider_name)
+            if catalog is not None:
+                metadata = catalog.model_metadata.get(model_name)
+                if metadata is not None:
+                    return metadata
+        return infer_model_metadata(provider_name, model_name)
 
     def provider_catalog(self, provider_name: str) -> ProviderModelCatalog | None:
         if self.model_catalog is None:

--- a/src/voidcode/provider/resolution.py
+++ b/src/voidcode/provider/resolution.py
@@ -33,6 +33,7 @@ def resolve_provider_model(
             source=provider_resolution.source,
             configured=provider_resolution.configured,
         ),
+        metadata=registry.model_metadata_for_model(provider_name, model_name),
     )
 
 

--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -492,6 +492,16 @@ class ProviderModelMetadata:
     supports_streaming: bool | None = None
     supports_reasoning: bool | None = None
     supports_json_mode: bool | None = None
+    cost_per_input_token: float | None = None
+    cost_per_output_token: float | None = None
+    cost_per_cache_read_token: float | None = None
+    cost_per_cache_write_token: float | None = None
+    supports_reasoning_effort: bool | None = None
+    default_reasoning_effort: str | None = None
+    supports_interleaved_reasoning: bool | None = None
+    modalities_input: tuple[str, ...] | None = None
+    modalities_output: tuple[str, ...] | None = None
+    model_status: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/voidcode/runtime/http.py
+++ b/src/voidcode/runtime/http.py
@@ -20,6 +20,7 @@ from .contracts import (
     GitStatusSnapshot,
     NoPendingQuestionError,
     ProviderInspectResult,
+    ProviderModelMetadata,
     ProviderModelsResult,
     ProviderSummary,
     ProviderValidationResult,
@@ -1723,26 +1724,44 @@ class RuntimeTransportApp:
         }
 
     @staticmethod
+    def _serialize_provider_model_metadata(metadata: ProviderModelMetadata) -> dict[str, object]:
+        return {
+            key: value
+            for key, value in {
+                "context_window": metadata.context_window,
+                "max_input_tokens": metadata.max_input_tokens,
+                "max_output_tokens": metadata.max_output_tokens,
+                "supports_tools": metadata.supports_tools,
+                "supports_vision": metadata.supports_vision,
+                "supports_streaming": metadata.supports_streaming,
+                "supports_reasoning": metadata.supports_reasoning,
+                "supports_json_mode": metadata.supports_json_mode,
+                "cost_per_input_token": metadata.cost_per_input_token,
+                "cost_per_output_token": metadata.cost_per_output_token,
+                "cost_per_cache_read_token": metadata.cost_per_cache_read_token,
+                "cost_per_cache_write_token": metadata.cost_per_cache_write_token,
+                "supports_reasoning_effort": metadata.supports_reasoning_effort,
+                "default_reasoning_effort": metadata.default_reasoning_effort,
+                "supports_interleaved_reasoning": metadata.supports_interleaved_reasoning,
+                "modalities_input": list(metadata.modalities_input)
+                if metadata.modalities_input is not None
+                else None,
+                "modalities_output": list(metadata.modalities_output)
+                if metadata.modalities_output is not None
+                else None,
+                "model_status": metadata.model_status,
+            }.items()
+            if value is not None
+        }
+
+    @staticmethod
     def _serialize_provider_models_result(result: ProviderModelsResult) -> dict[str, object]:
         return {
             "provider": result.provider,
             "configured": result.configured,
             "models": list(result.models),
             "model_metadata": {
-                model: {
-                    key: value
-                    for key, value in {
-                        "context_window": metadata.context_window,
-                        "max_input_tokens": metadata.max_input_tokens,
-                        "max_output_tokens": metadata.max_output_tokens,
-                        "supports_tools": metadata.supports_tools,
-                        "supports_vision": metadata.supports_vision,
-                        "supports_streaming": metadata.supports_streaming,
-                        "supports_reasoning": metadata.supports_reasoning,
-                        "supports_json_mode": metadata.supports_json_mode,
-                    }.items()
-                    if value is not None
-                }
+                model: RuntimeTransportApp._serialize_provider_model_metadata(metadata)
                 for model, metadata in result.model_metadata.items()
             },
             "source": result.source,
@@ -1763,20 +1782,9 @@ class RuntimeTransportApp:
             "current_model_metadata": (
                 None
                 if result.current_model_metadata is None
-                else {
-                    key: value
-                    for key, value in {
-                        "context_window": result.current_model_metadata.context_window,
-                        "max_input_tokens": result.current_model_metadata.max_input_tokens,
-                        "max_output_tokens": result.current_model_metadata.max_output_tokens,
-                        "supports_tools": result.current_model_metadata.supports_tools,
-                        "supports_vision": result.current_model_metadata.supports_vision,
-                        "supports_streaming": result.current_model_metadata.supports_streaming,
-                        "supports_reasoning": result.current_model_metadata.supports_reasoning,
-                        "supports_json_mode": result.current_model_metadata.supports_json_mode,
-                    }.items()
-                    if value is not None
-                }
+                else RuntimeTransportApp._serialize_provider_model_metadata(
+                    result.current_model_metadata
+                )
             ),
         }
 

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -2191,28 +2191,7 @@ class VoidCodeRuntime:
                 cast(dict[object, object], raw_metadata) if isinstance(raw_metadata, dict) else {}
             )
             model_metadata = {
-                model: CatalogProviderModelMetadata(
-                    context_window=VoidCodeRuntime._optional_positive_int(
-                        payload.get("context_window")
-                    ),
-                    max_input_tokens=VoidCodeRuntime._optional_positive_int(
-                        payload.get("max_input_tokens")
-                    ),
-                    max_output_tokens=VoidCodeRuntime._optional_positive_int(
-                        payload.get("max_output_tokens")
-                    ),
-                    supports_tools=VoidCodeRuntime._optional_bool(payload.get("supports_tools")),
-                    supports_vision=VoidCodeRuntime._optional_bool(payload.get("supports_vision")),
-                    supports_streaming=VoidCodeRuntime._optional_bool(
-                        payload.get("supports_streaming")
-                    ),
-                    supports_reasoning=VoidCodeRuntime._optional_bool(
-                        payload.get("supports_reasoning")
-                    ),
-                    supports_json_mode=VoidCodeRuntime._optional_bool(
-                        payload.get("supports_json_mode")
-                    ),
-                )
+                model: VoidCodeRuntime._catalog_metadata_from_payload(payload)
                 for model, raw_payload in metadata_payloads.items()
                 if isinstance(model, str) and isinstance(raw_payload, dict)
                 for payload in (cast(dict[str, object], raw_payload),)
@@ -2292,28 +2271,7 @@ class VoidCodeRuntime:
             raw_payload = metadata_payloads.get(model_name)
             if isinstance(raw_payload, dict):
                 payload = cast(dict[str, object], raw_payload)
-                return ProviderModelMetadata(
-                    context_window=VoidCodeRuntime._optional_positive_int(
-                        payload.get("context_window")
-                    ),
-                    max_input_tokens=VoidCodeRuntime._optional_positive_int(
-                        payload.get("max_input_tokens")
-                    ),
-                    max_output_tokens=VoidCodeRuntime._optional_positive_int(
-                        payload.get("max_output_tokens")
-                    ),
-                    supports_tools=VoidCodeRuntime._optional_bool(payload.get("supports_tools")),
-                    supports_vision=VoidCodeRuntime._optional_bool(payload.get("supports_vision")),
-                    supports_streaming=VoidCodeRuntime._optional_bool(
-                        payload.get("supports_streaming")
-                    ),
-                    supports_reasoning=VoidCodeRuntime._optional_bool(
-                        payload.get("supports_reasoning")
-                    ),
-                    supports_json_mode=VoidCodeRuntime._optional_bool(
-                        payload.get("supports_json_mode")
-                    ),
-                )
+                return VoidCodeRuntime._contract_metadata_from_payload(payload)
         inferred = infer_model_metadata(provider_name, model_name)
         if inferred is None:
             return None
@@ -2326,6 +2284,16 @@ class VoidCodeRuntime:
             supports_streaming=inferred.supports_streaming,
             supports_reasoning=inferred.supports_reasoning,
             supports_json_mode=inferred.supports_json_mode,
+            cost_per_input_token=inferred.cost_per_input_token,
+            cost_per_output_token=inferred.cost_per_output_token,
+            cost_per_cache_read_token=inferred.cost_per_cache_read_token,
+            cost_per_cache_write_token=inferred.cost_per_cache_write_token,
+            supports_reasoning_effort=inferred.supports_reasoning_effort,
+            default_reasoning_effort=inferred.default_reasoning_effort,
+            supports_interleaved_reasoning=inferred.supports_interleaved_reasoning,
+            modalities_input=inferred.modalities_input,
+            modalities_output=inferred.modalities_output,
+            model_status=inferred.model_status,
         )
 
     def _context_window_policy_for_provider_attempt(
@@ -2383,28 +2351,7 @@ class VoidCodeRuntime:
             configured=configured,
             models=tuple(cast(list[str], catalog["models"])),
             model_metadata={
-                model: ProviderModelMetadata(
-                    context_window=VoidCodeRuntime._optional_positive_int(
-                        payload.get("context_window")
-                    ),
-                    max_input_tokens=VoidCodeRuntime._optional_positive_int(
-                        payload.get("max_input_tokens")
-                    ),
-                    max_output_tokens=VoidCodeRuntime._optional_positive_int(
-                        payload.get("max_output_tokens")
-                    ),
-                    supports_tools=VoidCodeRuntime._optional_bool(payload.get("supports_tools")),
-                    supports_vision=VoidCodeRuntime._optional_bool(payload.get("supports_vision")),
-                    supports_streaming=VoidCodeRuntime._optional_bool(
-                        payload.get("supports_streaming")
-                    ),
-                    supports_reasoning=VoidCodeRuntime._optional_bool(
-                        payload.get("supports_reasoning")
-                    ),
-                    supports_json_mode=VoidCodeRuntime._optional_bool(
-                        payload.get("supports_json_mode")
-                    ),
-                )
+                model: VoidCodeRuntime._contract_metadata_from_payload(payload)
                 for model, raw_payload in cast(
                     dict[str, object], catalog.get("model_metadata", {})
                 ).items()
@@ -2648,6 +2595,96 @@ class VoidCodeRuntime:
     @staticmethod
     def _optional_bool(value: object) -> bool | None:
         return value if isinstance(value, bool) else None
+
+    @staticmethod
+    def _optional_positive_float(value: object) -> float | None:
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            return None
+        normalized = float(value)
+        return normalized if normalized > 0 else None
+
+    @staticmethod
+    def _optional_string(value: object) -> str | None:
+        return value if isinstance(value, str) and value else None
+
+    @staticmethod
+    def _optional_string_tuple(value: object) -> tuple[str, ...] | None:
+        if not isinstance(value, list | tuple):
+            return None
+        raw_items = cast(Iterable[object], value)
+        items = tuple(item for item in raw_items if isinstance(item, str) and item)
+        return items or None
+
+    @staticmethod
+    def _catalog_metadata_from_payload(
+        payload: dict[str, object],
+    ) -> CatalogProviderModelMetadata:
+        return CatalogProviderModelMetadata(
+            context_window=VoidCodeRuntime._optional_positive_int(payload.get("context_window")),
+            max_input_tokens=VoidCodeRuntime._optional_positive_int(
+                payload.get("max_input_tokens")
+            ),
+            max_output_tokens=VoidCodeRuntime._optional_positive_int(
+                payload.get("max_output_tokens")
+            ),
+            supports_tools=VoidCodeRuntime._optional_bool(payload.get("supports_tools")),
+            supports_vision=VoidCodeRuntime._optional_bool(payload.get("supports_vision")),
+            supports_streaming=VoidCodeRuntime._optional_bool(payload.get("supports_streaming")),
+            supports_reasoning=VoidCodeRuntime._optional_bool(payload.get("supports_reasoning")),
+            supports_json_mode=VoidCodeRuntime._optional_bool(payload.get("supports_json_mode")),
+            cost_per_input_token=VoidCodeRuntime._optional_positive_float(
+                payload.get("cost_per_input_token")
+            ),
+            cost_per_output_token=VoidCodeRuntime._optional_positive_float(
+                payload.get("cost_per_output_token")
+            ),
+            cost_per_cache_read_token=VoidCodeRuntime._optional_positive_float(
+                payload.get("cost_per_cache_read_token")
+            ),
+            cost_per_cache_write_token=VoidCodeRuntime._optional_positive_float(
+                payload.get("cost_per_cache_write_token")
+            ),
+            supports_reasoning_effort=VoidCodeRuntime._optional_bool(
+                payload.get("supports_reasoning_effort")
+            ),
+            default_reasoning_effort=VoidCodeRuntime._optional_string(
+                payload.get("default_reasoning_effort")
+            ),
+            supports_interleaved_reasoning=VoidCodeRuntime._optional_bool(
+                payload.get("supports_interleaved_reasoning")
+            ),
+            modalities_input=VoidCodeRuntime._optional_string_tuple(
+                payload.get("modalities_input")
+            ),
+            modalities_output=VoidCodeRuntime._optional_string_tuple(
+                payload.get("modalities_output")
+            ),
+            model_status=VoidCodeRuntime._optional_string(payload.get("model_status")),
+        )
+
+    @staticmethod
+    def _contract_metadata_from_payload(payload: dict[str, object]) -> ProviderModelMetadata:
+        catalog_metadata = VoidCodeRuntime._catalog_metadata_from_payload(payload)
+        return ProviderModelMetadata(
+            context_window=catalog_metadata.context_window,
+            max_input_tokens=catalog_metadata.max_input_tokens,
+            max_output_tokens=catalog_metadata.max_output_tokens,
+            supports_tools=catalog_metadata.supports_tools,
+            supports_vision=catalog_metadata.supports_vision,
+            supports_streaming=catalog_metadata.supports_streaming,
+            supports_reasoning=catalog_metadata.supports_reasoning,
+            supports_json_mode=catalog_metadata.supports_json_mode,
+            cost_per_input_token=catalog_metadata.cost_per_input_token,
+            cost_per_output_token=catalog_metadata.cost_per_output_token,
+            cost_per_cache_read_token=catalog_metadata.cost_per_cache_read_token,
+            cost_per_cache_write_token=catalog_metadata.cost_per_cache_write_token,
+            supports_reasoning_effort=catalog_metadata.supports_reasoning_effort,
+            default_reasoning_effort=catalog_metadata.default_reasoning_effort,
+            supports_interleaved_reasoning=catalog_metadata.supports_interleaved_reasoning,
+            modalities_input=catalog_metadata.modalities_input,
+            modalities_output=catalog_metadata.modalities_output,
+            model_status=catalog_metadata.model_status,
+        )
 
     def list_agent_summaries(self) -> tuple[AgentSummary, ...]:
         summaries: list[AgentSummary] = []

--- a/tests/unit/provider/test_model_catalog.py
+++ b/tests/unit/provider/test_model_catalog.py
@@ -143,6 +143,69 @@ def test_discover_available_models_merges_partial_remote_metadata() -> None:
     assert metadata.model_status == "active"
 
 
+def test_discover_available_models_recomputes_input_limit_for_remote_context_override() -> None:
+    result = discover_available_models(
+        "openai",
+        LiteLLMProviderConfig(discovery_base_url="https://api.openai.com"),
+        fetcher=lambda _request: ModelDiscoveryFetchResult(
+            models=("gpt-4o",),
+            model_metadata={
+                "gpt-4o": ProviderModelMetadata(
+                    context_window=64_000,
+                )
+            },
+        ),
+    )
+
+    metadata = result.model_metadata["gpt-4o"]
+    assert metadata.context_window == 64_000
+    assert metadata.max_output_tokens == 16_384
+    assert metadata.max_input_tokens == 47_616
+
+
+def test_google_discovery_preserves_preview_model_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Response:
+        def __enter__(self) -> _Response:
+            return self
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: TracebackType | None,
+        ) -> bool:
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "models": [
+                        {
+                            "name": "models/gemini-3-pro-preview",
+                            "inputTokenLimit": 64_000,
+                        }
+                    ]
+                }
+            ).encode("utf-8")
+
+    def _fake_urlopen(_request: Request, timeout: float) -> _Response:
+        assert timeout == 10.0
+        return _Response()
+
+    monkeypatch.setattr(model_catalog, "urlopen", _fake_urlopen)
+
+    result = discover_available_models(
+        "google",
+        LiteLLMProviderConfig(discovery_base_url="https://generativelanguage.googleapis.com"),
+    )
+
+    metadata = result.model_metadata["gemini-3-pro-preview"]
+    assert metadata.context_window == 64_000
+    assert metadata.model_status == "preview"
+
+
 @pytest.mark.parametrize(
     ("provider", "model", "context_window", "max_output_tokens"),
     [

--- a/tests/unit/provider/test_model_catalog.py
+++ b/tests/unit/provider/test_model_catalog.py
@@ -223,7 +223,18 @@ def test_google_discovery_preserves_preview_model_status(
 
     metadata = result.model_metadata["gemini-3-pro-preview"]
     assert metadata.context_window == 64_000
+    assert metadata.max_input_tokens == 64_000
+    assert metadata.max_output_tokens == 65_536
     assert metadata.model_status == "preview"
+
+
+def test_deepseek_reasoning_effort_metadata_is_internally_consistent() -> None:
+    metadata = infer_model_metadata("deepseek", "deepseek-reasoner")
+
+    assert metadata is not None
+    assert metadata.supports_reasoning is True
+    assert metadata.supports_reasoning_effort is False
+    assert metadata.default_reasoning_effort is None
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/provider/test_model_catalog.py
+++ b/tests/unit/provider/test_model_catalog.py
@@ -11,6 +11,7 @@ from voidcode.provider import model_catalog
 from voidcode.provider.config import LiteLLMProviderConfig
 from voidcode.provider.model_catalog import (
     DiscoveryRequest,
+    ModelDiscoveryFetchResult,
     ProviderModelMetadata,
     discover_available_models,
     infer_model_metadata,
@@ -78,7 +79,36 @@ def test_discover_available_models_includes_known_model_budget_metadata() -> Non
     assert metadata.max_output_tokens == 16_384
     assert metadata.supports_tools is True
     assert metadata.supports_vision is True
+    assert metadata.cost_per_input_token is not None
+    assert metadata.modalities_input == ("text", "image")
     assert "unknown-model" not in result.model_metadata
+
+
+def test_discover_available_models_prefers_remote_metadata_when_present() -> None:
+    result = discover_available_models(
+        "openai",
+        LiteLLMProviderConfig(discovery_base_url="https://api.openai.com"),
+        fetcher=lambda _request: ModelDiscoveryFetchResult(
+            models=("gpt-4o",),
+            model_metadata={
+                "gpt-4o": ProviderModelMetadata(
+                    context_window=64_000,
+                    max_output_tokens=4_096,
+                    cost_per_input_token=0.000001,
+                    supports_tools=True,
+                    modalities_input=("text",),
+                    model_status="preview",
+                )
+            },
+        ),
+    )
+
+    metadata = result.model_metadata["gpt-4o"]
+    assert metadata.context_window == 64_000
+    assert metadata.max_input_tokens == 59_904
+    assert metadata.cost_per_input_token == 0.000001
+    assert metadata.modalities_input == ("text",)
+    assert metadata.model_status == "preview"
 
 
 @pytest.mark.parametrize(
@@ -103,15 +133,13 @@ def test_infer_model_metadata_covers_current_frontier_provider_models(
 ) -> None:
     metadata = infer_model_metadata(provider, model)
     assert metadata is not None
-    assert metadata == ProviderModelMetadata(
-        context_window=context_window,
-        max_output_tokens=max_output_tokens,
-        supports_tools=metadata.supports_tools,
-        supports_vision=metadata.supports_vision,
-        supports_streaming=metadata.supports_streaming,
-        supports_reasoning=metadata.supports_reasoning,
-        supports_json_mode=metadata.supports_json_mode,
-    )
+    assert metadata.context_window == context_window
+    assert metadata.max_output_tokens == max_output_tokens
+    assert metadata.cost_per_input_token is not None
+    assert metadata.cost_per_output_token is not None
+    assert metadata.modalities_input is not None
+    assert metadata.modalities_output == ("text",)
+    assert metadata.model_status in {"active", "preview"}
 
 
 def test_infer_model_metadata_exposes_model_capability_flags() -> None:
@@ -125,6 +153,14 @@ def test_infer_model_metadata_exposes_model_capability_flags() -> None:
         supports_streaming=True,
         supports_reasoning=True,
         supports_json_mode=False,
+        cost_per_input_token=0.000003,
+        cost_per_output_token=0.000015,
+        supports_reasoning_effort=True,
+        default_reasoning_effort="medium",
+        supports_interleaved_reasoning=True,
+        modalities_input=("text", "image"),
+        modalities_output=("text",),
+        model_status="active",
     )
 
 
@@ -135,6 +171,14 @@ def test_provider_model_metadata_payload_includes_limits_and_capabilities() -> N
         supports_tools=True,
         supports_vision=False,
         supports_streaming=True,
+        cost_per_input_token=0.000001,
+        cost_per_output_token=0.000002,
+        supports_reasoning_effort=True,
+        default_reasoning_effort="low",
+        supports_interleaved_reasoning=False,
+        modalities_input=("text",),
+        modalities_output=("text",),
+        model_status="active",
     ).payload()
 
     assert payload == {
@@ -144,6 +188,14 @@ def test_provider_model_metadata_payload_includes_limits_and_capabilities() -> N
         "supports_tools": True,
         "supports_vision": False,
         "supports_streaming": True,
+        "cost_per_input_token": 0.000001,
+        "cost_per_output_token": 0.000002,
+        "supports_reasoning_effort": True,
+        "default_reasoning_effort": "low",
+        "supports_interleaved_reasoning": False,
+        "modalities_input": ["text"],
+        "modalities_output": ["text"],
+        "model_status": "active",
     }
 
 

--- a/tests/unit/provider/test_model_catalog.py
+++ b/tests/unit/provider/test_model_catalog.py
@@ -116,6 +116,26 @@ def test_discover_available_models_merges_remote_metadata_over_inferred_defaults
     assert metadata.model_status == "preview"
 
 
+def test_discover_available_models_preserves_zero_priced_remote_costs() -> None:
+    result = discover_available_models(
+        "openai",
+        LiteLLMProviderConfig(discovery_base_url="https://api.openai.com"),
+        fetcher=lambda _request: ModelDiscoveryFetchResult(
+            models=("gpt-4o",),
+            model_metadata={
+                "gpt-4o": ProviderModelMetadata(
+                    cost_per_input_token=0.0,
+                    cost_per_output_token=0.0,
+                )
+            },
+        ),
+    )
+
+    metadata = result.model_metadata["gpt-4o"]
+    assert metadata.cost_per_input_token == 0.0
+    assert metadata.cost_per_output_token == 0.0
+
+
 def test_discover_available_models_merges_partial_remote_metadata() -> None:
     result = discover_available_models(
         "google",
@@ -225,6 +245,8 @@ def test_google_discovery_preserves_preview_model_status(
     assert metadata.context_window == 64_000
     assert metadata.max_input_tokens == 64_000
     assert metadata.max_output_tokens == 65_536
+    assert metadata.modalities_input == ("text", "image", "audio", "video")
+    assert metadata.modalities_output == ("text",)
     assert metadata.model_status == "preview"
 
 

--- a/tests/unit/provider/test_model_catalog.py
+++ b/tests/unit/provider/test_model_catalog.py
@@ -163,6 +163,26 @@ def test_discover_available_models_recomputes_input_limit_for_remote_context_ove
     assert metadata.max_input_tokens == 47_616
 
 
+def test_discover_available_models_recomputes_input_limit_for_remote_output_override() -> None:
+    result = discover_available_models(
+        "openai",
+        LiteLLMProviderConfig(discovery_base_url="https://api.openai.com"),
+        fetcher=lambda _request: ModelDiscoveryFetchResult(
+            models=("gpt-4o",),
+            model_metadata={
+                "gpt-4o": ProviderModelMetadata(
+                    max_output_tokens=4_096,
+                )
+            },
+        ),
+    )
+
+    metadata = result.model_metadata["gpt-4o"]
+    assert metadata.context_window == 128_000
+    assert metadata.max_output_tokens == 4_096
+    assert metadata.max_input_tokens == 123_904
+
+
 def test_google_discovery_preserves_preview_model_status(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/provider/test_model_catalog.py
+++ b/tests/unit/provider/test_model_catalog.py
@@ -84,7 +84,7 @@ def test_discover_available_models_includes_known_model_budget_metadata() -> Non
     assert "unknown-model" not in result.model_metadata
 
 
-def test_discover_available_models_prefers_remote_metadata_when_present() -> None:
+def test_discover_available_models_merges_remote_metadata_over_inferred_defaults() -> None:
     result = discover_available_models(
         "openai",
         LiteLLMProviderConfig(discovery_base_url="https://api.openai.com"),
@@ -106,9 +106,41 @@ def test_discover_available_models_prefers_remote_metadata_when_present() -> Non
     metadata = result.model_metadata["gpt-4o"]
     assert metadata.context_window == 64_000
     assert metadata.max_input_tokens == 59_904
+    assert metadata.max_output_tokens == 4_096
     assert metadata.cost_per_input_token == 0.000001
+    assert metadata.cost_per_output_token == 0.00001
+    assert metadata.supports_vision is True
+    assert metadata.supports_json_mode is True
     assert metadata.modalities_input == ("text",)
+    assert metadata.modalities_output == ("text",)
     assert metadata.model_status == "preview"
+
+
+def test_discover_available_models_merges_partial_remote_metadata() -> None:
+    result = discover_available_models(
+        "google",
+        LiteLLMProviderConfig(discovery_base_url="https://generativelanguage.googleapis.com"),
+        fetcher=lambda _request: ModelDiscoveryFetchResult(
+            models=("gemini-2.5-pro",),
+            model_metadata={
+                "gemini-2.5-pro": ProviderModelMetadata(
+                    supports_tools=True,
+                    supports_streaming=True,
+                    modalities_input=("text", "image"),
+                )
+            },
+        ),
+    )
+
+    metadata = result.model_metadata["gemini-2.5-pro"]
+    assert metadata.context_window == 1_000_000
+    assert metadata.max_output_tokens == 65_536
+    assert metadata.supports_reasoning is True
+    assert metadata.supports_reasoning_effort is True
+    assert metadata.default_reasoning_effort == "medium"
+    assert metadata.cost_per_input_token is not None
+    assert metadata.cost_per_output_token is not None
+    assert metadata.model_status == "active"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/provider/test_registry.py
+++ b/tests/unit/provider/test_registry.py
@@ -22,6 +22,7 @@ from voidcode.provider.openai import OpenAIModelProvider
 from voidcode.provider.opencode_go import OpenCodeGoModelProvider
 from voidcode.provider.qwen import QwenModelProvider
 from voidcode.provider.registry import ModelProviderRegistry, StaticModelProvider
+from voidcode.provider.resolution import resolve_provider_model
 
 
 def test_registry_registers_concrete_provider_adapters() -> None:
@@ -143,11 +144,25 @@ def test_registry_refresh_available_models_stores_model_metadata() -> None:
     assert "gpt-4o" in models
     assert catalog is not None
     assert catalog.model_metadata["gpt-4o"].context_window == 128_000
+    assert catalog.model_metadata["gpt-4o"].cost_per_output_token is not None
     assert registry.available_models("litellm") == models
     catalog = registry.provider_catalog("litellm")
     assert catalog is not None
     assert catalog.last_refresh_status in {"ok", "failed", "skipped"}
     assert catalog.discovery_mode in {"configured_endpoint", "configured_base_url", "disabled"}
+
+
+def test_resolved_provider_model_carries_catalog_metadata_for_routing() -> None:
+    registry = ModelProviderRegistry.with_defaults()
+    registry.refresh_available_models("openai")
+
+    resolved = resolve_provider_model("openai/gpt-4o", registry=registry)
+
+    assert resolved.metadata is not None
+    assert resolved.metadata.context_window == 128_000
+    assert resolved.metadata.supports_tools is True
+    assert resolved.metadata.cost_per_input_token is not None
+    assert resolved.metadata.model_status == "active"
 
 
 def test_registry_refresh_custom_provider_uses_custom_config() -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -10561,6 +10561,8 @@ def test_runtime_persists_provider_model_catalog_cache(tmp_path: Path) -> None:
     assert result.source == "fallback"
     assert result.last_refresh_status == "skipped"
     assert result.model_metadata["gpt-4o"].max_input_tokens == 111_616
+    assert result.model_metadata["gpt-4o"].cost_per_input_token is not None
+    assert result.model_metadata["gpt-4o"].modalities_input == ("text", "image")
 
 
 def test_runtime_provider_validation_refreshes_past_persisted_catalog_cache(
@@ -10625,6 +10627,12 @@ def test_runtime_provider_models_result_exposes_capability_metadata(tmp_path: Pa
                     supports_streaming=True,
                     supports_reasoning=False,
                     supports_json_mode=True,
+                    cost_per_input_token=0.0000025,
+                    cost_per_output_token=0.00001,
+                    supports_reasoning_effort=False,
+                    modalities_input=("text", "image"),
+                    modalities_output=("text",),
+                    model_status="active",
                 )
             },
         )
@@ -10638,6 +10646,9 @@ def test_runtime_provider_models_result_exposes_capability_metadata(tmp_path: Pa
     assert result.model_metadata["gpt-4o"].supports_tools is True
     assert result.model_metadata["gpt-4o"].supports_vision is True
     assert result.model_metadata["gpt-4o"].supports_json_mode is True
+    assert result.model_metadata["gpt-4o"].cost_per_output_token == 0.00001
+    assert result.model_metadata["gpt-4o"].modalities_input == ("text", "image")
+    assert result.model_metadata["gpt-4o"].model_status == "active"
 
 
 def test_runtime_inspect_provider_combines_status_models_and_validation(tmp_path: Path) -> None:
@@ -10657,6 +10668,8 @@ def test_runtime_inspect_provider_combines_status_models_and_validation(tmp_path
     assert result.current_model_metadata.context_window == 128_000
     assert result.current_model_metadata.max_input_tokens == 111_616
     assert result.current_model_metadata.supports_tools is True
+    assert result.current_model_metadata.cost_per_input_token is not None
+    assert result.current_model_metadata.model_status == "active"
 
 
 def test_runtime_context_window_policy_uses_active_model_limit(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Extend provider model metadata with cost, reasoning-effort, modality, and model status fields.
- Preserve remote discovery metadata when available and persist rich catalog metadata through runtime cache hydration.
- Expose resolved provider model metadata for future routing and serialize the richer payload through CLI/HTTP surfaces.

## Verification
- `mise run check`
- `mise run lint && mise run typecheck`
- `uv run pytest -n auto tests/unit/provider/test_model_catalog.py tests/unit/provider/test_registry.py tests/unit/runtime/test_runtime_service_extensions.py -q`

Closes #286