### PR TITLE
feat: add first-task readiness diagnostics

### DIFF
--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -1068,7 +1068,16 @@ def _handle_config_init_command(args: argparse.Namespace) -> int:
             f"error: runtime config already exists: {config_path}; pass --force to overwrite"
         )
     written_path = write_runtime_config_payload(workspace, payload)
-    print(json.dumps({"workspace": str(workspace), "config_path": str(written_path)}))
+    print(
+        json.dumps(
+            {
+                "workspace": str(workspace),
+                "config_path": str(written_path),
+                "next_command": f"voidcode doctor --workspace {workspace}",
+                "first_task_command": f'voidcode run "read README.md" --workspace {workspace}',
+            }
+        )
+    )
     return 0
 
 

--- a/src/voidcode/doctor/doctor.py
+++ b/src/voidcode/doctor/doctor.py
@@ -252,51 +252,52 @@ def create_doctor_for_config(
         for server_name, server_config in mcp_config.servers.items():
             doctor.add_mcp_server_check(server_name, server_config)
 
-    if config.execution_engine == "provider" or config.model is not None:
-        from ..runtime.service import VoidCodeRuntime
+    from ..runtime.service import VoidCodeRuntime
 
-        runtime: VoidCodeRuntime | None = None
-        try:
-            runtime = VoidCodeRuntime(workspace=workspace, config=config)
-            readiness = runtime.provider_readiness()
-        except ValueError as exc:
-            doctor.add_result(
-                CapabilityCheckResult(
-                    status=CapabilityCheckStatus.ERROR,
-                    name="provider.readiness",
-                    check_type=DoctorCheckType.PROVIDER_READINESS.value,
-                    details={
-                        "model": config.model,
-                        "status": "invalid_config",
-                    },
-                    error_message=str(exc),
-                )
-            )
-            return doctor
-        finally:
-            if runtime is not None:
-                exit_method = getattr(runtime, "__exit__", None)
-                if callable(exit_method):
-                    exit_method(None, None, None)
-        status = CapabilityCheckStatus.READY if readiness.ok else CapabilityCheckStatus.ERROR
+    runtime: VoidCodeRuntime | None = None
+    try:
+        runtime = VoidCodeRuntime(workspace=workspace, config=config)
+        readiness = runtime.provider_readiness()
+    except ValueError as exc:
         doctor.add_result(
             CapabilityCheckResult(
-                status=status,
+                status=CapabilityCheckStatus.ERROR,
                 name="provider.readiness",
                 check_type=DoctorCheckType.PROVIDER_READINESS.value,
                 details={
-                    "provider": readiness.provider,
-                    "model": readiness.model,
-                    "configured": readiness.configured,
-                    "auth_present": readiness.auth_present,
-                    "streaming_supported": readiness.streaming_supported,
-                    "context_window": readiness.context_window,
-                    "max_output_tokens": readiness.max_output_tokens,
-                    "fallback_chain": list(readiness.fallback_chain),
-                    "status": readiness.status,
+                    "model": config.model,
+                    "execution_engine": config.execution_engine,
+                    "status": "invalid_config",
                 },
-                error_message=None if readiness.ok else readiness.guidance,
+                error_message=str(exc),
             )
         )
+        return doctor
+    finally:
+        if runtime is not None:
+            exit_method = getattr(runtime, "__exit__", None)
+            if callable(exit_method):
+                exit_method(None, None, None)
+    status = CapabilityCheckStatus.READY if readiness.ok else CapabilityCheckStatus.ERROR
+    doctor.add_result(
+        CapabilityCheckResult(
+            status=status,
+            name="provider.readiness",
+            check_type=DoctorCheckType.PROVIDER_READINESS.value,
+            details={
+                "provider": readiness.provider,
+                "model": readiness.model,
+                "configured": readiness.configured,
+                "auth_present": readiness.auth_present,
+                "streaming_configured": readiness.streaming_configured,
+                "streaming_supported": readiness.streaming_supported,
+                "context_window": readiness.context_window,
+                "max_output_tokens": readiness.max_output_tokens,
+                "fallback_chain": list(readiness.fallback_chain),
+                "status": readiness.status,
+            },
+            error_message=None if readiness.ok else readiness.guidance,
+        )
+    )
 
     return doctor

--- a/src/voidcode/doctor/doctor.py
+++ b/src/voidcode/doctor/doctor.py
@@ -252,52 +252,53 @@ def create_doctor_for_config(
         for server_name, server_config in mcp_config.servers.items():
             doctor.add_mcp_server_check(server_name, server_config)
 
-    from ..runtime.service import VoidCodeRuntime
+    if config.execution_engine == "provider" or config.model is not None:
+        from ..runtime.service import VoidCodeRuntime
 
-    runtime: VoidCodeRuntime | None = None
-    try:
-        runtime = VoidCodeRuntime(workspace=workspace, config=config)
-        readiness = runtime.provider_readiness()
-    except ValueError as exc:
+        runtime: VoidCodeRuntime | None = None
+        try:
+            runtime = VoidCodeRuntime(workspace=workspace, config=config)
+            readiness = runtime.provider_readiness()
+        except ValueError as exc:
+            doctor.add_result(
+                CapabilityCheckResult(
+                    status=CapabilityCheckStatus.ERROR,
+                    name="provider.readiness",
+                    check_type=DoctorCheckType.PROVIDER_READINESS.value,
+                    details={
+                        "model": config.model,
+                        "execution_engine": config.execution_engine,
+                        "status": "invalid_config",
+                    },
+                    error_message=str(exc),
+                )
+            )
+            return doctor
+        finally:
+            if runtime is not None:
+                exit_method = getattr(runtime, "__exit__", None)
+                if callable(exit_method):
+                    exit_method(None, None, None)
+        status = CapabilityCheckStatus.READY if readiness.ok else CapabilityCheckStatus.ERROR
         doctor.add_result(
             CapabilityCheckResult(
-                status=CapabilityCheckStatus.ERROR,
+                status=status,
                 name="provider.readiness",
                 check_type=DoctorCheckType.PROVIDER_READINESS.value,
                 details={
-                    "model": config.model,
-                    "execution_engine": config.execution_engine,
-                    "status": "invalid_config",
+                    "provider": readiness.provider,
+                    "model": readiness.model,
+                    "configured": readiness.configured,
+                    "auth_present": readiness.auth_present,
+                    "streaming_configured": readiness.streaming_configured,
+                    "streaming_supported": readiness.streaming_supported,
+                    "context_window": readiness.context_window,
+                    "max_output_tokens": readiness.max_output_tokens,
+                    "fallback_chain": list(readiness.fallback_chain),
+                    "status": readiness.status,
                 },
-                error_message=str(exc),
+                error_message=None if readiness.ok else readiness.guidance,
             )
         )
-        return doctor
-    finally:
-        if runtime is not None:
-            exit_method = getattr(runtime, "__exit__", None)
-            if callable(exit_method):
-                exit_method(None, None, None)
-    status = CapabilityCheckStatus.READY if readiness.ok else CapabilityCheckStatus.ERROR
-    doctor.add_result(
-        CapabilityCheckResult(
-            status=status,
-            name="provider.readiness",
-            check_type=DoctorCheckType.PROVIDER_READINESS.value,
-            details={
-                "provider": readiness.provider,
-                "model": readiness.model,
-                "configured": readiness.configured,
-                "auth_present": readiness.auth_present,
-                "streaming_configured": readiness.streaming_configured,
-                "streaming_supported": readiness.streaming_supported,
-                "context_window": readiness.context_window,
-                "max_output_tokens": readiness.max_output_tokens,
-                "fallback_chain": list(readiness.fallback_chain),
-                "status": readiness.status,
-            },
-            error_message=None if readiness.ok else readiness.guidance,
-        )
-    )
 
     return doctor

--- a/src/voidcode/doctor/reporter.py
+++ b/src/voidcode/doctor/reporter.py
@@ -5,9 +5,32 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from .checker import CapabilityCheckResult, CapabilityCheckStatus
+
+
+@dataclass
+class FirstTaskReadiness:
+    """Readiness summary for the first provider-backed coding task."""
+
+    status: str
+    summary: str
+    next_step: str
+    blockers: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert readiness summary to JSON-safe payload."""
+        return {
+            "status": self.status,
+            "summary": self.summary,
+            "next_step": self.next_step,
+            "blockers": list(self.blockers),
+            "warnings": list(self.warnings),
+            "details": dict(self.details),
+        }
 
 
 @dataclass
@@ -18,6 +41,7 @@ class CapabilityReport:
     summary: dict[str, int]
     results: list[CapabilityCheckResult]
     errors: list[CapabilityCheckResult] = field(default_factory=list)
+    first_task_readiness: FirstTaskReadiness | None = None
 
     @property
     def has_errors(self) -> bool:
@@ -44,6 +68,9 @@ class CapabilityReport:
                 }
                 for r in self.results
             ],
+            "first_task_readiness": (
+                self.first_task_readiness.to_dict() if self.first_task_readiness else None
+            ),
             "has_errors": self.has_errors,
             "is_healthy": self.is_healthy,
         }
@@ -77,7 +104,125 @@ def create_report(
         summary=summary,
         results=list(results),
         errors=errors,
+        first_task_readiness=_create_first_task_readiness(results, workspace),
     )
+
+
+def _create_first_task_readiness(
+    results: list[CapabilityCheckResult], workspace: Path | None
+) -> FirstTaskReadiness:
+    provider_result = next((r for r in results if r.name == "provider.readiness"), None)
+    config_result = next((r for r in results if r.name == "runtime.config"), None)
+    workspace_arg = f" --workspace {workspace}" if workspace else ""
+    doctor_command = f"voidcode doctor{workspace_arg}"
+    run_command = f'voidcode run "read README.md"{workspace_arg}'
+
+    if config_result is not None and config_result.status != CapabilityCheckStatus.READY:
+        message = config_result.error_message or "Runtime config could not be parsed."
+        return FirstTaskReadiness(
+            status="not_ready",
+            summary="VoidCode cannot evaluate first-task readiness until runtime config is valid.",
+            next_step=f"Fix .voidcode.json, then run `{doctor_command}` again.",
+            blockers=[message],
+            details={
+                "workspace_config_valid": False,
+                "runtime_config_status": config_result.status.value,
+                "local_tools": _local_tool_availability(results),
+            },
+        )
+
+    if provider_result is None:
+        return FirstTaskReadiness(
+            status="not_ready",
+            summary="No provider-backed readiness check ran for the first coding task.",
+            next_step=f"Configure a provider/model, then run `{doctor_command}` again.",
+            blockers=["provider.readiness check is missing"],
+        )
+
+    provider_details = dict(provider_result.details)
+    if provider_result.status != CapabilityCheckStatus.READY:
+        provider_status = str(provider_details.get("status") or provider_result.status.value)
+        blocker = provider_result.error_message or "Provider/model readiness is incomplete."
+        return FirstTaskReadiness(
+            status="not_ready",
+            summary=f"First provider-backed coding task is blocked: {provider_status}.",
+            next_step=_next_step_for_provider_status(provider_status, workspace_arg),
+            blockers=[blocker],
+            details=_first_task_details(provider_result, results),
+        )
+
+    warnings = [
+        f"{result.name}: {result.error_message or result.status.value}"
+        for result in results
+        if result.status != CapabilityCheckStatus.READY
+        and result.name != "provider.readiness"
+        and result.name != "runtime.config"
+    ]
+    if warnings:
+        return FirstTaskReadiness(
+            status="degraded",
+            summary=(
+                "Provider/model/auth are ready, but local tooling may reduce first-task quality."
+            ),
+            next_step=f"You can try `{run_command}` now, then address the warnings below.",
+            warnings=warnings,
+            details=_first_task_details(provider_result, results),
+        )
+
+    return FirstTaskReadiness(
+        status="ready",
+        summary="Provider/model/auth and local checks are ready for a first coding task.",
+        next_step=f"Try `{run_command}`.",
+        details=_first_task_details(provider_result, results),
+    )
+
+
+def _first_task_details(
+    result: CapabilityCheckResult, results: list[CapabilityCheckResult]
+) -> dict[str, Any]:
+    details = dict(result.details)
+    return {
+        "execution_engine": "provider",
+        "workspace_config_valid": True,
+        "provider": details.get("provider"),
+        "model": details.get("model"),
+        "provider_status": details.get("status"),
+        "auth_present": details.get("auth_present"),
+        "context_window": details.get("context_window"),
+        "max_output_tokens": details.get("max_output_tokens"),
+        "fallback_chain": list(details.get("fallback_chain") or []),
+        "local_tools": _local_tool_availability(results),
+    }
+
+
+def _local_tool_availability(results: list[CapabilityCheckResult]) -> list[dict[str, str]]:
+    return [
+        {
+            "name": result.name,
+            "status": result.status.value,
+        }
+        for result in results
+        if result.name not in {"provider.readiness", "runtime.config"}
+    ]
+
+
+def _next_step_for_provider_status(provider_status: str, workspace_arg: str) -> str:
+    if provider_status == "missing_model":
+        return (
+            "Run `voidcode config init --execution-engine provider --model provider/model"
+            f"{workspace_arg}` with a real provider/model, then rerun doctor."
+        )
+    if provider_status in {"missing_auth", "unconfigured"}:
+        return (
+            "Set the provider API key in your environment or user config, then run "
+            f"`voidcode doctor{workspace_arg}` again."
+        )
+    if provider_status == "invalid_model":
+        return (
+            "Choose a supported provider/model with `voidcode provider models <provider>`, "
+            f"then run `voidcode doctor{workspace_arg}` again."
+        )
+    return f"Follow the provider guidance above, then run `voidcode doctor{workspace_arg}` again."
 
 
 def format_report(report: CapabilityReport, *, verbose: bool = False) -> str:
@@ -114,6 +259,43 @@ def format_report(report: CapabilityReport, *, verbose: bool = False) -> str:
         lines.append(f"  {WARN_ICON} Errors: {report.summary['errors']}")
     if report.summary["not_configured"] > 0:
         lines.append(f"  {CIRCLE_ICON} Not configured: {report.summary['not_configured']}")
+
+    if report.first_task_readiness is not None:
+        lines.append("\nFirst task readiness:")
+        readiness = report.first_task_readiness
+        lines.append(f"  status: {readiness.status}")
+        lines.append(f"  summary: {readiness.summary}")
+        lines.append(f"  next: {readiness.next_step}")
+        details = readiness.details
+        if "execution_engine" in details:
+            lines.append(f"  execution_engine: {details['execution_engine']}")
+        if "workspace_config_valid" in details:
+            lines.append(f"  workspace_config_valid: {details['workspace_config_valid']}")
+        if "provider" in details:
+            lines.append(f"  provider: {details['provider']}")
+        if "model" in details:
+            lines.append(f"  model: {details['model']}")
+        if "auth_present" in details:
+            lines.append(f"  auth_present: {details['auth_present']}")
+        if "context_window" in details and details["context_window"] is not None:
+            lines.append(f"  context_window: {details['context_window']}")
+        if "max_output_tokens" in details and details["max_output_tokens"] is not None:
+            lines.append(f"  max_output_tokens: {details['max_output_tokens']}")
+        local_tools = details.get("local_tools")
+        if isinstance(local_tools, list) and local_tools:
+            lines.append("  local_tools:")
+            for tool in cast(list[object], local_tools):
+                if isinstance(tool, dict):
+                    tool_map = cast(dict[str, object], tool)
+                    lines.append(f"    - {tool_map.get('name')}: {tool_map.get('status')}")
+        if readiness.blockers:
+            lines.append("  blockers:")
+            for blocker in readiness.blockers:
+                lines.append(f"    - {blocker}")
+        if readiness.warnings:
+            lines.append("  warnings:")
+            for warning in readiness.warnings:
+                lines.append(f"    - {warning}")
 
     # Detailed results
     lines.append("\nResults:")

--- a/src/voidcode/doctor/reporter.py
+++ b/src/voidcode/doctor/reporter.py
@@ -135,8 +135,15 @@ def _create_first_task_readiness(
         return FirstTaskReadiness(
             status="not_ready",
             summary="No provider-backed readiness check ran for the first coding task.",
-            next_step=f"Configure a provider/model, then run `{doctor_command}` again.",
+            next_step=(
+                "Run `voidcode config init --execution-engine provider --model provider/model"
+                f"{workspace_arg}` with a real provider/model, then run `{doctor_command}` again."
+            ),
             blockers=["provider.readiness check is missing"],
+            details={
+                "workspace_config_valid": True,
+                "local_tools": _local_tool_availability(results),
+            },
         )
 
     provider_details = dict(provider_result.details)

--- a/tests/unit/doctor/test_doctor.py
+++ b/tests/unit/doctor/test_doctor.py
@@ -147,6 +147,19 @@ class TestCreateDoctorForConfig:
         assert readiness.error_message is not None
         assert "openai.api_key" in readiness.error_message
 
+    def test_adds_provider_readiness_check_for_missing_model(self, tmp_path: Path) -> None:
+        config = RuntimeConfig()
+
+        doctor = create_doctor_for_config(tmp_path, config)
+
+        readiness = next(result for result in doctor.results if result.name == "provider.readiness")
+        assert readiness.check_type == DoctorCheckType.PROVIDER_READINESS.value
+        assert readiness.status == CapabilityCheckStatus.ERROR
+        assert readiness.details["status"] == "missing_model"
+        assert readiness.details["auth_present"] is None
+        assert readiness.error_message is not None
+        assert "provider/model" in readiness.error_message
+
     def test_provider_readiness_runtime_error_is_structured_result(self, tmp_path: Path) -> None:
         config = RuntimeConfig(
             model="malformed-model",
@@ -160,6 +173,7 @@ class TestCreateDoctorForConfig:
         assert readiness.status == CapabilityCheckStatus.ERROR
         assert readiness.details == {
             "model": "malformed-model",
+            "execution_engine": "provider",
             "status": "invalid_config",
         }
         assert readiness.error_message is not None

--- a/tests/unit/doctor/test_doctor.py
+++ b/tests/unit/doctor/test_doctor.py
@@ -129,6 +129,18 @@ class TestCreateDoctorForConfig:
             CapabilityCheckStatus.NOT_FOUND,
         }
 
+    def test_skips_provider_readiness_for_deterministic_config_without_model(
+        self, tmp_path: Path
+    ) -> None:
+        config = RuntimeConfig(execution_engine="deterministic")
+
+        doctor = create_doctor_for_config(tmp_path, config)
+
+        readiness_results = [
+            result for result in doctor.results if result.name == "provider.readiness"
+        ]
+        assert readiness_results == []
+
     def test_adds_provider_readiness_check_for_provider_config(self, tmp_path: Path) -> None:
         config = RuntimeConfig(
             model="openai/gpt-4o",
@@ -147,8 +159,8 @@ class TestCreateDoctorForConfig:
         assert readiness.error_message is not None
         assert "openai.api_key" in readiness.error_message
 
-    def test_adds_provider_readiness_check_for_missing_model(self, tmp_path: Path) -> None:
-        config = RuntimeConfig()
+    def test_adds_provider_readiness_check_for_provider_missing_model(self, tmp_path: Path) -> None:
+        config = RuntimeConfig(execution_engine="provider")
 
         doctor = create_doctor_for_config(tmp_path, config)
 

--- a/tests/unit/doctor/test_reporter.py
+++ b/tests/unit/doctor/test_reporter.py
@@ -43,6 +43,28 @@ class TestCreateReport:
         assert report.is_healthy is True
         assert report.has_errors is False
 
+    def test_create_report_without_provider_check_stays_healthy(self) -> None:
+        results = [
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.READY,
+                name="ast-grep",
+                check_type="executable",
+                details={"command": "ast-grep"},
+            )
+        ]
+
+        report = create_report(results)
+
+        assert report.is_healthy is True
+        assert report.has_errors is False
+        assert report.first_task_readiness is not None
+        assert report.first_task_readiness.status == "not_ready"
+        assert report.first_task_readiness.details["workspace_config_valid"] is True
+        assert report.first_task_readiness.details["local_tools"] == [
+            {"name": "ast-grep", "status": "ready"}
+        ]
+        assert report.first_task_readiness.blockers == ["provider.readiness check is missing"]
+
     def test_create_report_with_missing(self) -> None:
         """Test report creation with missing capabilities."""
         results = [

--- a/tests/unit/doctor/test_reporter.py
+++ b/tests/unit/doctor/test_reporter.py
@@ -92,6 +92,67 @@ class TestCreateReport:
         assert report.summary["errors"] == 1
         assert report.is_healthy is False
         assert report.has_errors is True
+        assert report.first_task_readiness is not None
+        assert report.first_task_readiness.status == "not_ready"
+        assert report.first_task_readiness.details["workspace_config_valid"] is False
+
+    def test_create_report_marks_missing_model_first_task_not_ready(self) -> None:
+        results = [
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.ERROR,
+                name="provider.readiness",
+                check_type="provider_readiness",
+                details={"status": "missing_model", "auth_present": None},
+                error_message="Configure a provider/model, for example model: 'openai/gpt-4o'.",
+            ),
+        ]
+
+        report = create_report(results)
+
+        assert report.first_task_readiness is not None
+        assert report.first_task_readiness.status == "not_ready"
+        assert report.first_task_readiness.details["workspace_config_valid"] is True
+        assert report.first_task_readiness.details["local_tools"] == []
+        assert report.first_task_readiness.blockers == [
+            "Configure a provider/model, for example model: 'openai/gpt-4o'."
+        ]
+        assert "config init --execution-engine provider" in report.first_task_readiness.next_step
+
+    def test_create_report_marks_ready_provider_with_missing_tool_degraded(self) -> None:
+        results = [
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.READY,
+                name="provider.readiness",
+                check_type="provider_readiness",
+                details={
+                    "provider": "openai",
+                    "model": "gpt-4o",
+                    "status": "ready",
+                    "auth_present": True,
+                    "context_window": 128_000,
+                    "fallback_chain": ["openai/gpt-4o"],
+                },
+            ),
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.NOT_FOUND,
+                name="ast-grep",
+                check_type="executable",
+                error_message="'ast-grep' not found. Tried: ast-grep",
+            ),
+        ]
+
+        report = create_report(results)
+
+        assert report.first_task_readiness is not None
+        assert report.first_task_readiness.status == "degraded"
+        assert report.first_task_readiness.details["workspace_config_valid"] is True
+        assert report.first_task_readiness.details["local_tools"] == [
+            {"name": "ast-grep", "status": "not_found"}
+        ]
+        assert report.first_task_readiness.blockers == []
+        assert report.first_task_readiness.warnings == [
+            "ast-grep: 'ast-grep' not found. Tried: ast-grep"
+        ]
 
 
 class TestFormatReport:
@@ -157,6 +218,59 @@ class TestFormatReport:
 
         assert "ready" in output.lower() or "capabilities are ready" in output.lower()
 
+    def test_format_report_includes_first_task_readiness_section(self) -> None:
+        results = [
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.ERROR,
+                name="provider.readiness",
+                check_type="provider_readiness",
+                details={"status": "missing_auth", "provider": "openai", "model": "gpt-4o"},
+                error_message="Add provider credentials.",
+            ),
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.NOT_FOUND,
+                name="ast-grep",
+                check_type="executable",
+                error_message="'ast-grep' not found. Tried: ast-grep",
+            ),
+        ]
+
+        report = create_report(results)
+        output = format_report(report)
+
+        assert "First task readiness:" in output
+        assert "status: not_ready" in output
+        assert "execution_engine: provider" in output
+        assert "workspace_config_valid: True" in output
+        assert "provider: openai" in output
+        assert "model: gpt-4o" in output
+        assert "local_tools:" in output
+        assert "ast-grep: not_found" in output
+        assert "Add provider credentials." in output
+
+    def test_format_report_includes_first_task_context_budget(self) -> None:
+        results = [
+            CapabilityCheckResult(
+                status=CapabilityCheckStatus.READY,
+                name="provider.readiness",
+                check_type="provider_readiness",
+                details={
+                    "status": "ready",
+                    "provider": "openai",
+                    "model": "gpt-4o",
+                    "auth_present": True,
+                    "context_window": 128_000,
+                    "max_output_tokens": 8_192,
+                },
+            ),
+        ]
+
+        report = create_report(results)
+        output = format_report(report)
+
+        assert "context_window: 128000" in output
+        assert "max_output_tokens: 8192" in output
+
 
 class TestFormatReportJson:
     """Tests for the format_report_json function."""
@@ -180,6 +294,7 @@ class TestFormatReportJson:
 
         assert "summary" in parsed
         assert "results" in parsed
+        assert "first_task_readiness" in parsed
         assert "is_healthy" in parsed
         assert parsed["summary"]["ready"] == 1
 

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -1853,7 +1853,12 @@ def test_config_init_writes_starter_config_and_refuses_overwrite() -> None:
         written_payload = json.loads((workspace / ".voidcode.json").read_text(encoding="utf-8"))
 
     assert first.returncode == 0
-    assert json.loads(first.stdout)["config_path"].endswith(".voidcode.json")
+    first_payload = json.loads(first.stdout)
+    assert first_payload["config_path"].endswith(".voidcode.json")
+    assert first_payload["next_command"] == f"voidcode doctor --workspace {workspace}"
+    assert first_payload["first_task_command"] == (
+        f'voidcode run "read README.md" --workspace {workspace}'
+    )
     assert written_payload == {
         "$schema": "https://voidcode.dev/schemas/runtime-config.schema.json",
         "approval_mode": "ask",
@@ -1879,6 +1884,75 @@ def test_config_init_provider_requires_model_without_traceback() -> None:
     assert result.returncode != 0
     assert result.stdout == ""
     assert "requires model" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_doctor_json_reports_first_task_readiness_missing_model() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        env = with_src_pythonpath(os.environ.copy())
+
+        result = _run_module_cli(
+            "doctor",
+            "--workspace",
+            str(workspace),
+            "--json",
+            env=env,
+        )
+
+    payload = json.loads(result.stdout)
+    assert result.returncode != 0
+    assert payload["first_task_readiness"]["status"] == "not_ready"
+    assert payload["first_task_readiness"]["details"]["workspace_config_valid"] is True
+    assert "local_tools" in payload["first_task_readiness"]["details"]
+    assert "provider/model" in payload["first_task_readiness"]["blockers"][0]
+    assert "config init --execution-engine provider" in payload["first_task_readiness"]["next_step"]
+    assert "api_key" not in result.stdout
+    assert "Traceback" not in result.stderr
+
+
+def test_doctor_json_reports_invalid_config_first_task_readiness() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        (workspace / ".voidcode.json").write_text("{", encoding="utf-8")
+        env = with_src_pythonpath(os.environ.copy())
+
+        result = _run_module_cli(
+            "doctor",
+            "--workspace",
+            str(workspace),
+            "--json",
+            env=env,
+        )
+
+    payload = json.loads(result.stdout)
+    assert result.returncode != 0
+    assert payload["first_task_readiness"]["status"] == "not_ready"
+    assert payload["first_task_readiness"]["details"]["workspace_config_valid"] is False
+    assert "runtime config" in payload["first_task_readiness"]["blockers"][0]
+    assert "Traceback" not in result.stderr
+
+
+def test_doctor_human_reports_first_task_readiness_without_leaking_auth() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        (workspace / ".voidcode.json").write_text(
+            json.dumps({"model": "openai/gpt-4o", "execution_engine": "provider"}),
+            encoding="utf-8",
+        )
+        env = with_src_pythonpath(os.environ.copy())
+        env["OPENAI_API_KEY"] = "doctor-secret"
+
+        result = _run_module_cli(
+            "doctor",
+            "--workspace",
+            str(workspace),
+            env=env,
+        )
+
+    assert "First task readiness:" in result.stdout
+    assert "doctor-secret" not in result.stdout
+    assert "doctor-secret" not in result.stderr
     assert "Traceback" not in result.stderr
 
 

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -1905,7 +1905,7 @@ def test_doctor_json_reports_first_task_readiness_missing_model() -> None:
     assert payload["first_task_readiness"]["status"] == "not_ready"
     assert payload["first_task_readiness"]["details"]["workspace_config_valid"] is True
     assert "local_tools" in payload["first_task_readiness"]["details"]
-    assert "provider/model" in payload["first_task_readiness"]["blockers"][0]
+    assert payload["first_task_readiness"]["blockers"] == ["provider.readiness check is missing"]
     assert "config init --execution-engine provider" in payload["first_task_readiness"]["next_step"]
     assert "api_key" not in result.stdout
     assert "Traceback" not in result.stderr


### PR DESCRIPTION
## Summary
- Add a first-task readiness summary to `voidcode doctor` with ready/not-ready/degraded status, provider/model/auth/context details, workspace config validity, and local tool availability.
- Always surface provider readiness in doctor output, including missing-model and invalid-config bootstrap cases.
- Extend `config init` write output with concrete next commands for doctor and a first run.

Closes #299

## Verification
- `uv run ruff check .`
- `uv run basedpyright --warnings src`
- `uv run pytest tests/unit/doctor/test_doctor.py tests/unit/doctor/test_reporter.py tests/unit/interface/test_cli_smoke.py::test_config_init_writes_starter_config_and_refuses_overwrite tests/unit/interface/test_cli_smoke.py::test_doctor_json_reports_first_task_readiness_missing_model tests/unit/interface/test_cli_smoke.py::test_doctor_json_reports_invalid_config_first_task_readiness tests/unit/interface/test_cli_smoke.py::test_doctor_human_reports_first_task_readiness_without_leaking_auth tests/unit/runtime/test_config_schema.py tests/unit/runtime/test_provider_readiness.py -q`
- `uv run pytest -n auto` (1595 passed)
- `uv build`

Note: `mise run lint/typecheck` was not used in the new worktree because mise refused the untrusted copied `mise.toml`; equivalent underlying `uv` commands passed.