### PR TITLE
feat(cli): polish delegated task operator UX

### DIFF
--- a/docs/contracts/background-task-delegation.md
+++ b/docs/contracts/background-task-delegation.md
@@ -343,6 +343,8 @@ Leader 读取结果时应遵守以下规则：
 
 - `background_output(task_id)` 默认返回紧凑结果视图。
 - `background_output(task_id, full_session=true)` 返回 bounded transcript payload，并带 child session id 与 transcript metadata。
+- CLI `voidcode tasks status/output/list/cancel --json` 返回 machine-readable payload，并保留 readable 默认输出；结构化字段应包含 `task_id`、`parent_session_id`、`requested_child_session_id`、`child_session_id`、approval / question request id、`result_available`、`error_type` 与 `next_steps`。
+- CLI readable 默认输出应继续先暴露兼容的 `TASK ...` correlation record，并在 waiting / running / failed / completed 等状态下打印 concrete next-step commands（例如 `sessions resume <child_session_id>`、`tasks output <task_id>`、`tasks cancel <task_id>`）。
 - `block=true` 等待超时时返回 `block_timed_out`，同时保留当前 task state，而不是把任务误标为失败。
 - failed child 输出可以提示用户显式请求 retry/continue，并使用 `session_id=<child_session_id>` 继承 child context；工具本身不得自动进入无限 retry loop。
 - repeated child failure 应升级给 leader / user，而不是继续隐藏在后台循环里。

--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -419,6 +419,189 @@ def _background_task_fields(task: BackgroundTaskState) -> list[tuple[str, object
     return fields
 
 
+def _background_task_routing_payload(routing: object | None) -> dict[str, object] | None:
+    if routing is None:
+        return None
+    return {
+        key: value
+        for key, value in {
+            "mode": getattr(routing, "mode", None),
+            "category": getattr(routing, "category", None),
+            "subagent_type": getattr(routing, "subagent_type", None),
+            "description": getattr(routing, "description", None),
+            "command": getattr(routing, "command", None),
+        }.items()
+        if value is not None
+    }
+
+
+def _background_task_error_type(error: str | None) -> str | None:
+    if error is None:
+        return None
+    normalized = error.lower()
+    if any(token in normalized for token in ("provider", "model", "api key", "unreachable")):
+        return "provider"
+    if any(
+        token in normalized
+        for token in ("tool", "write_file", "read_file", "shell_exec", "permission")
+    ):
+        return "tool"
+    return "runtime"
+
+
+def _background_task_next_steps(
+    *,
+    task_id: str,
+    status: str,
+    workspace: Path,
+    child_session_id: str | None,
+    approval_request_id: str | None,
+    question_request_id: str | None,
+    result_available: bool,
+    error: str | None,
+) -> list[str]:
+    workspace_arg = f"--workspace {workspace}"
+    steps: list[str] = []
+    if approval_request_id is not None and child_session_id is not None:
+        steps.append(
+            "Resolve approval: "
+            f"voidcode sessions resume {child_session_id} {workspace_arg} "
+            f"--approval-request-id {approval_request_id} --approval-decision allow"
+        )
+        steps.append(f"Cancel delegated task: voidcode tasks cancel {task_id} {workspace_arg}")
+    elif question_request_id is not None and child_session_id is not None:
+        steps.append(
+            "Inspect waiting child session before answering questions: "
+            f"voidcode sessions debug {child_session_id} {workspace_arg}"
+        )
+        steps.append(f"Cancel delegated task: voidcode tasks cancel {task_id} {workspace_arg}")
+    elif status in {"queued", "running"}:
+        steps.append(f"Refresh state: voidcode tasks status {task_id} {workspace_arg}")
+        steps.append(f"Read partial result view: voidcode tasks output {task_id} {workspace_arg}")
+        steps.append(f"Cancel delegated task: voidcode tasks cancel {task_id} {workspace_arg}")
+    elif status == "completed":
+        steps.append(f"Read output: voidcode tasks output {task_id} {workspace_arg}")
+        if child_session_id is not None:
+            steps.append(
+                f"Replay child session: voidcode sessions resume {child_session_id} {workspace_arg}"
+            )
+    elif status == "failed":
+        error_type = _background_task_error_type(error)
+        if result_available:
+            steps.append(f"Inspect failure output: voidcode tasks output {task_id} {workspace_arg}")
+        if child_session_id is not None:
+            steps.append(
+                f"Resume child context: voidcode sessions resume {child_session_id} {workspace_arg}"
+            )
+        if error_type == "provider":
+            steps.append("Check provider configuration: voidcode provider inspect <provider>")
+        elif error_type == "tool":
+            steps.append(
+                "Inspect the child session events to find the failed tool call and approval state."
+            )
+        else:
+            steps.append(
+                "Inspect runtime events and retry explicitly from the parent flow if needed."
+            )
+    elif status == "cancelled":
+        steps.append(f"Inspect final task state: voidcode tasks status {task_id} {workspace_arg}")
+    return steps
+
+
+def _background_task_state_payload(
+    task: BackgroundTaskState, *, workspace: Path
+) -> dict[str, object]:
+    error = getattr(task, "error", None)
+    cancellation_cause = getattr(task, "cancellation_cause", None)
+    error_type = _background_task_error_type(error)
+    next_steps = _background_task_next_steps(
+        task_id=task.task.id,
+        status=task.status,
+        workspace=workspace,
+        child_session_id=task.child_session_id,
+        approval_request_id=task.approval_request_id,
+        question_request_id=task.question_request_id,
+        result_available=task.result_available,
+        error=error,
+    )
+    payload: dict[str, object] = {
+        "task_id": task.task.id,
+        "status": task.status,
+        "parent_session_id": task.parent_session_id,
+        "requested_child_session_id": task.request.session_id,
+        "child_session_id": task.child_session_id,
+        "approval_request_id": task.approval_request_id,
+        "question_request_id": task.question_request_id,
+        "approval_blocked": task.approval_request_id is not None,
+        "result_available": task.result_available,
+        "cancellation_cause": cancellation_cause,
+        "error": error,
+        "error_type": error_type,
+        "routing": _background_task_routing_payload(task.routing_identity),
+        "next_steps": next_steps,
+    }
+    return payload
+
+
+def _background_task_result_payload(
+    result: BackgroundTaskResult, *, workspace: Path
+) -> dict[str, object]:
+    cancellation_cause = getattr(result, "cancellation_cause", None)
+    error_type = _background_task_error_type(result.error)
+    next_steps = _background_task_next_steps(
+        task_id=result.task_id,
+        status=result.status,
+        workspace=workspace,
+        child_session_id=result.child_session_id,
+        approval_request_id=result.approval_request_id,
+        question_request_id=result.question_request_id,
+        result_available=result.result_available,
+        error=result.error,
+    )
+    return {
+        "task_id": result.task_id,
+        "status": result.status,
+        "parent_session_id": result.parent_session_id,
+        "requested_child_session_id": result.requested_child_session_id,
+        "child_session_id": result.child_session_id,
+        "approval_request_id": result.approval_request_id,
+        "question_request_id": result.question_request_id,
+        "approval_blocked": result.approval_blocked,
+        "result_available": result.result_available,
+        "summary_output": result.summary_output,
+        "error": result.error,
+        "error_type": error_type,
+        "cancellation_cause": cancellation_cause,
+        "routing": _background_task_routing_payload(result.routing),
+        "next_steps": next_steps,
+    }
+
+
+def _background_task_summary_payload(task: StoredBackgroundTaskSummary) -> dict[str, object]:
+    error = getattr(task, "error", None)
+    return {
+        "task_id": task.task.id,
+        "status": task.status,
+        "child_session_id": task.session_id,
+        "created_at": task.created_at,
+        "updated_at": task.updated_at,
+        "prompt": task.prompt,
+        "error": error,
+        "error_type": _background_task_error_type(error),
+    }
+
+
+def _print_background_task_guidance(payload: dict[str, object]) -> None:
+    error_type = payload.get("error_type")
+    if error_type is not None:
+        print(f"ERROR type={error_type} summary={payload.get('error')!r}")
+    next_steps = payload.get("next_steps")
+    if isinstance(next_steps, list) and next_steps:
+        print("NEXT")
+        for index, step in enumerate(cast(list[str], next_steps), start=1):
+            print(f"  {index}. {step}")
+
+
 def _format_background_task_state(task: BackgroundTaskState) -> str:
     return _format_named_record("TASK", _background_task_fields(task))
 
@@ -439,6 +622,9 @@ def _background_task_result_fields(result: BackgroundTaskResult) -> list[tuple[s
         fields.append(("summary_output", repr(result.summary_output)))
     if result.error is not None:
         fields.append(("error", result.error))
+    cancellation_cause = getattr(result, "cancellation_cause", None)
+    if cancellation_cause is not None:
+        fields.append(("cancellation_cause", cancellation_cause))
     routing = result.routing
     if routing is not None:
         fields.append(("delegation_mode", routing.mode))
@@ -458,17 +644,18 @@ def _format_background_task_result(result: BackgroundTaskResult) -> str:
 
 
 def _format_background_task_summary(task: StoredBackgroundTaskSummary) -> str:
-    return _format_named_record(
-        "TASK",
-        [
-            ("id", task.task.id),
-            ("status", task.status),
-            ("session_id", task.session_id),
-            ("created_at", task.created_at),
-            ("updated_at", task.updated_at),
-            ("prompt", repr(task.prompt)),
-        ],
-    )
+    fields: list[tuple[str, object]] = [
+        ("id", task.task.id),
+        ("status", task.status),
+        ("child_session_id", task.session_id),
+        ("created_at", task.created_at),
+        ("updated_at", task.updated_at),
+        ("prompt", repr(task.prompt)),
+    ]
+    error = getattr(task, "error", None)
+    if error is not None:
+        fields.append(("error", error))
+    return _format_named_record("TASK", fields)
 
 
 def _serialize_session_debug_snapshot(snapshot: RuntimeSessionDebugSnapshot) -> dict[str, object]:
@@ -600,6 +787,7 @@ def _handle_sessions_debug_command(args: argparse.Namespace) -> int:
 def _handle_tasks_status_command(args: argparse.Namespace) -> int:
     workspace = cast(Path, args.workspace)
     task_id = cast(str, args.task_id)
+    json_output = cast(bool, getattr(args, "json", False))
     runtime = VoidCodeRuntime(workspace=workspace)
     try:
         try:
@@ -609,13 +797,19 @@ def _handle_tasks_status_command(args: argparse.Namespace) -> int:
     finally:
         _close_runtime(runtime)
 
+    payload = _background_task_state_payload(task, workspace=workspace)
+    if json_output:
+        print_json({"workspace": str(workspace), "task": payload})
+        return 0
     print(_format_background_task_state(task))
+    _print_background_task_guidance(payload)
     return 0
 
 
 def _handle_tasks_output_command(args: argparse.Namespace) -> int:
     workspace = cast(Path, args.workspace)
     task_id = cast(str, args.task_id)
+    json_output = cast(bool, getattr(args, "json", False))
     runtime = VoidCodeRuntime(workspace=workspace)
     task_result: BackgroundTaskResult | None = None
     session_output: str | None = None
@@ -635,17 +829,24 @@ def _handle_tasks_output_command(args: argparse.Namespace) -> int:
         _close_runtime(runtime)
 
     assert task_result is not None
-    print(_format_background_task_result(task_result))
     fallback_output = (
         task_result.summary_output if task_result.summary_output is not None else task_result.error
     )
-    _print_runtime_output(session_output if session_output is not None else fallback_output)
+    output = session_output if session_output is not None else fallback_output
+    payload = _background_task_result_payload(task_result, workspace=workspace)
+    if json_output:
+        print_json({"workspace": str(workspace), "task": payload, "output": output})
+        return 0
+    print(_format_background_task_result(task_result))
+    _print_background_task_guidance(payload)
+    _print_runtime_output(output)
     return 0
 
 
 def _handle_tasks_cancel_command(args: argparse.Namespace) -> int:
     workspace = cast(Path, args.workspace)
     task_id = cast(str, args.task_id)
+    json_output = cast(bool, getattr(args, "json", False))
     runtime = VoidCodeRuntime(workspace=workspace)
     try:
         try:
@@ -655,13 +856,19 @@ def _handle_tasks_cancel_command(args: argparse.Namespace) -> int:
     finally:
         _close_runtime(runtime)
 
+    payload = _background_task_state_payload(task, workspace=workspace)
+    if json_output:
+        print_json({"workspace": str(workspace), "task": payload})
+        return 0
     print(_format_background_task_state(task))
+    _print_background_task_guidance(payload)
     return 0
 
 
 def _handle_tasks_list_command(args: argparse.Namespace) -> int:
     workspace = cast(Path, args.workspace)
     parent_session_id = cast(str | None, getattr(args, "parent_session_id", None))
+    json_output = cast(bool, getattr(args, "json", False))
     runtime = VoidCodeRuntime(workspace=workspace)
     try:
         try:
@@ -674,6 +881,16 @@ def _handle_tasks_list_command(args: argparse.Namespace) -> int:
             raise SystemExit(f"error: {exc}") from None
     finally:
         _close_runtime(runtime)
+
+    if json_output:
+        print_json(
+            {
+                "workspace": str(workspace),
+                "parent_session_id": parent_session_id,
+                "tasks": [_background_task_summary_payload(task) for task in tasks],
+            }
+        )
+        return 0
 
     for task in tasks:
         print(_format_background_task_summary(task))
@@ -1551,6 +1768,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=Path.cwd(),
         help="Workspace root used to resolve the local session database.",
     )
+    _ = tasks_status_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output delegated task state as JSON.",
+    )
     tasks_status_parser.set_defaults(handler=_handle_tasks_status_command)
 
     tasks_output_parser = tasks_subparsers.add_parser(
@@ -1563,6 +1785,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=Path.cwd(),
         help="Workspace root used to resolve the local session database.",
     )
+    _ = tasks_output_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output delegated task result and guidance as JSON.",
+    )
     tasks_output_parser.set_defaults(handler=_handle_tasks_output_command)
 
     tasks_cancel_parser = tasks_subparsers.add_parser(
@@ -1574,6 +1801,11 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         default=Path.cwd(),
         help="Workspace root used to resolve the local session database.",
+    )
+    _ = tasks_cancel_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output cancelled delegated task state as JSON.",
     )
     tasks_cancel_parser.set_defaults(handler=_handle_tasks_cancel_command)
 
@@ -1588,6 +1820,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--parent-session",
         dest="parent_session_id",
         help="Optional parent session identifier used to filter delegated tasks.",
+    )
+    _ = tasks_list_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output delegated task summaries as JSON.",
     )
     tasks_list_parser.set_defaults(handler=_handle_tasks_list_command)
 

--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
 import sys
 from collections.abc import Callable, Iterator, Sequence
 from pathlib import Path
@@ -460,7 +461,7 @@ def _background_task_next_steps(
     result_available: bool,
     error: str | None,
 ) -> list[str]:
-    workspace_arg = f"--workspace {workspace}"
+    workspace_arg = f"--workspace {shlex.quote(str(workspace))}"
     steps: list[str] = []
     if approval_request_id is not None and child_session_id is not None:
         steps.append(

--- a/tests/unit/interface/test_cli_delegated_parity.py
+++ b/tests/unit/interface/test_cli_delegated_parity.py
@@ -18,6 +18,7 @@ Day-1 delegated lifecycle surfaces covered:
 from __future__ import annotations
 
 import importlib
+import json
 import os
 import subprocess
 import sys
@@ -643,6 +644,49 @@ def test_cli_tasks_status_delegates_to_runtime_load_background_task(capsys: Any)
     assert "approval_request_id=approval-1" in captured.out
     assert "delegation_mode=background" in captured.out
     assert "category=quick" in captured.out
+    assert "NEXT" in captured.out
+    assert "voidcode sessions resume child-session" in captured.out
+    assert "--approval-request-id approval-1 --approval-decision allow" in captured.out
+
+
+def test_cli_tasks_status_supports_json_guidance(capsys: Any) -> None:
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/demo-workspace")
+    task_state = SimpleNamespace(
+        task=SimpleNamespace(id="task-json"),
+        status="failed",
+        parent_session_id="leader-session",
+        request=SimpleNamespace(session_id="requested-child"),
+        child_session_id="child-session",
+        approval_request_id=None,
+        question_request_id=None,
+        result_available=True,
+        cancellation_cause=None,
+        error="provider execution requires a configured provider/model",
+        routing_identity=SimpleNamespace(
+            mode="background",
+            category=None,
+            subagent_type="worker",
+            description="Run child",
+            command=None,
+        ),
+    )
+
+    with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
+        runtime_class.return_value.load_background_task.return_value = task_state
+        result = cli.main(["tasks", "status", "task-json", "--workspace", str(workspace), "--json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert result == 0
+    assert payload["workspace"] == str(workspace)
+    assert payload["task"]["task_id"] == "task-json"
+    assert payload["task"]["parent_session_id"] == "leader-session"
+    assert payload["task"]["requested_child_session_id"] == "requested-child"
+    assert payload["task"]["child_session_id"] == "child-session"
+    assert payload["task"]["error_type"] == "provider"
+    assert payload["task"]["routing"]["subagent_type"] == "worker"
+    assert any("provider inspect" in step for step in payload["task"]["next_steps"])
 
 
 def test_cli_tasks_surfaces_real_runtime_completed_delegated_lifecycle(
@@ -738,7 +782,48 @@ def test_cli_tasks_output_delegates_to_runtime_and_prints_child_result(capsys: A
     runtime.session_result.assert_called_once_with(session_id="child-session")
     assert "TASK id=task-1 status=completed" in captured.out
     assert "subagent_type=explore" in captured.out
+    assert "NEXT" in captured.out
+    assert "voidcode sessions resume child-session" in captured.out
     assert "RESULT\nchild output\n" in captured.out
+
+
+def test_cli_tasks_output_supports_json_failure_guidance(capsys: Any) -> None:
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/demo-workspace")
+    task_result = SimpleNamespace(
+        task_id="task-failed-json",
+        status="failed",
+        parent_session_id="leader-session",
+        requested_child_session_id="requested-child",
+        child_session_id="child-session",
+        approval_request_id=None,
+        question_request_id=None,
+        approval_blocked=False,
+        result_available=True,
+        summary_output="Failed: child tool failed",
+        error="tool write_file failed",
+        cancellation_cause=None,
+        routing=None,
+    )
+    session_result = SimpleNamespace(output="tool failure details\n")
+
+    with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
+        runtime = runtime_class.return_value
+        runtime.load_background_task_result.return_value = task_result
+        runtime.session_result.return_value = session_result
+        result = cli.main(
+            ["tasks", "output", "task-failed-json", "--workspace", str(workspace), "--json"]
+        )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert result == 0
+    assert payload["task"]["task_id"] == "task-failed-json"
+    assert payload["task"]["error_type"] == "tool"
+    assert payload["task"]["parent_session_id"] == "leader-session"
+    assert payload["task"]["child_session_id"] == "child-session"
+    assert payload["output"] == "tool failure details\n"
+    assert any("child session events" in step for step in payload["task"]["next_steps"])
 
 
 def test_cli_tasks_surfaces_real_runtime_waiting_approval_and_cancel(
@@ -959,6 +1044,44 @@ def test_cli_tasks_list_lists_all_background_tasks(capsys: Any) -> None:
     assert "TASK id=task-2 status=completed" in captured.out
     assert "prompt='Investigate'" in captured.out
     assert "prompt='Summarize'" in captured.out
+
+
+def test_cli_tasks_list_supports_json(capsys: Any) -> None:
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/demo-workspace")
+    tasks = (
+        SimpleNamespace(
+            task=SimpleNamespace(id="task-1"),
+            status="queued",
+            session_id=None,
+            created_at=1,
+            updated_at=2,
+            prompt="Investigate",
+            error=None,
+        ),
+        SimpleNamespace(
+            task=SimpleNamespace(id="task-2"),
+            status="failed",
+            session_id="child-session",
+            created_at=3,
+            updated_at=4,
+            prompt="Summarize",
+            error="runtime failed",
+        ),
+    )
+
+    with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
+        runtime_class.return_value.list_background_tasks.return_value = tasks
+        result = cli.main(["tasks", "list", "--workspace", str(workspace), "--json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert result == 0
+    assert payload["workspace"] == str(workspace)
+    assert payload["parent_session_id"] is None
+    assert payload["tasks"][0]["task_id"] == "task-1"
+    assert payload["tasks"][1]["child_session_id"] == "child-session"
+    assert payload["tasks"][1]["error_type"] == "runtime"
 
 
 def test_cli_tasks_list_filters_by_parent_session(capsys: Any) -> None:

--- a/tests/unit/interface/test_cli_delegated_parity.py
+++ b/tests/unit/interface/test_cli_delegated_parity.py
@@ -689,6 +689,67 @@ def test_cli_tasks_status_supports_json_guidance(capsys: Any) -> None:
     assert any("provider inspect" in step for step in payload["task"]["next_steps"])
 
 
+def test_cli_tasks_guidance_quotes_workspace_with_spaces(capsys: Any) -> None:
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/demo workspace")
+    task_state = SimpleNamespace(
+        task=SimpleNamespace(id="task-spaces"),
+        status="running",
+        parent_session_id="leader-session",
+        request=SimpleNamespace(session_id="requested-child"),
+        child_session_id="child-session",
+        approval_request_id="approval-1",
+        question_request_id=None,
+        result_available=False,
+        cancellation_cause=None,
+        error=None,
+        routing_identity=None,
+    )
+
+    with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
+        runtime_class.return_value.load_background_task.return_value = task_state
+        result = cli.main(["tasks", "status", "task-spaces", "--workspace", str(workspace)])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "--workspace '/tmp/demo workspace'" in captured.out
+
+
+def test_cli_tasks_json_guidance_quotes_workspace_with_shell_metacharacters(
+    capsys: Any,
+) -> None:
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/demo repo; rm -rf no")
+    task_state = SimpleNamespace(
+        task=SimpleNamespace(id="task-shell"),
+        status="completed",
+        parent_session_id="leader-session",
+        request=SimpleNamespace(session_id="requested-child"),
+        child_session_id="child-session",
+        approval_request_id=None,
+        question_request_id=None,
+        result_available=True,
+        cancellation_cause=None,
+        error=None,
+        routing_identity=None,
+    )
+
+    with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
+        runtime_class.return_value.load_background_task.return_value = task_state
+        result = cli.main(
+            ["tasks", "status", "task-shell", "--workspace", str(workspace), "--json"]
+        )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert result == 0
+    assert payload["task"]["next_steps"] == [
+        "Read output: voidcode tasks output task-shell --workspace '/tmp/demo repo; rm -rf no'",
+        "Replay child session: voidcode sessions resume child-session "
+        "--workspace '/tmp/demo repo; rm -rf no'",
+    ]
+
+
 def test_cli_tasks_surfaces_real_runtime_completed_delegated_lifecycle(
     tmp_path: Path, capsys: Any
 ) -> None:


### PR DESCRIPTION
## Summary
- Add JSON output for `voidcode tasks status/output/list/cancel` with parent/child linkage, routing, error type, and next-step guidance.
- Keep readable `TASK ...` output compatible while adding concrete operator `NEXT` guidance for approval, output, cancel, replay, and failure paths.
- Document the delegated task CLI guidance contract and cover the new structured/readable behavior in delegated parity tests.

## Verification
- `uv run ruff check .`
- `uv run basedpyright --warnings src`
- `uv run python -X utf8 -m pytest -n auto` (1585 passed)
- `bun run lint`
- `bun run typecheck`
- `bun run test:run` (86 passed)

Closes #298