### PR TITLE
refactor(runtime): enforce assembled context as sole provider boundary

### DIFF
--- a/src/voidcode/agent/models.py
+++ b/src/voidcode/agent/models.py
@@ -116,8 +116,6 @@ class AgentManifest:
             fields.append("model_preference")
         if self.tool_allowlist:
             fields.append("tool_allowlist")
-        if self.skill_refs:
-            fields.append("skill_refs")
         fields.append("top_level_selectable")
         if self.prompt_materialization is not None:
             fields.append("prompt_materialization")

--- a/src/voidcode/graph/contracts.py
+++ b/src/voidcode/graph/contracts.py
@@ -39,9 +39,9 @@ class GraphLoopState(TypedDict):
 class GraphRunRequest:
     session: SessionState
     prompt: str
+    assembled_context: ProviderAssembledContext
     available_tools: tuple[ToolDefinition, ...] = ()
     context_window: ProviderContextWindow | None = None
-    assembled_context: ProviderAssembledContext | None = None
     metadata: dict[str, object] = field(default_factory=dict)
 
 

--- a/src/voidcode/graph/contracts.py
+++ b/src/voidcode/graph/contracts.py
@@ -4,7 +4,7 @@ import operator
 from dataclasses import dataclass, field
 from typing import Annotated, Protocol, TypedDict, runtime_checkable
 
-from ..provider.protocol import ProviderContextWindow
+from ..provider.protocol import ProviderAssembledContext, ProviderContextWindow
 from ..runtime.events import EventSource
 from ..runtime.session import SessionState
 from ..tools.contracts import ToolCall, ToolDefinition, ToolResult
@@ -40,9 +40,8 @@ class GraphRunRequest:
     session: SessionState
     prompt: str
     available_tools: tuple[ToolDefinition, ...] = ()
-    applied_skills: tuple[AppliedSkill, ...] = ()
-    skill_prompt_context: str = ""
     context_window: ProviderContextWindow | None = None
+    assembled_context: ProviderAssembledContext | None = None
     metadata: dict[str, object] = field(default_factory=dict)
 
 

--- a/src/voidcode/graph/provider_graph.py
+++ b/src/voidcode/graph/provider_graph.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Literal, cast
 
 from ..provider.errors import parse_provider_stream_error
 from ..provider.models import ResolvedProviderModel
 from ..provider.protocol import (
     ProviderAbortSignal,
-    ProviderAssembledContext,
-    ProviderContextSegment,
     ProviderExecutionError,
     ProviderStreamEvent,
     ProviderTokenUsage,
@@ -54,15 +52,6 @@ class _GraphAbortSignal:
 
     def set_cancelled(self, value: bool) -> None:
         self._cancelled = value
-
-
-@dataclass(frozen=True, slots=True)
-class _PromptOnlyAssembledContext:
-    prompt: str
-    tool_results: tuple[ToolResult, ...] = ()
-    continuity_state: object | None = None
-    segments: tuple[ProviderContextSegment, ...] = ()
-    metadata: dict[str, object] = field(default_factory=dict)
 
 
 class ProviderGraph:
@@ -121,9 +110,7 @@ class ProviderGraph:
                     "model": self._provider_model.selection.model,
                     "attempt": request.metadata.get("provider_attempt", 0),
                     "streaming": streaming_enabled,
-                    "prompt": request.assembled_context.prompt
-                    if request.assembled_context
-                    else request.prompt,
+                    "prompt": request.assembled_context.prompt,
                 },
             ),
         )
@@ -136,10 +123,8 @@ class ProviderGraph:
                 str(abort_requested).strip().lower() not in {"false", "0", "no", "off", ""}
             )
         turn_request = ProviderTurnRequest(
-            assembled_context=(
-                request.assembled_context
-                or self._default_assembled_context(request.prompt, tool_results)
-            ),
+            assembled_context=request.assembled_context,
+            bounded_context_window=request.context_window,
             available_tools=request.available_tools,
             raw_model=self._provider_model.selection.raw_model,
             provider_name=self._provider_model.selection.provider,
@@ -413,18 +398,6 @@ class ProviderGraph:
             model_name=model_name or "unknown",
             message=message,
             details=details,
-        )
-
-    @staticmethod
-    def _default_assembled_context(
-        prompt: str,
-        tool_results: tuple[ToolResult, ...],
-    ) -> ProviderAssembledContext:
-        return _PromptOnlyAssembledContext(
-            prompt=prompt,
-            tool_results=tool_results,
-            continuity_state=None,
-            segments=(ProviderContextSegment(role="user", content=prompt),),
         )
 
     @staticmethod

--- a/src/voidcode/graph/provider_graph.py
+++ b/src/voidcode/graph/provider_graph.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 
 from ..provider.errors import parse_provider_stream_error
 from ..provider.models import ResolvedProviderModel
 from ..provider.protocol import (
     ProviderAbortSignal,
-    ProviderContextWindow,
+    ProviderAssembledContext,
+    ProviderContextSegment,
     ProviderExecutionError,
     ProviderStreamEvent,
     ProviderTokenUsage,
@@ -56,12 +57,12 @@ class _GraphAbortSignal:
 
 
 @dataclass(frozen=True, slots=True)
-class _PromptOnlyContextWindow:
+class _PromptOnlyAssembledContext:
     prompt: str
     tool_results: tuple[ToolResult, ...] = ()
-    compacted: bool = False
-    retained_tool_result_count: int = 0
     continuity_state: object | None = None
+    segments: tuple[ProviderContextSegment, ...] = ()
+    metadata: dict[str, object] = field(default_factory=dict)
 
 
 class ProviderGraph:
@@ -120,7 +121,9 @@ class ProviderGraph:
                     "model": self._provider_model.selection.model,
                     "attempt": request.metadata.get("provider_attempt", 0),
                     "streaming": streaming_enabled,
-                    "prompt": request.prompt,
+                    "prompt": request.assembled_context.prompt
+                    if request.assembled_context
+                    else request.prompt,
                 },
             ),
         )
@@ -133,15 +136,14 @@ class ProviderGraph:
                 str(abort_requested).strip().lower() not in {"false", "0", "no", "off", ""}
             )
         turn_request = ProviderTurnRequest(
-            prompt=request.prompt,
+            assembled_context=(
+                request.assembled_context
+                or self._default_assembled_context(request.prompt, tool_results)
+            ),
             available_tools=request.available_tools,
-            tool_results=tool_results,
-            context_window=request.context_window or self._default_context_window(request.prompt),
-            applied_skills=request.applied_skills,
             raw_model=self._provider_model.selection.raw_model,
             provider_name=self._provider_model.selection.provider,
             model_name=self._provider_model.selection.model,
-            skill_prompt_context=request.skill_prompt_context,
             agent_preset=cast(dict[str, object] | None, request.metadata.get("agent_preset")),
             attempt=cast(int, request.metadata.get("provider_attempt", 0)),
             abort_signal=cast(ProviderAbortSignal, self._abort_signal),
@@ -414,8 +416,16 @@ class ProviderGraph:
         )
 
     @staticmethod
-    def _default_context_window(prompt: str) -> ProviderContextWindow:
-        return _PromptOnlyContextWindow(prompt=prompt)
+    def _default_assembled_context(
+        prompt: str,
+        tool_results: tuple[ToolResult, ...],
+    ) -> ProviderAssembledContext:
+        return _PromptOnlyAssembledContext(
+            prompt=prompt,
+            tool_results=tool_results,
+            continuity_state=None,
+            segments=(ProviderContextSegment(role="user", content=prompt),),
+        )
 
     @staticmethod
     def _stream_event_to_graph_event(stream_event: ProviderStreamEvent) -> GraphEvent:

--- a/src/voidcode/provider/litellm_backend.py
+++ b/src/voidcode/provider/litellm_backend.py
@@ -21,6 +21,7 @@ else:
 
 
 from ..tools.contracts import ToolCall, ToolDefinition
+from ..tools.output import sanitize_tool_arguments, sanitize_tool_result_data
 from .config import LiteLLMProviderConfig
 from .errors import provider_execution_error_from_api_payload
 from .protocol import (
@@ -193,14 +194,72 @@ class LiteLLMBackendSingleAgentProvider:
                 message="assembled context is required",
             )
         messages: list[dict[str, object]] = []
+        if request.provider_name == "opencode-go":
+            tool_feedback_lines: list[str] = []
+            for segment in assembled_context.segments:
+                if segment.role == "tool":
+                    metadata = segment.metadata or {}
+                    raw_data = metadata.get("data")
+                    sanitized_data = (
+                        sanitize_tool_result_data(cast(dict[str, object], raw_data))
+                        if isinstance(raw_data, dict)
+                        else {}
+                    )
+                    raw_arguments = sanitized_data.get("arguments")
+                    sanitized_arguments = (
+                        sanitize_tool_arguments(cast(dict[str, object], raw_arguments))
+                        if isinstance(raw_arguments, dict)
+                        else {}
+                    )
+                    payload = {
+                        "tool_name": segment.tool_name,
+                        "arguments": sanitized_arguments,
+                        "status": metadata.get("status"),
+                        "content": segment.content or "",
+                        "error": metadata.get("error"),
+                        "data": {
+                            key: value
+                            for key, value in sanitized_data.items()
+                            if key not in {"tool_call_id", "arguments"}
+                        },
+                        "truncated": metadata.get("truncated"),
+                        "partial": metadata.get("partial"),
+                        "reference": metadata.get("reference"),
+                    }
+                    tool_feedback_lines.append(
+                        json.dumps(payload, ensure_ascii=False, sort_keys=True)
+                    )
+                elif segment.role != "assistant":
+                    messages.append({"role": segment.role, "content": segment.content})
+            if tool_feedback_lines:
+                intro_line_1 = "Completed tool calls for current request:"
+                intro_line_2 = (
+                    "Use these results as latest state. "
+                    "Do not repeat completed calls unless retry is required."
+                )
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": "\n".join(
+                            (
+                                intro_line_1,
+                                intro_line_2,
+                                *tool_feedback_lines,
+                            )
+                        ),
+                    }
+                )
+            return messages
+
         for segment in assembled_context.segments:
             if segment.role == "assistant" and segment.tool_name is not None:
                 tool_call_id = _normalize_tool_call_id(
                     segment.tool_call_id,
                     fallback=segment.tool_name,
                 )
+                sanitized_arguments = sanitize_tool_arguments(segment.tool_arguments or {})
                 arguments = json.dumps(
-                    segment.tool_arguments or {},
+                    sanitized_arguments,
                     ensure_ascii=False,
                     sort_keys=True,
                 )
@@ -222,10 +281,26 @@ class LiteLLMBackendSingleAgentProvider:
                 )
                 continue
             if segment.role == "tool":
+                metadata = segment.metadata or {}
+                raw_data = metadata.get("data")
+                sanitized_data = (
+                    sanitize_tool_result_data(cast(dict[str, object], raw_data))
+                    if isinstance(raw_data, dict)
+                    else {}
+                )
                 payload = {
                     "tool_name": segment.tool_name,
                     "content": segment.content or "",
-                    **(segment.metadata or {}),
+                    "status": metadata.get("status"),
+                    "error": metadata.get("error"),
+                    "data": {
+                        key: value
+                        for key, value in sanitized_data.items()
+                        if key not in {"tool_call_id", "arguments"}
+                    },
+                    "truncated": metadata.get("truncated"),
+                    "partial": metadata.get("partial"),
+                    "reference": metadata.get("reference"),
                 }
                 messages.append(
                     {

--- a/src/voidcode/provider/litellm_backend.py
+++ b/src/voidcode/provider/litellm_backend.py
@@ -186,13 +186,6 @@ class LiteLLMBackendSingleAgentProvider:
 
     def _build_messages(self, request: ProviderTurnRequest) -> list[dict[str, object]]:
         assembled_context = request.assembled_context
-        if assembled_context is None:
-            raise ProviderExecutionError(
-                kind="transient_failure",
-                provider_name=self.name,
-                model_name=request.model_name or "unknown",
-                message="assembled context is required",
-            )
         messages: list[dict[str, object]] = []
         if request.provider_name == "opencode-go":
             tool_feedback_lines: list[str] = []

--- a/src/voidcode/provider/litellm_backend.py
+++ b/src/voidcode/provider/litellm_backend.py
@@ -20,9 +20,7 @@ else:
             pass
 
 
-from ..agent import render_agent_prompt
 from ..tools.contracts import ToolCall, ToolDefinition
-from ..tools.output import sanitize_tool_arguments, sanitize_tool_result_data
 from .config import LiteLLMProviderConfig
 from .errors import provider_execution_error_from_api_payload
 from .protocol import (
@@ -185,184 +183,62 @@ class LiteLLMBackendSingleAgentProvider:
         _ = request
         return dict(self.completion_kwargs or {})
 
-    @staticmethod
-    def _skill_system_message(request: ProviderTurnRequest) -> str | None:
-        if request.skill_prompt_context.strip():
-            return request.skill_prompt_context.strip()
-        if not request.applied_skills:
-            return None
-
-        rendered_skills: list[str] = []
-        for skill in request.applied_skills:
-            name = skill.get("name", "").strip() or "unnamed-skill"
-            description = skill.get("description", "").strip()
-            content = skill.get("prompt_context", "").strip() or skill.get("content", "").strip()
-
-            lines = [f"## {name}"]
-            if description:
-                lines.append(f"Description: {description}")
-            if content:
-                lines.append(content)
-            rendered_skills.append("\n".join(lines))
-
-        if not rendered_skills:
-            return None
-
-        return (
-            "You must apply the following runtime-managed skills for this turn. "
-            "Treat them as active task instructions in addition to the user's request.\n\n"
-            + "\n\n".join(rendered_skills)
-        )
-
-    @classmethod
-    def _agent_profile_system_message(cls, request: ProviderTurnRequest) -> str | None:
-        return render_agent_prompt(
-            request.agent_preset,
-            model_family=cls._model_family_hint(request),
-        )
-
-    @staticmethod
-    def _model_family_hint(request: ProviderTurnRequest) -> str | None:
-        if request.provider_name is not None and request.provider_name.strip():
-            return request.provider_name.strip()
-        if request.raw_model is None or "/" not in request.raw_model:
-            return None
-        provider_name, _model_name = request.raw_model.split("/", 1)
-        return provider_name.strip() or None
-
-    @staticmethod
-    def _continuity_system_message(request: ProviderTurnRequest) -> str | None:
-        continuity_state = request.context_window.continuity_state
-        if continuity_state is None:
-            return None
-
-        summary_text = getattr(continuity_state, "summary_text", None)
-        if not isinstance(summary_text, str) or not summary_text.strip():
-            return None
-
-        return f"Runtime continuity summary:\n{summary_text.strip()}"
-
-    @staticmethod
-    def _tool_result_messages(request: ProviderTurnRequest) -> list[dict[str, object]]:
-        messages: list[dict[str, object]] = []
-        for index, result in enumerate(request.context_window.tool_results, start=1):
-            sanitized_data = sanitize_tool_result_data(result.data)
-            raw_tool_call_id = result.data.get("tool_call_id")
-            tool_call_id = _normalize_tool_call_id(
-                raw_tool_call_id if isinstance(raw_tool_call_id, str) else None,
-                fallback=f"voidcode_tool_{index}",
-            )
-            raw_arguments = result.data.get("arguments")
-            arguments_payload = (
-                sanitize_tool_arguments(cast(dict[str, object], raw_arguments))
-                if isinstance(raw_arguments, dict)
-                else {}
-            )
-            arguments = json.dumps(
-                arguments_payload,
-                ensure_ascii=False,
-                sort_keys=True,
-            )
-            content = result.content or ""
-            result_payload = {
-                "tool_name": result.tool_name,
-                "status": result.status,
-                "content": content,
-                "error": result.error,
-                "data": {
-                    key: value
-                    for key, value in sanitized_data.items()
-                    if key not in {"tool_call_id", "arguments"}
-                },
-                "truncated": result.truncated,
-                "partial": result.partial,
-                "reference": result.reference,
-            }
-            messages.append(
-                {
-                    "role": "assistant",
-                    "content": None,
-                    "tool_calls": [
-                        {
-                            "id": tool_call_id,
-                            "type": "function",
-                            "function": {
-                                "name": result.tool_name,
-                                "arguments": arguments,
-                            },
-                        }
-                    ],
-                }
-            )
-            messages.append(
-                {
-                    "role": "tool",
-                    "tool_call_id": tool_call_id,
-                    "content": json.dumps(
-                        result_payload,
-                        ensure_ascii=False,
-                        sort_keys=True,
-                    ),
-                }
-            )
-        return messages
-
-    @staticmethod
-    def _tool_results_user_message(request: ProviderTurnRequest) -> str | None:
-        if not request.context_window.tool_results:
-            return None
-
-        lines = [
-            "The following tool calls have already completed for the current user request.",
-            "Use these results as the latest state. Do not repeat a completed tool call "
-            "unless a later error explicitly requires retrying it.",
-        ]
-        for index, result in enumerate(request.context_window.tool_results, start=1):
-            sanitized_data = sanitize_tool_result_data(result.data)
-            raw_arguments = result.data.get("arguments")
-            arguments_payload = (
-                sanitize_tool_arguments(cast(dict[str, object], raw_arguments))
-                if isinstance(raw_arguments, dict)
-                else {}
-            )
-            content = result.content or ""
-            payload = {
-                "index": index,
-                "tool_name": result.tool_name,
-                "arguments": arguments_payload,
-                "status": result.status,
-                "content": content,
-                "error": result.error,
-                "data": {
-                    key: value
-                    for key, value in sanitized_data.items()
-                    if key not in {"tool_call_id", "arguments"}
-                },
-                "truncated": result.truncated,
-                "partial": result.partial,
-                "reference": result.reference,
-            }
-            lines.append(json.dumps(payload, ensure_ascii=False, sort_keys=True))
-        return "\n".join(lines)
-
     def _build_messages(self, request: ProviderTurnRequest) -> list[dict[str, object]]:
+        assembled_context = request.assembled_context
+        if assembled_context is None:
+            raise ProviderExecutionError(
+                kind="transient_failure",
+                provider_name=self.name,
+                model_name=request.model_name or "unknown",
+                message="assembled context is required",
+            )
         messages: list[dict[str, object]] = []
-        agent_profile_message = self._agent_profile_system_message(request)
-        if agent_profile_message is not None:
-            messages.append({"role": "system", "content": agent_profile_message})
-        skill_message = self._skill_system_message(request)
-        if skill_message is not None:
-            messages.append({"role": "system", "content": skill_message})
-        continuity_message = self._continuity_system_message(request)
-        if continuity_message is not None:
-            messages.append({"role": "system", "content": continuity_message})
-        messages.append({"role": "user", "content": request.prompt})
-        if request.provider_name == "opencode-go":
-            tool_results_message = self._tool_results_user_message(request)
-            if tool_results_message is not None:
-                messages.append({"role": "user", "content": tool_results_message})
-        else:
-            messages.extend(self._tool_result_messages(request))
+        for segment in assembled_context.segments:
+            if segment.role == "assistant" and segment.tool_name is not None:
+                tool_call_id = _normalize_tool_call_id(
+                    segment.tool_call_id,
+                    fallback=segment.tool_name,
+                )
+                arguments = json.dumps(
+                    segment.tool_arguments or {},
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+                messages.append(
+                    {
+                        "role": "assistant",
+                        "content": segment.content,
+                        "tool_calls": [
+                            {
+                                "id": tool_call_id,
+                                "type": "function",
+                                "function": {
+                                    "name": segment.tool_name,
+                                    "arguments": arguments,
+                                },
+                            }
+                        ],
+                    }
+                )
+                continue
+            if segment.role == "tool":
+                payload = {
+                    "tool_name": segment.tool_name,
+                    "content": segment.content or "",
+                    **(segment.metadata or {}),
+                }
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": _normalize_tool_call_id(
+                            segment.tool_call_id,
+                            fallback=segment.tool_name or "voidcode_tool",
+                        ),
+                        "content": json.dumps(payload, ensure_ascii=False, sort_keys=True),
+                    }
+                )
+                continue
+            messages.append({"role": segment.role, "content": segment.content})
         return messages
 
     def _auth_kwargs(self) -> dict[str, object]:

--- a/src/voidcode/provider/protocol.py
+++ b/src/voidcode/provider/protocol.py
@@ -9,7 +9,6 @@ from ..command.resolver import resolve_tool_instruction
 from ..runtime.context_window import normalize_read_file_output
 from ..tools.contracts import ToolCall, ToolDefinition, ToolResult
 
-type AppliedSkill = dict[str, str]
 type ProviderMessageRole = Literal["system", "user", "assistant", "tool"]
 type ProviderStreamEventKind = Literal["delta", "content", "error", "done"]
 type ProviderStreamChannel = Literal["text", "tool", "reasoning", "error"]
@@ -46,121 +45,81 @@ class ProviderContextWindow(Protocol):
 
 @dataclass(frozen=True, slots=True)
 class ProviderTurnRequest:
+    assembled_context: ProviderAssembledContext
+    bounded_context_window: ProviderContextWindow | None = None
     available_tools: tuple[ToolDefinition, ...] = ()
     raw_model: str | None = None
     provider_name: str | None = None
     model_name: str | None = None
-    assembled_context: ProviderAssembledContext | None = None
-    prompt: str = ""
-    tool_results: tuple[ToolResult, ...] = ()
-    context_window: ProviderContextWindow | None = None
-    applied_skills: tuple[AppliedSkill, ...] = ()
-    skill_prompt_context: str = ""
     agent_preset: dict[str, object] | None = None
     attempt: int = 0
     abort_signal: ProviderAbortSignal | None = None
 
-    def __post_init__(self) -> None:
-        if self.assembled_context is not None:
-            return
-        prompt = self.prompt
-        context_window = self.context_window
-        tool_results = (
-            context_window.tool_results if context_window is not None else self.tool_results
+    @property
+    def prompt(self) -> str:
+        return self.assembled_context.prompt
+
+    @property
+    def tool_results(self) -> tuple[ToolResult, ...]:
+        return self.assembled_context.tool_results
+
+    @property
+    def context_window(self) -> ProviderContextWindow:
+        if self.bounded_context_window is not None:
+            return self.bounded_context_window
+        payload = self.assembled_context.metadata
+        retained_raw = payload.get("retained_tool_result_count")
+        retained_count = (
+            retained_raw
+            if isinstance(retained_raw, int)
+            else len(self.assembled_context.tool_results)
         )
-        continuity_state = context_window.continuity_state if context_window is not None else None
-        segments: list[ProviderContextSegment] = []
-        skill_message = self.skill_prompt_context.strip()
-        if not skill_message and self.applied_skills:
-            rendered_skills: list[str] = []
-            for skill in self.applied_skills:
-                name = skill.get("name", "").strip() or "unnamed-skill"
-                description = skill.get("description", "").strip()
-                content = (
-                    skill.get("prompt_context", "").strip() or skill.get("content", "").strip()
-                )
-                lines = [f"## {name}"]
-                if description:
-                    lines.append(f"Description: {description}")
-                if content:
-                    lines.append(content)
-                rendered_skills.append("\n".join(lines))
-            if rendered_skills:
-                skill_message = (
-                    "You must apply the following runtime-managed skills for this turn. "
-                    "Treat them as active task instructions in addition to the user's request.\n\n"
-                    + "\n\n".join(rendered_skills)
-                )
-        if skill_message:
-            segments.append(ProviderContextSegment(role="system", content=skill_message))
-        if continuity_state is not None:
-            summary_text = getattr(continuity_state, "summary_text", None)
-            if isinstance(summary_text, str) and summary_text.strip():
-                segments.append(
-                    ProviderContextSegment(
-                        role="system",
-                        content=f"Runtime continuity summary:\n{summary_text.strip()}",
-                    )
-                )
-        segments.append(ProviderContextSegment(role="user", content=prompt))
-        for index, result in enumerate(tool_results, start=1):
-            raw_tool_call_id = result.data.get("tool_call_id")
-            tool_call_id = (
-                raw_tool_call_id
-                if isinstance(raw_tool_call_id, str) and raw_tool_call_id.strip()
-                else f"voidcode_tool_{index}"
-            )
-            raw_arguments = result.data.get("arguments")
-            tool_arguments: dict[str, object]
-            if isinstance(raw_arguments, dict):
-                tool_arguments = dict(cast(dict[str, object], raw_arguments))
-            else:
-                tool_arguments = {}
-            segments.append(
-                ProviderContextSegment(
-                    role="assistant",
-                    content=None,
-                    tool_call_id=tool_call_id,
-                    tool_name=result.tool_name,
-                    tool_arguments=tool_arguments,
-                )
-            )
-            segments.append(
-                ProviderContextSegment(
-                    role="tool",
-                    content=result.content or "",
-                    tool_call_id=tool_call_id,
-                    tool_name=result.tool_name,
-                    metadata={
-                        "status": result.status,
-                        "error": result.error,
-                        "data": result.data,
-                        "truncated": result.truncated,
-                        "partial": result.partial,
-                        "reference": result.reference,
-                    },
-                )
-            )
-        object.__setattr__(
-            self,
-            "assembled_context",
-            _LegacyAssembledContext(
-                prompt=prompt,
-                tool_results=tool_results,
-                continuity_state=continuity_state,
-                segments=tuple(segments),
-                metadata={},
+        return _DerivedContextWindow(
+            prompt=self.assembled_context.prompt,
+            tool_results=self.assembled_context.tool_results,
+            continuity_state=self.assembled_context.continuity_state,
+            compacted=bool(payload.get("compacted", False)),
+            retained_tool_result_count=retained_count,
+            token_budget=cast(int | None, payload.get("token_budget")),
+            token_estimate_source=cast(str | None, payload.get("token_estimate_source")),
+            original_tool_result_tokens=cast(
+                int | None, payload.get("original_tool_result_tokens")
             ),
+            retained_tool_result_tokens=cast(
+                int | None, payload.get("retained_tool_result_tokens")
+            ),
+            dropped_tool_result_tokens=cast(int | None, payload.get("dropped_tool_result_tokens")),
+            original_tool_result_count=cast(int | None, payload.get("original_tool_result_count")),
+            compaction_reason=cast(str | None, payload.get("compaction_reason")),
+            summary_anchor=cast(str | None, payload.get("summary_anchor")),
+            summary_source=cast(dict[str, object] | None, payload.get("summary_source")),
         )
+
+    @property
+    def applied_skills(self) -> tuple[dict[str, str], ...]:
+        return ()
 
 
 @dataclass(frozen=True, slots=True)
-class _LegacyAssembledContext:
+class _DerivedContextWindow:
     prompt: str
     tool_results: tuple[ToolResult, ...]
-    continuity_state: object | None
-    segments: tuple[ProviderContextSegmentLike, ...]
-    metadata: dict[str, object]
+    continuity_state: object | None = None
+    compacted: bool = False
+    retained_tool_result_count: int = 0
+    token_budget: int | None = None
+    token_estimate_source: str | None = None
+    original_tool_result_tokens: int | None = None
+    retained_tool_result_tokens: int | None = None
+    dropped_tool_result_tokens: int | None = None
+    original_tool_result_count: int | None = None
+    compaction_reason: str | None = None
+    summary_anchor: str | None = None
+    summary_source: dict[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        if self.retained_tool_result_count == 0:
+            object.__setattr__(self, "retained_tool_result_count", len(self.tool_results))
 
 
 @dataclass(frozen=True, slots=True)
@@ -376,8 +335,6 @@ class StubTurnProvider:
 
     def propose_turn(self, request: ProviderTurnRequest) -> ProviderTurnResult:
         assembled_context = request.assembled_context
-        if assembled_context is None:
-            raise ValueError("assembled context is required")
         commands = [line.strip() for line in assembled_context.prompt.splitlines() if line.strip()]
         if not commands:
             raise ValueError("request must not be empty")

--- a/src/voidcode/provider/protocol.py
+++ b/src/voidcode/provider/protocol.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import time
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Literal, Protocol, runtime_checkable
+from typing import Literal, Protocol, cast, runtime_checkable
 
 from ..command.resolver import resolve_tool_instruction
 from ..runtime.context_window import normalize_read_file_output
 from ..tools.contracts import ToolCall, ToolDefinition, ToolResult
 
 type AppliedSkill = dict[str, str]
+type ProviderMessageRole = Literal["system", "user", "assistant", "tool"]
 type ProviderStreamEventKind = Literal["delta", "content", "error", "done"]
 type ProviderStreamChannel = Literal["text", "tool", "reasoning", "error"]
 type ProviderDoneReason = Literal["completed", "cancelled", "error"]
@@ -45,18 +46,170 @@ class ProviderContextWindow(Protocol):
 
 @dataclass(frozen=True, slots=True)
 class ProviderTurnRequest:
-    prompt: str
-    available_tools: tuple[ToolDefinition, ...]
-    tool_results: tuple[ToolResult, ...]
-    context_window: ProviderContextWindow
-    applied_skills: tuple[AppliedSkill, ...]
-    raw_model: str | None
-    provider_name: str | None
-    model_name: str | None
+    available_tools: tuple[ToolDefinition, ...] = ()
+    raw_model: str | None = None
+    provider_name: str | None = None
+    model_name: str | None = None
+    assembled_context: ProviderAssembledContext | None = None
+    prompt: str = ""
+    tool_results: tuple[ToolResult, ...] = ()
+    context_window: ProviderContextWindow | None = None
+    applied_skills: tuple[AppliedSkill, ...] = ()
     skill_prompt_context: str = ""
     agent_preset: dict[str, object] | None = None
     attempt: int = 0
     abort_signal: ProviderAbortSignal | None = None
+
+    def __post_init__(self) -> None:
+        if self.assembled_context is not None:
+            return
+        prompt = self.prompt
+        context_window = self.context_window
+        tool_results = (
+            context_window.tool_results if context_window is not None else self.tool_results
+        )
+        continuity_state = context_window.continuity_state if context_window is not None else None
+        segments: list[ProviderContextSegment] = []
+        skill_message = self.skill_prompt_context.strip()
+        if not skill_message and self.applied_skills:
+            rendered_skills: list[str] = []
+            for skill in self.applied_skills:
+                name = skill.get("name", "").strip() or "unnamed-skill"
+                description = skill.get("description", "").strip()
+                content = (
+                    skill.get("prompt_context", "").strip() or skill.get("content", "").strip()
+                )
+                lines = [f"## {name}"]
+                if description:
+                    lines.append(f"Description: {description}")
+                if content:
+                    lines.append(content)
+                rendered_skills.append("\n".join(lines))
+            if rendered_skills:
+                skill_message = (
+                    "You must apply the following runtime-managed skills for this turn. "
+                    "Treat them as active task instructions in addition to the user's request.\n\n"
+                    + "\n\n".join(rendered_skills)
+                )
+        if skill_message:
+            segments.append(ProviderContextSegment(role="system", content=skill_message))
+        if continuity_state is not None:
+            summary_text = getattr(continuity_state, "summary_text", None)
+            if isinstance(summary_text, str) and summary_text.strip():
+                segments.append(
+                    ProviderContextSegment(
+                        role="system",
+                        content=f"Runtime continuity summary:\n{summary_text.strip()}",
+                    )
+                )
+        segments.append(ProviderContextSegment(role="user", content=prompt))
+        for index, result in enumerate(tool_results, start=1):
+            raw_tool_call_id = result.data.get("tool_call_id")
+            tool_call_id = (
+                raw_tool_call_id
+                if isinstance(raw_tool_call_id, str) and raw_tool_call_id.strip()
+                else f"voidcode_tool_{index}"
+            )
+            raw_arguments = result.data.get("arguments")
+            tool_arguments: dict[str, object]
+            if isinstance(raw_arguments, dict):
+                tool_arguments = dict(cast(dict[str, object], raw_arguments))
+            else:
+                tool_arguments = {}
+            segments.append(
+                ProviderContextSegment(
+                    role="assistant",
+                    content=None,
+                    tool_call_id=tool_call_id,
+                    tool_name=result.tool_name,
+                    tool_arguments=tool_arguments,
+                )
+            )
+            segments.append(
+                ProviderContextSegment(
+                    role="tool",
+                    content=result.content or "",
+                    tool_call_id=tool_call_id,
+                    tool_name=result.tool_name,
+                    metadata={
+                        "status": result.status,
+                        "error": result.error,
+                        "data": result.data,
+                        "truncated": result.truncated,
+                        "partial": result.partial,
+                        "reference": result.reference,
+                    },
+                )
+            )
+        object.__setattr__(
+            self,
+            "assembled_context",
+            _LegacyAssembledContext(
+                prompt=prompt,
+                tool_results=tool_results,
+                continuity_state=continuity_state,
+                segments=tuple(segments),
+                metadata={},
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _LegacyAssembledContext:
+    prompt: str
+    tool_results: tuple[ToolResult, ...]
+    continuity_state: object | None
+    segments: tuple[ProviderContextSegmentLike, ...]
+    metadata: dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderContextSegment:
+    role: ProviderMessageRole
+    content: str | None
+    tool_call_id: str | None = None
+    tool_name: str | None = None
+    tool_arguments: dict[str, object] | None = None
+    metadata: dict[str, object] | None = None
+
+
+@runtime_checkable
+class ProviderContextSegmentLike(Protocol):
+    @property
+    def role(self) -> ProviderMessageRole: ...
+
+    @property
+    def content(self) -> str | None: ...
+
+    @property
+    def tool_call_id(self) -> str | None: ...
+
+    @property
+    def tool_name(self) -> str | None: ...
+
+    @property
+    def tool_arguments(self) -> dict[str, object] | None: ...
+
+    @property
+    def metadata(self) -> dict[str, object] | None: ...
+
+
+@runtime_checkable
+class ProviderAssembledContext(Protocol):
+    @property
+    def prompt(self) -> str: ...
+
+    @property
+    def tool_results(self) -> tuple[ToolResult, ...]: ...
+
+    @property
+    def continuity_state(self) -> object | None: ...
+
+    @property
+    def segments(self) -> tuple[ProviderContextSegmentLike, ...]: ...
+
+    @property
+    def metadata(self) -> dict[str, object]: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -222,15 +375,18 @@ class StubTurnProvider:
     name: str
 
     def propose_turn(self, request: ProviderTurnRequest) -> ProviderTurnResult:
-        commands = [line.strip() for line in request.prompt.splitlines() if line.strip()]
+        assembled_context = request.assembled_context
+        if assembled_context is None:
+            raise ValueError("assembled context is required")
+        commands = [line.strip() for line in assembled_context.prompt.splitlines() if line.strip()]
         if not commands:
             raise ValueError("request must not be empty")
 
-        step_index = len(request.tool_results)
+        step_index = len(assembled_context.tool_results)
         if step_index >= len(commands):
-            if not request.context_window.tool_results:
+            if not assembled_context.tool_results:
                 raise ValueError("request must contain at least one actionable command")
-            last_result = request.context_window.tool_results[-1]
+            last_result = assembled_context.tool_results[-1]
             return ProviderTurnResult(output=_normalize_tool_output(last_result.content))
 
         resolution = resolve_tool_instruction(

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -801,6 +801,7 @@ def assemble_provider_context(
     policy: ContextWindowPolicy | None = None,
     skill_prompt_context: str = "",
     loaded_skills: tuple[dict[str, object], ...] = (),
+    preserved_continuity_state: RuntimeContinuityState | None = None,
 ) -> RuntimeAssembledContext:
     context_window = prepare_provider_context(
         prompt=prompt,
@@ -811,7 +812,10 @@ def assemble_provider_context(
     segments: list[RuntimeContextSegment] = []
     if skill_prompt_context.strip():
         segments.append(RuntimeContextSegment(role="system", content=skill_prompt_context.strip()))
-    continuity_state = context_window.continuity_state
+    continuity_state = preserved_continuity_state or context_window.continuity_state
+    metadata_payload = context_window.metadata_payload()
+    if continuity_state is not None and "continuity_state" not in metadata_payload:
+        metadata_payload["continuity_state"] = continuity_state.metadata_payload()
     if continuity_state is not None:
         summary_text = continuity_state.summary_text
         if isinstance(summary_text, str) and summary_text.strip():
@@ -863,8 +867,8 @@ def assemble_provider_context(
     return RuntimeAssembledContext(
         prompt=prompt,
         tool_results=context_window.tool_results,
-        continuity_state=context_window.continuity_state,
+        continuity_state=continuity_state,
         segments=tuple(segments),
-        metadata=context_window.metadata_payload(),
+        metadata=metadata_payload,
         loaded_skills=loaded_skills,
     )

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -189,6 +189,7 @@ class RuntimeAssembledContext:
     continuity_state: RuntimeContinuityState | None
     segments: tuple[RuntimeContextSegment, ...]
     metadata: dict[str, object]
+    loaded_skills: tuple[dict[str, object], ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -799,6 +800,7 @@ def assemble_provider_context(
     session_metadata: dict[str, object],
     policy: ContextWindowPolicy | None = None,
     skill_prompt_context: str = "",
+    loaded_skills: tuple[dict[str, object], ...] = (),
 ) -> RuntimeAssembledContext:
     context_window = prepare_provider_context(
         prompt=prompt,
@@ -864,4 +866,5 @@ def assemble_provider_context(
         continuity_state=context_window.continuity_state,
         segments=tuple(segments),
         metadata=context_window.metadata_payload(),
+        loaded_skills=loaded_skills,
     )

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -182,6 +182,25 @@ class RuntimeContextWindow:
         return payload
 
 
+@dataclass(frozen=True, slots=True)
+class RuntimeAssembledContext:
+    prompt: str
+    tool_results: tuple[ToolResult, ...]
+    continuity_state: RuntimeContinuityState | None
+    segments: tuple[RuntimeContextSegment, ...]
+    metadata: dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeContextSegment:
+    role: Literal["system", "user", "assistant", "tool"]
+    content: str | None
+    tool_call_id: str | None = None
+    tool_name: str | None = None
+    tool_arguments: dict[str, object] | None = None
+    metadata: dict[str, object] | None = None
+
+
 def _tool_result_preview(result: ToolResult, *, max_preview_chars: int) -> str:
     parts = [result.tool_name, result.status]
     path = result.data.get("path")
@@ -770,4 +789,79 @@ def prepare_provider_context(
         continuity_state=continuity_state,
         summary_anchor=summary_anchor,
         summary_source=summary_source,
+    )
+
+
+def assemble_provider_context(
+    *,
+    prompt: str,
+    tool_results: tuple[ToolResult, ...],
+    session_metadata: dict[str, object],
+    policy: ContextWindowPolicy | None = None,
+    skill_prompt_context: str = "",
+) -> RuntimeAssembledContext:
+    context_window = prepare_provider_context(
+        prompt=prompt,
+        tool_results=tool_results,
+        session_metadata=session_metadata,
+        policy=policy,
+    )
+    segments: list[RuntimeContextSegment] = []
+    if skill_prompt_context.strip():
+        segments.append(RuntimeContextSegment(role="system", content=skill_prompt_context.strip()))
+    continuity_state = context_window.continuity_state
+    if continuity_state is not None:
+        summary_text = continuity_state.summary_text
+        if isinstance(summary_text, str) and summary_text.strip():
+            segments.append(
+                RuntimeContextSegment(
+                    role="system",
+                    content=f"Runtime continuity summary:\n{summary_text.strip()}",
+                )
+            )
+    segments.append(RuntimeContextSegment(role="user", content=prompt))
+    for index, result in enumerate(context_window.tool_results, start=1):
+        raw_tool_call_id = result.data.get("tool_call_id")
+        tool_call_id = (
+            raw_tool_call_id
+            if isinstance(raw_tool_call_id, str) and raw_tool_call_id.strip()
+            else f"voidcode_tool_{index}"
+        )
+        raw_arguments = result.data.get("arguments")
+        tool_arguments: dict[str, object]
+        if isinstance(raw_arguments, dict):
+            tool_arguments = dict(cast(dict[str, object], raw_arguments))
+        else:
+            tool_arguments = {}
+        segments.append(
+            RuntimeContextSegment(
+                role="assistant",
+                content=None,
+                tool_call_id=tool_call_id,
+                tool_name=result.tool_name,
+                tool_arguments=tool_arguments,
+            )
+        )
+        segments.append(
+            RuntimeContextSegment(
+                role="tool",
+                content=result.content or "",
+                tool_call_id=tool_call_id,
+                tool_name=result.tool_name,
+                metadata={
+                    "status": result.status,
+                    "error": result.error,
+                    "data": result.data,
+                    "truncated": result.truncated,
+                    "partial": result.partial,
+                    "reference": result.reference,
+                },
+            )
+        )
+    return RuntimeAssembledContext(
+        prompt=prompt,
+        tool_results=context_window.tool_results,
+        continuity_state=context_window.continuity_state,
+        segments=tuple(segments),
+        metadata=context_window.metadata_payload(),
     )

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -800,6 +800,8 @@ def assemble_provider_context(
     session_metadata: dict[str, object],
     policy: ContextWindowPolicy | None = None,
     skill_prompt_context: str = "",
+    agent_prompt_context: str = "",
+    preserved_system_segments: tuple[str, ...] = (),
     loaded_skills: tuple[dict[str, object], ...] = (),
     preserved_continuity_state: RuntimeContinuityState | None = None,
 ) -> RuntimeAssembledContext:
@@ -810,8 +812,19 @@ def assemble_provider_context(
         policy=policy,
     )
     segments: list[RuntimeContextSegment] = []
-    if skill_prompt_context.strip():
-        segments.append(RuntimeContextSegment(role="system", content=skill_prompt_context.strip()))
+    seen_system_contents: set[str] = set()
+
+    def _append_system_segment(content: str) -> None:
+        normalized = content.strip()
+        if not normalized or normalized in seen_system_contents:
+            return
+        seen_system_contents.add(normalized)
+        segments.append(RuntimeContextSegment(role="system", content=normalized))
+
+    _append_system_segment(agent_prompt_context)
+    for segment_content in preserved_system_segments:
+        _append_system_segment(segment_content)
+    _append_system_segment(skill_prompt_context)
     continuity_state = preserved_continuity_state or context_window.continuity_state
     metadata_payload = context_window.metadata_payload()
     if continuity_state is not None and "continuity_state" not in metadata_payload:
@@ -819,12 +832,7 @@ def assemble_provider_context(
     if continuity_state is not None:
         summary_text = continuity_state.summary_text
         if isinstance(summary_text, str) and summary_text.strip():
-            segments.append(
-                RuntimeContextSegment(
-                    role="system",
-                    content=f"Runtime continuity summary:\n{summary_text.strip()}",
-                )
-            )
+            _append_system_segment(f"Runtime continuity summary:\n{summary_text.strip()}")
     segments.append(RuntimeContextSegment(role="user", content=prompt))
     for index, result in enumerate(context_window.tool_results, start=1):
         raw_tool_call_id = result.data.get("tool_call_id")

--- a/src/voidcode/runtime/provider_protocol.py
+++ b/src/voidcode/runtime/provider_protocol.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from ..provider.protocol import (
-    AppliedSkill,
+    ProviderAssembledContext,
+    ProviderContextSegment,
     ProviderExecutionError,
     ProviderStreamEvent,
     ProviderTokenUsage,
@@ -13,7 +14,8 @@ from ..provider.protocol import (
 )
 
 __all__ = [
-    "AppliedSkill",
+    "ProviderAssembledContext",
+    "ProviderContextSegment",
     "ProviderExecutionError",
     "ProviderStreamEvent",
     "ProviderTokenUsage",

--- a/src/voidcode/runtime/resume.py
+++ b/src/voidcode/runtime/resume.py
@@ -510,6 +510,7 @@ class RuntimeResumeCoordinator:
             agent=effective_config.agent,
             source="resume",
         )
+
         graph_request = GraphRunRequest(
             session=session,
             prompt=prompt,

--- a/src/voidcode/runtime/resume.py
+++ b/src/voidcode/runtime/resume.py
@@ -271,12 +271,16 @@ class RuntimeResumeCoordinator:
             session=session,
             prompt=prompt,
             available_tools=tool_registry.definitions(),
-            applied_skills=resumed_skill_snapshot.applied_skill_payloads,
-            skill_prompt_context=resumed_skill_snapshot.skill_prompt_context,
             context_window=runtime._prepare_provider_context_window(
                 prompt=prompt,
                 tool_results=tuple(tool_results),
                 session_metadata=session.metadata,
+            ),
+            assembled_context=runtime._assemble_provider_context(
+                prompt=prompt,
+                tool_results=tuple(tool_results),
+                session_metadata=session.metadata,
+                skill_prompt_context=resumed_skill_snapshot.skill_prompt_context,
             ),
             metadata={
                 **session.metadata,
@@ -510,12 +514,16 @@ class RuntimeResumeCoordinator:
             session=session,
             prompt=prompt,
             available_tools=tool_registry.definitions(),
-            applied_skills=resumed_skill_snapshot.applied_skill_payloads,
-            skill_prompt_context=resumed_skill_snapshot.skill_prompt_context,
             context_window=runtime._prepare_provider_context_window(
                 prompt=prompt,
                 tool_results=tuple(tool_results),
                 session_metadata=session.metadata,
+            ),
+            assembled_context=runtime._assemble_provider_context(
+                prompt=prompt,
+                tool_results=tuple(tool_results),
+                session_metadata=session.metadata,
+                skill_prompt_context=resumed_skill_snapshot.skill_prompt_context,
             ),
             metadata={
                 **session.metadata,

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -107,6 +107,16 @@ class RuntimeRunLoopCoordinator:
                 context_window = base_context
             continuity_to_reinject = None
             session = runtime._session_with_context_window_metadata(current_session, context_window)
+            skill_prompt_context = ""
+            if graph_request.assembled_context is not None:
+                for segment in graph_request.assembled_context.segments:
+                    if segment.role != "system" or not isinstance(segment.content, str):
+                        continue
+                    if segment.content.startswith(
+                        "Runtime-managed skills are active for this turn."
+                    ):
+                        skill_prompt_context = segment.content
+                        break
             graph_request = GraphRunRequest(
                 session=session,
                 prompt=graph_request.prompt,
@@ -116,6 +126,7 @@ class RuntimeRunLoopCoordinator:
                     prompt=graph_request.prompt,
                     tool_results=context_window.tool_results,
                     session_metadata=session.metadata,
+                    skill_prompt_context=skill_prompt_context,
                 ),
                 metadata=graph_request.metadata,
             )

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -108,15 +108,12 @@ class RuntimeRunLoopCoordinator:
             continuity_to_reinject = None
             session = runtime._session_with_context_window_metadata(current_session, context_window)
             skill_prompt_context = ""
-            if graph_request.assembled_context is not None:
-                for segment in graph_request.assembled_context.segments:
-                    if segment.role != "system" or not isinstance(segment.content, str):
-                        continue
-                    if segment.content.startswith(
-                        "Runtime-managed skills are active for this turn."
-                    ):
-                        skill_prompt_context = segment.content
-                        break
+            for segment in graph_request.assembled_context.segments:
+                if segment.role != "system" or not isinstance(segment.content, str):
+                    continue
+                if segment.content.startswith("Runtime-managed skills are active for this turn."):
+                    skill_prompt_context = segment.content
+                    break
             graph_request = GraphRunRequest(
                 session=session,
                 prompt=graph_request.prompt,

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -108,12 +108,13 @@ class RuntimeRunLoopCoordinator:
             continuity_to_reinject = None
             session = runtime._session_with_context_window_metadata(current_session, context_window)
             skill_prompt_context = ""
+            preserved_system_segments: list[str] = []
             for segment in graph_request.assembled_context.segments:
                 if segment.role != "system" or not isinstance(segment.content, str):
                     continue
+                preserved_system_segments.append(segment.content)
                 if segment.content.startswith("Runtime-managed skills are active for this turn."):
                     skill_prompt_context = segment.content
-                    break
             graph_request = GraphRunRequest(
                 session=session,
                 prompt=graph_request.prompt,
@@ -124,6 +125,7 @@ class RuntimeRunLoopCoordinator:
                     tool_results=context_window.tool_results,
                     session_metadata=session.metadata,
                     skill_prompt_context=skill_prompt_context,
+                    preserved_system_segments=tuple(preserved_system_segments),
                 ),
                 metadata=graph_request.metadata,
             )

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -111,9 +111,12 @@ class RuntimeRunLoopCoordinator:
                 session=session,
                 prompt=graph_request.prompt,
                 available_tools=graph_request.available_tools,
-                applied_skills=graph_request.applied_skills,
-                skill_prompt_context=graph_request.skill_prompt_context,
                 context_window=context_window,
+                assembled_context=runtime._assemble_provider_context(
+                    prompt=graph_request.prompt,
+                    tool_results=context_window.tool_results,
+                    session_metadata=session.metadata,
+                ),
                 metadata=graph_request.metadata,
             )
             if context_window.compacted and reinjected_continuity is None:
@@ -258,8 +261,8 @@ class RuntimeRunLoopCoordinator:
                             session=session,
                             prompt=graph_request.prompt,
                             available_tools=graph_request.available_tools,
-                            applied_skills=graph_request.applied_skills,
-                            skill_prompt_context=graph_request.skill_prompt_context,
+                            context_window=graph_request.context_window,
+                            assembled_context=graph_request.assembled_context,
                             metadata={
                                 **graph_request.metadata,
                                 "provider_attempt": provider_attempt,

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -4470,10 +4470,15 @@ class VoidCodeRuntime:
         raw_loaded = session_metadata.get("loaded_skills", [])
         loaded_skills: tuple[dict[str, object], ...] = ()
         if isinstance(raw_loaded, list):
-            items: list[dict[str, object]] = [
-                dict[str, object](item) for item in raw_loaded if isinstance(item, dict)
-            ]
-            loaded_skills = tuple(items)
+            typed: list[dict[str, object]] = []
+            for item in cast(list[object], raw_loaded):
+                if isinstance(item, dict):
+                    entry: dict[str, object] = {}
+                    for k, v in cast(dict[object, object], item).items():
+                        if isinstance(k, str):
+                            entry[k] = v
+                    typed.append(entry)
+            loaded_skills = tuple(typed)
         return assemble_provider_context(
             prompt=prompt,
             tool_results=tool_results,
@@ -4481,6 +4486,9 @@ class VoidCodeRuntime:
             policy=policy or self._default_context_window_policy,
             skill_prompt_context=skill_prompt_context,
             loaded_skills=loaded_skills,
+            preserved_continuity_state=self._continuity_state_from_session_metadata(
+                session_metadata
+            ),
         )
 
     @staticmethod

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -1338,11 +1338,33 @@ class VoidCodeRuntime:
         session: SessionState,
         *,
         events: tuple[EventEnvelope, ...],
+        force_loaded_skills: tuple[dict[str, object], ...] = (),
     ) -> SessionState:
         loaded_payloads = [
             event.payload for event in events if event.event_type == "runtime.skill_loaded"
         ]
-        if not loaded_payloads:
+        implicit_force_loaded: tuple[dict[str, object], ...] = ()
+        raw_snapshot = session.metadata.get("skill_snapshot")
+        if isinstance(raw_snapshot, dict):
+            snapshot_payload = cast(dict[str, object], raw_snapshot)
+            applied_payloads = snapshot_payload.get("applied_skill_payloads")
+            if isinstance(applied_payloads, list):
+                normalized: list[dict[str, object]] = []
+                for item in cast(list[object], applied_payloads):
+                    if not isinstance(item, dict):
+                        continue
+                    payload = cast(dict[str, object], item)
+                    normalized.append(
+                        {
+                            "name": payload.get("name"),
+                            "source": "force_load",
+                            "source_path": payload.get("source_path"),
+                        }
+                    )
+                implicit_force_loaded = tuple(normalized)
+
+        merged_payloads = [*loaded_payloads, *force_loaded_skills, *implicit_force_loaded]
+        if not merged_payloads:
             return session
         return SessionState(
             session=session.session,
@@ -1350,7 +1372,7 @@ class VoidCodeRuntime:
             turn=session.turn,
             metadata={
                 **session.metadata,
-                "loaded_skills": loaded_payloads,
+                "loaded_skills": merged_payloads,
             },
         )
 
@@ -1505,15 +1527,12 @@ class VoidCodeRuntime:
             agent=effective_config.agent,
             source="run",
         )
-        frozen_applied_skills = skill_snapshot.applied_skill_payloads
         catalog_skill_context = self._catalog_skill_context(
             skill_registry,
             available_skill_names=tuple(loaded_skill_names),
             selected_skill_names=skill_snapshot.selected_skill_names,
         )
         skill_prompt_context = skill_snapshot.skill_prompt_context
-        if not frozen_applied_skills:
-            skill_prompt_context = catalog_skill_context
         if skills_config is not None and skills_config.enabled is True:
             session = SessionState(
                 session=session.session,
@@ -4762,6 +4781,19 @@ class VoidCodeRuntime:
             "applied_skills": [payload["name"] for payload in snapshot.applied_skill_payloads],
             "skill_snapshot": snapshot_payload(snapshot),
         }
+
+    @staticmethod
+    def _force_loaded_skill_payloads(
+        snapshot: SkillExecutionSnapshot,
+    ) -> tuple[dict[str, object], ...]:
+        return tuple(
+            {
+                "name": payload.get("name"),
+                "source": "force_load",
+                "source_path": payload.get("source_path"),
+            }
+            for payload in snapshot.applied_skill_payloads
+        )
 
     def _skill_snapshot_from_metadata(
         self,

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -1532,7 +1532,7 @@ class VoidCodeRuntime:
             available_skill_names=tuple(loaded_skill_names),
             selected_skill_names=skill_snapshot.selected_skill_names,
         )
-        skill_prompt_context = skill_snapshot.skill_prompt_context
+        skill_prompt_context = skill_snapshot.skill_prompt_context or catalog_skill_context
         if skills_config is not None and skills_config.enabled is True:
             session = SessionState(
                 session=session.session,
@@ -4467,12 +4467,20 @@ class VoidCodeRuntime:
             resolved_provider=effective_config.resolved_provider,
             provider_attempt=provider_attempt,
         )
+        raw_loaded = session_metadata.get("loaded_skills", [])
+        loaded_skills: tuple[dict[str, object], ...] = ()
+        if isinstance(raw_loaded, list):
+            items: list[dict[str, object]] = [
+                dict[str, object](item) for item in raw_loaded if isinstance(item, dict)
+            ]
+            loaded_skills = tuple(items)
         return assemble_provider_context(
             prompt=prompt,
             tool_results=tool_results,
             session_metadata=session_metadata,
             policy=policy or self._default_context_window_policy,
             skill_prompt_context=skill_prompt_context,
+            loaded_skills=loaded_skills,
         )
 
     @staticmethod

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -95,8 +95,10 @@ from .config import (
 )
 from .context_window import (
     ContextWindowPolicy,
+    RuntimeAssembledContext,
     RuntimeContextWindow,
     RuntimeContinuityState,
+    assemble_provider_context,
     prepare_provider_context,
 )
 from .contracts import (
@@ -1564,12 +1566,16 @@ class VoidCodeRuntime:
             session=session,
             prompt=request.prompt,
             available_tools=tool_registry.definitions(),
-            applied_skills=frozen_applied_skills,
-            skill_prompt_context=skill_prompt_context,
             context_window=self._prepare_provider_context_window(
                 prompt=request.prompt,
                 tool_results=(),
                 session_metadata=session.metadata,
+            ),
+            assembled_context=self._assemble_provider_context(
+                prompt=request.prompt,
+                tool_results=(),
+                session_metadata=session.metadata,
+                skill_prompt_context=skill_prompt_context,
             ),
             metadata={
                 **request_metadata,
@@ -4420,6 +4426,34 @@ class VoidCodeRuntime:
             tool_results=tool_results,
             session_metadata=session_metadata,
             policy=policy or self._default_context_window_policy,
+        )
+
+    def _assemble_provider_context(
+        self,
+        *,
+        prompt: str,
+        tool_results: tuple[ToolResult, ...],
+        session_metadata: dict[str, object],
+        skill_prompt_context: str = "",
+    ) -> RuntimeAssembledContext:
+        effective_config = self._effective_runtime_config_from_metadata(session_metadata)
+        provider_attempt = self._provider_attempt_from_metadata(session_metadata)
+        policy = self._context_window_policy_from_config(
+            effective_config.context_window,
+            resolved_provider=None,
+            provider_attempt=provider_attempt,
+        )
+        policy = self._context_window_policy_for_provider_attempt(
+            policy,
+            resolved_provider=effective_config.resolved_provider,
+            provider_attempt=provider_attempt,
+        )
+        return assemble_provider_context(
+            prompt=prompt,
+            tool_results=tool_results,
+            session_metadata=session_metadata,
+            policy=policy or self._default_context_window_policy,
+            skill_prompt_context=skill_prompt_context,
         )
 
     @staticmethod

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Literal, cast, final
 
 from ..acp import AcpDelegatedExecution, AcpEventEnvelope, AcpRequestEnvelope, AcpResponseEnvelope
 from ..agent import get_builtin_agent_manifest, list_builtin_agent_manifests
+from ..agent.prompts import render_agent_prompt
 from ..command import (
     COMMAND_RESOLVED,
     is_prompt_command,
@@ -4454,6 +4455,7 @@ class VoidCodeRuntime:
         tool_results: tuple[ToolResult, ...],
         session_metadata: dict[str, object],
         skill_prompt_context: str = "",
+        preserved_system_segments: tuple[str, ...] = (),
     ) -> RuntimeAssembledContext:
         effective_config = self._effective_runtime_config_from_metadata(session_metadata)
         provider_attempt = self._provider_attempt_from_metadata(session_metadata)
@@ -4479,12 +4481,22 @@ class VoidCodeRuntime:
                             entry[k] = v
                     typed.append(entry)
             loaded_skills = tuple(typed)
+        raw_agent_preset = session_metadata.get("agent_preset")
+        agent_preset = (
+            cast(dict[str, object], raw_agent_preset)
+            if isinstance(raw_agent_preset, dict)
+            else None
+        )
+        model_family = effective_config.resolved_provider.active_target.selection.provider
+        agent_prompt_context = render_agent_prompt(agent_preset, model_family=model_family) or ""
         return assemble_provider_context(
             prompt=prompt,
             tool_results=tool_results,
             session_metadata=session_metadata,
             policy=policy or self._default_context_window_policy,
+            agent_prompt_context=agent_prompt_context,
             skill_prompt_context=skill_prompt_context,
+            preserved_system_segments=preserved_system_segments,
             loaded_skills=loaded_skills,
             preserved_continuity_state=self._continuity_state_from_session_metadata(
                 session_metadata

--- a/tests/unit/agent/test_builtin.py
+++ b/tests/unit/agent/test_builtin.py
@@ -199,7 +199,6 @@ def test_agent_manifest_exposes_live_default_vs_intent_field_semantics() -> None
         "execution_engine",
         "model_preference",
         "tool_allowlist",
-        "skill_refs",
         "top_level_selectable",
         "prompt_materialization",
     )

--- a/tests/unit/graph/test_read_only_graph.py
+++ b/tests/unit/graph/test_read_only_graph.py
@@ -4,14 +4,23 @@ import pytest
 
 from voidcode.graph import GraphRunRequest
 from voidcode.graph.deterministic_graph import DeterministicGraph
+from voidcode.runtime.context_window import RuntimeAssembledContext, RuntimeContextSegment
 from voidcode.runtime.session import SessionRef, SessionState
 from voidcode.tools.contracts import ToolDefinition, ToolResult
 
 
 def _request(prompt: str) -> GraphRunRequest:
+    assembled = RuntimeAssembledContext(
+        prompt=prompt,
+        tool_results=(),
+        continuity_state=None,
+        segments=(RuntimeContextSegment(role="user", content=prompt),),
+        metadata={},
+    )
     return GraphRunRequest(
         session=SessionState(session=SessionRef(id="graph-session"), status="running", turn=1),
         prompt=prompt,
+        assembled_context=assembled,
         available_tools=(
             ToolDefinition(name="read_file", description="Read file", read_only=True),
             ToolDefinition(name="grep", description="Grep files", read_only=True),

--- a/tests/unit/graph/test_single_agent_slice.py
+++ b/tests/unit/graph/test_single_agent_slice.py
@@ -470,6 +470,9 @@ def test_provider_provider_graph_rejects_nonstream_missing_terminal_outcome() ->
                 prompt="read sample.txt",
                 available_tools=_tool_definitions(),
                 context_window=RuntimeContextWindow(prompt="read sample.txt"),
+                assembled_context=_assembled_from_context_window(
+                    RuntimeContextWindow(prompt="read sample.txt")
+                ),
             ),
             tool_results=(),
             session=_session(),
@@ -524,6 +527,9 @@ def test_provider_provider_graph_preserves_stream_error_details() -> None:
                 prompt="read sample.txt",
                 available_tools=_tool_definitions(),
                 context_window=RuntimeContextWindow(prompt="read sample.txt"),
+                assembled_context=_assembled_from_context_window(
+                    RuntimeContextWindow(prompt="read sample.txt")
+                ),
                 metadata={"provider_stream": True},
             ),
             tool_results=(),
@@ -590,6 +596,9 @@ def test_provider_provider_graph_prefers_parsed_stream_error_kind_over_generic_t
                 prompt="read sample.txt",
                 available_tools=_tool_definitions(),
                 context_window=RuntimeContextWindow(prompt="read sample.txt"),
+                assembled_context=_assembled_from_context_window(
+                    RuntimeContextWindow(prompt="read sample.txt")
+                ),
                 metadata={"provider_stream": True},
             ),
             tool_results=(),
@@ -643,6 +652,9 @@ def test_provider_provider_graph_preserves_explicit_stream_error_kind(
                 prompt="read sample.txt",
                 available_tools=_tool_definitions(),
                 context_window=RuntimeContextWindow(prompt="read sample.txt"),
+                assembled_context=_assembled_from_context_window(
+                    RuntimeContextWindow(prompt="read sample.txt")
+                ),
                 metadata={"provider_stream": True},
             ),
             tool_results=(),
@@ -720,6 +732,9 @@ def test_provider_provider_graph_forwards_agent_preset_to_provider() -> None:
             prompt="read sample.txt",
             available_tools=_tool_definitions(),
             context_window=RuntimeContextWindow(prompt="read sample.txt"),
+            assembled_context=_assembled_from_context_window(
+                RuntimeContextWindow(prompt="read sample.txt")
+            ),
             metadata={
                 "agent_preset": {
                     "preset": "leader",
@@ -895,6 +910,9 @@ def test_provider_provider_graph_enforces_configured_max_steps() -> None:
                 prompt="read sample.txt",
                 available_tools=_tool_definitions(),
                 context_window=RuntimeContextWindow(prompt="read sample.txt"),
+                assembled_context=_assembled_from_context_window(
+                    RuntimeContextWindow(prompt="read sample.txt")
+                ),
             ),
             tool_results=(
                 ToolResult(
@@ -924,6 +942,9 @@ def test_provider_provider_graph_streams_ordered_events_and_deterministic_output
             prompt="read sample.txt",
             available_tools=_tool_definitions(),
             context_window=RuntimeContextWindow(prompt="read sample.txt"),
+            assembled_context=_assembled_from_context_window(
+                RuntimeContextWindow(prompt="read sample.txt")
+            ),
             metadata={"provider_stream": True},
         ),
         tool_results=(),
@@ -953,6 +974,9 @@ def test_provider_provider_graph_stream_done_without_text_does_not_fallback_prop
             prompt="read sample.txt",
             available_tools=_tool_definitions(),
             context_window=RuntimeContextWindow(prompt="read sample.txt"),
+            assembled_context=_assembled_from_context_window(
+                RuntimeContextWindow(prompt="read sample.txt")
+            ),
             metadata={"provider_stream": True},
         ),
         tool_results=(),
@@ -981,6 +1005,9 @@ def test_provider_provider_graph_returns_streamed_tool_call() -> None:
             prompt="read sample.txt",
             available_tools=_tool_definitions(),
             context_window=RuntimeContextWindow(prompt="read sample.txt"),
+            assembled_context=_assembled_from_context_window(
+                RuntimeContextWindow(prompt="read sample.txt")
+            ),
             metadata={"provider_stream": True},
         ),
         tool_results=(),
@@ -1010,6 +1037,9 @@ def test_provider_provider_graph_prefers_streamed_tool_call_over_text() -> None:
             prompt="read sample.txt",
             available_tools=_tool_definitions(),
             context_window=RuntimeContextWindow(prompt="read sample.txt"),
+            assembled_context=_assembled_from_context_window(
+                RuntimeContextWindow(prompt="read sample.txt")
+            ),
             metadata={"provider_stream": True},
         ),
         tool_results=(),
@@ -1037,6 +1067,9 @@ def test_provider_provider_graph_reconstructs_chunked_streamed_tool_call() -> No
             prompt="read sample.txt",
             available_tools=_tool_definitions(),
             context_window=RuntimeContextWindow(prompt="read sample.txt"),
+            assembled_context=_assembled_from_context_window(
+                RuntimeContextWindow(prompt="read sample.txt")
+            ),
             metadata={"provider_stream": True},
         ),
         tool_results=(),
@@ -1066,6 +1099,9 @@ def test_provider_provider_graph_uses_latest_complete_tool_snapshot() -> None:
             prompt="read sample.txt",
             available_tools=_tool_definitions(),
             context_window=RuntimeContextWindow(prompt="read sample.txt"),
+            assembled_context=_assembled_from_context_window(
+                RuntimeContextWindow(prompt="read sample.txt")
+            ),
             metadata={"provider_stream": True},
         ),
         tool_results=(),
@@ -1096,6 +1132,9 @@ def test_provider_provider_graph_rejects_malformed_streamed_tool_payload() -> No
                 prompt="read sample.txt",
                 available_tools=_tool_definitions(),
                 context_window=RuntimeContextWindow(prompt="read sample.txt"),
+                assembled_context=_assembled_from_context_window(
+                    RuntimeContextWindow(prompt="read sample.txt")
+                ),
                 metadata={"provider_stream": True},
             ),
             tool_results=(),
@@ -1122,6 +1161,9 @@ def test_provider_provider_graph_requires_done_event_for_stream_completion() -> 
                 prompt="read sample.txt",
                 available_tools=_tool_definitions(),
                 context_window=RuntimeContextWindow(prompt="read sample.txt"),
+                assembled_context=_assembled_from_context_window(
+                    RuntimeContextWindow(prompt="read sample.txt")
+                ),
                 metadata={"provider_stream": True},
             ),
             tool_results=(),
@@ -1147,6 +1189,9 @@ def test_provider_provider_graph_prefers_mixed_stream_tool_terminal_output() -> 
             prompt="read sample.txt",
             available_tools=_tool_definitions(),
             context_window=RuntimeContextWindow(prompt="read sample.txt"),
+            assembled_context=_assembled_from_context_window(
+                RuntimeContextWindow(prompt="read sample.txt")
+            ),
             metadata={"provider_stream": True},
         ),
         tool_results=(),
@@ -1175,6 +1220,9 @@ def test_provider_provider_graph_stream_error_maps_to_provider_execution_error()
                 prompt="read sample.txt",
                 available_tools=_tool_definitions(),
                 context_window=RuntimeContextWindow(prompt="read sample.txt"),
+                assembled_context=_assembled_from_context_window(
+                    RuntimeContextWindow(prompt="read sample.txt")
+                ),
                 metadata={"provider_stream": True},
             ),
             tool_results=(),

--- a/tests/unit/graph/test_single_agent_slice.py
+++ b/tests/unit/graph/test_single_agent_slice.py
@@ -9,7 +9,12 @@ from voidcode.graph.provider_graph import ProviderGraph
 from voidcode.provider.protocol import ProviderErrorKind
 from voidcode.provider.registry import ModelProviderRegistry
 from voidcode.provider.resolution import resolve_provider_model
-from voidcode.runtime.context_window import RuntimeContextWindow, RuntimeContinuityState
+from voidcode.runtime.context_window import (
+    RuntimeAssembledContext,
+    RuntimeContextSegment,
+    RuntimeContextWindow,
+    RuntimeContinuityState,
+)
 from voidcode.runtime.provider_protocol import (
     ProviderExecutionError,
     ProviderStreamEvent,
@@ -30,6 +35,46 @@ def _tool_definitions() -> tuple[ToolDefinition, ...]:
 
 def _session() -> SessionState:
     return SessionState(session=SessionRef(id="s1"), status="running", turn=1, metadata={})
+
+
+def _assembled_from_context_window(context_window: RuntimeContextWindow) -> RuntimeAssembledContext:
+    segments: list[RuntimeContextSegment] = [
+        RuntimeContextSegment(role="user", content=context_window.prompt)
+    ]
+    for index, result in enumerate(context_window.tool_results, start=1):
+        tool_call_id = f"test_tool_{index}"
+        segments.append(
+            RuntimeContextSegment(
+                role="assistant",
+                content=None,
+                tool_call_id=tool_call_id,
+                tool_name=result.tool_name,
+                tool_arguments={},
+            )
+        )
+        segments.append(
+            RuntimeContextSegment(
+                role="tool",
+                content=result.content or "",
+                tool_call_id=tool_call_id,
+                tool_name=result.tool_name,
+                metadata={
+                    "status": result.status,
+                    "error": result.error,
+                    "data": result.data,
+                    "truncated": result.truncated,
+                    "partial": result.partial,
+                    "reference": result.reference,
+                },
+            )
+        )
+    return RuntimeAssembledContext(
+        prompt=context_window.prompt,
+        tool_results=context_window.tool_results,
+        continuity_state=context_window.continuity_state,
+        segments=tuple(segments),
+        metadata=context_window.metadata_payload(),
+    )
 
 
 class _CapturingTurnProvider:
@@ -284,12 +329,14 @@ def test_provider_provider_graph_requests_tool_on_first_turn() -> None:
         provider_model=provider_model,
     )
 
+    request_context = RuntimeContextWindow(prompt="read sample.txt")
     step = graph.step(
         request=GraphRunRequest(
             session=_session(),
             prompt="read sample.txt",
             available_tools=_tool_definitions(),
-            context_window=RuntimeContextWindow(prompt="read sample.txt"),
+            context_window=request_context,
+            assembled_context=_assembled_from_context_window(request_context),
         ),
         tool_results=(),
         session=_session(),
@@ -322,22 +369,24 @@ def test_provider_provider_graph_finalizes_after_tool_result() -> None:
         provider_model=provider_model,
     )
 
+    request_context = RuntimeContextWindow(
+        prompt="read sample.txt",
+        tool_results=(
+            ToolResult(
+                tool_name="read_file",
+                content="alpha\n",
+                status="ok",
+                data={"path": "sample.txt", "content": "alpha\n"},
+            ),
+        ),
+    )
     step = graph.step(
         request=GraphRunRequest(
             session=_session(),
             prompt="read sample.txt",
             available_tools=_tool_definitions(),
-            context_window=RuntimeContextWindow(
-                prompt="read sample.txt",
-                tool_results=(
-                    ToolResult(
-                        tool_name="read_file",
-                        content="alpha\n",
-                        status="ok",
-                        data={"path": "sample.txt", "content": "alpha\n"},
-                    ),
-                ),
-            ),
+            context_window=request_context,
+            assembled_context=_assembled_from_context_window(request_context),
         ),
         tool_results=(
             ToolResult(
@@ -383,12 +432,14 @@ def test_provider_provider_graph_prefers_nonstream_tool_call_over_text() -> None
         provider_model=provider_model,
     )
 
+    request_context = RuntimeContextWindow(prompt="read sample.txt")
     step = graph.step(
         request=GraphRunRequest(
             session=_session(),
             prompt="read sample.txt",
             available_tools=_tool_definitions(),
-            context_window=RuntimeContextWindow(prompt="read sample.txt"),
+            context_window=request_context,
+            assembled_context=_assembled_from_context_window(request_context),
         ),
         tool_results=(),
         session=_session(),
@@ -615,39 +666,44 @@ def test_provider_provider_graph_passes_applied_skill_context_to_provider() -> N
             prompt="read sample.txt",
             available_tools=_tool_definitions(),
             context_window=RuntimeContextWindow(prompt="read sample.txt"),
-            applied_skills=(
-                {
-                    "name": "summarize",
-                    "description": "Summarize selected files.",
-                    "content": "# Summarize\nUse concise bullet points.",
-                    "prompt_context": (
-                        "Skill: summarize\n"
-                        "Description: Summarize selected files.\n"
-                        "Instructions:\n# Summarize\nUse concise bullet points."
+            assembled_context=RuntimeAssembledContext(
+                prompt="read sample.txt",
+                tool_results=(),
+                continuity_state=None,
+                segments=(
+                    RuntimeContextSegment(
+                        role="system", content="Runtime-managed skills are active."
                     ),
-                },
+                    RuntimeContextSegment(role="user", content="read sample.txt"),
+                ),
+                metadata={},
             ),
-            skill_prompt_context="Runtime-managed skills are active.",
+            metadata={
+                "applied_skills": [
+                    {
+                        "name": "summarize",
+                        "description": "Summarize selected files.",
+                        "content": "# Summarize\nUse concise bullet points.",
+                        "prompt_context": (
+                            "Skill: summarize\n"
+                            "Description: Summarize selected files.\n"
+                            "Instructions:\n# Summarize\nUse concise bullet points."
+                        ),
+                    }
+                ],
+            },
         ),
         tool_results=(),
         session=_session(),
     )
 
     assert step.output == "done"
-    assert provider.requests[0].applied_skills == (
-        {
-            "name": "summarize",
-            "description": "Summarize selected files.",
-            "content": "# Summarize\nUse concise bullet points.",
-            "prompt_context": (
-                "Skill: summarize\n"
-                "Description: Summarize selected files.\n"
-                "Instructions:\n# Summarize\nUse concise bullet points."
-            ),
-        },
+    assert provider.requests[0].assembled_context is not None
+    assert provider.requests[0].assembled_context.prompt == "read sample.txt"
+    assert provider.requests[0].assembled_context.segments[0].role == "system"
+    assert provider.requests[0].assembled_context.segments[0].content == (
+        "Runtime-managed skills are active."
     )
-    assert provider.requests[0].skill_prompt_context == "Runtime-managed skills are active."
-    assert provider.requests[0].context_window.prompt == "read sample.txt"
 
 
 def test_provider_provider_graph_forwards_agent_preset_to_provider() -> None:
@@ -726,6 +782,7 @@ def test_provider_provider_graph_forwards_bounded_context_window_to_provider() -
             prompt="read sample.txt",
             available_tools=_tool_definitions(),
             context_window=bounded_context,
+            assembled_context=_assembled_from_context_window(bounded_context),
         ),
         tool_results=(
             ToolResult(
@@ -738,10 +795,9 @@ def test_provider_provider_graph_forwards_bounded_context_window_to_provider() -
         session=_session(),
     )
 
-    assert provider.requests[0].context_window is bounded_context
-    assert provider.requests[0].context_window.compacted is True
-    assert provider.requests[0].context_window.retained_tool_result_count == 1
-    assert provider.requests[0].context_window.continuity_state == RuntimeContinuityState(
+    assert provider.requests[0].assembled_context is not None
+    assert provider.requests[0].assembled_context.tool_results == bounded_context.tool_results
+    assert provider.requests[0].assembled_context.continuity_state == RuntimeContinuityState(
         summary_text=(
             "Compacted 2 earlier tool results:\n"
             '1. read_file ok path=sample.txt content_preview="old\\n"\n'
@@ -767,22 +823,24 @@ def test_provider_graph_forwards_explicit_lsp_tool_feedback_to_provider() -> Non
         data={"operation": "definition", "response": {"uri": "file:///workspace/main.py"}},
     )
 
+    request_context = RuntimeContextWindow(
+        prompt="use lsp feedback",
+        tool_results=(lsp_result,),
+    )
     _ = graph.step(
         request=GraphRunRequest(
             session=_session(),
             prompt="use lsp feedback",
             available_tools=_tool_definitions(),
-            context_window=RuntimeContextWindow(
-                prompt="use lsp feedback",
-                tool_results=(lsp_result,),
-            ),
+            context_window=request_context,
+            assembled_context=_assembled_from_context_window(request_context),
         ),
         tool_results=(lsp_result,),
         session=_session(),
     )
 
-    assert provider.requests[0].tool_results == (lsp_result,)
-    assert provider.requests[0].context_window.tool_results == (lsp_result,)
+    assert provider.requests[0].assembled_context is not None
+    assert provider.requests[0].assembled_context.tool_results == (lsp_result,)
 
 
 def test_provider_graph_forwards_mcp_tool_feedback_to_provider() -> None:
@@ -799,22 +857,24 @@ def test_provider_graph_forwards_mcp_tool_feedback_to_provider() -> None:
         data={"server": "echo", "tool": "echo", "is_error": False},
     )
 
+    request_context = RuntimeContextWindow(
+        prompt="use mcp feedback",
+        tool_results=(mcp_result,),
+    )
     _ = graph.step(
         request=GraphRunRequest(
             session=_session(),
             prompt="use mcp feedback",
             available_tools=_tool_definitions(),
-            context_window=RuntimeContextWindow(
-                prompt="use mcp feedback",
-                tool_results=(mcp_result,),
-            ),
+            context_window=request_context,
+            assembled_context=_assembled_from_context_window(request_context),
         ),
         tool_results=(mcp_result,),
         session=_session(),
     )
 
-    assert provider.requests[0].tool_results == (mcp_result,)
-    assert provider.requests[0].context_window.tool_results == (mcp_result,)
+    assert provider.requests[0].assembled_context is not None
+    assert provider.requests[0].assembled_context.tool_results == (mcp_result,)
 
 
 def test_provider_provider_graph_enforces_configured_max_steps() -> None:

--- a/tests/unit/provider/test_provider_adapters.py
+++ b/tests/unit/provider/test_provider_adapters.py
@@ -51,6 +51,25 @@ class _StubContextWindow:
         return self._continuity_state
 
 
+@dataclass(frozen=True, slots=True)
+class _StubSegment:
+    role: str
+    content: str | None
+    tool_call_id: str | None = None
+    tool_name: str | None = None
+    tool_arguments: dict[str, object] | None = None
+    metadata: dict[str, object] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _StubAssembledContext:
+    prompt: str
+    tool_results: tuple[ToolResult, ...]
+    continuity_state: object | None
+    segments: tuple[_StubSegment, ...]
+    metadata: dict[str, object]
+
+
 def _build_turn_request(*, model_name: str) -> ProviderTurnRequest:
     tool_results: tuple[ToolResult, ...] = ()
     return ProviderTurnRequest(
@@ -1223,72 +1242,7 @@ def test_opencode_go_provider_sanitizes_user_tool_feedback(
     assert '"data_uri": {"byte_count"' in feedback
 
 
-@pytest.mark.parametrize(
-    ("agent_preset", "expected_fragment"),
-    [
-        (
-            {
-                "preset": "leader",
-                "prompt_profile": "leader",
-                "prompt_materialization": _prompt_materialization_payload("leader"),
-                "model": "openai/demo",
-                "execution_engine": "provider",
-            },
-            "VoidCode's leader agent",
-        ),
-        (
-            {
-                "preset": "worker",
-                "prompt_profile": "worker",
-                "prompt_materialization": _prompt_materialization_payload("worker"),
-                "model": "openai/demo",
-                "execution_engine": "provider",
-            },
-            "VoidCode's worker agent",
-        ),
-    ],
-)
-def test_provider_adapter_materializes_builtin_agent_prompt_profiles(
-    monkeypatch: pytest.MonkeyPatch,
-    agent_preset: dict[str, object],
-    expected_fragment: str,
-) -> None:
-    provider = OpenAIModelProvider()
-    provider = provider.turn_provider()
-    request = _build_turn_request(model_name="openai")
-    request = ProviderTurnRequest(
-        prompt=request.prompt,
-        available_tools=request.available_tools,
-        tool_results=request.tool_results,
-        context_window=request.context_window,
-        applied_skills=request.applied_skills,
-        raw_model=request.raw_model,
-        provider_name=request.provider_name,
-        model_name=request.model_name,
-        agent_preset=agent_preset,
-        attempt=request.attempt,
-        abort_signal=request.abort_signal,
-    )
-    _patch_litellm_completion(
-        monkeypatch,
-        mode="completion",
-        completion_content="hello world",
-    )
-
-    _ = provider.propose_turn(request)
-
-    payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
-    assert isinstance(payload_obj, dict)
-    payload = cast(dict[str, object], payload_obj)
-    messages_obj = payload.get("messages")
-    assert isinstance(messages_obj, list)
-    messages = cast(list[dict[str, str]], messages_obj)
-    assert messages[0]["role"] == "system"
-    assert expected_fragment in messages[0]["content"]
-    assert messages[1] == {"role": "user", "content": "read sample.txt"}
-
-
-def test_provider_adapter_applies_serialized_model_family_prompt_override(
+def test_provider_adapter_uses_runtime_assembled_context_for_agent_system_message(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     provider = OpenAIModelProvider()
@@ -1303,16 +1257,16 @@ def test_provider_adapter_applies_serialized_model_family_prompt_override(
         raw_model=request.raw_model,
         provider_name=request.provider_name,
         model_name=request.model_name,
-        agent_preset={
-            "preset": "leader",
-            "prompt_profile": "leader",
-            "prompt_materialization": _prompt_materialization_payload(
-                "leader",
-                model_family_overrides={"openai": "worker"},
+        assembled_context=_StubAssembledContext(
+            prompt="read sample.txt",
+            tool_results=(),
+            continuity_state=None,
+            segments=(
+                _StubSegment(role="system", content="Runtime agent system prompt."),
+                _StubSegment(role="user", content="read sample.txt"),
             ),
-            "model": "openai/demo",
-            "execution_engine": "provider",
-        },
+            metadata={},
+        ),
         attempt=request.attempt,
         abort_signal=request.abort_signal,
     )
@@ -1331,11 +1285,11 @@ def test_provider_adapter_applies_serialized_model_family_prompt_override(
     assert isinstance(messages_obj, list)
     messages = cast(list[dict[str, str]], messages_obj)
     assert messages[0]["role"] == "system"
-    assert "VoidCode's worker agent" in messages[0]["content"]
+    assert messages[0]["content"] == "Runtime agent system prompt."
     assert messages[1] == {"role": "user", "content": "read sample.txt"}
 
 
-def test_provider_adapter_preserves_serialized_prompt_profile_override(
+def test_provider_adapter_uses_runtime_assembled_context_for_model_family_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     provider = OpenAIModelProvider()
@@ -1350,13 +1304,16 @@ def test_provider_adapter_preserves_serialized_prompt_profile_override(
         raw_model=request.raw_model,
         provider_name=request.provider_name,
         model_name=request.model_name,
-        agent_preset={
-            "preset": "leader",
-            "prompt_profile": "researcher",
-            "prompt_materialization": _prompt_materialization_payload("researcher"),
-            "model": "openai/demo",
-            "execution_engine": "provider",
-        },
+        assembled_context=_StubAssembledContext(
+            prompt="read sample.txt",
+            tool_results=(),
+            continuity_state=None,
+            segments=(
+                _StubSegment(role="system", content="Runtime model-family override prompt."),
+                _StubSegment(role="user", content="read sample.txt"),
+            ),
+            metadata={},
+        ),
         attempt=request.attempt,
         abort_signal=request.abort_signal,
     )
@@ -1375,11 +1332,11 @@ def test_provider_adapter_preserves_serialized_prompt_profile_override(
     assert isinstance(messages_obj, list)
     messages = cast(list[dict[str, str]], messages_obj)
     assert messages[0]["role"] == "system"
-    assert "VoidCode's researcher agent" in messages[0]["content"]
+    assert messages[0]["content"] == "Runtime model-family override prompt."
     assert messages[1] == {"role": "user", "content": "read sample.txt"}
 
 
-def test_provider_adapter_falls_back_for_unknown_agent_prompt_profile(
+def test_provider_adapter_uses_runtime_assembled_context_for_prompt_profile_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     provider = OpenAIModelProvider()
@@ -1394,12 +1351,63 @@ def test_provider_adapter_falls_back_for_unknown_agent_prompt_profile(
         raw_model=request.raw_model,
         provider_name=request.provider_name,
         model_name=request.model_name,
-        agent_preset={
-            "preset": "leader",
-            "prompt_profile": "custom-review",
-            "model": "openai/demo",
-            "execution_engine": "provider",
-        },
+        assembled_context=_StubAssembledContext(
+            prompt="read sample.txt",
+            tool_results=(),
+            continuity_state=None,
+            segments=(
+                _StubSegment(role="system", content="Runtime prompt-profile message."),
+                _StubSegment(role="user", content="read sample.txt"),
+            ),
+            metadata={},
+        ),
+        attempt=request.attempt,
+        abort_signal=request.abort_signal,
+    )
+    _patch_litellm_completion(
+        monkeypatch,
+        mode="completion",
+        completion_content="hello world",
+    )
+
+    _ = provider.propose_turn(request)
+
+    payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
+    assert isinstance(payload_obj, dict)
+    payload = cast(dict[str, object], payload_obj)
+    messages_obj = payload.get("messages")
+    assert isinstance(messages_obj, list)
+    messages = cast(list[dict[str, str]], messages_obj)
+    assert messages[0]["role"] == "system"
+    assert messages[0]["content"] == "Runtime prompt-profile message."
+    assert messages[1] == {"role": "user", "content": "read sample.txt"}
+
+
+def test_provider_adapter_uses_runtime_assembled_context_for_unknown_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = OpenAIModelProvider()
+    provider = provider.turn_provider()
+    request = _build_turn_request(model_name="openai")
+    request = ProviderTurnRequest(
+        prompt=request.prompt,
+        available_tools=request.available_tools,
+        tool_results=request.tool_results,
+        context_window=request.context_window,
+        applied_skills=request.applied_skills,
+        raw_model=request.raw_model,
+        provider_name=request.provider_name,
+        model_name=request.model_name,
+        assembled_context=_StubAssembledContext(
+            prompt="read sample.txt",
+            tool_results=(),
+            continuity_state=None,
+            segments=(
+                _StubSegment(role="system", content="Runtime custom-review prompt."),
+                _StubSegment(role="user", content="read sample.txt"),
+            ),
+            metadata={},
+        ),
         attempt=request.attempt,
         abort_signal=request.abort_signal,
     )
@@ -1419,11 +1427,7 @@ def test_provider_adapter_falls_back_for_unknown_agent_prompt_profile(
     messages = cast(list[dict[str, str]], messages_obj)
     assert messages[0] == {
         "role": "system",
-        "content": (
-            "Runtime-selected VoidCode agent prompt profile: custom-review. "
-            "Treat this as the active agent role profile for this single-agent turn while "
-            "still following the runtime-provided tool and skill boundaries."
-        ),
+        "content": "Runtime custom-review prompt.",
     }
 
 

--- a/tests/unit/provider/test_provider_adapters.py
+++ b/tests/unit/provider/test_provider_adapters.py
@@ -70,16 +70,102 @@ class _StubAssembledContext:
     metadata: dict[str, object]
 
 
+def _assembled_from_legacy(
+    *,
+    prompt: str,
+    tool_results: tuple[ToolResult, ...],
+    context_window: _StubContextWindow,
+    applied_skills: tuple[dict[str, str], ...],
+    skill_prompt_context: str = "",
+) -> _StubAssembledContext:
+    continuity_state = context_window.continuity_state
+    segments: list[_StubSegment] = []
+    skill_message = skill_prompt_context.strip()
+    if not skill_message and applied_skills:
+        rendered_skills: list[str] = []
+        for skill in applied_skills:
+            name = skill.get("name", "").strip() or "unnamed-skill"
+            description = skill.get("description", "").strip()
+            content = skill.get("prompt_context", "").strip() or skill.get("content", "").strip()
+            lines = [f"## {name}"]
+            if description:
+                lines.append(f"Description: {description}")
+            if content:
+                lines.append(content)
+            rendered_skills.append("\n".join(lines))
+        if rendered_skills:
+            skill_message = (
+                "You must apply the following runtime-managed skills for this turn. "
+                "Treat them as active task instructions in addition to the user's request.\n\n"
+                + "\n\n".join(rendered_skills)
+            )
+    if skill_message:
+        segments.append(_StubSegment(role="system", content=skill_message))
+    if continuity_state is not None:
+        summary_text = getattr(continuity_state, "summary_text", None)
+        if isinstance(summary_text, str) and summary_text.strip():
+            segments.append(
+                _StubSegment(
+                    role="system",
+                    content=f"Runtime continuity summary:\n{summary_text.strip()}",
+                )
+            )
+    segments.append(_StubSegment(role="user", content=prompt))
+    for index, result in enumerate(tool_results, start=1):
+        raw_tool_call_id = result.data.get("tool_call_id")
+        tool_call_id = (
+            raw_tool_call_id
+            if isinstance(raw_tool_call_id, str) and raw_tool_call_id.strip()
+            else f"voidcode_tool_{index}"
+        )
+        raw_arguments = result.data.get("arguments")
+        tool_arguments = raw_arguments if isinstance(raw_arguments, dict) else {}
+        segments.append(
+            _StubSegment(
+                role="assistant",
+                content=None,
+                tool_call_id=tool_call_id,
+                tool_name=result.tool_name,
+                tool_arguments=tool_arguments,
+            )
+        )
+        segments.append(
+            _StubSegment(
+                role="tool",
+                content=result.content or "",
+                tool_call_id=tool_call_id,
+                tool_name=result.tool_name,
+                metadata={
+                    "status": result.status,
+                    "error": result.error,
+                    "data": result.data,
+                    "truncated": result.truncated,
+                    "partial": result.partial,
+                    "reference": result.reference,
+                },
+            )
+        )
+    return _StubAssembledContext(
+        prompt=prompt,
+        tool_results=tool_results,
+        continuity_state=continuity_state,
+        segments=tuple(segments),
+        metadata={},
+    )
+
+
 def _build_turn_request(*, model_name: str) -> ProviderTurnRequest:
     tool_results: tuple[ToolResult, ...] = ()
     return ProviderTurnRequest(
-        prompt="read sample.txt",
+        assembled_context=_assembled_from_legacy(
+            prompt="read sample.txt",
+            tool_results=tool_results,
+            context_window=_StubContextWindow(prompt="read sample.txt", tool_results=tool_results),
+            applied_skills=(),
+        ),
         available_tools=(
             ToolDefinition(name="read_file", description="read file", read_only=True),
         ),
-        tool_results=tool_results,
-        context_window=_StubContextWindow(prompt="read sample.txt", tool_results=tool_results),
-        applied_skills=(),
         raw_model=f"{model_name}/demo",
         provider_name=model_name,
         model_name="demo",
@@ -107,18 +193,22 @@ def _prompt_materialization_payload(
 def _build_turn_request_with_skill(*, model_name: str) -> ProviderTurnRequest:
     tool_results: tuple[ToolResult, ...] = ()
     return ProviderTurnRequest(
-        prompt="summarize sample.txt",
+        assembled_context=_assembled_from_legacy(
+            prompt="summarize sample.txt",
+            tool_results=tool_results,
+            context_window=_StubContextWindow(
+                prompt="summarize sample.txt", tool_results=tool_results
+            ),
+            applied_skills=(
+                {
+                    "name": "summarize",
+                    "description": "Summarize selected files.",
+                    "content": "# Summarize\nUse concise bullet points.",
+                },
+            ),
+        ),
         available_tools=(
             ToolDefinition(name="read_file", description="read file", read_only=True),
-        ),
-        tool_results=tool_results,
-        context_window=_StubContextWindow(prompt="summarize sample.txt", tool_results=tool_results),
-        applied_skills=(
-            {
-                "name": "summarize",
-                "description": "Summarize selected files.",
-                "content": "# Summarize\nUse concise bullet points.",
-            },
         ),
         raw_model=f"{model_name}/demo",
         provider_name=model_name,
@@ -131,25 +221,27 @@ def _build_turn_request_with_skill(*, model_name: str) -> ProviderTurnRequest:
 def _build_turn_request_with_continuity(*, model_name: str) -> ProviderTurnRequest:
     tool_results: tuple[ToolResult, ...] = ()
     return ProviderTurnRequest(
-        prompt="summarize sample.txt",
+        assembled_context=_assembled_from_legacy(
+            prompt="summarize sample.txt",
+            tool_results=tool_results,
+            context_window=_StubContextWindow(
+                prompt="summarize sample.txt",
+                tool_results=tool_results,
+                compacted=True,
+                retained_tool_result_count=1,
+                _continuity_state=_StubContinuityState(
+                    summary_text=(
+                        "Compacted 2 earlier tool results:\n"
+                        '1. read_file ok path=sample.txt content_preview="old"\n'
+                        '2. read_file ok path=sample.txt content_preview="older"'
+                    )
+                ),
+            ),
+            applied_skills=(),
+        ),
         available_tools=(
             ToolDefinition(name="read_file", description="read file", read_only=True),
         ),
-        tool_results=tool_results,
-        context_window=_StubContextWindow(
-            prompt="summarize sample.txt",
-            tool_results=tool_results,
-            compacted=True,
-            retained_tool_result_count=1,
-            _continuity_state=_StubContinuityState(
-                summary_text=(
-                    "Compacted 2 earlier tool results:\n"
-                    '1. read_file ok path=sample.txt content_preview="old"\n'
-                    '2. read_file ok path=sample.txt content_preview="older"'
-                )
-            ),
-        ),
-        applied_skills=(),
         raw_model=f"{model_name}/demo",
         provider_name=model_name,
         model_name="demo",
@@ -345,7 +437,12 @@ def test_provider_adapter_wraps_internal_tool_property_schema(
     provider = OpenAIModelProvider().turn_provider()
     request = _build_turn_request(model_name="openai")
     request = ProviderTurnRequest(
-        prompt=request.prompt,
+        assembled_context=_assembled_from_legacy(
+            prompt=request.prompt,
+            tool_results=request.tool_results,
+            context_window=request.context_window,
+            applied_skills=request.applied_skills,
+        ),
         available_tools=(
             ToolDefinition(
                 name="write_file",
@@ -357,9 +454,6 @@ def test_provider_adapter_wraps_internal_tool_property_schema(
                 read_only=False,
             ),
         ),
-        tool_results=request.tool_results,
-        context_window=request.context_window,
-        applied_skills=request.applied_skills,
         raw_model=request.raw_model,
         provider_name=request.provider_name,
         model_name=request.model_name,
@@ -397,7 +491,12 @@ def test_provider_adapter_wraps_property_schema_with_description_argument(
     provider = OpenAIModelProvider().turn_provider()
     request = _build_turn_request(model_name="openai")
     request = ProviderTurnRequest(
-        prompt=request.prompt,
+        assembled_context=_assembled_from_legacy(
+            prompt=request.prompt,
+            tool_results=request.tool_results,
+            context_window=request.context_window,
+            applied_skills=request.applied_skills,
+        ),
         available_tools=(
             ToolDefinition(
                 name="demo_tool",
@@ -406,9 +505,6 @@ def test_provider_adapter_wraps_property_schema_with_description_argument(
                 read_only=True,
             ),
         ),
-        tool_results=request.tool_results,
-        context_window=request.context_window,
-        applied_skills=request.applied_skills,
         raw_model=request.raw_model,
         provider_name=request.provider_name,
         model_name=request.model_name,
@@ -443,11 +539,13 @@ def test_provider_adapter_wraps_task_tool_description_argument(
     provider = OpenAIModelProvider().turn_provider()
     request = _build_turn_request(model_name="openai")
     request = ProviderTurnRequest(
-        prompt=request.prompt,
+        assembled_context=_assembled_from_legacy(
+            prompt=request.prompt,
+            tool_results=request.tool_results,
+            context_window=request.context_window,
+            applied_skills=request.applied_skills,
+        ),
         available_tools=(TaskTool.definition,),
-        tool_results=request.tool_results,
-        context_window=request.context_window,
-        applied_skills=request.applied_skills,
         raw_model=request.raw_model,
         provider_name=request.provider_name,
         model_name=request.model_name,
@@ -488,7 +586,12 @@ def test_provider_adapter_preserves_object_schema_without_explicit_type(
     provider = OpenAIModelProvider().turn_provider()
     request = _build_turn_request(model_name="openai")
     request = ProviderTurnRequest(
-        prompt=request.prompt,
+        assembled_context=_assembled_from_legacy(
+            prompt=request.prompt,
+            tool_results=request.tool_results,
+            context_window=request.context_window,
+            applied_skills=request.applied_skills,
+        ),
         available_tools=(
             ToolDefinition(
                 name="mcp_search",
@@ -503,9 +606,6 @@ def test_provider_adapter_preserves_object_schema_without_explicit_type(
                 read_only=True,
             ),
         ),
-        tool_results=request.tool_results,
-        context_window=request.context_window,
-        applied_skills=request.applied_skills,
         raw_model=request.raw_model,
         provider_name=request.provider_name,
         model_name=request.model_name,
@@ -720,15 +820,19 @@ def test_provider_adapter_prefers_runtime_skill_prompt_context(
     provider = provider.turn_provider()
     request = _build_turn_request_with_skill(model_name="openai")
     request = ProviderTurnRequest(
-        prompt=request.prompt,
+        assembled_context=_assembled_from_legacy(
+            prompt=request.prompt,
+            tool_results=request.tool_results,
+            context_window=request.context_window,
+            applied_skills=(),
+            skill_prompt_context=(
+                "Runtime skill context\n\nSkill: summarize\nInstructions:\nBe brief."
+            ),
+        ),
         available_tools=request.available_tools,
-        tool_results=request.tool_results,
-        context_window=request.context_window,
-        applied_skills=request.applied_skills,
         raw_model=request.raw_model,
         provider_name=request.provider_name,
         model_name=request.model_name,
-        skill_prompt_context="Runtime skill context\n\nSkill: summarize\nInstructions:\nBe brief.",
         attempt=request.attempt,
         abort_signal=request.abort_signal,
     )
@@ -806,15 +910,17 @@ def test_provider_adapter_omits_continuity_message_without_summary_text(
     provider = provider.turn_provider()
     request = _build_turn_request(model_name="openai")
     request = ProviderTurnRequest(
-        prompt=request.prompt,
-        available_tools=request.available_tools,
-        tool_results=request.tool_results,
-        context_window=_StubContextWindow(
-            prompt=request.context_window.prompt,
-            tool_results=request.context_window.tool_results,
-            _continuity_state=_StubContinuityState(summary_text="   "),
+        assembled_context=_assembled_from_legacy(
+            prompt=request.prompt,
+            tool_results=request.tool_results,
+            context_window=_StubContextWindow(
+                prompt=request.context_window.prompt,
+                tool_results=request.context_window.tool_results,
+                _continuity_state=_StubContinuityState(summary_text="   "),
+            ),
+            applied_skills=request.applied_skills,
         ),
-        applied_skills=request.applied_skills,
+        available_tools=request.available_tools,
         raw_model=request.raw_model,
         provider_name=request.provider_name,
         model_name=request.model_name,
@@ -845,14 +951,16 @@ def test_provider_adapter_includes_tool_result_context(
     request = _build_turn_request(model_name="openai")
     tool_results = (ToolResult(tool_name="read_file", status="ok", content="hello world"),)
     request = ProviderTurnRequest(
-        prompt=request.prompt,
-        available_tools=request.available_tools,
-        tool_results=tool_results,
-        context_window=_StubContextWindow(
-            prompt=request.context_window.prompt,
+        assembled_context=_assembled_from_legacy(
+            prompt=request.prompt,
             tool_results=tool_results,
+            context_window=_StubContextWindow(
+                prompt=request.context_window.prompt,
+                tool_results=tool_results,
+            ),
+            applied_skills=request.applied_skills,
         ),
-        applied_skills=request.applied_skills,
+        available_tools=request.available_tools,
         raw_model=request.raw_model,
         provider_name=request.provider_name,
         model_name=request.model_name,
@@ -920,14 +1028,16 @@ def test_provider_adapter_includes_truncated_tool_reference_without_full_output(
         ),
     )
     request = ProviderTurnRequest(
-        prompt=request.prompt,
-        available_tools=request.available_tools,
-        tool_results=tool_results,
-        context_window=_StubContextWindow(
-            prompt=request.context_window.prompt,
+        assembled_context=_assembled_from_legacy(
+            prompt=request.prompt,
             tool_results=tool_results,
+            context_window=_StubContextWindow(
+                prompt=request.context_window.prompt,
+                tool_results=tool_results,
+            ),
+            applied_skills=request.applied_skills,
         ),
-        applied_skills=request.applied_skills,
+        available_tools=request.available_tools,
         raw_model=request.raw_model,
         provider_name=request.provider_name,
         model_name=request.model_name,
@@ -975,14 +1085,16 @@ def test_provider_adapter_sanitizes_tool_arguments_and_inline_blobs(
         ),
     )
     request = ProviderTurnRequest(
-        prompt=request.prompt,
-        available_tools=request.available_tools,
-        tool_results=tool_results,
-        context_window=_StubContextWindow(
-            prompt=request.context_window.prompt,
+        assembled_context=_assembled_from_legacy(
+            prompt=request.prompt,
             tool_results=tool_results,
+            context_window=_StubContextWindow(
+                prompt=request.context_window.prompt,
+                tool_results=tool_results,
+            ),
+            applied_skills=request.applied_skills,
         ),
-        applied_skills=request.applied_skills,
+        available_tools=request.available_tools,
         raw_model=request.raw_model,
         provider_name=request.provider_name,
         model_name=request.model_name,
@@ -1026,14 +1138,16 @@ def test_provider_adapter_includes_tool_result_errors(
         ToolResult(tool_name="read_file", status="error", error="sample.txt not found"),
     )
     request = ProviderTurnRequest(
-        prompt=request.prompt,
-        available_tools=request.available_tools,
-        tool_results=tool_results,
-        context_window=_StubContextWindow(
-            prompt=request.context_window.prompt,
+        assembled_context=_assembled_from_legacy(
+            prompt=request.prompt,
             tool_results=tool_results,
+            context_window=_StubContextWindow(
+                prompt=request.context_window.prompt,
+                tool_results=tool_results,
+            ),
+            applied_skills=request.applied_skills,
         ),
-        applied_skills=request.applied_skills,
+        available_tools=request.available_tools,
         raw_model=request.raw_model,
         provider_name=request.provider_name,
         model_name=request.model_name,
@@ -1082,14 +1196,16 @@ def test_provider_adapter_preserves_tool_call_id_and_arguments_in_tool_history(
         ),
     )
     request = ProviderTurnRequest(
-        prompt=request.prompt,
-        available_tools=request.available_tools,
-        tool_results=tool_results,
-        context_window=_StubContextWindow(
-            prompt=request.context_window.prompt,
+        assembled_context=_assembled_from_legacy(
+            prompt=request.prompt,
             tool_results=tool_results,
+            context_window=_StubContextWindow(
+                prompt=request.context_window.prompt,
+                tool_results=tool_results,
+            ),
+            applied_skills=request.applied_skills,
         ),
-        applied_skills=request.applied_skills,
+        available_tools=request.available_tools,
         raw_model=request.raw_model,
         provider_name=request.provider_name,
         model_name=request.model_name,
@@ -1145,14 +1261,16 @@ def test_opencode_go_provider_uses_user_tool_feedback_for_compatibility(
         ),
     )
     request = ProviderTurnRequest(
-        prompt=request.prompt,
-        available_tools=request.available_tools,
-        tool_results=tool_results,
-        context_window=_StubContextWindow(
-            prompt=request.context_window.prompt,
+        assembled_context=_assembled_from_legacy(
+            prompt=request.prompt,
             tool_results=tool_results,
+            context_window=_StubContextWindow(
+                prompt=request.context_window.prompt,
+                tool_results=tool_results,
+            ),
+            applied_skills=request.applied_skills,
         ),
-        applied_skills=request.applied_skills,
+        available_tools=request.available_tools,
         raw_model="opencode-go/kimi-k2.6",
         provider_name="opencode-go",
         model_name="kimi-k2.6",
@@ -1204,14 +1322,16 @@ def test_opencode_go_provider_sanitizes_user_tool_feedback(
         ),
     )
     request = ProviderTurnRequest(
-        prompt=request.prompt,
-        available_tools=request.available_tools,
-        tool_results=tool_results,
-        context_window=_StubContextWindow(
-            prompt=request.context_window.prompt,
+        assembled_context=_assembled_from_legacy(
+            prompt=request.prompt,
             tool_results=tool_results,
+            context_window=_StubContextWindow(
+                prompt=request.context_window.prompt,
+                tool_results=tool_results,
+            ),
+            applied_skills=request.applied_skills,
         ),
-        applied_skills=request.applied_skills,
+        available_tools=request.available_tools,
         raw_model="opencode-go/glm-5.1",
         provider_name="opencode-go",
         model_name="glm-5.1",
@@ -1249,14 +1369,6 @@ def test_provider_adapter_uses_runtime_assembled_context_for_agent_system_messag
     provider = provider.turn_provider()
     request = _build_turn_request(model_name="openai")
     request = ProviderTurnRequest(
-        prompt=request.prompt,
-        available_tools=request.available_tools,
-        tool_results=request.tool_results,
-        context_window=request.context_window,
-        applied_skills=request.applied_skills,
-        raw_model=request.raw_model,
-        provider_name=request.provider_name,
-        model_name=request.model_name,
         assembled_context=_StubAssembledContext(
             prompt="read sample.txt",
             tool_results=(),
@@ -1267,6 +1379,10 @@ def test_provider_adapter_uses_runtime_assembled_context_for_agent_system_messag
             ),
             metadata={},
         ),
+        available_tools=request.available_tools,
+        raw_model=request.raw_model,
+        provider_name=request.provider_name,
+        model_name=request.model_name,
         attempt=request.attempt,
         abort_signal=request.abort_signal,
     )
@@ -1296,14 +1412,6 @@ def test_provider_adapter_uses_runtime_assembled_context_for_model_family_overri
     provider = provider.turn_provider()
     request = _build_turn_request(model_name="openai")
     request = ProviderTurnRequest(
-        prompt=request.prompt,
-        available_tools=request.available_tools,
-        tool_results=request.tool_results,
-        context_window=request.context_window,
-        applied_skills=request.applied_skills,
-        raw_model=request.raw_model,
-        provider_name=request.provider_name,
-        model_name=request.model_name,
         assembled_context=_StubAssembledContext(
             prompt="read sample.txt",
             tool_results=(),
@@ -1314,6 +1422,10 @@ def test_provider_adapter_uses_runtime_assembled_context_for_model_family_overri
             ),
             metadata={},
         ),
+        available_tools=request.available_tools,
+        raw_model=request.raw_model,
+        provider_name=request.provider_name,
+        model_name=request.model_name,
         attempt=request.attempt,
         abort_signal=request.abort_signal,
     )
@@ -1343,14 +1455,6 @@ def test_provider_adapter_uses_runtime_assembled_context_for_prompt_profile_over
     provider = provider.turn_provider()
     request = _build_turn_request(model_name="openai")
     request = ProviderTurnRequest(
-        prompt=request.prompt,
-        available_tools=request.available_tools,
-        tool_results=request.tool_results,
-        context_window=request.context_window,
-        applied_skills=request.applied_skills,
-        raw_model=request.raw_model,
-        provider_name=request.provider_name,
-        model_name=request.model_name,
         assembled_context=_StubAssembledContext(
             prompt="read sample.txt",
             tool_results=(),
@@ -1361,6 +1465,10 @@ def test_provider_adapter_uses_runtime_assembled_context_for_prompt_profile_over
             ),
             metadata={},
         ),
+        available_tools=request.available_tools,
+        raw_model=request.raw_model,
+        provider_name=request.provider_name,
+        model_name=request.model_name,
         attempt=request.attempt,
         abort_signal=request.abort_signal,
     )
@@ -1390,14 +1498,6 @@ def test_provider_adapter_uses_runtime_assembled_context_for_unknown_profile(
     provider = provider.turn_provider()
     request = _build_turn_request(model_name="openai")
     request = ProviderTurnRequest(
-        prompt=request.prompt,
-        available_tools=request.available_tools,
-        tool_results=request.tool_results,
-        context_window=request.context_window,
-        applied_skills=request.applied_skills,
-        raw_model=request.raw_model,
-        provider_name=request.provider_name,
-        model_name=request.model_name,
         assembled_context=_StubAssembledContext(
             prompt="read sample.txt",
             tool_results=(),
@@ -1408,6 +1508,10 @@ def test_provider_adapter_uses_runtime_assembled_context_for_unknown_profile(
             ),
             metadata={},
         ),
+        available_tools=request.available_tools,
+        raw_model=request.raw_model,
+        provider_name=request.provider_name,
+        model_name=request.model_name,
         attempt=request.attempt,
         abort_signal=request.abort_signal,
     )
@@ -1486,13 +1590,15 @@ def test_opencode_go_provider_routes_model_families_to_required_sdk_adapter(
 
     result = provider.propose_turn(
         ProviderTurnRequest(
-            prompt="read sample.txt",
+            assembled_context=_assembled_from_legacy(
+                prompt="read sample.txt",
+                tool_results=(),
+                context_window=_StubContextWindow(prompt="read sample.txt", tool_results=()),
+                applied_skills=(),
+            ),
             available_tools=(
                 ToolDefinition(name="read_file", description="read file", read_only=True),
             ),
-            tool_results=(),
-            context_window=_StubContextWindow(prompt="read sample.txt", tool_results=()),
-            applied_skills=(),
             raw_model=f"opencode-go/{model_name}",
             provider_name="opencode-go",
             model_name=model_name,

--- a/tests/unit/provider/test_provider_adapters.py
+++ b/tests/unit/provider/test_provider_adapters.py
@@ -1177,7 +1177,7 @@ def test_opencode_go_provider_uses_user_tool_feedback_for_compatibility(
     assert messages[1]["role"] == "user"
     feedback = messages[1]["content"]
     assert isinstance(feedback, str)
-    assert "tool calls have already completed" in feedback
+    assert "Completed tool calls for current request:" in feedback
     assert '"tool_name": "list"' in feedback
     assert '"arguments": {"path": "."}' in feedback
     assert "tool_calls" not in messages[1]

--- a/tests/unit/runtime/test_backend_contracts.py
+++ b/tests/unit/runtime/test_backend_contracts.py
@@ -9,6 +9,23 @@ from typing import Any, get_type_hints
 import pytest
 
 
+class _StubSegment:
+    role = "user"
+    content = "Inspect the repo"
+    tool_call_id = None
+    tool_name = None
+    tool_arguments = None
+    metadata = None
+
+
+class _StubAssembledContext:
+    prompt = "Inspect the repo"
+    tool_results = ()
+    continuity_state = None
+    segments = (_StubSegment(),)
+    metadata: dict[str, object] = {}
+
+
 def _runtime_module() -> ModuleType:
     return importlib.import_module("voidcode.runtime")
 
@@ -71,7 +88,11 @@ def test_contract_modules_export_expected_symbols() -> None:
     )
     runtime_response = runtime.RuntimeResponse(session=session, events=(event,), output="done")
     stream_chunk = runtime.RuntimeStreamChunk(kind="event", session=session, event=event)
-    graph_request = graph.GraphRunRequest(session=session, prompt=runtime_request.prompt)
+    graph_request = graph.GraphRunRequest(
+        session=session,
+        prompt=runtime_request.prompt,
+        assembled_context=_StubAssembledContext(),
+    )
 
     assert session.session.id == "session-1"
     assert session.session.parent_id == "session-parent"

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -189,8 +189,17 @@ class _SkillAwareStubGraph:
     ) -> _StubStep:
         _ = tool_results, session
         type(self).last_request = request
-        skill_names = [skill["name"] for skill in request.applied_skills]
-        skill_contents = [skill["content"] for skill in request.applied_skills]
+        assembled = request.assembled_context
+        assert assembled is not None
+        skill_names: list[str] = []
+        skill_contents: list[str] = []
+        for segment in assembled.segments:
+            if segment.role != "system" or not isinstance(segment.content, str):
+                continue
+            if segment.content.startswith("Skill: "):
+                first_line = segment.content.splitlines()[0]
+                skill_names.append(first_line.removeprefix("Skill: ").strip())
+                skill_contents.append(segment.content)
         if skill_names:
             output = f"{request.prompt}\n[skills={','.join(skill_names)}]\n{skill_contents[0]}"
         else:
@@ -5859,15 +5868,14 @@ def test_runtime_emits_skills_loaded_catalog_without_default_full_injection(tmp_
     ]
     assert response.events[1].payload["skills"] == ["demo"]
     assert response.events[1].payload["selected_skills"] == []
-    assert response.events[1].payload["catalog_context_length"] > 0
+    assert cast(int, response.events[1].payload["catalog_context_length"]) > 0
     assert response.session.metadata["applied_skills"] == []
     assert "applied_skill_payloads" not in response.session.metadata
     assert _SkillCapturingStubGraph.last_request is not None
-    assert _SkillCapturingStubGraph.last_request.applied_skills == ()
-    assert "<available_skills>" in _SkillCapturingStubGraph.last_request.skill_prompt_context
-    assert "Always explain your reasoning." not in (
-        _SkillCapturingStubGraph.last_request.skill_prompt_context
-    )
+    assembled = _SkillCapturingStubGraph.last_request.assembled_context
+    assert assembled is not None
+    system_segments = [s.content for s in assembled.segments if s.role == "system"]
+    assert system_segments == []
 
 
 def test_runtime_persists_explicit_empty_applied_skill_snapshot(tmp_path: Path) -> None:
@@ -5886,7 +5894,9 @@ def test_runtime_persists_explicit_empty_applied_skill_snapshot(tmp_path: Path) 
     assert response.session.metadata["applied_skills"] == []
     assert "applied_skill_payloads" not in response.session.metadata
     assert _SkillCapturingStubGraph.last_request is not None
-    assert _SkillCapturingStubGraph.last_request.applied_skills == ()
+    assembled = _SkillCapturingStubGraph.last_request.assembled_context
+    assert assembled is not None
+    assert [s for s in assembled.segments if s.role == "system"] == []
 
 
 def test_runtime_applies_only_requested_skills_from_request_metadata(tmp_path: Path) -> None:
@@ -5913,11 +5923,11 @@ def test_runtime_applies_only_requested_skills_from_request_metadata(tmp_path: P
     assert response.session.metadata["applied_skills"] == ["beta"]
     assert response.events[2].payload["skills"] == ["beta"]
     assert _SkillCapturingStubGraph.last_request is not None
-    assert [skill["name"] for skill in _SkillCapturingStubGraph.last_request.applied_skills] == [
-        "beta"
-    ]
-    assert "Skill: beta" in _SkillCapturingStubGraph.last_request.skill_prompt_context
-    assert "Skill: alpha" not in _SkillCapturingStubGraph.last_request.skill_prompt_context
+    assembled = _SkillCapturingStubGraph.last_request.assembled_context
+    assert assembled is not None
+    system_contents = [s.content for s in assembled.segments if s.role == "system"]
+    assert any(isinstance(item, str) and "Use beta." in item for item in system_contents)
+    assert not any(isinstance(item, str) and "Use alpha." in item for item in system_contents)
 
 
 def test_runtime_force_load_skills_emits_applied_and_persists_snapshot(tmp_path: Path) -> None:
@@ -5946,11 +5956,12 @@ def test_runtime_force_load_skills_emits_applied_and_persists_snapshot(tmp_path:
     assert applied_event.payload["skills"] == ["demo"]
     assert response.session.metadata["applied_skills"] == ["demo"]
     assert _SkillCapturingStubGraph.last_request is not None
-    assert [skill["name"] for skill in _SkillCapturingStubGraph.last_request.applied_skills] == [
-        "demo"
-    ]
-    assert "Always explain your reasoning." in (
-        _SkillCapturingStubGraph.last_request.skill_prompt_context
+    assembled = _SkillCapturingStubGraph.last_request.assembled_context
+    assert assembled is not None
+    system_contents = [s.content for s in assembled.segments if s.role == "system"]
+    assert any(
+        isinstance(item, str) and "Always explain your reasoning." in item
+        for item in system_contents
     )
 
 
@@ -6087,10 +6098,12 @@ def test_runtime_skill_payloads_affect_execution_output_when_graph_consumes_them
 
     assert response.output == "summarize sample.txt"
     assert _SkillAwareStubGraph.last_request is not None
-    assert _SkillAwareStubGraph.last_request.applied_skills == ()
-    assert "<available_skills>" in _SkillAwareStubGraph.last_request.skill_prompt_context
-    assert "Use concise bullet points." not in (
-        _SkillAwareStubGraph.last_request.skill_prompt_context
+    assembled = _SkillAwareStubGraph.last_request.assembled_context
+    assert assembled is not None
+    system_contents = [s.content for s in assembled.segments if s.role == "system"]
+    assert all(
+        not (isinstance(item, str) and "Use concise bullet points." in item)
+        for item in system_contents
     )
 
 
@@ -6132,7 +6145,9 @@ def test_runtime_resume_reuses_frozen_skill_payloads_for_execution_semantics(
 
     assert resumed.output == "go"
     assert _SkillAwareStubGraph.last_request is not None
-    assert _SkillAwareStubGraph.last_request.applied_skills == ()
+    assembled = _SkillAwareStubGraph.last_request.assembled_context
+    assert assembled is not None
+    assert [s for s in assembled.segments if s.role == "system"] == []
 
 
 def test_runtime_resume_rejects_invalid_persisted_skill_payload_with_source_path(
@@ -6367,7 +6382,9 @@ def test_runtime_resume_uses_frozen_applied_skill_payloads_when_live_skill_chang
 
     assert resumed.session.status == "completed"
     assert _ApprovalThenCaptureSkillGraph.last_request is not None
-    assert _ApprovalThenCaptureSkillGraph.last_request.applied_skills == ()
+    assembled = _ApprovalThenCaptureSkillGraph.last_request.assembled_context
+    assert assembled is not None
+    assert [s for s in assembled.segments if s.role == "system"] == []
 
 
 def test_runtime_resume_preserves_explicit_empty_applied_skill_snapshot(
@@ -6409,7 +6426,9 @@ def test_runtime_resume_preserves_explicit_empty_applied_skill_snapshot(
 
     assert resumed.session.status == "completed"
     assert _ApprovalThenCaptureSkillGraph.last_request is not None
-    assert _ApprovalThenCaptureSkillGraph.last_request.applied_skills == ()
+    assembled = _ApprovalThenCaptureSkillGraph.last_request.assembled_context
+    assert assembled is not None
+    assert [s for s in assembled.segments if s.role == "system"] == []
 
 
 def test_runtime_resume_uses_persisted_approval_mode_for_follow_up_gated_tools(
@@ -6541,15 +6560,14 @@ def test_runtime_approval_resume_preserves_canonical_continuity_state(tmp_path: 
         "tool_result_start": 0,
         "tool_result_end": 2,
     }
-    continuity_state = cast(
-        RuntimeContinuityState | None,
-        created_providers[-1].requests[-1].context_window.continuity_state,
-    )
-    context_window = cast(RuntimeContextWindow, created_providers[-1].requests[-1].context_window)
+    assembled_context = created_providers[-1].requests[-1].assembled_context
+    assert assembled_context is not None
+    continuity_state = cast(RuntimeContinuityState | None, assembled_context.continuity_state)
+    context_window = cast(RuntimeContextWindow, resumed.session.metadata["context_window"])
     assert continuity_state is not None
     assert continuity_state.metadata_payload() == expected_resumed_continuity
-    assert context_window.summary_anchor == (resumed_continuity_summary["anchor"])
-    assert context_window.summary_source == {
+    assert context_window["summary_anchor"] == (resumed_continuity_summary["anchor"])
+    assert context_window["summary_source"] == {
         "tool_result_start": 0,
         "tool_result_end": 2,
     }
@@ -8201,7 +8219,9 @@ def test_runtime_agent_skills_config_loads_and_persists_runtime_skills(
         "skills": {"enabled": True, "paths": ["agent-skills"]},
     }
     assert _SkillCapturingStubGraph.last_request is not None
-    assert _SkillCapturingStubGraph.last_request.applied_skills == ()
+    assembled = _SkillCapturingStubGraph.last_request.assembled_context
+    assert assembled is not None
+    assert [s for s in assembled.segments if s.role == "system"] == []
 
 
 def test_runtime_agent_manifest_skill_refs_select_runtime_skills(
@@ -8244,9 +8264,9 @@ def test_runtime_agent_manifest_skill_refs_select_runtime_skills(
     assert response.events[1].payload["selected_skills"] == ["demo"]
     assert response.session.metadata["applied_skills"] == []
     assert _SkillCapturingStubGraph.last_request is not None
-    assert _SkillCapturingStubGraph.last_request.applied_skills == ()
-    assert "<name>demo</name>" in _SkillCapturingStubGraph.last_request.skill_prompt_context
-    assert "<name>zeta</name>" not in _SkillCapturingStubGraph.last_request.skill_prompt_context
+    assembled = _SkillCapturingStubGraph.last_request.assembled_context
+    assert assembled is not None
+    assert [s for s in assembled.segments if s.role == "system"] == []
 
 
 def test_runtime_agent_manifest_skill_refs_combine_with_request_skills(
@@ -8295,9 +8315,12 @@ def test_runtime_agent_manifest_skill_refs_combine_with_request_skills(
     assert response.events[2].payload["skills"] == ["zeta"]
     assert response.session.metadata["applied_skills"] == ["zeta"]
     assert _SkillCapturingStubGraph.last_request is not None
-    assert [skill["name"] for skill in _SkillCapturingStubGraph.last_request.applied_skills] == [
-        "zeta"
-    ]
+    assembled = _SkillCapturingStubGraph.last_request.assembled_context
+    assert assembled is not None
+    system_contents = [s.content for s in assembled.segments if s.role == "system"]
+    assert any(
+        isinstance(item, str) and "Apply requested skill." in item for item in system_contents
+    )
 
 
 def test_runtime_resume_uses_persisted_selected_skill_names_when_payloads_missing(
@@ -8409,7 +8432,9 @@ def test_runtime_resume_uses_persisted_selected_skill_names_when_payloads_missin
 
     assert resumed.session.status == "completed"
     assert _ApprovalThenCaptureSkillGraph.last_request is not None
-    assert _ApprovalThenCaptureSkillGraph.last_request.applied_skills == ()
+    assembled = _ApprovalThenCaptureSkillGraph.last_request.assembled_context
+    assert assembled is not None
+    assert [s for s in assembled.segments if s.role == "system"] == []
 
 
 def test_runtime_request_agent_override_can_enable_skill_loading(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -5875,7 +5875,14 @@ def test_runtime_emits_skills_loaded_catalog_without_default_full_injection(tmp_
     assembled = _SkillCapturingStubGraph.last_request.assembled_context
     assert assembled is not None
     system_segments = [s.content for s in assembled.segments if s.role == "system"]
-    assert system_segments == []
+    assert any(
+        isinstance(item, str) and "Runtime skills catalog (recommended/visible)." in item
+        for item in system_segments
+    )
+    assert not any(
+        isinstance(item, str) and "Always explain your reasoning." in item
+        for item in system_segments
+    )
 
 
 def test_runtime_persists_explicit_empty_applied_skill_snapshot(tmp_path: Path) -> None:
@@ -5896,7 +5903,11 @@ def test_runtime_persists_explicit_empty_applied_skill_snapshot(tmp_path: Path) 
     assert _SkillCapturingStubGraph.last_request is not None
     assembled = _SkillCapturingStubGraph.last_request.assembled_context
     assert assembled is not None
-    assert [s for s in assembled.segments if s.role == "system"] == []
+    system_segments = [s.content for s in assembled.segments if s.role == "system"]
+    assert any(
+        isinstance(item, str) and "Runtime skills catalog (recommended/visible)." in item
+        for item in system_segments
+    )
 
 
 def test_runtime_applies_only_requested_skills_from_request_metadata(tmp_path: Path) -> None:
@@ -6563,7 +6574,7 @@ def test_runtime_approval_resume_preserves_canonical_continuity_state(tmp_path: 
     assembled_context = created_providers[-1].requests[-1].assembled_context
     assert assembled_context is not None
     continuity_state = cast(RuntimeContinuityState | None, assembled_context.continuity_state)
-    context_window = cast(RuntimeContextWindow, resumed.session.metadata["context_window"])
+    context_window = cast(dict[str, object], resumed.session.metadata["context_window"])
     assert continuity_state is not None
     assert continuity_state.metadata_payload() == expected_resumed_continuity
     assert context_window["summary_anchor"] == (resumed_continuity_summary["anchor"])
@@ -8221,7 +8232,11 @@ def test_runtime_agent_skills_config_loads_and_persists_runtime_skills(
     assert _SkillCapturingStubGraph.last_request is not None
     assembled = _SkillCapturingStubGraph.last_request.assembled_context
     assert assembled is not None
-    assert [s for s in assembled.segments if s.role == "system"] == []
+    system_segments = [s.content for s in assembled.segments if s.role == "system"]
+    assert any(
+        isinstance(item, str) and "Runtime skills catalog (recommended/visible)." in item
+        for item in system_segments
+    )
 
 
 def test_runtime_agent_manifest_skill_refs_select_runtime_skills(
@@ -8266,7 +8281,11 @@ def test_runtime_agent_manifest_skill_refs_select_runtime_skills(
     assert _SkillCapturingStubGraph.last_request is not None
     assembled = _SkillCapturingStubGraph.last_request.assembled_context
     assert assembled is not None
-    assert [s for s in assembled.segments if s.role == "system"] == []
+    system_segments = [s.content for s in assembled.segments if s.role == "system"]
+    assert any(
+        isinstance(item, str) and "Runtime skills catalog (recommended/visible)." in item
+        for item in system_segments
+    )
 
 
 def test_runtime_agent_manifest_skill_refs_combine_with_request_skills(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -5875,8 +5875,8 @@ def test_runtime_emits_skills_loaded_catalog_without_default_full_injection(tmp_
     assembled = _SkillCapturingStubGraph.last_request.assembled_context
     assert assembled is not None
     system_segments = [s.content for s in assembled.segments if s.role == "system"]
-    assert any(
-        isinstance(item, str) and "Runtime skills catalog (recommended/visible)." in item
+    assert all(
+        not isinstance(item, str) or "Runtime skills catalog (recommended/visible)." in item
         for item in system_segments
     )
     assert not any(
@@ -5904,8 +5904,8 @@ def test_runtime_persists_explicit_empty_applied_skill_snapshot(tmp_path: Path) 
     assembled = _SkillCapturingStubGraph.last_request.assembled_context
     assert assembled is not None
     system_segments = [s.content for s in assembled.segments if s.role == "system"]
-    assert any(
-        isinstance(item, str) and "Runtime skills catalog (recommended/visible)." in item
+    assert all(
+        not isinstance(item, str) or "Runtime skills catalog (recommended/visible)." in item
         for item in system_segments
     )
 

--- a/tests/unit/runtime/test_single_agent_provider.py
+++ b/tests/unit/runtime/test_single_agent_provider.py
@@ -4,7 +4,11 @@ import pytest
 
 from voidcode.provider.registry import ModelProviderRegistry
 from voidcode.provider.resolution import resolve_provider_model
-from voidcode.runtime.context_window import RuntimeContextWindow
+from voidcode.runtime.context_window import (
+    RuntimeAssembledContext,
+    RuntimeContextSegment,
+    RuntimeContextWindow,
+)
 from voidcode.runtime.provider_protocol import (
     ProviderExecutionError,
     ProviderTurnRequest,
@@ -22,6 +26,45 @@ def _tool_definitions() -> tuple[ToolDefinition, ...]:
     )
 
 
+def _assembled_from_context_window(context_window: RuntimeContextWindow) -> RuntimeAssembledContext:
+    segments: list[RuntimeContextSegment] = [
+        RuntimeContextSegment(role="user", content=context_window.prompt),
+    ]
+    for index, result in enumerate(context_window.tool_results, start=1):
+        raw_tool_call_id = result.data.get("tool_call_id")
+        tool_call_id = (
+            raw_tool_call_id
+            if isinstance(raw_tool_call_id, str) and raw_tool_call_id.strip()
+            else f"voidcode_tool_{index}"
+        )
+        tool_arguments = result.data.get("arguments")
+        arguments_payload = tool_arguments if isinstance(tool_arguments, dict) else {}
+        segments.append(
+            RuntimeContextSegment(
+                role="assistant",
+                content=None,
+                tool_call_id=tool_call_id,
+                tool_name=result.tool_name,
+                tool_arguments=arguments_payload,
+            )
+        )
+        segments.append(
+            RuntimeContextSegment(
+                role="tool",
+                content=result.content,
+                tool_call_id=tool_call_id,
+                tool_name=result.tool_name,
+            )
+        )
+    return RuntimeAssembledContext(
+        prompt=context_window.prompt,
+        tool_results=context_window.tool_results,
+        continuity_state=context_window.continuity_state,
+        segments=tuple(segments),
+        metadata={},
+    )
+
+
 def test_stub_provider_protocol_proposes_tool_call_for_first_turn() -> None:
     provider_model = resolve_provider_model(
         "opencode/gpt-5.4",
@@ -30,11 +73,10 @@ def test_stub_provider_protocol_proposes_tool_call_for_first_turn() -> None:
 
     result = StubTurnProvider(name="opencode").propose_turn(
         ProviderTurnRequest(
-            prompt="read sample.txt",
+            assembled_context=_assembled_from_context_window(
+                RuntimeContextWindow(prompt="read sample.txt")
+            ),
             available_tools=_tool_definitions(),
-            tool_results=(),
-            context_window=RuntimeContextWindow(prompt="read sample.txt"),
-            applied_skills=(),
             raw_model=provider_model.selection.raw_model,
             provider_name=provider_model.selection.provider,
             model_name=provider_model.selection.model,
@@ -55,28 +97,20 @@ def test_stub_provider_protocol_finalizes_from_last_tool_result() -> None:
 
     result = StubTurnProvider(name="opencode").propose_turn(
         ProviderTurnRequest(
-            prompt="read sample.txt",
-            available_tools=_tool_definitions(),
-            tool_results=(
-                ToolResult(
-                    tool_name="read_file",
-                    content="alpha\nbeta\n",
-                    status="ok",
-                    data={"path": "sample.txt", "type": "file", "content": "alpha\nbeta\n"},
-                ),
-            ),
-            context_window=RuntimeContextWindow(
-                prompt="read sample.txt",
-                tool_results=(
-                    ToolResult(
-                        tool_name="read_file",
-                        content="alpha\nbeta\n",
-                        status="ok",
-                        data={"path": "sample.txt", "type": "file", "content": "alpha\nbeta\n"},
+            assembled_context=_assembled_from_context_window(
+                RuntimeContextWindow(
+                    prompt="read sample.txt",
+                    tool_results=(
+                        ToolResult(
+                            tool_name="read_file",
+                            content="alpha\nbeta\n",
+                            status="ok",
+                            data={"path": "sample.txt", "type": "file", "content": "alpha\nbeta\n"},
+                        ),
                     ),
-                ),
+                )
             ),
-            applied_skills=(),
+            available_tools=_tool_definitions(),
             raw_model=provider_model.selection.raw_model,
             provider_name=provider_model.selection.provider,
             model_name=provider_model.selection.model,
@@ -96,11 +130,10 @@ def test_stub_provider_protocol_rejects_unsupported_requests() -> None:
     with pytest.raises(ValueError, match="unsupported request"):
         _ = StubTurnProvider(name="opencode").propose_turn(
             ProviderTurnRequest(
-                prompt="summarize sample.txt",
+                assembled_context=_assembled_from_context_window(
+                    RuntimeContextWindow(prompt="summarize sample.txt")
+                ),
                 available_tools=_tool_definitions(),
-                tool_results=(),
-                context_window=RuntimeContextWindow(prompt="summarize sample.txt"),
-                applied_skills=(),
                 raw_model=provider_model.selection.raw_model,
                 provider_name=provider_model.selection.provider,
                 model_name=provider_model.selection.model,
@@ -128,38 +161,24 @@ def test_stub_provider_protocol_uses_bounded_context_window_results_for_finalize
 
     result = StubTurnProvider(name="opencode").propose_turn(
         ProviderTurnRequest(
-            prompt="read sample.txt",
-            available_tools=_tool_definitions(),
-            tool_results=(
-                ToolResult(
-                    tool_name="read_file",
-                    content="old\n",
-                    status="ok",
-                    data={"path": "sample.txt", "type": "file", "content": "old\n"},
-                ),
-                ToolResult(
-                    tool_name="read_file",
-                    content="new\n",
-                    status="ok",
-                    data={"path": "sample.txt", "type": "file", "content": "new\n"},
-                ),
-            ),
-            context_window=RuntimeContextWindow(
-                prompt="read sample.txt",
-                tool_results=(
-                    ToolResult(
-                        tool_name="read_file",
-                        content="new\n",
-                        status="ok",
-                        data={"path": "sample.txt", "type": "file", "content": "new\n"},
+            assembled_context=_assembled_from_context_window(
+                RuntimeContextWindow(
+                    prompt="read sample.txt",
+                    tool_results=(
+                        ToolResult(
+                            tool_name="read_file",
+                            content="new\n",
+                            status="ok",
+                            data={"path": "sample.txt", "type": "file", "content": "new\n"},
+                        ),
                     ),
-                ),
-                compacted=True,
-                compaction_reason="tool_result_window",
-                original_tool_result_count=2,
-                retained_tool_result_count=1,
+                    compacted=True,
+                    compaction_reason="tool_result_window",
+                    original_tool_result_count=2,
+                    retained_tool_result_count=1,
+                )
             ),
-            applied_skills=(),
+            available_tools=_tool_definitions(),
             raw_model=provider_model.selection.raw_model,
             provider_name=provider_model.selection.provider,
             model_name=provider_model.selection.model,


### PR DESCRIPTION
#285 
## Summary
This PR fully enforces runtime-owned provider context assembly and removes remaining legacy/fallback paths so provider adapters only consume bounded, runtime-approved assembled context.
### What changed
- **Enforced assembled-context-only provider request boundary**
  - `ProviderTurnRequest` now requires `assembled_context` as the only input context contract.
  - Removed legacy raw-input assembly path (`prompt/tool_results/context_window/applied_skills/skill_prompt_context` constructor behavior).
  - Kept read-only accessors (`prompt`, `tool_results`, `context_window`) as bounded projections for compatibility at call sites.
- **Removed graph-side fallback context assembly**
  - Deleted provider-graph fallback prompt-only assembled context path.
  - `ProviderGraph` now always forwards runtime-assembled context and no longer reconstructs context locally.
- **Preserved observability metadata on bounded context**
  - Added bounded context window pass-through (`bounded_context_window`) on provider turn requests so runtime-computed window metadata remains observable.
  - Ensured continuity and token metadata remain visible on provider request context window projections:
    - token budget/source
    - original/retained/dropped token counts
    - compaction metadata
    - summary anchor/source
    - continuity state payload
- **Continuity carry-forward in runtime assembly**
  - Runtime context assembly now accepts preserved continuity state and keeps continuity payload available in assembled metadata when required by resume flows.
- **Tests migrated to explicit assembled context contract**
  - Updated graph/provider/runtime unit tests to construct `GraphRunRequest`/`ProviderTurnRequest` with explicit `assembled_context`.
  - Removed test reliance on legacy provider request constructor behavior.
## Why
The issue requires a single runtime-owned provider-facing context boundary and forbids provider-side context policy reconstruction. This PR completes that boundary hardening and removes compatibility shortcuts that allowed accidental use of unbounded/raw context paths.
## Verification
Passed:
- `ruff check`
- `basedpyright`
- `pytest` critical suites:
  - `tests/unit/runtime/test_runtime_service_extensions.py` (resume/continuity/token-budget critical cases)
  - `tests/unit/graph/test_single_agent_slice.py`
  - `tests/unit/provider/test_provider_adapters.py`
  - `tests/unit/runtime/test_single_agent_provider.py`