### PR TITLE
feat(runtime): add context-pressure event, config thresholds, and non-fatal hook surface

### DIFF
--- a/src/voidcode/hook/config.py
+++ b/src/voidcode/hook/config.py
@@ -15,6 +15,7 @@ type RuntimeHookSurface = Literal[
     "background_task_failed",
     "background_task_cancelled",
     "delegated_result_available",
+    "context_pressure",
 ]
 
 type FormatterCwdPolicy = Literal["workspace", "nearest_root", "file_directory"]
@@ -173,6 +174,7 @@ class RuntimeHooksConfig:
     on_background_task_failed: tuple[tuple[str, ...], ...] = ()
     on_background_task_cancelled: tuple[tuple[str, ...], ...] = ()
     on_delegated_result_available: tuple[tuple[str, ...], ...] = ()
+    on_context_pressure: tuple[tuple[str, ...], ...] = ()
     formatter_presets: Mapping[str, RuntimeFormatterPresetConfig] = field(
         default_factory=_empty_formatter_presets
     )
@@ -188,6 +190,7 @@ class RuntimeHooksConfig:
             "background_task_failed": self.on_background_task_failed,
             "background_task_cancelled": self.on_background_task_cancelled,
             "delegated_result_available": self.on_delegated_result_available,
+            "context_pressure": self.on_context_pressure,
         }[surface]
 
     def resolve_formatter(self, file_path: Path) -> tuple[str, RuntimeFormatterPresetConfig] | None:

--- a/src/voidcode/hook/executor.py
+++ b/src/voidcode/hook/executor.py
@@ -13,6 +13,7 @@ from ..runtime.events import (
     RUNTIME_BACKGROUND_TASK_CANCELLED,
     RUNTIME_BACKGROUND_TASK_COMPLETED,
     RUNTIME_BACKGROUND_TASK_FAILED,
+    RUNTIME_CONTEXT_PRESSURE,
     RUNTIME_DELEGATED_RESULT_AVAILABLE,
     RUNTIME_SESSION_ENDED,
     RUNTIME_SESSION_IDLE,
@@ -138,6 +139,7 @@ def run_lifecycle_hooks(request: LifecycleHookExecutionRequest) -> HookExecution
         "surface": request.surface,
         "session_id": request.session_id,
         **dict(request.payload),
+        **({"kind": "hook_result"} if request.surface == "context_pressure" else {}),
     }
     for command in commands:
         last_sequence += 1
@@ -195,6 +197,7 @@ def _event_type_for_surface(surface: RuntimeHookSurface) -> str:
         "background_task_failed": RUNTIME_BACKGROUND_TASK_FAILED,
         "background_task_cancelled": RUNTIME_BACKGROUND_TASK_CANCELLED,
         "delegated_result_available": RUNTIME_DELEGATED_RESULT_AVAILABLE,
+        "context_pressure": RUNTIME_CONTEXT_PRESSURE,
     }[surface]
 
 

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -91,7 +91,29 @@ _HOOKS_CONFIG_KEYS = frozenset(
         "on_background_task_failed",
         "on_background_task_cancelled",
         "on_delegated_result_available",
+        "on_context_pressure",
         "formatter_presets",
+    }
+)
+_CONTEXT_WINDOW_CONFIG_KEYS = frozenset(
+    {
+        "version",
+        "auto_compaction",
+        "max_tool_results",
+        "max_tool_result_tokens",
+        "max_context_ratio",
+        "model_context_window_tokens",
+        "reserved_output_tokens",
+        "minimum_retained_tool_results",
+        "recent_tool_result_count",
+        "recent_tool_result_tokens",
+        "default_tool_result_tokens",
+        "per_tool_result_tokens",
+        "tokenizer_model",
+        "continuity_preview_items",
+        "continuity_preview_chars",
+        "context_pressure_threshold",
+        "context_pressure_cooldown_steps",
     }
 )
 _FORMATTER_PRESET_CONFIG_KEYS = frozenset(
@@ -224,6 +246,8 @@ class RuntimeContextWindowConfig:
     tokenizer_model: str | None = None
     continuity_preview_items: int = 3
     continuity_preview_chars: int = 80
+    context_pressure_threshold: float = 0.7
+    context_pressure_cooldown_steps: int = 3
 
 
 @dataclass(frozen=True, slots=True)
@@ -722,6 +746,10 @@ def _parse_hooks_config(raw_hooks: object) -> RuntimeHooksConfig | None:
         hooks_payload.get("on_delegated_result_available"),
         field_path="hooks.on_delegated_result_available",
     )
+    on_context_pressure = _parse_command_list(
+        hooks_payload.get("on_context_pressure"),
+        field_path="hooks.on_context_pressure",
+    )
     formatter_presets: dict[str, RuntimeFormatterPresetConfig] = _parse_formatter_presets_config(
         hooks_payload.get("formatter_presets"),
         field_path="hooks.formatter_presets",
@@ -739,6 +767,7 @@ def _parse_hooks_config(raw_hooks: object) -> RuntimeHooksConfig | None:
         on_background_task_failed=on_background_task_failed,
         on_background_task_cancelled=on_background_task_cancelled,
         on_delegated_result_available=on_delegated_result_available,
+        on_context_pressure=on_context_pressure,
         formatter_presets=formatter_presets,
     )
 
@@ -1012,6 +1041,8 @@ class _RuntimeContextWindowValidationModel(BaseModel):
     tokenizer_model: str | None = None
     continuity_preview_items: int = 3
     continuity_preview_chars: int = 80
+    context_pressure_threshold: float = 0.7
+    context_pressure_cooldown_steps: int = 3
 
     @field_validator("auto_compaction", mode="before")
     @classmethod
@@ -1104,6 +1135,40 @@ class _RuntimeContextWindowValidationModel(BaseModel):
             )
         return parsed
 
+    @field_validator("context_pressure_threshold", mode="before")
+    @classmethod
+    def _validate_context_pressure_threshold(cls, value: object) -> float:
+        if value is None:
+            return 0.7
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            raise ValueError(
+                "runtime config field 'context_window.context_pressure_threshold' must be a number"
+            )
+        parsed = float(value)
+        if not 0 < parsed <= 1:
+            raise ValueError(
+                "runtime config field 'context_window.context_pressure_threshold' must be greater "
+                "than 0 and less than or equal to 1"
+            )
+        return parsed
+
+    @field_validator("context_pressure_cooldown_steps", mode="before")
+    @classmethod
+    def _validate_context_pressure_cooldown_steps(cls, value: object) -> int:
+        if value is None:
+            return 3
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise ValueError(
+                "runtime config field 'context_window.context_pressure_cooldown_steps' "
+                "must be an integer"
+            )
+        if value < 1:
+            raise ValueError(
+                "runtime config field 'context_window.context_pressure_cooldown_steps' "
+                "must be greater than or equal to 1"
+            )
+        return value
+
     @field_validator("per_tool_result_tokens", mode="before")
     @classmethod
     def _validate_per_tool_result_tokens(cls, value: object) -> dict[str, int]:
@@ -1155,6 +1220,8 @@ class _RuntimeContextWindowValidationModel(BaseModel):
             tokenizer_model=self.tokenizer_model,
             continuity_preview_items=self.continuity_preview_items,
             continuity_preview_chars=self.continuity_preview_chars,
+            context_pressure_threshold=self.context_pressure_threshold,
+            context_pressure_cooldown_steps=self.context_pressure_cooldown_steps,
         )
 
 
@@ -1555,6 +1622,11 @@ def _parse_context_window_config(raw_context_window: object) -> RuntimeContextWi
         raise ValueError("runtime config field 'context_window' must be an object when provided")
 
     context_window_payload = cast(dict[str, object], raw_context_window)
+    _reject_unknown_config_keys(
+        context_window_payload,
+        allowed_keys=_CONTEXT_WINDOW_CONFIG_KEYS,
+        field_path="context_window",
+    )
     return cast(
         RuntimeContextWindowConfig | None,
         _parse_runtime_config_section(
@@ -2000,6 +2072,8 @@ def serialize_runtime_context_window_config(
         "recent_tool_result_count": context_window.recent_tool_result_count,
         "continuity_preview_items": context_window.continuity_preview_items,
         "continuity_preview_chars": context_window.continuity_preview_chars,
+        "context_pressure_threshold": context_window.context_pressure_threshold,
+        "context_pressure_cooldown_steps": context_window.context_pressure_cooldown_steps,
     }
     if context_window.max_tool_result_tokens is not None:
         payload["max_tool_result_tokens"] = context_window.max_tool_result_tokens

--- a/src/voidcode/runtime/config_schema.py
+++ b/src/voidcode/runtime/config_schema.py
@@ -101,6 +101,7 @@ def runtime_config_json_schema() -> dict[str, object]:
                     "on_background_task_failed": {"$ref": "#/$defs/commandList"},
                     "on_background_task_cancelled": {"$ref": "#/$defs/commandList"},
                     "on_delegated_result_available": {"$ref": "#/$defs/commandList"},
+                    "on_context_pressure": {"$ref": "#/$defs/commandList"},
                     "formatter_presets": {
                         "type": "object",
                         "additionalProperties": {"$ref": "#/$defs/formatterPresetConfig"},
@@ -322,6 +323,12 @@ def runtime_config_json_schema() -> dict[str, object]:
                     "tokenizer_model": {"type": "string", "minLength": 1},
                     "continuity_preview_items": {"type": "integer", "minimum": 1},
                     "continuity_preview_chars": {"type": "integer", "minimum": 1},
+                    "context_pressure_threshold": {
+                        "type": "number",
+                        "exclusiveMinimum": 0,
+                        "maximum": 1,
+                    },
+                    "context_pressure_cooldown_steps": {"type": "integer", "minimum": 1},
                 },
             },
             "lspServerConfig": {

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -69,6 +69,8 @@ class ContextWindowPolicy:
     tokenizer_model: str | None = None
     continuity_preview_items: int = 3
     continuity_preview_chars: int = 80
+    context_pressure_threshold: float = 0.7
+    context_pressure_cooldown_steps: int = 3
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "per_tool_result_tokens", dict(self.per_tool_result_tokens))
@@ -101,6 +103,10 @@ class ContextWindowPolicy:
             raise ValueError("continuity_preview_items must be >= 1")
         if self.continuity_preview_chars < 1:
             raise ValueError("continuity_preview_chars must be >= 1")
+        if not 0 < self.context_pressure_threshold <= 1:
+            raise ValueError("context_pressure_threshold must be > 0 and <= 1")
+        if self.context_pressure_cooldown_steps < 1:
+            raise ValueError("context_pressure_cooldown_steps must be >= 1")
 
     def metadata_payload(self) -> dict[str, object]:
         payload: dict[str, object] = {
@@ -128,6 +134,8 @@ class ContextWindowPolicy:
             payload["per_tool_result_tokens"] = dict(self.per_tool_result_tokens)
         if self.tokenizer_model is not None:
             payload["tokenizer_model"] = self.tokenizer_model
+        payload["context_pressure_threshold"] = self.context_pressure_threshold
+        payload["context_pressure_cooldown_steps"] = self.context_pressure_cooldown_steps
         return payload
 
 
@@ -467,6 +475,15 @@ def _coerce_int(payload: Mapping[str, object], key: str, *, default: int) -> int
     return value
 
 
+def _coerce_float(payload: Mapping[str, object], key: str, *, default: float) -> float:
+    raw = payload.get(key)
+    if raw is None:
+        return default
+    if isinstance(raw, bool) or not isinstance(raw, int | float):
+        raise ValueError(f"context window policy field '{key}' must be a number")
+    return float(raw)
+
+
 def context_window_policy_from_payload(raw_payload: object) -> ContextWindowPolicy:
     if not isinstance(raw_payload, dict):
         raise ValueError("context window policy payload must be an object")
@@ -527,6 +544,16 @@ def context_window_policy_from_payload(raw_payload: object) -> ContextWindowPoli
             payload,
             "continuity_preview_chars",
             default=ContextWindowPolicy().continuity_preview_chars,
+        ),
+        context_pressure_threshold=_coerce_float(
+            payload,
+            "context_pressure_threshold",
+            default=ContextWindowPolicy().context_pressure_threshold,
+        ),
+        context_pressure_cooldown_steps=_coerce_int(
+            payload,
+            "context_pressure_cooldown_steps",
+            default=ContextWindowPolicy().context_pressure_cooldown_steps,
         ),
     )
 

--- a/src/voidcode/runtime/events.py
+++ b/src/voidcode/runtime/events.py
@@ -46,6 +46,7 @@ type ExistingEventType = Literal[
 ]
 type PrototypeAdditiveEventType = Literal[
     "runtime.memory_refreshed",
+    "runtime.context_pressure",
     "runtime.session_started",
     "runtime.session_ended",
     "runtime.session_idle",
@@ -114,6 +115,7 @@ RUNTIME_QUESTION_ANSWERED: Final[ExistingEventType] = "runtime.question_answered
 RUNTIME_FAILED: Final[ExistingEventType] = "runtime.failed"
 
 RUNTIME_MEMORY_REFRESHED: Final[PrototypeAdditiveEventType] = "runtime.memory_refreshed"
+RUNTIME_CONTEXT_PRESSURE: Final[PrototypeAdditiveEventType] = "runtime.context_pressure"
 RUNTIME_SESSION_STARTED: Final[PrototypeAdditiveEventType] = "runtime.session_started"
 RUNTIME_SESSION_ENDED: Final[PrototypeAdditiveEventType] = "runtime.session_ended"
 RUNTIME_SESSION_IDLE: Final[PrototypeAdditiveEventType] = "runtime.session_idle"
@@ -175,6 +177,7 @@ EMITTED_EVENT_TYPES: Final[tuple[ExistingEventType, ...]] = (
 )
 PROTOTYPE_ADDITIVE_EVENT_TYPES: Final[tuple[PrototypeAdditiveEventType, ...]] = (
     RUNTIME_MEMORY_REFRESHED,
+    RUNTIME_CONTEXT_PRESSURE,
     RUNTIME_SESSION_STARTED,
     RUNTIME_SESSION_ENDED,
     RUNTIME_SESSION_IDLE,

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -30,6 +30,7 @@ from .context_window import (
 )
 from .contracts import RuntimeStreamChunk
 from .events import (
+    RUNTIME_CONTEXT_PRESSURE,
     RUNTIME_MEMORY_REFRESHED,
     RUNTIME_QUESTION_REQUESTED,
     RUNTIME_SKILL_LOADED,
@@ -129,6 +130,64 @@ class RuntimeRunLoopCoordinator:
                 ),
                 metadata=graph_request.metadata,
             )
+            effective_runtime_config = runtime._effective_runtime_config_from_metadata(
+                session.metadata
+            )
+            context_window_config = effective_runtime_config.context_window
+            pressure_threshold = (
+                context_window_config.context_pressure_threshold
+                if context_window_config is not None
+                else 0.7
+            )
+            pressure_cooldown_steps = (
+                context_window_config.context_pressure_cooldown_steps
+                if context_window_config is not None
+                else 3
+            )
+            pressure_payload = self._build_context_pressure_payload(
+                session=session,
+                context_window=context_window,
+                threshold=pressure_threshold,
+            )
+            if pressure_payload is not None and self._should_emit_context_pressure(
+                session=session,
+                pressure_ratio=cast(float, pressure_payload["pressure_ratio"]),
+                threshold=pressure_threshold,
+                cooldown_steps=pressure_cooldown_steps,
+                tool_result_count=context_window.original_tool_result_count,
+            ):
+                session = self._session_with_context_pressure_state(
+                    session=session,
+                    pressure_ratio=cast(float, pressure_payload["pressure_ratio"]),
+                    threshold=pressure_threshold,
+                    tool_result_count=context_window.original_tool_result_count,
+                )
+                sequence += 1
+                yield RuntimeStreamChunk(
+                    kind="event",
+                    session=session,
+                    event=EventEnvelope(
+                        session_id=session.session.id,
+                        sequence=sequence,
+                        event_type=RUNTIME_CONTEXT_PRESSURE,
+                        source="runtime",
+                        payload=pressure_payload,
+                    ),
+                )
+                hook_outcome = runtime._run_lifecycle_hooks(
+                    session=session,
+                    sequence=sequence,
+                    surface="context_pressure",
+                    payload=pressure_payload,
+                )
+                yield from hook_outcome.chunks
+                sequence = hook_outcome.last_sequence
+                if hook_outcome.failed_error is not None:
+                    logger.warning(
+                        "context_pressure hook failed for %s: %s",
+                        session.session.id,
+                        hook_outcome.failed_error,
+                    )
             if context_window.compacted and reinjected_continuity is None:
                 token_metadata: dict[str, object] = {}
                 if context_window.token_budget is not None:
@@ -165,8 +224,7 @@ class RuntimeRunLoopCoordinator:
                     ),
                 )
             tool_exception_recovery_enabled = (
-                runtime._effective_runtime_config_from_metadata(session.metadata).execution_engine
-                == "provider"
+                effective_runtime_config.execution_engine == "provider"
             )
             try:
                 graph_step = graph.step(
@@ -733,6 +791,109 @@ class RuntimeRunLoopCoordinator:
                     },
                 )
             )
+
+    @staticmethod
+    def _build_context_pressure_payload(
+        *,
+        session: SessionState,
+        context_window: RuntimeContextWindow,
+        threshold: float,
+    ) -> dict[str, object] | None:
+        budget = context_window.token_budget
+        estimated_tokens = context_window.original_tool_result_tokens
+        if budget is None or estimated_tokens is None or budget <= 0 or estimated_tokens <= 0:
+            return None
+        pressure_ratio = estimated_tokens / budget
+        payload: dict[str, object] = {
+            "kind": "pressure_signal",
+            "session_id": session.session.id,
+            "estimated_tokens": estimated_tokens,
+            "budget_max_tokens": budget,
+            "pressure_ratio": pressure_ratio,
+            "threshold": threshold,
+            "reason": "token_budget_ratio_exceeded",
+            "compacted": context_window.compacted,
+            "token_estimate_source": context_window.token_estimate_source,
+            "original_tool_result_count": context_window.original_tool_result_count,
+            "retained_tool_result_count": context_window.retained_tool_result_count,
+        }
+        if context_window.summary_anchor is not None:
+            payload["summary_anchor"] = context_window.summary_anchor
+        if context_window.summary_source is not None:
+            payload["summary_source"] = context_window.summary_source
+        if context_window.continuity_state is not None:
+            payload["continuity_state"] = context_window.continuity_state.metadata_payload()
+        return payload
+
+    @staticmethod
+    def _should_emit_context_pressure(
+        *,
+        session: SessionState,
+        pressure_ratio: float,
+        threshold: float,
+        cooldown_steps: int,
+        tool_result_count: int,
+    ) -> bool:
+        if pressure_ratio < threshold:
+            return False
+        raw_runtime_state = session.metadata.get("runtime_state")
+        runtime_state = (
+            cast(dict[str, object], raw_runtime_state)
+            if isinstance(raw_runtime_state, dict)
+            else {}
+        )
+        current_run_id_raw = runtime_state.get("run_id")
+        current_run_id = current_run_id_raw if isinstance(current_run_id_raw, str) else None
+        raw_pressure_state = runtime_state.get("context_pressure")
+        pressure_state = (
+            cast(dict[str, object], raw_pressure_state)
+            if isinstance(raw_pressure_state, dict)
+            else {}
+        )
+        last_count_raw = pressure_state.get("last_emitted_tool_result_count")
+        last_count = (
+            last_count_raw
+            if isinstance(last_count_raw, int) and not isinstance(last_count_raw, bool)
+            else None
+        )
+        if last_count is None:
+            return True
+        last_run_id_raw = pressure_state.get("last_emitted_run_id")
+        last_run_id = last_run_id_raw if isinstance(last_run_id_raw, str) else None
+        if current_run_id is not None and last_run_id is not None and current_run_id != last_run_id:
+            return True
+        return (tool_result_count - last_count) >= cooldown_steps
+
+    @staticmethod
+    def _session_with_context_pressure_state(
+        *,
+        session: SessionState,
+        pressure_ratio: float,
+        threshold: float,
+        tool_result_count: int,
+    ) -> SessionState:
+        raw_runtime_state = session.metadata.get("runtime_state")
+        runtime_state = (
+            dict(cast(dict[str, object], raw_runtime_state))
+            if isinstance(raw_runtime_state, dict)
+            else {}
+        )
+        runtime_state["context_pressure"] = {
+            "last_emitted_tool_result_count": tool_result_count,
+            "last_pressure_ratio": pressure_ratio,
+            "threshold": threshold,
+            "last_emitted_run_id": (
+                runtime_state.get("run_id")
+                if isinstance(runtime_state.get("run_id"), str)
+                else None
+            ),
+        }
+        return SessionState(
+            session=session.session,
+            status=session.status,
+            turn=session.turn,
+            metadata={**session.metadata, "runtime_state": runtime_state},
+        )
 
     def _drain_runtime_events(
         self,

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -4269,8 +4269,6 @@ class VoidCodeRuntime:
             or (event.event_type == "graph.loop_step" and event.payload.get("phase") == "finalize")
             or event.event_type
             in {
-                "runtime.context_pressure",
-                "runtime.memory_refreshed",
                 "runtime.session_ended",
                 "runtime.mcp_server_released",
                 "runtime.mcp_server_stopped",

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -4267,6 +4267,15 @@ class VoidCodeRuntime:
         elif response_session.status == "completed" and (
             event.event_type == "graph.response_ready"
             or (event.event_type == "graph.loop_step" and event.payload.get("phase") == "finalize")
+            or event.event_type
+            in {
+                "runtime.context_pressure",
+                "runtime.memory_refreshed",
+                "runtime.session_ended",
+                "runtime.mcp_server_released",
+                "runtime.mcp_server_stopped",
+                "runtime.acp_disconnected",
+            }
         ):
             status = "completed"
         return VoidCodeRuntime._session_with_status(response_session, status)
@@ -4497,6 +4506,8 @@ class VoidCodeRuntime:
             tokenizer_model=policy.tokenizer_model,
             continuity_preview_items=policy.continuity_preview_items,
             continuity_preview_chars=policy.continuity_preview_chars,
+            context_pressure_threshold=policy.context_pressure_threshold,
+            context_pressure_cooldown_steps=policy.context_pressure_cooldown_steps,
         )
 
     @staticmethod
@@ -4534,6 +4545,8 @@ class VoidCodeRuntime:
             tokenizer_model=config.tokenizer_model,
             continuity_preview_items=config.continuity_preview_items,
             continuity_preview_chars=config.continuity_preview_chars,
+            context_pressure_threshold=config.context_pressure_threshold,
+            context_pressure_cooldown_steps=config.context_pressure_cooldown_steps,
         )
 
     def _prepare_provider_context_window(

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -4269,7 +4269,6 @@ class VoidCodeRuntime:
             or (event.event_type == "graph.loop_step" and event.payload.get("phase") == "finalize")
             or event.event_type
             in {
-                "runtime.session_ended",
                 "runtime.acp_disconnected",
             }
         ):

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -4270,8 +4270,6 @@ class VoidCodeRuntime:
             or event.event_type
             in {
                 "runtime.session_ended",
-                "runtime.mcp_server_released",
-                "runtime.mcp_server_stopped",
                 "runtime.acp_disconnected",
             }
         ):

--- a/tests/unit/hook/test_executor.py
+++ b/tests/unit/hook/test_executor.py
@@ -58,6 +58,7 @@ def test_runtime_hooks_config_exposes_async_lifecycle_surfaces() -> None:
         on_background_task_failed=(("python", "scripts/task_failed.py"),),
         on_background_task_cancelled=(("python", "scripts/task_cancelled.py"),),
         on_delegated_result_available=(("python", "scripts/delegated_result.py"),),
+        on_context_pressure=(("python", "scripts/context_pressure.py"),),
     )
 
     assert hooks.commands_for_surface("session_start") == (("python", "scripts/session_start.py"),)
@@ -74,6 +75,9 @@ def test_runtime_hooks_config_exposes_async_lifecycle_surfaces() -> None:
     )
     assert hooks.commands_for_surface("delegated_result_available") == (
         ("python", "scripts/delegated_result.py"),
+    )
+    assert hooks.commands_for_surface("context_pressure") == (
+        ("python", "scripts/context_pressure.py"),
     )
 
 

--- a/tests/unit/runtime/test_config_schema.py
+++ b/tests/unit/runtime/test_config_schema.py
@@ -83,6 +83,7 @@ def test_runtime_config_json_schema_exposes_core_fields() -> None:
     }
     hooks_schema = cast(dict[str, object], properties["hooks"])
     hooks_properties = cast(dict[str, object], hooks_schema["properties"])
+    assert hooks_properties["on_context_pressure"] == {"$ref": "#/$defs/commandList"}
     formatter_presets = cast(dict[str, object], hooks_properties["formatter_presets"])
     assert formatter_presets["additionalProperties"] == {"$ref": "#/$defs/formatterPresetConfig"}
     formatter_preset_config = cast(dict[str, object], defs["formatterPresetConfig"])
@@ -105,6 +106,15 @@ def test_runtime_config_json_schema_exposes_core_fields() -> None:
     ):
         numeric_property = cast(dict[str, object], context_window_properties[key])
         assert numeric_property["minimum"] == 1
+    pressure_threshold = cast(
+        dict[str, object], context_window_properties["context_pressure_threshold"]
+    )
+    assert pressure_threshold["exclusiveMinimum"] == 0
+    assert pressure_threshold["maximum"] == 1
+    pressure_cooldown = cast(
+        dict[str, object], context_window_properties["context_pressure_cooldown_steps"]
+    )
+    assert pressure_cooldown["minimum"] == 1
     tools_config = cast(dict[str, object], defs["toolsConfig"])
     assert tools_config["additionalProperties"] is False
     tools_properties = cast(dict[str, object], tools_config["properties"])

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -322,6 +322,8 @@ def test_runtime_config_loads_context_window_policy_from_repo_file(tmp_path: Pat
                     "tokenizer_model": "gpt-4o",
                     "continuity_preview_items": 4,
                     "continuity_preview_chars": 120,
+                    "context_pressure_threshold": 0.75,
+                    "context_pressure_cooldown_steps": 5,
                 }
             }
         ),
@@ -345,6 +347,8 @@ def test_runtime_config_loads_context_window_policy_from_repo_file(tmp_path: Pat
         tokenizer_model="gpt-4o",
         continuity_preview_items=4,
         continuity_preview_chars=120,
+        context_pressure_threshold=0.75,
+        context_pressure_cooldown_steps=5,
     )
 
 
@@ -353,6 +357,8 @@ def test_runtime_context_window_config_serializes_for_session_resume() -> None:
         max_tool_results=5,
         reserved_output_tokens=100,
         per_tool_result_tokens={"shell_exec": 400},
+        context_pressure_threshold=0.72,
+        context_pressure_cooldown_steps=4,
     )
 
     payload = serialize_runtime_context_window_config(config)
@@ -449,6 +455,7 @@ def test_runtime_config_parses_async_lifecycle_hook_surfaces(tmp_path: Path) -> 
                     "on_background_task_failed": [["python", "scripts/task_failed.py"]],
                     "on_background_task_cancelled": [["python", "scripts/task_cancelled.py"]],
                     "on_delegated_result_available": [["python", "scripts/delegated_result.py"]],
+                    "on_context_pressure": [["python", "scripts/context_pressure.py"]],
                 }
             }
         ),
@@ -468,6 +475,7 @@ def test_runtime_config_parses_async_lifecycle_hook_surfaces(tmp_path: Path) -> 
         on_background_task_failed=(("python", "scripts/task_failed.py"),),
         on_background_task_cancelled=(("python", "scripts/task_cancelled.py"),),
         on_delegated_result_available=(("python", "scripts/delegated_result.py"),),
+        on_context_pressure=(("python", "scripts/context_pressure.py"),),
     )
 
 
@@ -1777,6 +1785,18 @@ def test_runtime_config_rejects_invalid_repo_local_execution_engine(tmp_path: Pa
             "runtime config field 'context_window.reserved_output_tokens'"
             ".*greater than or equal to 1",
             id="context-window-reserved-output-zero",
+        ),
+        pytest.param(
+            {"context_window": {"context_pressure_threshold": 0}},
+            "runtime config field 'context_window.context_pressure_threshold'"
+            ".*greater than 0 and less than or equal to 1",
+            id="context-window-pressure-threshold-zero",
+        ),
+        pytest.param(
+            {"context_window": {"context_pressure_cooldown_steps": 0}},
+            "runtime config field 'context_window.context_pressure_cooldown_steps'"
+            ".*greater than or equal to 1",
+            id="context-window-pressure-cooldown-zero",
         ),
     ],
 )

--- a/tests/unit/runtime/test_runtime_events.py
+++ b/tests/unit/runtime/test_runtime_events.py
@@ -13,6 +13,7 @@ from voidcode.runtime.events import (
     RUNTIME_BACKGROUND_TASK_COMPLETED,
     RUNTIME_BACKGROUND_TASK_FAILED,
     RUNTIME_BACKGROUND_TASK_WAITING_APPROVAL,
+    RUNTIME_CONTEXT_PRESSURE,
     RUNTIME_DELEGATED_RESULT_AVAILABLE,
     RUNTIME_LSP_SERVER_FAILED,
     RUNTIME_LSP_SERVER_STARTED,
@@ -53,6 +54,7 @@ def test_runtime_event_types_include_stable_emitted_events() -> None:
 def test_future_additive_event_types_cover_async_lifecycle_surfaces() -> None:
     assert PROTOTYPE_ADDITIVE_EVENT_TYPES == (
         RUNTIME_MEMORY_REFRESHED,
+        RUNTIME_CONTEXT_PRESSURE,
         RUNTIME_SESSION_STARTED,
         RUNTIME_SESSION_ENDED,
         RUNTIME_SESSION_IDLE,

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -7976,7 +7976,7 @@ def test_runtime_context_pressure_payload_reason_is_consistently_exceeded(tmp_pa
     )
 
 
-def test_runtime_context_pressure_replay_uses_completed_status_for_completed_session(
+def test_runtime_context_pressure_replay_keeps_running_status_until_terminal_event(
     tmp_path: Path,
 ) -> None:
     sample_file = tmp_path / "sample.txt"
@@ -8018,7 +8018,55 @@ def test_runtime_context_pressure_replay_uses_completed_status_for_completed_ses
 
     assert response.session.status == "completed"
     assert replay_pressure_sessions
-    assert all(status == "completed" for status in replay_pressure_sessions)
+    assert all(status == "running" for status in replay_pressure_sessions)
+
+
+def test_runtime_memory_refreshed_replay_keeps_running_status_until_terminal_event(
+    tmp_path: Path,
+) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("x" * 300, encoding="utf-8")
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderTurnResult(tool_call=ToolCall("read_file", {"filePath": "sample.txt"})),
+                    ProviderTurnResult(tool_call=ToolCall("read_file", {"filePath": "sample.txt"})),
+                    ProviderTurnResult(output="done"),
+                ),
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                max_tool_result_tokens=1,
+            ),
+        ),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(
+        RuntimeRequest(
+            prompt="read sample.txt\nread sample.txt", session_id="memory-refresh-replay"
+        )
+    )
+    replay_chunks = list(runtime.resume_stream("memory-refresh-replay"))
+    replay_memory_sessions = [
+        chunk.session.status
+        for chunk in replay_chunks
+        if chunk.kind == "event"
+        and chunk.event is not None
+        and chunk.event.event_type == RUNTIME_MEMORY_REFRESHED
+    ]
+
+    assert response.session.status == "completed"
+    assert replay_memory_sessions
+    assert all(status == "running" for status in replay_memory_sessions)
 
 
 def test_runtime_provider_turn_usage_is_persisted_in_session_metadata(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -65,6 +65,7 @@ from voidcode.runtime.events import (
     RUNTIME_BACKGROUND_TASK_COMPLETED,
     RUNTIME_BACKGROUND_TASK_FAILED,
     RUNTIME_BACKGROUND_TASK_WAITING_APPROVAL,
+    RUNTIME_CONTEXT_PRESSURE,
     RUNTIME_MCP_SERVER_FAILED,
     RUNTIME_MCP_SERVER_STARTED,
     RUNTIME_MCP_SERVER_STOPPED,
@@ -7839,6 +7840,185 @@ def test_runtime_provider_compaction_emits_continuity_state_and_persists_metadat
     }
     replay_runtime_state = cast(dict[str, object], replay.session.metadata["runtime_state"])
     assert replay_runtime_state["continuity"] == expected_continuity
+
+
+def test_runtime_emits_context_pressure_with_cooldown_edge_control(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("x" * 300, encoding="utf-8")
+    created_providers: list[_ScriptedTurnProvider] = []
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderTurnResult(tool_call=ToolCall("read_file", {"filePath": "sample.txt"})),
+                    ProviderTurnResult(tool_call=ToolCall("read_file", {"filePath": "sample.txt"})),
+                    ProviderTurnResult(tool_call=ToolCall("read_file", {"filePath": "sample.txt"})),
+                    ProviderTurnResult(output="done"),
+                ),
+                created_providers=created_providers,
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                max_tool_result_tokens=1,
+                context_pressure_threshold=0.7,
+                context_pressure_cooldown_steps=2,
+            ),
+        ),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(
+        RuntimeRequest(prompt="read sample.txt\nread sample.txt\nread sample.txt")
+    )
+
+    pressure_events = [
+        event for event in response.events if event.event_type == RUNTIME_CONTEXT_PRESSURE
+    ]
+    assert response.session.status == "completed"
+    assert len(pressure_events) == 2
+    assert pressure_events[0].payload["reason"] == "token_budget_ratio_exceeded"
+    first_pressure_ratio = cast(float, pressure_events[0].payload["pressure_ratio"])
+    first_threshold = cast(float, pressure_events[0].payload["threshold"])
+    assert first_pressure_ratio >= first_threshold
+    second_count = cast(int, pressure_events[1].payload["original_tool_result_count"])
+    first_count = cast(int, pressure_events[0].payload["original_tool_result_count"])
+    assert second_count - first_count >= 2
+
+
+def test_runtime_context_pressure_hook_failure_is_non_fatal(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("x" * 300, encoding="utf-8")
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderTurnResult(tool_call=ToolCall("read_file", {"filePath": "sample.txt"})),
+                    ProviderTurnResult(output="done"),
+                ),
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                max_tool_result_tokens=1,
+                context_pressure_threshold=0.7,
+                context_pressure_cooldown_steps=1,
+            ),
+            hooks=RuntimeHooksConfig(
+                enabled=True,
+                on_context_pressure=((sys.executable, "-c", "raise SystemExit(7)"),),
+            ),
+        ),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="read sample.txt"))
+
+    assert response.session.status == "completed"
+    pressure_events = [
+        event for event in response.events if event.event_type == RUNTIME_CONTEXT_PRESSURE
+    ]
+    assert pressure_events
+    assert any(event.payload.get("kind") == "pressure_signal" for event in pressure_events)
+    assert any(event.payload.get("kind") == "hook_result" for event in pressure_events)
+    assert any(event.payload.get("hook_status") == "error" for event in pressure_events)
+    assert not any(event.event_type == "runtime.failed" for event in response.events)
+
+
+def test_runtime_context_pressure_payload_reason_is_consistently_exceeded(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("x" * 300, encoding="utf-8")
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderTurnResult(tool_call=ToolCall("read_file", {"filePath": "sample.txt"})),
+                    ProviderTurnResult(output="done"),
+                ),
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                max_tool_result_tokens=1,
+                context_pressure_threshold=0.7,
+                context_pressure_cooldown_steps=1,
+            ),
+        ),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="read sample.txt"))
+    pressure_events = [
+        event for event in response.events if event.event_type == RUNTIME_CONTEXT_PRESSURE
+    ]
+
+    assert pressure_events
+    assert all(
+        event.payload["reason"] == "token_budget_ratio_exceeded" for event in pressure_events
+    )
+
+
+def test_runtime_context_pressure_replay_uses_completed_status_for_completed_session(
+    tmp_path: Path,
+) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("x" * 300, encoding="utf-8")
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderTurnResult(tool_call=ToolCall("read_file", {"filePath": "sample.txt"})),
+                    ProviderTurnResult(output="done"),
+                ),
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                max_tool_result_tokens=1,
+                context_pressure_threshold=0.7,
+                context_pressure_cooldown_steps=1,
+            ),
+        ),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="read sample.txt", session_id="pressure-replay"))
+    replay_chunks = list(runtime.resume_stream("pressure-replay"))
+    replay_pressure_sessions = [
+        chunk.session.status
+        for chunk in replay_chunks
+        if chunk.kind == "event"
+        and chunk.event is not None
+        and chunk.event.event_type == RUNTIME_CONTEXT_PRESSURE
+    ]
+
+    assert response.session.status == "completed"
+    assert replay_pressure_sessions
+    assert all(status == "completed" for status in replay_pressure_sessions)
 
 
 def test_runtime_provider_turn_usage_is_persisted_in_session_metadata(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -6208,6 +6208,78 @@ def test_runtime_resume_stream_replay_keeps_running_for_midrun_mcp_stop_event(
     assert response_ready_statuses == ["completed"]
 
 
+def test_runtime_resume_stream_replay_keeps_running_for_session_end_hook_event(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+    store = _private_attr(runtime, "_session_store")
+    store.save_run(
+        workspace=tmp_path,
+        request=RuntimeRequest(prompt="session-end replay", session_id="session-end-replay"),
+        response=RuntimeResponse(
+            session=SessionState(
+                session=runtime_service_module.SessionRef(id="session-end-replay"),
+                status="completed",
+                turn=1,
+            ),
+            events=(
+                EventEnvelope(
+                    session_id="session-end-replay",
+                    sequence=1,
+                    event_type="runtime.request_received",
+                    source="runtime",
+                    payload={"prompt": "session-end replay"},
+                ),
+                EventEnvelope(
+                    session_id="session-end-replay",
+                    sequence=2,
+                    event_type="runtime.session_ended",
+                    source="runtime",
+                    payload={"session_status": "completed"},
+                ),
+                EventEnvelope(
+                    session_id="session-end-replay",
+                    sequence=3,
+                    event_type="runtime.mcp_server_stopped",
+                    source="runtime",
+                    payload={
+                        "server": "demo",
+                        "scope": "runtime",
+                        "workspace_root": str(tmp_path),
+                    },
+                ),
+                EventEnvelope(
+                    session_id="session-end-replay",
+                    sequence=4,
+                    event_type="graph.response_ready",
+                    source="graph",
+                    payload={},
+                ),
+            ),
+            output="done",
+        ),
+    )
+
+    replay_chunks = list(runtime.resume_stream("session-end-replay"))
+    session_end_statuses = [
+        chunk.session.status
+        for chunk in replay_chunks
+        if chunk.kind == "event"
+        and chunk.event is not None
+        and chunk.event.event_type == "runtime.session_ended"
+    ]
+    response_ready_statuses = [
+        chunk.session.status
+        for chunk in replay_chunks
+        if chunk.kind == "event"
+        and chunk.event is not None
+        and chunk.event.event_type == "graph.response_ready"
+    ]
+
+    assert session_end_statuses == ["running"]
+    assert response_ready_statuses == ["completed"]
+
+
 def test_runtime_emits_skills_loaded_catalog_without_default_full_injection(tmp_path: Path) -> None:
     skill_dir = tmp_path / ".voidcode" / "skills" / "demo"
     _write_demo_skill(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -6143,6 +6143,71 @@ def test_runtime_resume_stream_replay_keeps_failed_status_on_trailing_acp_discon
     assert replay_chunks[-1].session.status == "failed"
 
 
+def test_runtime_resume_stream_replay_keeps_running_for_midrun_mcp_stop_event(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+    store = _private_attr(runtime, "_session_store")
+    store.save_run(
+        workspace=tmp_path,
+        request=RuntimeRequest(prompt="mcp replay", session_id="mcp-stop-replay"),
+        response=RuntimeResponse(
+            session=SessionState(
+                session=runtime_service_module.SessionRef(id="mcp-stop-replay"),
+                status="completed",
+                turn=1,
+            ),
+            events=(
+                EventEnvelope(
+                    session_id="mcp-stop-replay",
+                    sequence=1,
+                    event_type="runtime.request_received",
+                    source="runtime",
+                    payload={"prompt": "mcp replay"},
+                ),
+                EventEnvelope(
+                    session_id="mcp-stop-replay",
+                    sequence=2,
+                    event_type="runtime.mcp_server_stopped",
+                    source="runtime",
+                    payload={
+                        "server": "demo",
+                        "scope": "runtime",
+                        "workspace_root": str(tmp_path),
+                    },
+                ),
+                EventEnvelope(
+                    session_id="mcp-stop-replay",
+                    sequence=3,
+                    event_type="graph.response_ready",
+                    source="graph",
+                    payload={},
+                ),
+            ),
+            output="done",
+        ),
+    )
+
+    replay_chunks = list(runtime.resume_stream("mcp-stop-replay"))
+    mcp_stopped_statuses = [
+        chunk.session.status
+        for chunk in replay_chunks
+        if chunk.kind == "event"
+        and chunk.event is not None
+        and chunk.event.event_type == "runtime.mcp_server_stopped"
+    ]
+    response_ready_statuses = [
+        chunk.session.status
+        for chunk in replay_chunks
+        if chunk.kind == "event"
+        and chunk.event is not None
+        and chunk.event.event_type == "graph.response_ready"
+    ]
+
+    assert mcp_stopped_statuses == ["running"]
+    assert response_ready_statuses == ["completed"]
+
+
 def test_runtime_emits_skills_loaded_catalog_without_default_full_injection(tmp_path: Path) -> None:
     skill_dir = tmp_path / ".voidcode" / "skills" / "demo"
     _write_demo_skill(


### PR DESCRIPTION
## Summary
#301 
- Add a runtime-owned `runtime.context_pressure` event and wire it through the existing event surface.
- Introduce configurable context pressure controls:
  - `context_window.context_pressure_threshold` (default `0.7`)
  - `context_window.context_pressure_cooldown_steps` (default `3`)
- Add optional hook surface support for context pressure (`on_context_pressure`) and keep hook failures non-fatal.
## Details
- Event payload includes session/runtime pressure metadata (session id, estimated tokens, budget/max tokens, pressure ratio, threshold, reason, continuity/summary-anchor related metadata when available).
- Emission is edge-controlled with cooldown to avoid per-step spam.
- Replay/session extension logic preserves correct event status semantics.
- No automatic compaction/summarization is introduced in this issue.
## Validation
- Updated runtime/hook/config/schema tests for:
  - threshold crossing behavior
  - cooldown/anti-spam behavior
  - optional hook execution
  - non-fatal hook failures
  - replay status consistency
- Pre-commit checks passed for all commits.