### PR TITLE
feat(runtime): add background task concurrency controls

### DIFF
--- a/src/voidcode/runtime/background_tasks.py
+++ b/src/voidcode/runtime/background_tasks.py
@@ -5,7 +5,7 @@ import logging
 import os
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
@@ -320,7 +320,10 @@ class RuntimeBackgroundTaskSupervisor:
             or self._runtime._config.background_task.model_concurrency
         ):
             return {}
-        return {"concurrency": self._concurrency_snapshot(task).as_payload()}
+        try:
+            return {"concurrency": self._concurrency_snapshot(task).as_payload()}
+        except (RuntimeRequestError, ValueError):
+            return {}
 
     def _drain_background_task_queue(self) -> None:
         runtime = self._runtime
@@ -515,21 +518,40 @@ class RuntimeBackgroundTaskSupervisor:
         result_available = task.result_available
         if not result_available and task.status != "cancelled" and child_result is not None:
             result_available = True
+        routing_error: str | None = None
+        try:
+            routing = task.routing_identity
+        except ValueError as exc:
+            routing = None
+            routing_error = str(exc)
         return BackgroundTaskResult(
             task_id=task.task.id,
             parent_session_id=task.parent_session_id,
             child_session_id=task.session_id,
             status=task.status,
             requested_child_session_id=task.request.session_id or task.session_id,
-            routing=task.routing_identity,
+            routing=routing,
             approval_request_id=task.approval_request_id,
             question_request_id=task.question_request_id,
             approval_blocked=approval_blocked,
             summary_output=summary_output,
-            error=error,
+            error=error or routing_error,
             result_available=result_available,
             cancellation_cause=task.cancellation_cause,
         )
+
+    def _delegated_lifecycle_payloads(
+        self,
+        result: BackgroundTaskResult,
+    ) -> tuple[BackgroundTaskResult, dict[str, object], dict[str, object]]:
+        try:
+            delegation = result.delegated_execution.as_payload()
+            message = result.delegated_message.as_payload()
+        except ValueError as exc:
+            result = replace(result, routing=None, error=result.error or str(exc))
+            delegation = result.delegated_execution.as_payload()
+            message = result.delegated_message.as_payload()
+        return result, delegation, message
 
     def emit_background_task_parent_terminal_event(self, *, task: BackgroundTaskState) -> None:
         runtime = self._runtime
@@ -549,13 +571,14 @@ class RuntimeBackgroundTaskSupervisor:
             "cancelled": RUNTIME_BACKGROUND_TASK_CANCELLED,
         }
         event_type = event_type_by_status[task.status]
+        result, delegation_payload, message_payload = self._delegated_lifecycle_payloads(result)
         payload: dict[str, object] = {
             "task_id": task.task.id,
             "parent_session_id": parent_session_id,
             "status": task.status,
             "result_available": result.result_available,
-            "delegation": result.delegated_execution.as_payload(),
-            "message": result.delegated_message.as_payload(),
+            "delegation": delegation_payload,
+            "message": message_payload,
             **self._concurrency_payload_for_event(task),
         }
         if result.child_session_id is not None:
@@ -663,6 +686,7 @@ class RuntimeBackgroundTaskSupervisor:
             )
             return
         result = self.background_task_result(task=task)
+        result, delegation_payload, message_payload = self._delegated_lifecycle_payloads(result)
         try:
             _ = session_event_appender.append_session_event(
                 workspace=runtime._workspace,
@@ -675,8 +699,8 @@ class RuntimeBackgroundTaskSupervisor:
                     "child_session_id": child_session_id,
                     "status": "running",
                     "approval_blocked": True,
-                    "delegation": result.delegated_execution.as_payload(),
-                    "message": result.delegated_message.as_payload(),
+                    "delegation": delegation_payload,
+                    "message": message_payload,
                     **self._concurrency_payload_for_event(task),
                     **(
                         {"approval_request_id": approval_request_id}

--- a/src/voidcode/runtime/background_tasks.py
+++ b/src/voidcode/runtime/background_tasks.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 import logging
 import os
 import threading
+import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
 from ..hook.config import RuntimeHookSurface
 from ..hook.executor import LifecycleHookExecutionRequest, run_lifecycle_hooks
+from ..provider.models import ResolvedProviderConfig
 from .contracts import (
     BackgroundTaskResult,
     InternalRuntimeRequestMetadata,
@@ -42,10 +45,56 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_BACKGROUND_TASK_RATE_LIMIT_RETRIES = 2
+_BACKGROUND_TASK_RATE_LIMIT_BASE_BACKOFF_SECONDS = 0.05
+
+
+@dataclass(frozen=True, slots=True)
+class _BackgroundTaskConcurrencyIdentity:
+    provider: str
+    model: str
+    limit: int
+    limit_source: str
+
+    @property
+    def model_key(self) -> str:
+        return f"{self.provider}/{self.model}"
+
+
+@dataclass(frozen=True, slots=True)
+class _BackgroundTaskConcurrencySnapshot:
+    provider: str
+    model: str
+    limit: int
+    limit_source: str
+    running_provider: int
+    running_model: int
+    running_total: int
+    queued_provider: int
+    queued_model: int
+    queued_total: int
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "provider": self.provider,
+            "model": self.model,
+            "limit": self.limit,
+            "limit_source": self.limit_source,
+            "running_provider": self.running_provider,
+            "running_model": self.running_model,
+            "running_total": self.running_total,
+            "queued_provider": self.queued_provider,
+            "queued_model": self.queued_model,
+            "queued_total": self.queued_total,
+        }
+
 
 class RuntimeBackgroundTaskSupervisor:
     def __init__(self, runtime: VoidCodeRuntime) -> None:
         self._runtime = runtime
+        self._queue_lock = threading.RLock()
+        self._provider_running_counts: dict[str, int] = {}
+        self._model_running_counts: dict[str, int] = {}
 
     def start_background_task(self, request: RuntimeRequest) -> BackgroundTaskState:
         runtime = self._runtime
@@ -66,15 +115,182 @@ class RuntimeBackgroundTaskSupervisor:
         runtime._session_store.create_background_task(
             workspace=runtime._workspace, task=initial_state
         )
-        worker = threading.Thread(
-            target=runtime._run_background_task_worker,
-            args=(task_id,),
-            name=f"voidcode-background-task-{task_id}",
-            daemon=True,
-        )
-        runtime._background_task_threads[task_id] = worker
-        worker.start()
+        self._drain_background_task_queue()
         return runtime.load_background_task(task_id)
+
+    def _concurrency_identity_for_request(
+        self, request: RuntimeRequest
+    ) -> _BackgroundTaskConcurrencyIdentity:
+        effective_config = self._runtime._runtime_config_for_request(request)
+        return self._concurrency_identity_for_resolved_provider(
+            effective_config.resolved_provider,
+        )
+
+    def _concurrency_identity_for_resolved_provider(
+        self, resolved_provider: ResolvedProviderConfig
+    ) -> _BackgroundTaskConcurrencyIdentity:
+        target = resolved_provider.active_target
+        provider = target.selection.provider or "deterministic"
+        model = target.selection.model or target.selection.raw_model or "deterministic"
+        model_key = f"{provider}/{model}"
+        background_task_config = self._runtime._config.background_task
+        model_limit = background_task_config.model_concurrency.get(model_key)
+        if model_limit is not None:
+            return _BackgroundTaskConcurrencyIdentity(
+                provider=provider,
+                model=model,
+                limit=model_limit,
+                limit_source="model",
+            )
+        provider_limit = background_task_config.provider_concurrency.get(provider)
+        if provider_limit is not None:
+            return _BackgroundTaskConcurrencyIdentity(
+                provider=provider,
+                model=model,
+                limit=provider_limit,
+                limit_source="provider",
+            )
+        return _BackgroundTaskConcurrencyIdentity(
+            provider=provider,
+            model=model,
+            limit=background_task_config.default_concurrency,
+            limit_source="default",
+        )
+
+    def _concurrency_identity_for_task(
+        self, task: BackgroundTaskState
+    ) -> _BackgroundTaskConcurrencyIdentity:
+        request = RuntimeRequest(
+            prompt=task.request.prompt,
+            session_id=task.request.session_id,
+            parent_session_id=task.request.parent_session_id,
+            metadata=cast(RuntimeRequestMetadataPayload, task.request.metadata),
+            allocate_session_id=task.request.allocate_session_id,
+        )
+        return self._concurrency_identity_for_request(request)
+
+    def _can_start_task(self, identity: _BackgroundTaskConcurrencyIdentity) -> bool:
+        running_provider = self._provider_running_counts.get(identity.provider, 0)
+        running_model = self._model_running_counts.get(identity.model_key, 0)
+        if identity.limit_source == "model":
+            return running_model < identity.limit
+        if identity.limit_source == "provider":
+            return running_provider < identity.limit
+        return sum(self._provider_running_counts.values()) < identity.limit
+
+    def _reserve_slot(self, identity: _BackgroundTaskConcurrencyIdentity) -> None:
+        self._provider_running_counts[identity.provider] = (
+            self._provider_running_counts.get(identity.provider, 0) + 1
+        )
+        self._model_running_counts[identity.model_key] = (
+            self._model_running_counts.get(identity.model_key, 0) + 1
+        )
+
+    def _release_slot(self, identity: _BackgroundTaskConcurrencyIdentity) -> None:
+        provider_count = max(0, self._provider_running_counts.get(identity.provider, 0) - 1)
+        model_count = max(0, self._model_running_counts.get(identity.model_key, 0) - 1)
+        if provider_count:
+            self._provider_running_counts[identity.provider] = provider_count
+        else:
+            self._provider_running_counts.pop(identity.provider, None)
+        if model_count:
+            self._model_running_counts[identity.model_key] = model_count
+        else:
+            self._model_running_counts.pop(identity.model_key, None)
+
+    def _queued_counts_for_identity(
+        self, identity: _BackgroundTaskConcurrencyIdentity
+    ) -> tuple[int, int, int]:
+        runtime = self._runtime
+        queued_provider = 0
+        queued_model = 0
+        queued_total = 0
+        for summary in runtime._session_store.list_background_tasks(workspace=runtime._workspace):
+            if summary.status != "queued":
+                continue
+            queued_total += 1
+            task = runtime._session_store.load_background_task(
+                workspace=runtime._workspace,
+                task_id=summary.task.id,
+            )
+            task_identity = self._concurrency_identity_for_task(task)
+            if task_identity.provider == identity.provider:
+                queued_provider += 1
+            if task_identity.model_key == identity.model_key:
+                queued_model += 1
+        return queued_provider, queued_model, queued_total
+
+    def _concurrency_snapshot(
+        self, task: BackgroundTaskState
+    ) -> _BackgroundTaskConcurrencySnapshot:
+        identity = self._concurrency_identity_for_task(task)
+        with self._queue_lock:
+            queued_provider, queued_model, queued_total = self._queued_counts_for_identity(identity)
+            return _BackgroundTaskConcurrencySnapshot(
+                provider=identity.provider,
+                model=identity.model,
+                limit=identity.limit,
+                limit_source=identity.limit_source,
+                running_provider=self._provider_running_counts.get(identity.provider, 0),
+                running_model=self._model_running_counts.get(identity.model_key, 0),
+                running_total=sum(self._provider_running_counts.values()),
+                queued_provider=queued_provider,
+                queued_model=queued_model,
+                queued_total=queued_total,
+            )
+
+    def _concurrency_payload_for_event(self, task: BackgroundTaskState) -> dict[str, object]:
+        if self._runtime._config.background_task.default_concurrency == 5 and not (
+            self._runtime._config.background_task.provider_concurrency
+            or self._runtime._config.background_task.model_concurrency
+        ):
+            return {}
+        return {"concurrency": self._concurrency_snapshot(task).as_payload()}
+
+    def _drain_background_task_queue(self) -> None:
+        runtime = self._runtime
+        with self._queue_lock:
+            summaries = sorted(
+                runtime._session_store.list_background_tasks(workspace=runtime._workspace),
+                key=lambda summary: (summary.created_at, summary.task.id),
+            )
+            for summary in summaries:
+                if summary.status != "queued":
+                    continue
+                task = runtime._session_store.load_background_task(
+                    workspace=runtime._workspace,
+                    task_id=summary.task.id,
+                )
+                if task.status != "queued" or task.task.id in runtime._background_task_threads:
+                    continue
+                identity = self._concurrency_identity_for_task(task)
+                if not self._can_start_task(identity):
+                    continue
+                request = RuntimeRequest(
+                    prompt=task.request.prompt,
+                    session_id=task.request.session_id,
+                    parent_session_id=task.request.parent_session_id,
+                    metadata=cast(RuntimeRequestMetadataPayload, task.request.metadata),
+                    allocate_session_id=task.request.allocate_session_id,
+                )
+                routing = runtime._session_routing_for_request(request)
+                self._reserve_slot(identity)
+                running_task = runtime._session_store.mark_background_task_running(
+                    workspace=runtime._workspace,
+                    task_id=task.task.id,
+                    session_id=routing.session_id,
+                )
+                if running_task.status != "running":
+                    self._release_slot(identity)
+                    continue
+                worker = threading.Thread(
+                    target=runtime._run_background_task_worker,
+                    args=(task.task.id,),
+                    name=f"voidcode-background-task-{task.task.id}",
+                    daemon=True,
+                )
+                runtime._background_task_threads[task.task.id] = worker
+                worker.start()
 
     def load_background_task_result(self, task_id: str) -> BackgroundTaskResult:
         task = self._runtime.load_background_task(task_id)
@@ -240,6 +456,7 @@ class RuntimeBackgroundTaskSupervisor:
             "result_available": result.result_available,
             "delegation": result.delegated_execution.as_payload(),
             "message": result.delegated_message.as_payload(),
+            **self._concurrency_payload_for_event(task),
         }
         if result.child_session_id is not None:
             payload["child_session_id"] = result.child_session_id
@@ -360,6 +577,7 @@ class RuntimeBackgroundTaskSupervisor:
                     "approval_blocked": True,
                     "delegation": result.delegated_execution.as_payload(),
                     "message": result.delegated_message.as_payload(),
+                    **self._concurrency_payload_for_event(task),
                     **(
                         {"approval_request_id": approval_request_id}
                         if approval_request_id is not None
@@ -531,6 +749,8 @@ class RuntimeBackgroundTaskSupervisor:
 
     def run_background_task_worker(self, task_id: str) -> None:
         runtime = self._runtime
+        slot_identity: _BackgroundTaskConcurrencyIdentity | None = None
+        slot_reserved = False
         try:
             task = runtime.load_background_task(task_id)
             if task.status == "cancelled":
@@ -542,13 +762,31 @@ class RuntimeBackgroundTaskSupervisor:
                 metadata=cast(RuntimeRequestMetadataPayload, task.request.metadata),
                 allocate_session_id=task.request.allocate_session_id,
             )
-            routing = runtime._session_routing_for_request(request)
-            session_id = routing.session_id
-            running_task = runtime._session_store.mark_background_task_running(
-                workspace=runtime._workspace,
-                task_id=task_id,
-                session_id=session_id,
-            )
+            slot_identity = self._concurrency_identity_for_request(request)
+            if task.status == "queued":
+                routing = runtime._session_routing_for_request(request)
+                session_id = routing.session_id
+                with self._queue_lock:
+                    if not self._can_start_task(slot_identity):
+                        return
+                    self._reserve_slot(slot_identity)
+                    slot_reserved = True
+                running_task = runtime._session_store.mark_background_task_running(
+                    workspace=runtime._workspace,
+                    task_id=task_id,
+                    session_id=session_id,
+                )
+                if running_task.status != "running":
+                    with self._queue_lock:
+                        self._release_slot(slot_identity)
+                    slot_reserved = False
+                    slot_identity = None
+            else:
+                running_task = task
+                slot_reserved = True
+                session_id = (
+                    task.session_id or runtime._session_routing_for_request(request).session_id
+                )
             if running_task.status != "running":
                 return
             dispatch_task = runtime.load_background_task(task_id)
@@ -563,89 +801,116 @@ class RuntimeBackgroundTaskSupervisor:
                 )
                 self.run_background_task_lifecycle_hook(terminal_task)
                 return
-            events: list[EventEnvelope] = []
-            output: str | None = None
-            final_session: Any | None = None
-            internal_request = RuntimeRequest(
-                prompt=dispatch_task.request.prompt,
-                session_id=session_id,
-                parent_session_id=dispatch_task.request.parent_session_id,
-                metadata=cast(
-                    InternalRuntimeRequestMetadata,
-                    {
-                        **dispatch_task.request.metadata,
-                        "background_task_id": task_id,
-                        "background_run": True,
-                    },
-                ),
-                allocate_session_id=False,
-            )
-            for chunk in runtime._run_with_persistence(
-                internal_request,
-                allow_internal_metadata=True,
-            ):
-                final_session = chunk.session
-                if chunk.event is not None:
-                    events.append(chunk.event)
-                if chunk.kind == "output":
-                    output = chunk.output
-                current_task_state = runtime._session_store.load_background_task(
-                    workspace=runtime._workspace,
-                    task_id=task_id,
-                )
-                if current_task_state.cancel_requested_at is not None:
-                    if final_session is None:
-                        raise ValueError("runtime stream emitted no chunks")
-                    cancel_metadata = dict(final_session.metadata)
-                    cancel_metadata["abort_requested"] = True
-                    cancelled_response = RuntimeResponse(
-                        session=SessionState(
-                            session=final_session.session,
-                            status="failed",
-                            turn=final_session.turn,
-                            metadata=cancel_metadata,
-                        ),
-                        events=tuple(events)
-                        + (
-                            EventEnvelope(
-                                session_id=session_id,
-                                sequence=(events[-1].sequence if events else 0) + 1,
-                                event_type=RUNTIME_FAILED,
-                                source="runtime",
-                                payload={
-                                    "error": "cancelled by parent during delegated execution",
-                                    "cancelled": True,
-                                    "delegated_task_id": task_id,
-                                },
+            retry_count = 0
+            while True:
+                events: list[EventEnvelope] = []
+                output: str | None = None
+                final_session: Any | None = None
+                internal_request = RuntimeRequest(
+                    prompt=dispatch_task.request.prompt,
+                    session_id=session_id,
+                    parent_session_id=dispatch_task.request.parent_session_id,
+                    metadata=cast(
+                        InternalRuntimeRequestMetadata,
+                        {
+                            **dispatch_task.request.metadata,
+                            **(
+                                {"background_rate_limit_retry": True}
+                                if retry_count < _BACKGROUND_TASK_RATE_LIMIT_RETRIES
+                                else {}
                             ),
-                        ),
-                        output=output,
-                    )
-                    runtime._session_store.save_run(
-                        workspace=runtime._workspace,
-                        request=internal_request,
-                        response=cancelled_response,
-                    )
-                    terminal_task = runtime._session_store.mark_background_task_terminal(
+                            "background_task_id": task_id,
+                            "background_run": True,
+                        },
+                    ),
+                    allocate_session_id=False,
+                )
+                for chunk in runtime._run_with_persistence(
+                    internal_request,
+                    allow_internal_metadata=True,
+                ):
+                    final_session = chunk.session
+                    if chunk.event is not None:
+                        events.append(chunk.event)
+                    if chunk.kind == "output":
+                        output = chunk.output
+                    current_task_state = runtime._session_store.load_background_task(
                         workspace=runtime._workspace,
                         task_id=task_id,
-                        status="cancelled",
-                        error="cancelled by parent during delegated execution",
                     )
-                    self.run_background_task_lifecycle_hook(terminal_task)
-                    return
-            if final_session is None:
-                raise ValueError("runtime stream emitted no chunks")
-            if final_session.status == "waiting":
-                final_session = runtime._reload_persisted_session(
-                    session_id=final_session.session.id
+                    if current_task_state.cancel_requested_at is not None:
+                        if final_session is None:
+                            raise ValueError("runtime stream emitted no chunks")
+                        cancel_metadata = dict(final_session.metadata)
+                        cancel_metadata["abort_requested"] = True
+                        cancelled_response = RuntimeResponse(
+                            session=SessionState(
+                                session=final_session.session,
+                                status="failed",
+                                turn=final_session.turn,
+                                metadata=cancel_metadata,
+                            ),
+                            events=tuple(events)
+                            + (
+                                EventEnvelope(
+                                    session_id=session_id,
+                                    sequence=(events[-1].sequence if events else 0) + 1,
+                                    event_type=RUNTIME_FAILED,
+                                    source="runtime",
+                                    payload={
+                                        "error": "cancelled by parent during delegated execution",
+                                        "cancelled": True,
+                                        "delegated_task_id": task_id,
+                                    },
+                                ),
+                            ),
+                            output=output,
+                        )
+                        runtime._session_store.save_run(
+                            workspace=runtime._workspace,
+                            request=internal_request,
+                            response=cancelled_response,
+                        )
+                        terminal_task = runtime._session_store.mark_background_task_terminal(
+                            workspace=runtime._workspace,
+                            task_id=task_id,
+                            status="cancelled",
+                            error="cancelled by parent during delegated execution",
+                        )
+                        self.run_background_task_lifecycle_hook(terminal_task)
+                        return
+                if final_session is None:
+                    raise ValueError("runtime stream emitted no chunks")
+                if final_session.status == "waiting":
+                    final_session = runtime._reload_persisted_session(
+                        session_id=final_session.session.id
+                    )
+                response = RuntimeResponse(
+                    session=final_session,
+                    events=tuple(events),
+                    output=output,
                 )
-            response = RuntimeResponse(
-                session=final_session,
-                events=tuple(events),
-                output=output,
-            )
-            self.finalize_background_task_from_session_response(session_response=response)
+                if (
+                    self._response_has_rate_limit_error(response)
+                    and retry_count < _BACKGROUND_TASK_RATE_LIMIT_RETRIES
+                    and slot_identity is not None
+                ):
+                    retry_count += 1
+                    with self._queue_lock:
+                        self._release_slot(slot_identity)
+                        slot_reserved = False
+                    self._drain_background_task_queue()
+                    time.sleep(self._rate_limit_backoff_seconds(retry_count))
+                    while True:
+                        with self._queue_lock:
+                            if self._can_start_task(slot_identity):
+                                self._reserve_slot(slot_identity)
+                                slot_reserved = True
+                                break
+                        time.sleep(0.01)
+                    continue
+                self.finalize_background_task_from_session_response(session_response=response)
+                return
         except Exception as exc:
             logger.exception("background task failed: %s", task_id)
             terminal_task = runtime._session_store.mark_background_task_terminal(
@@ -656,4 +921,22 @@ class RuntimeBackgroundTaskSupervisor:
             )
             self.run_background_task_lifecycle_hook(terminal_task)
         finally:
+            if slot_identity is not None and slot_reserved:
+                with self._queue_lock:
+                    self._release_slot(slot_identity)
             runtime._background_task_threads.pop(task_id, None)
+            self._drain_background_task_queue()
+
+    @staticmethod
+    def _response_has_rate_limit_error(response: RuntimeResponse) -> bool:
+        if response.session.status != "failed":
+            return False
+        for event in reversed(response.events):
+            if event.event_type != RUNTIME_FAILED:
+                continue
+            return event.payload.get("provider_error_kind") == "rate_limit"
+        return False
+
+    @staticmethod
+    def _rate_limit_backoff_seconds(retry_count: int) -> float:
+        return _BACKGROUND_TASK_RATE_LIMIT_BASE_BACKOFF_SECONDS * (2 ** max(0, retry_count - 1))

--- a/src/voidcode/runtime/background_tasks.py
+++ b/src/voidcode/runtime/background_tasks.py
@@ -785,6 +785,7 @@ class RuntimeBackgroundTaskSupervisor:
                 fail_incomplete(
                     workspace=runtime._workspace,
                     message="background task interrupted before completion",
+                    include_queued=False,
                 ),
             )
             for failed_task in failed_tasks:
@@ -797,6 +798,7 @@ class RuntimeBackgroundTaskSupervisor:
             )
             self.backfill_parent_background_task_event(task=task)
         runtime._background_tasks_reconciled = True
+        self._drain_background_task_queue()
 
     def run_background_task_worker(self, task_id: str) -> None:
         runtime = self._runtime

--- a/src/voidcode/runtime/background_tasks.py
+++ b/src/voidcode/runtime/background_tasks.py
@@ -16,6 +16,7 @@ from .contracts import (
     BackgroundTaskResult,
     InternalRuntimeRequestMetadata,
     RuntimeRequest,
+    RuntimeRequestError,
     RuntimeRequestMetadataPayload,
     RuntimeResponse,
     RuntimeSessionResult,
@@ -300,6 +301,7 @@ class RuntimeBackgroundTaskSupervisor:
 
     def _drain_background_task_queue(self) -> None:
         runtime = self._runtime
+        failed_tasks: list[BackgroundTaskState] = []
         with self._queue_lock:
             summaries = sorted(
                 runtime._session_store.list_background_tasks(workspace=runtime._workspace),
@@ -314,9 +316,6 @@ class RuntimeBackgroundTaskSupervisor:
                 )
                 if task.status != "queued" or task.task.id in runtime._background_task_threads:
                     continue
-                identity = self._concurrency_identity_for_task(task)
-                if not self._can_start_task(identity):
-                    continue
                 request = RuntimeRequest(
                     prompt=task.request.prompt,
                     session_id=task.request.session_id,
@@ -324,7 +323,20 @@ class RuntimeBackgroundTaskSupervisor:
                     metadata=cast(RuntimeRequestMetadataPayload, task.request.metadata),
                     allocate_session_id=task.request.allocate_session_id,
                 )
-                routing = runtime._session_routing_for_request(request)
+                try:
+                    identity = self._concurrency_identity_for_task(task)
+                    routing = runtime._session_routing_for_request(request)
+                except (RuntimeRequestError, ValueError) as exc:
+                    failed_task = runtime._session_store.mark_background_task_terminal(
+                        workspace=runtime._workspace,
+                        task_id=task.task.id,
+                        status="failed",
+                        error=str(exc),
+                    )
+                    failed_tasks.append(failed_task)
+                    continue
+                if not self._can_start_task(identity):
+                    continue
                 self._reserve_slot(identity)
                 running_task = runtime._session_store.mark_background_task_running(
                     workspace=runtime._workspace,
@@ -342,6 +354,8 @@ class RuntimeBackgroundTaskSupervisor:
                 )
                 runtime._background_task_threads[task.task.id] = worker
                 worker.start()
+        for failed_task in failed_tasks:
+            self.run_background_task_lifecycle_hook(failed_task)
 
     def load_background_task_result(self, task_id: str) -> BackgroundTaskResult:
         task = self._runtime.load_background_task(task_id)

--- a/src/voidcode/runtime/background_tasks.py
+++ b/src/voidcode/runtime/background_tasks.py
@@ -93,6 +93,7 @@ class RuntimeBackgroundTaskSupervisor:
     def __init__(self, runtime: VoidCodeRuntime) -> None:
         self._runtime = runtime
         self._queue_lock = threading.RLock()
+        self._slot_available = threading.Condition(self._queue_lock)
         self._provider_running_counts: dict[str, int] = {}
         self._model_running_counts: dict[str, int] = {}
 
@@ -197,6 +198,56 @@ class RuntimeBackgroundTaskSupervisor:
             self._model_running_counts[identity.model_key] = model_count
         else:
             self._model_running_counts.pop(identity.model_key, None)
+        self._slot_available.notify_all()
+
+    def _task_cancel_requested(self, task_id: str) -> bool:
+        task = self._runtime._session_store.load_background_task(
+            workspace=self._runtime._workspace,
+            task_id=task_id,
+        )
+        return task.status == "cancelled" or task.cancel_requested_at is not None
+
+    def _mark_background_task_cancelled_during_retry_wait(
+        self,
+        *,
+        task_id: str,
+    ) -> None:
+        terminal_task = self._runtime._session_store.mark_background_task_terminal(
+            workspace=self._runtime._workspace,
+            task_id=task_id,
+            status="cancelled",
+            error="cancelled by parent during delegated execution",
+        )
+        self.run_background_task_lifecycle_hook(terminal_task)
+
+    def _wait_for_rate_limit_backoff_or_cancel(
+        self,
+        *,
+        task_id: str,
+        retry_count: int,
+    ) -> bool:
+        deadline = time.monotonic() + self._rate_limit_backoff_seconds(retry_count)
+        while True:
+            if self._task_cancel_requested(task_id):
+                return True
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            time.sleep(min(remaining, 0.05))
+
+    def _wait_for_slot_or_cancel(
+        self,
+        *,
+        task_id: str,
+        identity: _BackgroundTaskConcurrencyIdentity,
+    ) -> bool:
+        with self._slot_available:
+            while not self._can_start_task(identity):
+                if self._task_cancel_requested(task_id):
+                    return True
+                self._slot_available.wait(timeout=0.5)
+            self._reserve_slot(identity)
+            return False
 
     def _queued_counts_for_identity(
         self, identity: _BackgroundTaskConcurrencyIdentity
@@ -900,14 +951,19 @@ class RuntimeBackgroundTaskSupervisor:
                         self._release_slot(slot_identity)
                         slot_reserved = False
                     self._drain_background_task_queue()
-                    time.sleep(self._rate_limit_backoff_seconds(retry_count))
-                    while True:
-                        with self._queue_lock:
-                            if self._can_start_task(slot_identity):
-                                self._reserve_slot(slot_identity)
-                                slot_reserved = True
-                                break
-                        time.sleep(0.01)
+                    if self._wait_for_rate_limit_backoff_or_cancel(
+                        task_id=task_id,
+                        retry_count=retry_count,
+                    ):
+                        self._mark_background_task_cancelled_during_retry_wait(task_id=task_id)
+                        return
+                    if self._wait_for_slot_or_cancel(
+                        task_id=task_id,
+                        identity=slot_identity,
+                    ):
+                        self._mark_background_task_cancelled_during_retry_wait(task_id=task_id)
+                        return
+                    slot_reserved = True
                     continue
                 self.finalize_background_task_from_session_response(session_response=response)
                 return

--- a/src/voidcode/runtime/background_tasks.py
+++ b/src/voidcode/runtime/background_tasks.py
@@ -28,6 +28,7 @@ from .events import (
     RUNTIME_BACKGROUND_TASK_FAILED,
     RUNTIME_BACKGROUND_TASK_WAITING_APPROVAL,
     RUNTIME_FAILED,
+    RUNTIME_PROVIDER_FALLBACK,
     EventEnvelope,
 )
 from .session import SessionState
@@ -134,6 +135,14 @@ class RuntimeBackgroundTaskSupervisor:
         target = resolved_provider.active_target
         provider = target.selection.provider or "deterministic"
         model = target.selection.model or target.selection.raw_model or "deterministic"
+        return self._concurrency_identity_for_provider_model(provider=provider, model=model)
+
+    def _concurrency_identity_for_provider_model(
+        self,
+        *,
+        provider: str,
+        model: str,
+    ) -> _BackgroundTaskConcurrencyIdentity:
         model_key = f"{provider}/{model}"
         background_task_config = self._runtime._config.background_task
         model_limit = background_task_config.model_concurrency.get(model_key)
@@ -158,6 +167,20 @@ class RuntimeBackgroundTaskSupervisor:
             limit=background_task_config.default_concurrency,
             limit_source="default",
         )
+
+    def _fallback_identity_for_event(
+        self,
+        event: EventEnvelope,
+    ) -> _BackgroundTaskConcurrencyIdentity | None:
+        if event.event_type != RUNTIME_PROVIDER_FALLBACK:
+            return None
+        provider = event.payload.get("to_provider")
+        model = event.payload.get("to_model")
+        if not isinstance(provider, str) or not provider:
+            return None
+        if not isinstance(model, str) or not model:
+            return None
+        return self._concurrency_identity_for_provider_model(provider=provider, model=model)
 
     def _concurrency_identity_for_task(
         self, task: BackgroundTaskState
@@ -353,7 +376,19 @@ class RuntimeBackgroundTaskSupervisor:
                     daemon=True,
                 )
                 runtime._background_task_threads[task.task.id] = worker
-                worker.start()
+                try:
+                    worker.start()
+                except RuntimeError as exc:
+                    runtime._background_task_threads.pop(task.task.id, None)
+                    self._release_slot(identity)
+                    failed_task = runtime._session_store.mark_background_task_terminal(
+                        workspace=runtime._workspace,
+                        task_id=task.task.id,
+                        status="failed",
+                        error=str(exc),
+                    )
+                    failed_tasks.append(failed_task)
+                    continue
         for failed_task in failed_tasks:
             self.run_background_task_lifecycle_hook(failed_task)
 
@@ -899,6 +934,23 @@ class RuntimeBackgroundTaskSupervisor:
                     final_session = chunk.session
                     if chunk.event is not None:
                         events.append(chunk.event)
+                        fallback_identity = self._fallback_identity_for_event(chunk.event)
+                        if fallback_identity is not None and fallback_identity != slot_identity:
+                            with self._queue_lock:
+                                if slot_identity is not None and slot_reserved:
+                                    self._release_slot(slot_identity)
+                                    slot_reserved = False
+                            self._drain_background_task_queue()
+                            if self._wait_for_slot_or_cancel(
+                                task_id=task_id,
+                                identity=fallback_identity,
+                            ):
+                                self._mark_background_task_cancelled_during_retry_wait(
+                                    task_id=task_id,
+                                )
+                                return
+                            slot_identity = fallback_identity
+                            slot_reserved = True
                     if chunk.kind == "output":
                         output = chunk.output
                     current_task_state = runtime._session_store.load_background_task(

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -168,6 +168,21 @@ class RuntimeAcpConfig:
     handshake_payload: dict[str, object] = field(default_factory=dict)
 
 
+def _empty_background_task_concurrency_map() -> dict[str, int]:
+    return {}
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeBackgroundTaskConfig:
+    default_concurrency: int = 5
+    provider_concurrency: Mapping[str, int] = field(
+        default_factory=_empty_background_task_concurrency_map
+    )
+    model_concurrency: Mapping[str, int] = field(
+        default_factory=_empty_background_task_concurrency_map
+    )
+
+
 type McpTransport = Literal["stdio"]
 
 
@@ -254,6 +269,9 @@ class RuntimeConfig:
     context_window: RuntimeContextWindowConfig | None = None
     lsp: RuntimeLspConfig | None = None
     acp: RuntimeAcpConfig | None = None
+    background_task: RuntimeBackgroundTaskConfig = field(
+        default_factory=RuntimeBackgroundTaskConfig
+    )
     mcp: RuntimeMcpConfig | None = None
     tui: RuntimeTuiConfig | None = None
     provider_fallback: RuntimeProviderFallbackConfig | None = None
@@ -277,6 +295,7 @@ class RuntimeConfigOverrides:
     context_window: RuntimeContextWindowConfig | None = None
     lsp: RuntimeLspConfig | None = None
     acp: RuntimeAcpConfig | None = None
+    background_task: RuntimeBackgroundTaskConfig | None = None
     mcp: RuntimeMcpConfig | None = None
     tui: RuntimeTuiConfig | None = None
     provider_fallback: RuntimeProviderFallbackConfig | None = None
@@ -424,6 +443,7 @@ def load_runtime_config(
         skills=repo_local.skills,
         context_window=repo_local.context_window,
         lsp=resolved_lsp,
+        background_task=repo_local.background_task or RuntimeBackgroundTaskConfig(),
         mcp=repo_local.mcp,
         tui=resolved_tui,
         provider_fallback=repo_local.provider_fallback,
@@ -502,6 +522,9 @@ def _load_repo_local_config(
     raw_mcp = payload.get("mcp")
     mcp = _parse_mcp_config(raw_mcp)
 
+    raw_background_task = payload.get("background_task")
+    background_task = _parse_background_task_config(raw_background_task)
+
     raw_tui = payload.get("tui")
     tui = _parse_tui_config(raw_tui)
 
@@ -537,6 +560,7 @@ def _load_repo_local_config(
         skills=skills,
         context_window=context_window,
         lsp=lsp,
+        background_task=background_task,
         mcp=mcp,
         tui=tui,
         provider_fallback=provider_fallback,
@@ -826,6 +850,55 @@ def _parse_optional_positive_int(value: object, *, field_path: str) -> int | Non
     if value < 1:
         raise ValueError(f"runtime config field '{field_path}' must be greater than or equal to 1")
     return value
+
+
+def _parse_concurrency_limit(value: object, *, field_path: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"runtime config field '{field_path}' must be an integer")
+    if value < 1:
+        raise ValueError(f"runtime config field '{field_path}' must be greater than or equal to 1")
+    return value
+
+
+def _parse_concurrency_map(value: object, *, field_path: str) -> dict[str, int]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"runtime config field '{field_path}' must be an object when provided")
+    parsed: dict[str, int] = {}
+    for raw_key, raw_limit in cast(dict[object, object], value).items():
+        if not isinstance(raw_key, str) or not raw_key.strip():
+            raise ValueError(f"runtime config field '{field_path}' keys must be non-empty strings")
+        parsed[raw_key] = _parse_concurrency_limit(
+            raw_limit,
+            field_path=f"{field_path}.{raw_key}",
+        )
+    return parsed
+
+
+def _parse_background_task_config(raw_value: object) -> RuntimeBackgroundTaskConfig | None:
+    if raw_value is None:
+        return None
+    if not isinstance(raw_value, dict):
+        raise ValueError("runtime config field 'background_task' must be an object when provided")
+    payload = cast(dict[str, object], raw_value)
+    default_concurrency = RuntimeBackgroundTaskConfig().default_concurrency
+    if "default_concurrency" in payload:
+        default_concurrency = _parse_concurrency_limit(
+            payload.get("default_concurrency"),
+            field_path="background_task.default_concurrency",
+        )
+    return RuntimeBackgroundTaskConfig(
+        default_concurrency=default_concurrency,
+        provider_concurrency=_parse_concurrency_map(
+            payload.get("provider_concurrency"),
+            field_path="background_task.provider_concurrency",
+        ),
+        model_concurrency=_parse_concurrency_map(
+            payload.get("model_concurrency"),
+            field_path="background_task.model_concurrency",
+        ),
+    )
 
 
 class _RuntimeContextWindowValidationModel(BaseModel):
@@ -1750,6 +1823,19 @@ def serialize_runtime_context_window_config(
         payload["per_tool_result_tokens"] = dict(context_window.per_tool_result_tokens)
     if context_window.tokenizer_model is not None:
         payload["tokenizer_model"] = context_window.tokenizer_model
+    return payload
+
+
+def serialize_runtime_background_task_config(
+    background_task: RuntimeBackgroundTaskConfig,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "default_concurrency": background_task.default_concurrency,
+    }
+    if background_task.provider_concurrency:
+        payload["provider_concurrency"] = dict(background_task.provider_concurrency)
+    if background_task.model_concurrency:
+        payload["model_concurrency"] = dict(background_task.model_concurrency)
     return payload
 
 

--- a/src/voidcode/runtime/config_schema.py
+++ b/src/voidcode/runtime/config_schema.py
@@ -239,6 +239,22 @@ def runtime_config_json_schema() -> dict[str, object]:
                     "prefer environment variables for secrets."
                 ),
             },
+            "background_task": {
+                "type": "object",
+                "additionalProperties": True,
+                "description": "Background task queue and concurrency limits.",
+                "properties": {
+                    "default_concurrency": {"type": "integer", "minimum": 1},
+                    "provider_concurrency": {
+                        "type": "object",
+                        "additionalProperties": {"type": "integer", "minimum": 1},
+                    },
+                    "model_concurrency": {
+                        "type": "object",
+                        "additionalProperties": {"type": "integer", "minimum": 1},
+                    },
+                },
+            },
             "plan": {
                 "type": "object",
                 "additionalProperties": True,

--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -56,6 +56,7 @@ class RuntimeRequestMetadata(TypedDict, total=False):
 
 class InternalRuntimeRequestMetadata(RuntimeRequestMetadata, total=False):
     background_run: bool
+    background_rate_limit_retry: bool
     background_task_id: str
 
 
@@ -79,7 +80,9 @@ class RuntimeSubagentRoutingMetadata(TypedDict, total=False):
 _STABLE_RUNTIME_REQUEST_METADATA_KEYS = frozenset(
     {"abort_requested", "agent", "command", "delegation", "max_steps", "provider_stream", "skills"}
 )
-_INTERNAL_RUNTIME_REQUEST_METADATA_KEYS = frozenset({"background_run", "background_task_id"})
+_INTERNAL_RUNTIME_REQUEST_METADATA_KEYS = frozenset(
+    {"background_run", "background_rate_limit_retry", "background_task_id"}
+)
 
 
 def _empty_runtime_request_metadata() -> RuntimeRequestMetadata:
@@ -391,6 +394,14 @@ def validate_runtime_request_metadata(
         if not isinstance(background_run, bool):
             raise RuntimeRequestError("request metadata 'background_run' must be a boolean")
         normalized["background_run"] = background_run
+
+    if allow_internal_fields and "background_rate_limit_retry" in metadata:
+        background_rate_limit_retry = metadata["background_rate_limit_retry"]
+        if not isinstance(background_rate_limit_retry, bool):
+            raise RuntimeRequestError(
+                "request metadata 'background_rate_limit_retry' must be a boolean"
+            )
+        normalized["background_rate_limit_retry"] = background_rate_limit_retry
 
     if allow_internal_fields and "background_task_id" in metadata:
         background_task_id = metadata["background_task_id"]

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -179,6 +179,27 @@ class RuntimeRunLoopCoordinator:
                             },
                         )
                         return
+                    if (
+                        provider_error.kind == "rate_limit"
+                        and graph_request.metadata.get("background_rate_limit_retry") is True
+                    ):
+                        yield runtime._failed_chunk(
+                            session=session,
+                            sequence=sequence + 1,
+                            error=str(provider_error),
+                            payload={
+                                "provider_error_kind": provider_error.kind,
+                                "provider": provider_error.provider_name,
+                                "model": provider_error.model_name,
+                                "background_retry_deferred_fallback": True,
+                                **(
+                                    {"provider_error_details": provider_error.details}
+                                    if provider_error.details is not None
+                                    else {}
+                                ),
+                            },
+                        )
+                        return
                     fallback_selection = runtime._fallback_graph_selection(
                         error=provider_error,
                         session_metadata=session.metadata,

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -1368,12 +1368,14 @@ class VoidCodeRuntime:
         if self._graph_override is None:
             self._validate_provider_execution_ready(effective_config)
         request_metadata = self._fresh_request_metadata(request.metadata)
+        session_request_metadata = dict(request_metadata)
+        session_request_metadata.pop("background_rate_limit_retry", None)
         session = SessionState(
             session=SessionRef(id=resolved_session_id, parent_id=request.parent_session_id),
             status="running",
             turn=1,
             metadata={
-                **request_metadata,
+                **session_request_metadata,
                 "workspace": str(self._workspace),
                 "runtime_config": self._runtime_config_metadata(effective_config),
                 "runtime_state": self._runtime_state_metadata(run_id=run_id),

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -4100,7 +4100,9 @@ class VoidCodeRuntime:
         return validate_runtime_request_metadata(
             normalized,
             allow_internal_fields=(
-                "background_run" in normalized or "background_task_id" in normalized
+                "background_run" in normalized
+                or "background_rate_limit_retry" in normalized
+                or "background_task_id" in normalized
             ),
         )
 

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -1131,7 +1131,10 @@ class VoidCodeRuntime:
         approval_blocked: bool | None = None,
         result_available: bool | None = None,
     ) -> AcpDelegatedExecution:
-        routing = task.routing_identity
+        try:
+            routing = task.routing_identity
+        except ValueError:
+            routing = None
         delegation_metadata = task.request.metadata.get("delegation")
         delegation_dict = (
             cast(dict[str, object], delegation_metadata)

--- a/src/voidcode/runtime/storage.py
+++ b/src/voidcode/runtime/storage.py
@@ -144,6 +144,7 @@ class SessionStore(Protocol):
         *,
         workspace: Path,
         message: str,
+        include_queued: bool = True,
     ) -> tuple[BackgroundTaskState, ...]: ...
 
 
@@ -1727,19 +1728,25 @@ class SqliteSessionStore:
         *,
         workspace: Path,
         message: str,
+        include_queued: bool = True,
     ) -> tuple[BackgroundTaskState, ...]:
+        incomplete_status_predicate = (
+            "background_tasks.status IN ('queued', 'running')"
+            if include_queued
+            else "background_tasks.status = 'running'"
+        )
         with self._connect(workspace) as connection:
             rows = cast(
                 list[sqlite3.Row],
                 connection.execute(
-                    """
+                    f"""
                     SELECT background_tasks.task_id, background_tasks.cancel_requested_at
                     FROM background_tasks
                     LEFT JOIN sessions
                       ON sessions.workspace = background_tasks.workspace
                      AND sessions.session_id = background_tasks.session_id
                     WHERE background_tasks.workspace = ?
-                      AND background_tasks.status IN ('queued', 'running')
+                      AND {incomplete_status_predicate}
                       AND NOT (
                           background_tasks.status = 'running'
                           AND background_tasks.session_id IS NOT NULL

--- a/tests/unit/runtime/test_config_schema.py
+++ b/tests/unit/runtime/test_config_schema.py
@@ -47,6 +47,19 @@ def test_runtime_config_json_schema_exposes_core_fields() -> None:
     mcp_servers = cast(dict[str, object], mcp_properties["servers"])
     mcp_server_schema = cast(dict[str, object], mcp_servers["additionalProperties"])
     assert mcp_server_schema["required"] == ["command"]
+    background_task_schema = cast(dict[str, object], properties["background_task"])
+    background_task_properties = cast(dict[str, object], background_task_schema["properties"])
+    assert background_task_properties["default_concurrency"] == {
+        "type": "integer",
+        "minimum": 1,
+    }
+    provider_concurrency = cast(
+        dict[str, object], background_task_properties["provider_concurrency"]
+    )
+    assert provider_concurrency["additionalProperties"] == {
+        "type": "integer",
+        "minimum": 1,
+    }
 
 
 def test_generate_starter_runtime_config_excludes_secrets() -> None:

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -27,6 +27,7 @@ from voidcode.runtime.config import (
     RUNTIME_CONFIG_FILE_NAME,
     TOOL_TIMEOUT_ENV_VAR,
     RuntimeAgentConfig,
+    RuntimeBackgroundTaskConfig,
     RuntimeConfig,
     RuntimeContextWindowConfig,
     RuntimeFormatterPresetConfig,
@@ -55,6 +56,7 @@ from voidcode.runtime.config import (
     save_workspace_tui_preferences,
     serialize_runtime_agent_config,
     serialize_runtime_agents_config,
+    serialize_runtime_background_task_config,
     serialize_runtime_context_window_config,
     user_runtime_config_path,
 )
@@ -215,7 +217,66 @@ def test_runtime_config_defaults_to_ask_without_file_or_env(tmp_path: Path) -> N
     assert config.model is None
     assert config.execution_engine == "provider"
     assert config.max_steps is None
+    assert config.background_task == RuntimeBackgroundTaskConfig()
     assert config.hooks is None
+
+
+def test_runtime_config_loads_background_task_concurrency_from_repo_file(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / RUNTIME_CONFIG_FILE_NAME
+    config_path.write_text(
+        json.dumps(
+            {
+                "background_task": {
+                    "default_concurrency": 3,
+                    "provider_concurrency": {"anthropic": 2},
+                    "model_concurrency": {"anthropic/claude-opus-4-7": 1},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.background_task == RuntimeBackgroundTaskConfig(
+        default_concurrency=3,
+        provider_concurrency={"anthropic": 2},
+        model_concurrency={"anthropic/claude-opus-4-7": 1},
+    )
+
+
+def test_runtime_config_rejects_invalid_background_task_concurrency(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / RUNTIME_CONFIG_FILE_NAME
+    config_path.write_text(
+        json.dumps({"background_task": {"provider_concurrency": {"openai": 0}}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="background_task.provider_concurrency.openai.*greater than or equal to 1",
+    ):
+        _ = load_runtime_config(tmp_path, env={})
+
+
+def test_runtime_background_task_config_serializes_non_default_maps() -> None:
+    payload = serialize_runtime_background_task_config(
+        RuntimeBackgroundTaskConfig(
+            default_concurrency=4,
+            provider_concurrency={"openai": 3},
+            model_concurrency={"openai/gpt-4.1": 2},
+        )
+    )
+
+    assert payload == {
+        "default_concurrency": 4,
+        "provider_concurrency": {"openai": 3},
+        "model_concurrency": {"openai/gpt-4.1": 2},
+    }
 
 
 def test_runtime_config_defaults_to_provider_for_product_runs(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -3814,7 +3814,7 @@ def test_runtime_cancel_background_task_reconciles_orphaned_queued_task(tmp_path
     assert cancelled.cancel_requested_at is None
 
 
-def test_runtime_reconciles_incomplete_background_tasks_on_init(tmp_path: Path) -> None:
+def test_runtime_reconciles_queued_background_tasks_on_init(tmp_path: Path) -> None:
     first_runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
     store = _private_attr(first_runtime, "_session_store")
     task_module = importlib.import_module("voidcode.runtime.task")
@@ -3829,10 +3829,10 @@ def test_runtime_reconciles_incomplete_background_tasks_on_init(tmp_path: Path) 
     )
 
     second_runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
-    reconciled = second_runtime.load_background_task("task-orphan")
+    reconciled = _wait_for_background_task(second_runtime, "task-orphan")
 
-    assert reconciled.status == "failed"
-    assert reconciled.error == "background task interrupted before completion"
+    assert reconciled.status == "completed"
+    assert reconciled.error is None
 
 
 def test_runtime_background_task_worker_exits_when_task_is_cancelled_before_start_transition(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -3912,7 +3912,12 @@ def test_runtime_reconciles_queued_background_tasks_on_init(tmp_path: Path) -> N
 def test_runtime_drain_marks_invalid_queued_task_failed_and_continues(
     tmp_path: Path,
 ) -> None:
-    first_runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    first_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_BackgroundTaskSuccessGraph(),
+        config=RuntimeConfig(background_task=RuntimeBackgroundTaskConfig(default_concurrency=1)),
+    )
+    parent = first_runtime.run(RuntimeRequest(prompt="parent"))
     store = _private_attr(first_runtime, "_session_store")
     task_module = importlib.import_module("voidcode.runtime.task")
     store.create_background_task(
@@ -3922,6 +3927,7 @@ def test_runtime_drain_marks_invalid_queued_task_failed_and_continues(
             request=task_module.BackgroundTaskRequestSnapshot(
                 prompt="invalid",
                 metadata={"agent": {"preset": "leader", "model": ""}},
+                parent_session_id=parent.session.session.id,
             ),
             created_at=1,
             updated_at=1,
@@ -3936,14 +3942,40 @@ def test_runtime_drain_marks_invalid_queued_task_failed_and_continues(
             updated_at=2,
         ),
     )
+    connection = sqlite3.connect(tmp_path / ".voidcode" / "sessions.sqlite3")
+    try:
+        _ = connection.execute(
+            """
+            UPDATE background_tasks
+            SET request_metadata_json = ?
+            WHERE task_id = ?
+            """,
+            (
+                json.dumps(
+                    {
+                        "agent": {"preset": "leader", "model": ""},
+                        "delegation": {"mode": "invalid"},
+                    },
+                    sort_keys=True,
+                ),
+                "task-invalid-metadata",
+            ),
+        )
+        connection.commit()
+    finally:
+        connection.close()
 
-    second_runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    second_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_BackgroundTaskSuccessGraph(),
+        config=RuntimeConfig(background_task=RuntimeBackgroundTaskConfig(default_concurrency=1)),
+    )
     completed = _wait_for_background_task(second_runtime, "task-after-invalid")
     failed = second_runtime.load_background_task("task-invalid-metadata")
 
     assert failed.status == "failed"
     assert failed.error is not None
-    assert "agent.model" in failed.error
+    assert "delegation.mode" in failed.error
     assert completed.status == "completed"
 
 

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -660,6 +660,41 @@ class _UnexpectedFallbackTurnProvider:
         return ProviderTurnResult(output="fallback used")
 
 
+class _BlockingFallbackModelProvider:
+    def __init__(self, *, name: str) -> None:
+        self.name = name
+        self.calls = 0
+        self.first_started = threading.Event()
+        self.second_started = threading.Event()
+        self.release_first = threading.Event()
+        self.lock = threading.Lock()
+
+    def turn_provider(self) -> _BlockingFallbackTurnProvider:
+        return _BlockingFallbackTurnProvider(model_provider=self)
+
+
+@dataclass(slots=True)
+class _BlockingFallbackTurnProvider:
+    model_provider: _BlockingFallbackModelProvider
+
+    @property
+    def name(self) -> str:
+        return self.model_provider.name
+
+    def propose_turn(self, request: object) -> ProviderTurnResult:
+        _ = request
+        with self.model_provider.lock:
+            self.model_provider.calls += 1
+            call_number = self.model_provider.calls
+        if call_number == 1:
+            self.model_provider.first_started.set()
+            if not self.model_provider.release_first.wait(timeout=2.0):
+                raise RuntimeError("first fallback call was not released")
+        else:
+            self.model_provider.second_started.set()
+        return ProviderTurnResult(output=f"fallback call {call_number}")
+
+
 class _ApprovalThenRateLimitModelProvider:
     def __init__(self, *, name: str) -> None:
         self.name = name
@@ -1100,6 +1135,45 @@ def test_runtime_background_rate_limit_retry_precedes_provider_fallback(
     assert child.output == "primary recovered"
     assert primary.attempts == 2
     assert fallback.calls == 0
+
+
+def test_runtime_background_fallback_reacquires_fallback_model_slot(
+    tmp_path: Path,
+) -> None:
+    primary = _AlwaysFailingModelProvider(name="opencode", error_kind="missing_auth")
+    fallback = _BlockingFallbackModelProvider(name="custom")
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        model_provider_registry=ModelProviderRegistry(
+            providers={"opencode": primary, "custom": fallback}
+        ),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            provider_fallback=RuntimeProviderFallbackConfig(
+                preferred_model="opencode/gpt-5.4",
+                fallback_models=("custom/demo",),
+            ),
+            background_task=RuntimeBackgroundTaskConfig(
+                default_concurrency=4,
+                model_concurrency={"custom/demo": 1},
+            ),
+        ),
+    )
+
+    first = runtime.start_background_task(RuntimeRequest(prompt="first fallback task"))
+    assert fallback.first_started.wait(timeout=2.0)
+    second = runtime.start_background_task(RuntimeRequest(prompt="second fallback task"))
+
+    assert not fallback.second_started.wait(timeout=0.2)
+
+    fallback.release_first.set()
+    first_terminal = _wait_for_background_task(runtime, first.task.id)
+    second_terminal = _wait_for_background_task(runtime, second.task.id)
+
+    assert first_terminal.status == "completed"
+    assert second_terminal.status == "completed"
+    assert fallback.calls == 2
 
 
 def test_runtime_background_retry_marker_does_not_persist_across_approval_resume(
@@ -3870,6 +3944,36 @@ def test_runtime_drain_marks_invalid_queued_task_failed_and_continues(
     assert failed.status == "failed"
     assert failed.error is not None
     assert "agent.model" in failed.error
+    assert completed.status == "completed"
+
+
+def test_runtime_drain_releases_slot_when_worker_start_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_BackgroundTaskSuccessGraph(),
+        config=RuntimeConfig(background_task=RuntimeBackgroundTaskConfig(default_concurrency=1)),
+    )
+    original_start = threading.Thread.start
+    start_calls = 0
+
+    def _start_once_then_fail(thread: threading.Thread) -> None:
+        nonlocal start_calls
+        start_calls += 1
+        if start_calls == 1:
+            raise RuntimeError("can't start new thread")
+        original_start(thread)
+
+    monkeypatch.setattr(threading.Thread, "start", _start_once_then_fail)
+
+    failed = runtime.start_background_task(RuntimeRequest(prompt="first background task"))
+    second = runtime.start_background_task(RuntimeRequest(prompt="second background task"))
+    completed = _wait_for_background_task(runtime, second.task.id)
+
+    assert failed.status == "failed"
+    assert failed.error == "can't start new thread"
     assert completed.status == "completed"
 
 

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1,4 +1,4 @@
-# pyright: reportArgumentType=false
+# pyright: reportArgumentType=false, reportUnusedFunction=false
 from __future__ import annotations
 
 import importlib
@@ -8,6 +8,7 @@ import os
 import re
 import sqlite3
 import sys
+import threading
 import time
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -38,6 +39,7 @@ from voidcode.runtime.acp import (
 from voidcode.runtime.config import (
     RuntimeAcpConfig,
     RuntimeAgentConfig,
+    RuntimeBackgroundTaskConfig,
     RuntimeConfig,
     RuntimeContextWindowConfig,
     RuntimeFormatterPresetConfig,
@@ -560,6 +562,104 @@ class _BackgroundTaskSuccessGraph:
         return _StubStep(output=request.prompt, is_finished=True)
 
 
+class _BlockingBackgroundTaskGraph:
+    def __init__(self) -> None:
+        self.release_first = threading.Event()
+        self.first_started = threading.Event()
+        self.prompts_seen: list[str] = []
+
+    def step(
+        self,
+        request: GraphRunRequest,
+        tool_results: tuple[object, ...],
+        *,
+        session: SessionState,
+    ) -> _StubStep:
+        _ = tool_results, session
+        self.prompts_seen.append(request.prompt)
+        if request.prompt == "first background task":
+            self.first_started.set()
+            if not self.release_first.wait(timeout=2.0):
+                raise RuntimeError("first background task was not released")
+        return _StubStep(output=request.prompt, is_finished=True)
+
+
+class _RateLimitThenSuccessGraph:
+    def __init__(self) -> None:
+        self.attempts = 0
+
+    def step(
+        self,
+        request: GraphRunRequest,
+        tool_results: tuple[object, ...],
+        *,
+        session: SessionState,
+    ) -> _StubStep:
+        _ = tool_results, session
+        self.attempts += 1
+        if self.attempts == 1:
+            raise ProviderExecutionError(
+                kind="rate_limit",
+                provider_name="openai",
+                model_name="gpt-4.1",
+                message="rate limited",
+            )
+        return _StubStep(output=request.prompt, is_finished=True)
+
+
+class _RateLimitOnceModelProvider:
+    def __init__(self, *, name: str) -> None:
+        self.name = name
+        self.attempts = 0
+
+    def turn_provider(self) -> _RateLimitOnceTurnProvider:
+        return _RateLimitOnceTurnProvider(model_provider=self)
+
+
+@dataclass(slots=True)
+class _RateLimitOnceTurnProvider:
+    model_provider: _RateLimitOnceModelProvider
+
+    @property
+    def name(self) -> str:
+        return self.model_provider.name
+
+    def propose_turn(self, request: object) -> ProviderTurnResult:
+        turn_request = cast(ProviderTurnRequest, request)
+        self.model_provider.attempts += 1
+        if self.model_provider.attempts == 1:
+            raise ProviderExecutionError(
+                kind="rate_limit",
+                provider_name=self.name,
+                model_name=turn_request.model_name or "gpt-5.4",
+                message="rate limited once",
+            )
+        return ProviderTurnResult(output="primary recovered")
+
+
+class _UnexpectedFallbackModelProvider:
+    def __init__(self, *, name: str) -> None:
+        self.name = name
+        self.calls = 0
+
+    def turn_provider(self) -> _UnexpectedFallbackTurnProvider:
+        return _UnexpectedFallbackTurnProvider(model_provider=self)
+
+
+@dataclass(slots=True)
+class _UnexpectedFallbackTurnProvider:
+    model_provider: _UnexpectedFallbackModelProvider
+
+    @property
+    def name(self) -> str:
+        return self.model_provider.name
+
+    def propose_turn(self, request: object) -> ProviderTurnResult:
+        _ = request
+        self.model_provider.calls += 1
+        return ProviderTurnResult(output="fallback used")
+
+
 class _TaskToolGraph:
     def step(
         self,
@@ -787,6 +887,184 @@ def test_runtime_background_task_executes_through_existing_runtime_path(tmp_path
     assert resumed.session.metadata["background_run"] is True
     assert resumed.output == "background hello"
     assert completed == loaded
+
+
+def test_runtime_background_task_concurrency_limit_queues_and_drains(tmp_path: Path) -> None:
+    graph = _BlockingBackgroundTaskGraph()
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=graph,
+        config=RuntimeConfig(background_task=RuntimeBackgroundTaskConfig(default_concurrency=1)),
+    )
+
+    first = runtime.start_background_task(RuntimeRequest(prompt="first background task"))
+    assert graph.first_started.wait(timeout=2.0)
+    second = runtime.start_background_task(RuntimeRequest(prompt="second background task"))
+
+    assert runtime.load_background_task(first.task.id).status == "running"
+    assert runtime.load_background_task(second.task.id).status == "queued"
+
+    graph.release_first.set()
+    first_terminal = _wait_for_background_task(runtime, first.task.id)
+    second_terminal = _wait_for_background_task(runtime, second.task.id)
+
+    assert first_terminal.status == "completed"
+    assert second_terminal.status == "completed"
+    assert graph.prompts_seen == ["first background task", "second background task"]
+
+
+def test_runtime_background_task_concurrency_identity_uses_model_provider_default_precedence(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_BackgroundTaskSuccessGraph(),
+        config=RuntimeConfig(
+            model="openai/gpt-4.1",
+            background_task=RuntimeBackgroundTaskConfig(
+                default_concurrency=4,
+                provider_concurrency={"openai": 2},
+                model_concurrency={"openai/gpt-4.1": 1},
+            ),
+        ),
+    )
+    supervisor = runtime._background_task_supervisor  # pyright: ignore[reportPrivateUsage]
+
+    model_identity = supervisor._concurrency_identity_for_request(  # pyright: ignore[reportPrivateUsage]
+        RuntimeRequest(prompt="model")
+    )
+    provider_identity = supervisor._concurrency_identity_for_request(  # pyright: ignore[reportPrivateUsage]
+        RuntimeRequest(
+            prompt="provider",
+            metadata={
+                "agent": {
+                    "preset": "leader",
+                    "execution_engine": "provider",
+                    "model": "openai/gpt-4o",
+                }
+            },
+        )
+    )
+    default_identity = supervisor._concurrency_identity_for_request(  # pyright: ignore[reportPrivateUsage]
+        RuntimeRequest(
+            prompt="default",
+            metadata={
+                "agent": {
+                    "preset": "leader",
+                    "execution_engine": "provider",
+                    "model": "anthropic/claude-sonnet-4",
+                }
+            },
+        )
+    )
+
+    assert (model_identity.limit, model_identity.limit_source) == (1, "model")
+    assert (provider_identity.limit, provider_identity.limit_source) == (2, "provider")
+    assert (default_identity.limit, default_identity.limit_source) == (4, "default")
+
+
+def test_runtime_background_task_configured_events_include_concurrency_metadata(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_BackgroundTaskSuccessGraph(),
+        config=RuntimeConfig(background_task=RuntimeBackgroundTaskConfig(default_concurrency=1)),
+    )
+    _ = runtime.run(RuntimeRequest(prompt="leader", session_id="leader-session"))
+
+    started = runtime.start_background_task(
+        RuntimeRequest(prompt="background child", parent_session_id="leader-session")
+    )
+    _ = _wait_for_background_task(runtime, started.task.id)
+    leader_response = _wait_for_session_event(
+        runtime,
+        "leader-session",
+        RUNTIME_BACKGROUND_TASK_COMPLETED,
+    )
+
+    completed_event = next(
+        event
+        for event in leader_response.events
+        if event.event_type == RUNTIME_BACKGROUND_TASK_COMPLETED
+    )
+    assert completed_event.payload["concurrency"] == {
+        "provider": "deterministic",
+        "model": "deterministic",
+        "limit": 1,
+        "limit_source": "default",
+        "running_provider": 1,
+        "running_model": 1,
+        "running_total": 1,
+        "queued_provider": 0,
+        "queued_model": 0,
+        "queued_total": 0,
+    }
+
+
+def test_runtime_background_task_rate_limit_retries_after_backoff(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _RateLimitThenSuccessGraph()
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=graph)
+
+    def _zero_backoff(retry_count: int) -> float:
+        _ = retry_count
+        return 0.0
+
+    monkeypatch.setattr(
+        runtime._background_task_supervisor,  # pyright: ignore[reportPrivateUsage]
+        "_rate_limit_backoff_seconds",
+        _zero_backoff,
+    )
+
+    started = runtime.start_background_task(RuntimeRequest(prompt="retry after rate limit"))
+    completed = _wait_for_background_task(runtime, started.task.id)
+
+    assert completed.status == "completed"
+    assert graph.attempts == 2
+
+
+def test_runtime_background_rate_limit_retry_precedes_provider_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    primary = _RateLimitOnceModelProvider(name="opencode")
+    fallback = _UnexpectedFallbackModelProvider(name="custom")
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        model_provider_registry=ModelProviderRegistry(
+            providers={"opencode": primary, "custom": fallback}
+        ),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            provider_fallback=RuntimeProviderFallbackConfig(
+                preferred_model="opencode/gpt-5.4",
+                fallback_models=("custom/demo",),
+            ),
+        ),
+    )
+
+    def _zero_backoff(retry_count: int) -> float:
+        _ = retry_count
+        return 0.0
+
+    monkeypatch.setattr(
+        runtime._background_task_supervisor,  # pyright: ignore[reportPrivateUsage]
+        "_rate_limit_backoff_seconds",
+        _zero_backoff,
+    )
+
+    started = runtime.start_background_task(RuntimeRequest(prompt="background provider retry"))
+    completed = _wait_for_background_task(runtime, started.task.id)
+    child = runtime.resume(cast(str, completed.session_id))
+
+    assert completed.status == "completed"
+    assert child.output == "primary recovered"
+    assert primary.attempts == 2
+    assert fallback.calls == 0
 
 
 def test_runtime_session_debug_snapshot_reports_completed_state(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -3835,6 +3835,44 @@ def test_runtime_reconciles_queued_background_tasks_on_init(tmp_path: Path) -> N
     assert reconciled.error is None
 
 
+def test_runtime_drain_marks_invalid_queued_task_failed_and_continues(
+    tmp_path: Path,
+) -> None:
+    first_runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    store = _private_attr(first_runtime, "_session_store")
+    task_module = importlib.import_module("voidcode.runtime.task")
+    store.create_background_task(
+        workspace=tmp_path,
+        task=task_module.BackgroundTaskState(
+            task=task_module.BackgroundTaskRef(id="task-invalid-metadata"),
+            request=task_module.BackgroundTaskRequestSnapshot(
+                prompt="invalid",
+                metadata={"agent": {"preset": "leader", "model": ""}},
+            ),
+            created_at=1,
+            updated_at=1,
+        ),
+    )
+    store.create_background_task(
+        workspace=tmp_path,
+        task=task_module.BackgroundTaskState(
+            task=task_module.BackgroundTaskRef(id="task-after-invalid"),
+            request=task_module.BackgroundTaskRequestSnapshot(prompt="background hello"),
+            created_at=2,
+            updated_at=2,
+        ),
+    )
+
+    second_runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    completed = _wait_for_background_task(second_runtime, "task-after-invalid")
+    failed = second_runtime.load_background_task("task-invalid-metadata")
+
+    assert failed.status == "failed"
+    assert failed.error is not None
+    assert "agent.model" in failed.error
+    assert completed.status == "completed"
+
+
 def test_runtime_background_task_worker_exits_when_task_is_cancelled_before_start_transition(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -660,6 +660,41 @@ class _UnexpectedFallbackTurnProvider:
         return ProviderTurnResult(output="fallback used")
 
 
+class _ApprovalThenRateLimitModelProvider:
+    def __init__(self, *, name: str) -> None:
+        self.name = name
+        self.calls = 0
+
+    def turn_provider(self) -> _ApprovalThenRateLimitTurnProvider:
+        return _ApprovalThenRateLimitTurnProvider(model_provider=self)
+
+
+@dataclass(slots=True)
+class _ApprovalThenRateLimitTurnProvider:
+    model_provider: _ApprovalThenRateLimitModelProvider
+
+    @property
+    def name(self) -> str:
+        return self.model_provider.name
+
+    def propose_turn(self, request: object) -> ProviderTurnResult:
+        turn_request = cast(ProviderTurnRequest, request)
+        self.model_provider.calls += 1
+        if not turn_request.tool_results:
+            return ProviderTurnResult(
+                tool_call=ToolCall(
+                    tool_name="write_file",
+                    arguments={"path": "alpha.txt", "content": "1"},
+                )
+            )
+        raise ProviderExecutionError(
+            kind="rate_limit",
+            provider_name=self.name,
+            model_name=turn_request.model_name or "gpt-5.4",
+            message="rate limited after approval",
+        )
+
+
 class _TaskToolGraph:
     def step(
         self,
@@ -1065,6 +1100,59 @@ def test_runtime_background_rate_limit_retry_precedes_provider_fallback(
     assert child.output == "primary recovered"
     assert primary.attempts == 2
     assert fallback.calls == 0
+
+
+def test_runtime_background_retry_marker_does_not_persist_across_approval_resume(
+    tmp_path: Path,
+) -> None:
+    primary = _ApprovalThenRateLimitModelProvider(name="opencode")
+    fallback = _UnexpectedFallbackModelProvider(name="custom")
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        model_provider_registry=ModelProviderRegistry(
+            providers={"opencode": primary, "custom": fallback}
+        ),
+        config=RuntimeConfig(
+            approval_mode="ask",
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            provider_fallback=RuntimeProviderFallbackConfig(
+                preferred_model="opencode/gpt-5.4",
+                fallback_models=("custom/demo",),
+            ),
+        ),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+
+    started = runtime.start_background_task(RuntimeRequest(prompt="background approval"))
+    running = _wait_for_background_task_session(runtime, started.task.id)
+    child_session_id = cast(str, running.session_id)
+    child_response = _wait_for_session_event(
+        runtime,
+        child_session_id,
+        "runtime.approval_requested",
+    )
+    approval_request_id = cast(str, child_response.events[-1].payload["request_id"])
+
+    assert child_response.session.status == "waiting"
+    assert "background_rate_limit_retry" not in child_response.session.metadata
+
+    resumed = runtime.resume(
+        child_session_id,
+        approval_request_id=approval_request_id,
+        approval_decision="allow",
+    )
+    completed = runtime.load_background_task(started.task.id)
+    fallback_events = [
+        event for event in resumed.events if event.event_type == "runtime.provider_fallback"
+    ]
+
+    assert resumed.session.status == "completed"
+    assert resumed.output == "fallback used"
+    assert completed.status == "completed"
+    assert primary.calls >= 2
+    assert fallback.calls == 1
+    assert len(fallback_events) == 1
 
 
 def test_runtime_session_debug_snapshot_reports_completed_state(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Adds `background_task` runtime config for default, provider, and model concurrency limits.
- Gates background task dispatch through provider/model-aware queue draining with observable concurrency metadata when configured.
- Retries background rate-limit failures with backoff before allowing provider fallback, with tests for queueing, precedence, and fallback ordering.

## Verification
- `mise run check`

Closes #288