### PR TITLE
feat: surface MCP health and config visibility

### DIFF
--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -57,6 +57,7 @@ from .runtime.config_schema import (
 )
 from .runtime.contracts import (
     BackgroundTaskResult,
+    CapabilityStatusSnapshot,
     ProviderInspectResult,
     ProviderModelMetadata,
     ProviderReadinessResult,
@@ -937,6 +938,7 @@ def _handle_config_show_command(args: argparse.Namespace) -> int:
             readiness = runtime.provider_readiness(session_id=session_id)
             categories = runtime.effective_category_model_config(session_id=session_id)
             agents = runtime.effective_agent_model_config(session_id=session_id)
+            status = runtime.current_status()
         except ValueError as exc:
             raise SystemExit(f"error: {exc}") from None
     finally:
@@ -964,8 +966,74 @@ def _handle_config_show_command(args: argparse.Namespace) -> int:
                 "context_window": readiness.context_window,
                 "max_output_tokens": readiness.max_output_tokens,
             },
+            "mcp": _mcp_status_payload(status.mcp),
         }
     )
+    return EXIT_SUCCESS
+
+
+def _mcp_status_payload(snapshot: CapabilityStatusSnapshot) -> dict[str, object]:
+    state = snapshot.state
+    error = snapshot.error
+    details = snapshot.details
+    return {
+        "state": state,
+        "error": error,
+        "details": details,
+    }
+
+
+def _handle_mcp_list_command(args: argparse.Namespace) -> int:
+    workspace = cast(Path, args.workspace)
+    if not workspace.exists() or not workspace.is_dir():
+        raise SystemExit(f"error: workspace does not exist: {workspace}")
+
+    runtime = VoidCodeRuntime(workspace=workspace)
+    try:
+        status = runtime.current_status()
+    finally:
+        _close_runtime(runtime)
+
+    payload = {
+        "workspace": str(workspace),
+        "mcp": _mcp_status_payload(status.mcp),
+    }
+    if cast(bool, args.json):
+        print_json(payload)
+        return EXIT_SUCCESS
+
+    details = status.mcp.details
+    print(
+        _format_named_record(
+            "MCP",
+            [
+                ("state", status.mcp.state),
+                ("mode", details.get("mode", "disabled")),
+                ("configured", details.get("configured", False)),
+                ("configured_enabled", details.get("configured_enabled", False)),
+                ("configured_server_count", details.get("configured_server_count", 0)),
+                ("running_server_count", details.get("running_server_count", 0)),
+                ("failed_server_count", details.get("failed_server_count", 0)),
+            ],
+        )
+    )
+    servers = cast(list[object], details.get("servers", []))
+    for item in servers:
+        server = cast(dict[str, object], item)
+        print(
+            _format_named_record(
+                "MCP_SERVER",
+                [
+                    ("name", server.get("server")),
+                    ("status", server.get("status")),
+                    ("scope", server.get("scope")),
+                    ("transport", server.get("transport")),
+                    ("command", repr(server.get("command", []))),
+                    ("stage", server.get("stage")),
+                    ("error", repr(server.get("error"))),
+                ],
+            )
+        )
     return EXIT_SUCCESS
 
 
@@ -1555,6 +1623,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     commands_subparsers = commands_parser.add_subparsers(dest="commands_command")
 
+    mcp_parser = subparsers.add_parser(
+        "mcp", help="Inspect runtime-managed MCP configuration and health."
+    )
+    mcp_subparsers = mcp_parser.add_subparsers(dest="mcp_command")
+
     config_show_parser = config_subparsers.add_parser(
         "show", help="Show effective runtime config for a workspace or session."
     )
@@ -1621,6 +1694,22 @@ def build_parser() -> argparse.ArgumentParser:
         help="Output the command definition as JSON.",
     )
     commands_show_parser.set_defaults(handler=_handle_commands_show_command)
+
+    mcp_list_parser = mcp_subparsers.add_parser(
+        "list", help="List configured MCP servers and passive runtime status."
+    )
+    _ = mcp_list_parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd(),
+        help="Workspace root used to resolve runtime config and MCP state.",
+    )
+    _ = mcp_list_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output MCP status as JSON.",
+    )
+    mcp_list_parser.set_defaults(handler=_handle_mcp_list_command)
 
     config_schema_parser = config_subparsers.add_parser(
         "schema", help="Print the JSON Schema for .voidcode.json."

--- a/src/voidcode/doctor/checker.py
+++ b/src/voidcode/doctor/checker.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
     from ..lsp.presets import LspServerPreset
     from ..mcp.config import McpServerConfig
 
+from ..mcp.redaction import format_redacted_mcp_command, redact_mcp_command
+
 # Timeout for executable checks
 _EXECUTABLE_CHECK_TIMEOUT = 5.0
 
@@ -257,7 +259,7 @@ class LspServerChecker:
                 details={
                     "server_name": self._server_name,
                     "preset_id": preset_id,
-                    "command": list(command),
+                    "command": redact_mcp_command(command),
                     "languages": list(self._preset.languages) if self._preset.languages else [],
                     "extensions": list(self._preset.extensions) if self._preset.extensions else [],
                 },
@@ -269,13 +271,13 @@ class LspServerChecker:
             check_type=DoctorCheckType.LSP_SERVER.value,
             details={
                 "server_name": self._server_name,
-                "command": list(command),
+                "command": redact_mcp_command(command),
                 "languages": list(self._preset.languages) if self._preset.languages else [],
                 "extensions": list(self._preset.extensions) if self._preset.extensions else [],
             },
             error_message=(
                 f"LSP server '{self._server_name}' command '{executable}' not found in PATH. "
-                f"Full command: {' '.join(command)}"
+                f"Full command: {format_redacted_mcp_command(command)}"
             ),
         )
 
@@ -302,6 +304,7 @@ class McpServerChecker:
                 details={
                     "server_name": self._server_name,
                     "transport": self._config.transport,
+                    "scope": getattr(self._config, "scope", "runtime"),
                 },
                 error_message=f"MCP server '{self._server_name}' has no command configured",
             )
@@ -314,6 +317,7 @@ class McpServerChecker:
                 check_type=DoctorCheckType.MCP_SERVER.value,
                 details={
                     "server_name": self._server_name,
+                    "scope": getattr(self._config, "scope", "runtime"),
                 },
                 error_message=f"MCP server '{self._server_name}' has empty command",
             )
@@ -325,8 +329,9 @@ class McpServerChecker:
                 check_type=DoctorCheckType.MCP_SERVER.value,
                 details={
                     "server_name": self._server_name,
-                    "command": list(command),
+                    "command": redact_mcp_command(command),
                     "transport": self._config.transport,
+                    "scope": getattr(self._config, "scope", "runtime"),
                     "has_env": bool(self._config.env),
                 },
             )
@@ -337,11 +342,12 @@ class McpServerChecker:
             check_type=DoctorCheckType.MCP_SERVER.value,
             details={
                 "server_name": self._server_name,
-                "command": list(command),
+                "command": redact_mcp_command(command),
                 "transport": self._config.transport,
+                "scope": getattr(self._config, "scope", "runtime"),
             },
             error_message=(
                 f"MCP server '{self._server_name}' command '{executable}' not found in PATH. "
-                f"Full command: {' '.join(command)}"
+                f"Full command: {format_redacted_mcp_command(command)}"
             ),
         )

--- a/src/voidcode/doctor/doctor.py
+++ b/src/voidcode/doctor/doctor.py
@@ -246,9 +246,55 @@ def create_doctor_for_config(
                 if preset:
                     doctor.add_lsp_server_check(server_name, preset)
 
-    # Check MCP servers (only when mcp.enabled is True).
+    # Always report MCP configuration state so disabled/unconfigured MCP is visible.
     mcp_config = config.mcp
-    if mcp_config is not None and mcp_config.enabled is True and mcp_config.servers:
+    if mcp_config is None:
+        doctor.add_result(
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.NOT_CONFIGURED,
+                name="mcp",
+                check_type=DoctorCheckType.MCP_SERVER.value,
+                details={
+                    "configured": False,
+                    "configured_enabled": False,
+                    "scope_boundary": "runtime/session-scoped when configured",
+                },
+                error_message=(
+                    "MCP is not configured; set mcp.enabled and mcp.servers to enable it."
+                ),
+            )
+        )
+    elif mcp_config.enabled is not True:
+        doctor.add_result(
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.NOT_CONFIGURED,
+                name="mcp",
+                check_type=DoctorCheckType.MCP_SERVER.value,
+                details={
+                    "configured": bool(mcp_config.servers),
+                    "configured_enabled": False,
+                    "configured_server_count": len(mcp_config.servers or {}),
+                    "scope_boundary": "runtime/session-scoped when enabled",
+                },
+                error_message="MCP is disabled; set mcp.enabled=true to run configured servers.",
+            )
+        )
+    elif not mcp_config.servers:
+        doctor.add_result(
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.NOT_CONFIGURED,
+                name="mcp",
+                check_type=DoctorCheckType.MCP_SERVER.value,
+                details={
+                    "configured": False,
+                    "configured_enabled": True,
+                    "configured_server_count": 0,
+                    "scope_boundary": "runtime/session-scoped when servers are configured",
+                },
+                error_message="MCP is enabled but no servers are configured.",
+            )
+        )
+    else:
         for server_name, server_config in mcp_config.servers.items():
             doctor.add_mcp_server_check(server_name, server_config)
 

--- a/src/voidcode/doctor/reporter.py
+++ b/src/voidcode/doctor/reporter.py
@@ -188,6 +188,16 @@ def _format_details(result: CapabilityCheckResult) -> list[str]:
 
     if "command" in d and result.status != CapabilityCheckStatus.READY:
         details.append(f"command: {d['command']}")
+    if "transport" in d:
+        details.append(f"transport: {d['transport']}")
+    if "scope" in d:
+        details.append(f"scope: {d['scope']}")
+    if "configured_enabled" in d:
+        details.append(f"configured_enabled: {d['configured_enabled']}")
+    if "configured_server_count" in d:
+        details.append(f"configured_server_count: {d['configured_server_count']}")
+    if "scope_boundary" in d:
+        details.append(f"scope_boundary: {d['scope_boundary']}")
     if "available_commands" in d:
         details.append(f"available: {', '.join(d['available_commands'])}")
     if "languages" in d and d["languages"]:

--- a/src/voidcode/mcp/__init__.py
+++ b/src/voidcode/mcp/__init__.py
@@ -41,6 +41,7 @@ from .observability import (
     create_diagnostic,
     diagnostic_message,
 )
+from .redaction import format_redacted_mcp_command, redact_mcp_command
 
 # Types - static data structures
 from .types import (
@@ -93,6 +94,8 @@ __all__ = [
     "McpEventType",
     "create_diagnostic",
     "diagnostic_message",
+    "format_redacted_mcp_command",
+    "redact_mcp_command",
 ]
 
 # Module version

--- a/src/voidcode/mcp/redaction.py
+++ b/src/voidcode/mcp/redaction.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+_SECRET_OPTION_NAMES = {
+    "--api-key",
+    "--apikey",
+    "--token",
+    "--access-token",
+    "--secret",
+    "--password",
+}
+_SECRET_OPTION_FRAGMENTS = ("key", "token", "secret", "password", "credential")
+_SECRET_ENV_SUFFIXES = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL")
+
+
+def redact_mcp_command(command: Sequence[str]) -> list[str]:
+    """Return an MCP command safe for diagnostics and user-visible status."""
+
+    redacted: list[str] = []
+    redact_next = False
+    for part in command:
+        if redact_next:
+            redacted.append("<redacted>")
+            redact_next = False
+            continue
+
+        option_name, separator, option_value = part.partition("=")
+        lowered_option = option_name.lower()
+        if option_name.isidentifier() and separator and _looks_like_secret_env(option_name):
+            redacted.append(f"{option_name}=<redacted>")
+            continue
+        if lowered_option in _SECRET_OPTION_NAMES or (
+            lowered_option.startswith("--")
+            and any(fragment in lowered_option for fragment in _SECRET_OPTION_FRAGMENTS)
+        ):
+            if separator:
+                redacted.append(f"{option_name}=<redacted>")
+            else:
+                redacted.append(part)
+                redact_next = True
+            continue
+        if option_value:
+            redacted.append(part)
+            continue
+        redacted.append(part)
+    return redacted
+
+
+def format_redacted_mcp_command(command: Sequence[str]) -> str:
+    return " ".join(redact_mcp_command(command))
+
+
+def _looks_like_secret_env(name: str) -> bool:
+    upper_name = name.upper()
+    return any(
+        upper_name == suffix or upper_name.endswith(f"_{suffix}") for suffix in _SECRET_ENV_SUFFIXES
+    )

--- a/src/voidcode/mcp/types.py
+++ b/src/voidcode/mcp/types.py
@@ -105,6 +105,7 @@ class McpServerRuntimeState:
     stage: str | None = None
     error: str | None = None
     command: list[str] = field(default_factory=list)
+    scope: Literal["runtime", "session"] = "runtime"
     retry_available: bool = False
 
 

--- a/src/voidcode/runtime/config_schema.py
+++ b/src/voidcode/runtime/config_schema.py
@@ -144,6 +144,14 @@ def runtime_config_json_schema() -> dict[str, object]:
                                     "type": "object",
                                     "additionalProperties": {"type": "string"},
                                 },
+                                "scope": {
+                                    "type": "string",
+                                    "enum": ["runtime", "session"],
+                                    "description": (
+                                        "Runtime-scoped servers are shared by the runtime; "
+                                        "session-scoped servers are isolated per session."
+                                    ),
+                                },
                             },
                         },
                     },

--- a/src/voidcode/runtime/mcp.py
+++ b/src/voidcode/runtime/mcp.py
@@ -43,6 +43,7 @@ from ..mcp import (
     McpToolDescriptor,
     McpToolSafety,
     create_diagnostic,
+    redact_mcp_command,
 )
 from .config import RuntimeMcpConfig
 from .events import (
@@ -190,6 +191,7 @@ class ManagedMcpManager:
                 server_name=name,
                 status="stopped",
                 command=list(server.command),
+                scope=getattr(server, "scope", "runtime"),
             )
             for name, server in self._configuration.servers.items()
         }
@@ -708,8 +710,9 @@ class ManagedMcpManager:
         if method is not None:
             payload["method"] = method
         if command is not None:
-            payload["command"] = command
-            payload["cmd"] = command
+            redacted_command = redact_mcp_command(command)
+            payload["command"] = redacted_command
+            payload["cmd"] = redacted_command
         if diagnostic is not None:
             payload["diagnostic"] = {
                 "severity": diagnostic.severity,
@@ -730,6 +733,7 @@ class ManagedMcpManager:
                         server_name, McpServerRuntimeState(server_name=server_name)
                     ).command
                 ),
+                scope=key.scope,
                 retry_available=True,
             )
             self._record_event(
@@ -755,6 +759,7 @@ class ManagedMcpManager:
                         server_name, McpServerRuntimeState(server_name=server_name)
                     ).command
                 ),
+                scope=key.scope,
                 retry_available=False,
             )
             self._record_event(
@@ -794,6 +799,7 @@ class ManagedMcpManager:
                     status="running",
                     workspace_root=str(remaining_session_owner.workspace_root),
                     command=list(existing_state.command),
+                    scope=remaining_session_owner.scope,
                     retry_available=False,
                 )
             elif not (
@@ -806,6 +812,7 @@ class ManagedMcpManager:
                     status="stopped",
                     workspace_root=str(workspace_root),
                     command=list(existing_state.command),
+                    scope=key.scope,
                     retry_available=bool(self._configuration.servers),
                 )
             self._record_event(

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -30,6 +30,7 @@ from ..hook.executor import (
     run_lifecycle_hooks,
     run_tool_hooks,
 )
+from ..mcp.redaction import redact_mcp_command
 from ..provider.auth import (
     ProviderAuthAuthorizeRequest,
     ProviderAuthResolutionError,
@@ -3066,6 +3067,7 @@ class VoidCodeRuntime:
             None,
         )
         mcp_servers = tuple(mcp_state.servers.values())
+        mcp_configured_servers = mcp_state.configuration.servers
         mcp_status = (
             "unconfigured"
             if mcp_state.mode != "managed" or not mcp_state.configuration.configured_enabled
@@ -3076,6 +3078,42 @@ class VoidCodeRuntime:
             else "stopped"
         )
         mcp_error = next((server.error for server in mcp_servers if server.error), None)
+        mcp_server_details: list[dict[str, object]] = []
+        for server_name, server_config in sorted(mcp_configured_servers.items()):
+            runtime_state = mcp_state.servers.get(server_name)
+            command = (
+                list(runtime_state.command)
+                if runtime_state is not None and runtime_state.command
+                else list(getattr(server_config, "command", ()))
+            )
+            server_status = (
+                runtime_state.status
+                if runtime_state is not None
+                else "disabled"
+                if mcp_state.mode != "managed" or not mcp_state.configuration.configured_enabled
+                else "stopped"
+            )
+            mcp_server_details.append(
+                {
+                    "server": server_name,
+                    "status": server_status,
+                    "scope": getattr(
+                        runtime_state,
+                        "scope",
+                        getattr(server_config, "scope", "runtime"),
+                    ),
+                    "transport": getattr(server_config, "transport", "stdio"),
+                    "workspace_root": (
+                        None if runtime_state is None else runtime_state.workspace_root
+                    ),
+                    "stage": None if runtime_state is None else runtime_state.stage,
+                    "error": None if runtime_state is None else runtime_state.error,
+                    "command": redact_mcp_command(command),
+                    "retry_available": (
+                        False if runtime_state is None else runtime_state.retry_available
+                    ),
+                }
+            )
         return RuntimeStatusSnapshot(
             git=git,
             lsp=CapabilityStatusSnapshot(state=lsp_status, error=lsp_error),
@@ -3083,7 +3121,11 @@ class VoidCodeRuntime:
                 state=mcp_status,
                 error=mcp_error,
                 details={
-                    "configured_server_count": len(mcp_servers),
+                    "mode": mcp_state.mode,
+                    "configured": bool(mcp_configured_servers),
+                    "configured_enabled": mcp_state.configuration.configured_enabled,
+                    "configured_server_count": len(mcp_configured_servers),
+                    "active_server_count": len(mcp_servers),
                     "running_server_count": sum(
                         1 for server in mcp_servers if server.status == "running"
                     ),
@@ -3091,18 +3133,7 @@ class VoidCodeRuntime:
                         1 for server in mcp_servers if server.status == "failed"
                     ),
                     "retry_available": any(server.retry_available for server in mcp_servers),
-                    "servers": [
-                        {
-                            "server": server.server_name,
-                            "status": server.status,
-                            "workspace_root": server.workspace_root,
-                            "stage": server.stage,
-                            "error": server.error,
-                            "command": list(server.command),
-                            "retry_available": server.retry_available,
-                        }
-                        for server in mcp_servers
-                    ],
+                    "servers": mcp_server_details,
                 },
             ),
             acp=self._acp_status_snapshot(acp_state),

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -2962,7 +2962,11 @@ def test_transport_run_stream_continues_after_mcp_startup_failure_and_status_sta
         "state": "failed",
         "error": _FailingMcpManager.startup_error,
         "details": {
+            "mode": "managed",
+            "configured": True,
+            "configured_enabled": True,
             "configured_server_count": 1,
+            "active_server_count": 1,
             "running_server_count": 0,
             "failed_server_count": 1,
             "retry_available": True,
@@ -2970,6 +2974,8 @@ def test_transport_run_stream_continues_after_mcp_startup_failure_and_status_sta
                 {
                     "server": "context7",
                     "status": "failed",
+                    "scope": "runtime",
+                    "transport": "stdio",
                     "workspace_root": str(tmp_path),
                     "stage": "startup",
                     "error": _FailingMcpManager.startup_error,
@@ -3063,11 +3069,14 @@ def test_transport_status_preserves_mcp_failed_state_across_fresh_requests(
         )
     )
     assert mcp_details["configured_server_count"] == 1
+    assert mcp_details["active_server_count"] == 1
     assert mcp_details["running_server_count"] == 0
     assert mcp_details["failed_server_count"] == 1
     assert mcp_details["retry_available"] is True
     assert server_payload["server"] == "broken"
     assert server_payload["status"] == "failed"
+    assert server_payload["scope"] == "runtime"
+    assert server_payload["transport"] == "stdio"
     assert server_payload["workspace_root"] == str(tmp_path)
     assert server_payload["stage"] == "startup"
     assert server_payload["retry_available"] is True

--- a/tests/unit/doctor/test_checker.py
+++ b/tests/unit/doctor/test_checker.py
@@ -158,7 +158,7 @@ class TestMcpServerChecker:
         from voidcode.mcp.config import McpServerConfig
 
         config = McpServerConfig(
-            command=("python", "--version"),
+            command=("python", "--api-key", "secret-token"),
             transport="stdio",
         )
         checker = McpServerChecker("test-mcp", config)
@@ -168,13 +168,16 @@ class TestMcpServerChecker:
         assert result.status == CapabilityCheckStatus.READY
         assert result.name == "mcp:test-mcp"
         assert result.check_type == DoctorCheckType.MCP_SERVER.value
+        assert result.details["scope"] == "runtime"
+        assert result.details["command"] == ["python", "--api-key", "<redacted>"]
+        assert "secret-token" not in str(result.details)
 
     def test_check_with_missing_mcp_server(self) -> None:
         """Test checker with a missing MCP server."""
         from voidcode.mcp.config import McpServerConfig
 
         config = McpServerConfig(
-            command=("missing-mcp-server-xyz",),
+            command=("missing-mcp-server-xyz", "--token=secret-token"),
             transport="stdio",
         )
         checker = McpServerChecker("missing-mcp", config)
@@ -182,6 +185,13 @@ class TestMcpServerChecker:
 
         assert result.status == CapabilityCheckStatus.NOT_FOUND
         assert result.error_message is not None
+        assert result.details["scope"] == "runtime"
+        assert result.details["command"] == [
+            "missing-mcp-server-xyz",
+            "--token=<redacted>",
+        ]
+        assert "secret-token" not in result.error_message
+        assert "secret-token" not in str(result.details)
 
     def test_check_with_no_command(self) -> None:
         """Test checker with MCP config that has no command."""

--- a/tests/unit/doctor/test_doctor.py
+++ b/tests/unit/doctor/test_doctor.py
@@ -14,7 +14,7 @@ from voidcode.doctor.checker import (
     DoctorCheckType,
 )
 from voidcode.provider.config import OpenAIProviderConfig, ProviderConfigs
-from voidcode.runtime.config import RuntimeConfig
+from voidcode.runtime.config import RuntimeConfig, RuntimeMcpConfig, RuntimeMcpServerConfig
 
 
 class TestCapabilityDoctor:
@@ -101,6 +101,37 @@ class TestCreateDoctorForConfig:
 
         # Should not raise and should have at least ast-grep
         assert len(doctor.results) >= 1
+        mcp_result = next(result for result in doctor.results if result.name == "mcp")
+        assert mcp_result.status == CapabilityCheckStatus.NOT_CONFIGURED
+        assert mcp_result.details["configured_enabled"] is False
+
+    def test_reports_disabled_mcp_configuration(self) -> None:
+        config = RuntimeConfig(
+            mcp=RuntimeMcpConfig(
+                enabled=False,
+                servers={
+                    "context7": RuntimeMcpServerConfig(command=("context7",), scope="session")
+                },
+            )
+        )
+
+        doctor = create_doctor_for_config(Path("/tmp"), config)
+
+        mcp_result = next(result for result in doctor.results if result.name == "mcp")
+        assert mcp_result.status == CapabilityCheckStatus.NOT_CONFIGURED
+        assert mcp_result.details["configured"] is True
+        assert mcp_result.details["configured_enabled"] is False
+        assert mcp_result.details["configured_server_count"] == 1
+
+    def test_reports_enabled_mcp_without_servers(self) -> None:
+        config = RuntimeConfig(mcp=RuntimeMcpConfig(enabled=True, servers={}))
+
+        doctor = create_doctor_for_config(Path("/tmp"), config)
+
+        mcp_result = next(result for result in doctor.results if result.name == "mcp")
+        assert mcp_result.status == CapabilityCheckStatus.NOT_CONFIGURED
+        assert mcp_result.details["configured_enabled"] is True
+        assert mcp_result.details["configured_server_count"] == 0
 
     def test_skips_formatter_checks_when_hooks_disabled(self) -> None:
         """Formatter checks should be skipped when hooks.enabled is False."""

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -106,6 +106,24 @@ def _expected_agent_models(global_model: str | None) -> dict[str, dict[str, obje
     }
 
 
+def _expected_unconfigured_mcp_status() -> dict[str, object]:
+    return {
+        "state": "unconfigured",
+        "error": None,
+        "details": {
+            "mode": "disabled",
+            "configured": False,
+            "configured_enabled": False,
+            "configured_server_count": 0,
+            "active_server_count": 0,
+            "running_server_count": 0,
+            "failed_server_count": 0,
+            "retry_available": False,
+            "servers": [],
+        },
+    }
+
+
 class _StubTtyStderr:
     def __init__(self) -> None:
         self.writes: list[str] = []
@@ -1395,6 +1413,7 @@ def test_config_show_outputs_workspace_effective_config() -> None:
             "fallback_chain": ["repo/model"],
         },
         "context_budget": {"context_window": None, "max_output_tokens": None},
+        "mcp": _expected_unconfigured_mcp_status(),
     }
     assert "Traceback" not in result.stderr
 
@@ -1622,6 +1641,7 @@ def test_config_show_outputs_resumed_session_effective_config() -> None:
             "fallback_chain": ["repo/model", "repo/session-fallback"],
         },
         "context_budget": {"context_window": None, "max_output_tokens": None},
+        "mcp": _expected_unconfigured_mcp_status(),
     }
     assert "Traceback" not in result.stderr
 
@@ -1667,6 +1687,9 @@ def test_config_show_delegates_to_runtime_effective_config(capsys: Any) -> None:
                 fallback_chain=("runtime/model",),
             )
             runtime_class.return_value.provider_readiness.return_value = readiness
+            runtime_class.return_value.current_status.return_value = SimpleNamespace(
+                mcp=SimpleNamespace(**_expected_unconfigured_mcp_status())
+            )
             result = cli.main(
                 [
                     "config",
@@ -1691,6 +1714,7 @@ def test_config_show_delegates_to_runtime_effective_config(capsys: Any) -> None:
     runtime_class.return_value.effective_category_model_config.assert_called_once_with(
         session_id="config-session"
     )
+    runtime_class.return_value.current_status.assert_called_once_with()
     assert json.loads(captured.out) == {
         "workspace": str(workspace),
         "session_id": "config-session",
@@ -1731,7 +1755,142 @@ def test_config_show_delegates_to_runtime_effective_config(capsys: Any) -> None:
             "fallback_chain": ["runtime/model"],
         },
         "context_budget": {"context_window": None, "max_output_tokens": None},
+        "mcp": _expected_unconfigured_mcp_status(),
     }
+
+
+def test_config_show_outputs_mcp_visibility_without_secrets() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        (workspace / ".voidcode.json").write_text(
+            json.dumps(
+                {
+                    "mcp": {
+                        "enabled": False,
+                        "servers": {
+                            "context7": {
+                                "command": [
+                                    "env",
+                                    "API_KEY=secret-token",
+                                    "context7",
+                                    "--token=other-secret",
+                                ],
+                                "scope": "session",
+                                "env": {"MCP_TOKEN": "secret-token"},
+                            }
+                        },
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        env = with_src_pythonpath(os.environ.copy())
+
+        result = _run_module_cli(
+            "config",
+            "show",
+            "--workspace",
+            str(workspace),
+            env=env,
+        )
+
+    payload = json.loads(result.stdout)
+    server = payload["mcp"]["details"]["servers"][0]
+    assert result.returncode == 0
+    assert payload["mcp"]["state"] == "unconfigured"
+    assert payload["mcp"]["details"]["configured"] is True
+    assert payload["mcp"]["details"]["configured_enabled"] is False
+    assert server["server"] == "context7"
+    assert server["status"] == "disabled"
+    assert server["scope"] == "session"
+    assert server["transport"] == "stdio"
+    assert server["command"] == [
+        "env",
+        "API_KEY=<redacted>",
+        "context7",
+        "--token=<redacted>",
+    ]
+    assert "MCP_TOKEN" not in result.stdout
+    assert "secret-token" not in result.stdout
+    assert "other-secret" not in result.stdout
+
+
+def test_mcp_list_outputs_passive_runtime_status() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        (workspace / ".voidcode.json").write_text(
+            json.dumps(
+                {
+                    "mcp": {
+                        "enabled": False,
+                        "servers": {
+                            "context7": {
+                                "command": ["context7", "--api-key", "secret-token"],
+                                "scope": "runtime",
+                            }
+                        },
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        env = with_src_pythonpath(os.environ.copy())
+
+        result = _run_module_cli(
+            "mcp",
+            "list",
+            "--workspace",
+            str(workspace),
+            "--json",
+            env=env,
+        )
+
+    payload = json.loads(result.stdout)
+    assert result.returncode == 0
+    assert payload["workspace"] == str(workspace)
+    assert payload["mcp"]["details"]["servers"][0]["server"] == "context7"
+    assert payload["mcp"]["details"]["servers"][0]["scope"] == "runtime"
+    assert payload["mcp"]["details"]["servers"][0]["command"] == [
+        "context7",
+        "--api-key",
+        "<redacted>",
+    ]
+    assert "secret-token" not in result.stdout
+
+
+def test_doctor_json_redacts_mcp_command_secrets() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        (workspace / ".voidcode.json").write_text(
+            json.dumps(
+                {
+                    "mcp": {
+                        "enabled": True,
+                        "servers": {
+                            "context7": {
+                                "command": ["python", "--api-key", "secret-token"],
+                                "scope": "runtime",
+                            }
+                        },
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        env = with_src_pythonpath(os.environ.copy())
+
+        result = _run_module_cli(
+            "doctor",
+            "--workspace",
+            str(workspace),
+            "--json",
+            env=env,
+        )
+
+    payload = json.loads(result.stdout)
+    mcp_result = next(item for item in payload["results"] if item["name"] == "mcp:context7")
+    assert mcp_result["details"]["command"] == ["python", "--api-key", "<redacted>"]
+    assert "secret-token" not in result.stdout
 
 
 def test_config_show_invalid_workspace_returns_error() -> None:

--- a/tests/unit/runtime/test_config_schema.py
+++ b/tests/unit/runtime/test_config_schema.py
@@ -68,6 +68,15 @@ def test_runtime_config_json_schema_exposes_core_fields() -> None:
     mcp_servers = cast(dict[str, object], mcp_properties["servers"])
     mcp_server_schema = cast(dict[str, object], mcp_servers["additionalProperties"])
     assert mcp_server_schema["required"] == ["command"]
+    mcp_server_properties = cast(dict[str, object], mcp_server_schema["properties"])
+    assert mcp_server_properties["scope"] == {
+        "type": "string",
+        "enum": ["runtime", "session"],
+        "description": (
+            "Runtime-scoped servers are shared by the runtime; "
+            "session-scoped servers are isolated per session."
+        ),
+    }
     background_task_schema = cast(dict[str, object], properties["background_task"])
     background_task_properties = cast(dict[str, object], background_task_schema["properties"])
     assert background_task_properties["default_concurrency"] == {

--- a/tests/unit/runtime/test_mcp.py
+++ b/tests/unit/runtime/test_mcp.py
@@ -1106,6 +1106,39 @@ def test_mcp_manager_emits_failure_event_when_startup_command_is_missing(tmp_pat
     assert failure_events[0].payload["command"] == ["voidcode-mcp-missing-binary"]
 
 
+def test_mcp_manager_redacts_failure_event_command_secrets(tmp_path: Path) -> None:
+    manager = build_mcp_manager(
+        RuntimeMcpConfig(
+            enabled=True,
+            servers={
+                "missing": RuntimeMcpServerConfig(
+                    transport="stdio",
+                    command=(
+                        "voidcode-mcp-missing-binary",
+                        "--api-key",
+                        "secret-token",
+                        "ACCESS_TOKEN=other-secret",
+                    ),
+                )
+            },
+        )
+    )
+
+    with pytest.raises(ValueError, match="command not found"):
+        manager.list_tools(workspace=tmp_path)
+
+    failure_event = manager.drain_events()[0]
+    assert failure_event.payload["command"] == [
+        "voidcode-mcp-missing-binary",
+        "--api-key",
+        "<redacted>",
+        "ACCESS_TOKEN=<redacted>",
+    ]
+    assert failure_event.payload["cmd"] == failure_event.payload["command"]
+    assert "secret-token" not in str(failure_event.payload)
+    assert "other-secret" not in str(failure_event.payload)
+
+
 def test_mcp_manager_preserves_failed_state_after_startup_failure_stop_event(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_mcp_config.py
+++ b/tests/unit/runtime/test_mcp_config.py
@@ -23,6 +23,7 @@ def test_runtime_config_parses_mcp_stdio_servers(tmp_path: Path) -> None:
                             "transport": "stdio",
                             "command": ["python", "tests/fixtures/echo_mcp.py"],
                             "env": {"ECHO_MODE": "1"},
+                            "scope": "session",
                         }
                     },
                 }
@@ -40,6 +41,7 @@ def test_runtime_config_parses_mcp_stdio_servers(tmp_path: Path) -> None:
                 transport="stdio",
                 command=("python", "tests/fixtures/echo_mcp.py"),
                 env={"ECHO_MODE": "1"},
+                scope="session",
             )
         },
     )
@@ -141,6 +143,11 @@ def test_parse_mcp_config_defaults_transport_and_preserves_public_dataclasses() 
             {"servers": {"echo": {"command": ["python"], "env": {1: "enabled"}}}},
             "runtime config field 'mcp.servers.echo.env' keys must be strings",
             id="env-key-type",
+        ),
+        pytest.param(
+            {"servers": {"echo": {"command": ["python"], "scope": "workspace"}}},
+            "runtime config field 'mcp.servers.echo.scope' must be one of: runtime, session",
+            id="scope-value",
         ),
         pytest.param(
             {"request_timeout_seconds": 0},

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -5227,7 +5227,11 @@ def test_runtime_emits_mcp_failed_and_continues_run_on_startup_refresh(
     assert status.mcp.state == "failed"
     assert status.mcp.error == _FailingMcpManager.startup_error
     assert status.mcp.details == {
+        "mode": "managed",
+        "configured": True,
+        "configured_enabled": True,
         "configured_server_count": 1,
+        "active_server_count": 1,
         "running_server_count": 0,
         "failed_server_count": 1,
         "retry_available": True,
@@ -5235,6 +5239,8 @@ def test_runtime_emits_mcp_failed_and_continues_run_on_startup_refresh(
             {
                 "server": "echo",
                 "status": "failed",
+                "scope": "runtime",
+                "transport": "stdio",
                 "workspace_root": str(tmp_path),
                 "stage": "startup",
                 "error": _FailingMcpManager.startup_error,


### PR DESCRIPTION
## Summary
- Adds passive MCP status/config visibility to `config show` and a new `voidcode mcp list` inspection command.
- Extends runtime and doctor MCP diagnostics with configured/enabled counts, server scope/status/stage/error, and redacted command details.
- Documents and tests `mcp.servers.*.scope` schema support while preserving runtime/session-scoped MCP boundaries.

## Verification
- `uv run ruff check .`
- `uv run basedpyright --warnings src`
- `uv run pytest -n auto tests/unit --ignore=tests/unit/tools/fuzz --ignore=tests/unit/runtime/test_http_question_payload_fuzz.py --ignore=tests/unit/runtime/test_runtime_service_extensions.py`
- `uv run pytest tests/unit/runtime/test_runtime_service_extensions.py::test_runtime_emits_mcp_failed_and_continues_run_on_startup_refresh tests/integration/test_http_transport.py::test_transport_run_stream_continues_after_mcp_startup_failure_and_status_stays_failed tests/integration/test_http_transport.py::test_transport_status_preserves_mcp_failed_state_across_fresh_requests -q`
- `uv build`

Closes #300