### PR TITLE
feat(runtime): harden SQLite storage operations

### DIFF
--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -899,6 +899,46 @@ def _handle_tasks_list_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def _handle_storage_diagnostics_command(args: argparse.Namespace) -> int:
+    workspace = cast(Path, args.workspace)
+    runtime = VoidCodeRuntime(workspace=workspace)
+    try:
+        diagnostics = runtime.storage_diagnostics()
+    finally:
+        _close_runtime(runtime)
+    print_json({"workspace": str(workspace), "storage": diagnostics})
+    return EXIT_SUCCESS
+
+
+def _handle_storage_prune_command(args: argparse.Namespace) -> int:
+    workspace = cast(Path, args.workspace)
+    runtime = VoidCodeRuntime(workspace=workspace)
+    try:
+        try:
+            counts = runtime.prune_runtime_storage(
+                keep_sessions=cast(int | None, args.keep_sessions),
+                keep_background_tasks=cast(int | None, args.keep_background_tasks),
+                older_than=cast(int | None, args.older_than),
+            )
+        except ValueError as exc:
+            raise SystemExit(f"error: {exc}") from None
+    finally:
+        _close_runtime(runtime)
+    print_json({"workspace": str(workspace), "pruned": counts})
+    return EXIT_SUCCESS
+
+
+def _handle_storage_reset_command(args: argparse.Namespace) -> int:
+    workspace = cast(Path, args.workspace)
+    runtime = VoidCodeRuntime(workspace=workspace)
+    try:
+        result = runtime.reset_runtime_storage()
+    finally:
+        _close_runtime(runtime)
+    print_json({"workspace": str(workspace), "storage": result})
+    return EXIT_SUCCESS
+
+
 def _handle_server_command(args: argparse.Namespace) -> int:
     workspace = cast(Path, args.workspace)
     config = load_runtime_config(
@@ -1621,6 +1661,12 @@ def build_parser() -> argparse.ArgumentParser:
     tasks_parser = subparsers.add_parser("tasks", help="Inspect delegated background tasks.")
     tasks_subparsers = tasks_parser.add_subparsers(dest="tasks_command")
 
+    storage_parser = subparsers.add_parser(
+        "storage",
+        help="Inspect and maintain the local runtime SQLite store.",
+    )
+    storage_subparsers = storage_parser.add_subparsers(dest="storage_command")
+
     config_parser = subparsers.add_parser("config", help="Inspect effective runtime configuration.")
     config_subparsers = config_parser.add_subparsers(dest="config_command")
 
@@ -1927,6 +1973,63 @@ def build_parser() -> argparse.ArgumentParser:
     )
     tasks_list_parser.set_defaults(handler=_handle_tasks_list_command)
 
+    storage_diagnostics_parser = storage_subparsers.add_parser(
+        "diagnostics",
+        help="Show SQLite runtime storage policy, checkpoint, size, and row counts.",
+    )
+    _ = storage_diagnostics_parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd(),
+        help="Workspace root used to resolve the local session database.",
+    )
+    _ = storage_diagnostics_parser.add_argument(
+        "--json",
+        action="store_true",
+        default=True,
+        help="Output storage diagnostics as JSON (default).",
+    )
+    storage_diagnostics_parser.set_defaults(handler=_handle_storage_diagnostics_command)
+
+    storage_prune_parser = storage_subparsers.add_parser(
+        "prune",
+        help="Prune terminal sessions and terminal background tasks from local storage.",
+    )
+    _ = storage_prune_parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd(),
+        help="Workspace root used to resolve the local session database.",
+    )
+    _ = storage_prune_parser.add_argument(
+        "--keep-sessions",
+        type=int,
+        help="Keep the newest N sessions and prune older terminal sessions.",
+    )
+    _ = storage_prune_parser.add_argument(
+        "--keep-background-tasks",
+        type=int,
+        help="Keep the newest N background tasks and prune older terminal tasks.",
+    )
+    _ = storage_prune_parser.add_argument(
+        "--older-than",
+        type=int,
+        help="Only prune records with updated_at lower than this runtime timestamp.",
+    )
+    storage_prune_parser.set_defaults(handler=_handle_storage_prune_command)
+
+    storage_reset_parser = storage_subparsers.add_parser(
+        "reset",
+        help="Delete the local pre-MVP runtime SQLite database and WAL/SHM files.",
+    )
+    _ = storage_reset_parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd(),
+        help="Workspace root used to resolve the local session database.",
+    )
+    storage_reset_parser.set_defaults(handler=_handle_storage_reset_command)
+
     # Capability doctor command
     doctor_parser = subparsers.add_parser(
         "doctor",
@@ -1973,3 +2076,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return handler(args)
     except SystemExit as exc:
         return _handle_cli_system_exit(exc)
+    except RuntimeError as exc:
+        message = f"error: {exc}"
+        print(message, file=sys.stderr)
+        return _classify_cli_error(message)

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -2293,6 +2293,26 @@ class VoidCodeRuntime:
             raise ValueError(f"unknown notification: {notification_id}")
         return notification
 
+    def storage_diagnostics(self) -> dict[str, object]:
+        return self._session_store.storage_diagnostics(workspace=self._workspace)
+
+    def prune_runtime_storage(
+        self,
+        *,
+        keep_sessions: int | None = None,
+        keep_background_tasks: int | None = None,
+        older_than: int | None = None,
+    ) -> dict[str, int]:
+        return self._session_store.prune_runtime_storage(
+            workspace=self._workspace,
+            keep_sessions=keep_sessions,
+            keep_background_tasks=keep_background_tasks,
+            older_than=older_than,
+        )
+
+    def reset_runtime_storage(self) -> dict[str, object]:
+        return self._session_store.reset_runtime_storage(workspace=self._workspace)
+
     def effective_runtime_config(self, *, session_id: str | None = None) -> EffectiveRuntimeConfig:
         if session_id is None:
             return self._effective_runtime_config_from_metadata(None)

--- a/src/voidcode/runtime/storage.py
+++ b/src/voidcode/runtime/storage.py
@@ -433,6 +433,68 @@ class SqliteSessionStore:
         _ = connection.execute(
             "INSERT OR IGNORE INTO storage_sequences (scope, value) VALUES ('auxiliary', 0)"
         )
+        SqliteSessionStore._bump_sequence_floor(
+            connection=connection,
+            scope="sessions",
+            floor=SqliteSessionStore._max_existing_timestamp(
+                connection=connection,
+                table="sessions",
+                columns=("updated_at",),
+            ),
+        )
+        SqliteSessionStore._bump_sequence_floor(
+            connection=connection,
+            scope="background_tasks",
+            floor=SqliteSessionStore._max_existing_timestamp(
+                connection=connection,
+                table="background_tasks",
+                columns=(
+                    "created_at",
+                    "updated_at",
+                    "started_at",
+                    "finished_at",
+                    "cancel_requested_at",
+                ),
+            ),
+        )
+        SqliteSessionStore._bump_sequence_floor(
+            connection=connection,
+            scope="auxiliary",
+            floor=max(
+                SqliteSessionStore._max_existing_timestamp(
+                    connection=connection,
+                    table="sessions",
+                    columns=("created_at",),
+                ),
+                SqliteSessionStore._max_existing_timestamp(
+                    connection=connection,
+                    table="session_notifications",
+                    columns=("created_at", "acknowledged_at"),
+                ),
+                SqliteSessionStore._max_existing_timestamp(
+                    connection=connection,
+                    table="session_event_deliveries",
+                    columns=("delivered_at",),
+                ),
+            ),
+        )
+
+    @staticmethod
+    def _max_existing_timestamp(
+        *, connection: sqlite3.Connection, table: str, columns: tuple[str, ...]
+    ) -> int:
+        maxima = [
+            int(connection.execute(f"SELECT COALESCE(MAX({column}), 0) FROM {table}").fetchone()[0])
+            for column in columns
+        ]
+        return max(maxima, default=0)
+
+    @staticmethod
+    def _bump_sequence_floor(*, connection: sqlite3.Connection, scope: str, floor: int) -> None:
+        _ = connection.execute(
+            "UPDATE storage_sequences SET value = MAX(value, ?) WHERE scope = ?",
+            (floor, scope),
+        )
 
     @classmethod
     def _assert_canonical_schema(

--- a/src/voidcode/runtime/storage.py
+++ b/src/voidcode/runtime/storage.py
@@ -4,7 +4,7 @@ import json
 import sqlite3
 from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Protocol, cast, final, runtime_checkable
 
@@ -147,6 +147,19 @@ class SessionStore(Protocol):
         include_queued: bool = True,
     ) -> tuple[BackgroundTaskState, ...]: ...
 
+    def storage_diagnostics(self, *, workspace: Path) -> dict[str, object]: ...
+
+    def prune_runtime_storage(
+        self,
+        *,
+        workspace: Path,
+        keep_sessions: int | None = None,
+        keep_background_tasks: int | None = None,
+        older_than: int | None = None,
+    ) -> dict[str, int]: ...
+
+    def reset_runtime_storage(self, *, workspace: Path) -> dict[str, object]: ...
+
 
 @runtime_checkable
 class SessionEventAppender(Protocol):
@@ -162,10 +175,18 @@ class SessionEventAppender(Protocol):
     ) -> EventEnvelope | None: ...
 
 
+@dataclass(frozen=True, slots=True)
+class _SQLitePolicy:
+    busy_timeout_ms: int = 5_000
+    synchronous: str = "NORMAL"
+    wal_autocheckpoint_pages: int = 1_000
+
+
 @final
 class SqliteSessionStore:
     _database_path: Path | None
     _RESUME_CHECKPOINT_KINDS = frozenset({"approval_wait", "question_wait", "terminal"})
+    _sqlite_policy = _SQLitePolicy()
 
     _CANONICAL_SCHEMA: dict[str, tuple[tuple[str, str, int, str | None, int], ...]] = {
         "sessions": (
@@ -237,6 +258,10 @@ class SqliteSessionStore:
             ("dedupe_key", "TEXT", 1, None, 3),
             ("delivered_at", "INTEGER", 1, None, 0),
         ),
+        "storage_sequences": (
+            ("scope", "TEXT", 0, None, 1),
+            ("value", "INTEGER", 1, None, 0),
+        ),
     }
     _CANONICAL_UNIQUE_INDEXES: dict[str, frozenset[tuple[str, ...]]] = {
         "sessions": frozenset(),
@@ -244,6 +269,7 @@ class SqliteSessionStore:
         "background_tasks": frozenset(),
         "session_notifications": frozenset({("workspace", "dedupe_key")}),
         "session_event_deliveries": frozenset(),
+        "storage_sequences": frozenset(),
     }
 
     def __init__(self, *, database_path: Path | None = None) -> None:
@@ -258,13 +284,38 @@ class SqliteSessionStore:
     def _connect(self, workspace: Path) -> Iterator[sqlite3.Connection]:
         database_path = self._resolve_database_path(workspace)
         database_path.parent.mkdir(parents=True, exist_ok=True)
-        connection = sqlite3.connect(database_path)
+        connection = sqlite3.connect(
+            database_path,
+            timeout=self._sqlite_policy.busy_timeout_ms / 1_000,
+            isolation_level=None,
+        )
         try:
             connection.row_factory = sqlite3.Row
+            self._configure_connection(connection=connection)
             self._ensure_schema(connection=connection, database_path=database_path)
             yield connection
         finally:
             connection.close()
+
+    def _configure_connection(self, *, connection: sqlite3.Connection) -> None:
+        _ = connection.execute(f"PRAGMA busy_timeout = {self._sqlite_policy.busy_timeout_ms}")
+        _ = connection.execute("PRAGMA journal_mode = WAL")
+        _ = connection.execute(f"PRAGMA synchronous = {self._sqlite_policy.synchronous}")
+        _ = connection.execute("PRAGMA foreign_keys = ON")
+        _ = connection.execute(
+            f"PRAGMA wal_autocheckpoint = {self._sqlite_policy.wal_autocheckpoint_pages}"
+        )
+        _ = connection.execute("PRAGMA wal_checkpoint(PASSIVE)").fetchone()
+
+    @contextmanager
+    def _write_connect(self, workspace: Path) -> Iterator[sqlite3.Connection]:
+        with self._connect(workspace) as connection:
+            _ = connection.execute("BEGIN IMMEDIATE")
+            try:
+                yield connection
+            except Exception:
+                connection.rollback()
+                raise
 
     def _ensure_schema(self, *, connection: sqlite3.Connection, database_path: Path) -> None:
         _ = connection.execute(
@@ -359,8 +410,26 @@ class SqliteSessionStore:
             )
             """
         )
+        _ = connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS storage_sequences (
+                scope TEXT PRIMARY KEY,
+                value INTEGER NOT NULL
+            )
+            """
+        )
         self._assert_canonical_schema(connection=connection, database_path=database_path)
+        self._ensure_storage_sequences(connection=connection)
         connection.commit()
+
+    @staticmethod
+    def _ensure_storage_sequences(*, connection: sqlite3.Connection) -> None:
+        _ = connection.execute(
+            "INSERT OR IGNORE INTO storage_sequences (scope, value) VALUES ('sessions', 0)"
+        )
+        _ = connection.execute(
+            "INSERT OR IGNORE INTO storage_sequences (scope, value) VALUES ('background_tasks', 0)"
+        )
 
     @classmethod
     def _assert_canonical_schema(
@@ -491,9 +560,18 @@ class SqliteSessionStore:
 
     @staticmethod
     def _raise_schema_mismatch(*, database_path: Path, detail: str) -> None:
+        workspace = (
+            database_path.parent.parent if database_path.parent.name == ".voidcode" else None
+        )
+        reset_command = (
+            f"uv run voidcode storage reset --workspace {workspace}"
+            if workspace is not None
+            else f"remove '{database_path}' plus matching -wal/-shm files"
+        )
         raise RuntimeError(
             "sqlite runtime schema mismatch: "
-            f"{detail}. Remove '{database_path}' and rerun to reset local runtime storage."
+            f"{detail}. This pre-MVP build does not migrate old schemas. "
+            f"Reset local runtime storage with: {reset_command}."
         )
 
     @staticmethod
@@ -775,7 +853,7 @@ class SqliteSessionStore:
         clear_pending_approval: bool = True,
     ) -> None:
         session_id = response.session.session.id
-        with self._connect(workspace) as connection:
+        with self._write_connect(workspace) as connection:
             updated_at = self._write_session_snapshot(
                 connection=connection,
                 workspace=workspace,
@@ -846,7 +924,7 @@ class SqliteSessionStore:
         response: RuntimeResponse,
         pending_approval: PendingApproval,
     ) -> None:
-        with self._connect(workspace) as connection:
+        with self._write_connect(workspace) as connection:
             updated_at = self._write_session_snapshot(
                 connection=connection,
                 workspace=workspace,
@@ -929,7 +1007,7 @@ class SqliteSessionStore:
         )
 
     def clear_pending_approval(self, *, workspace: Path, session_id: str) -> None:
-        with self._connect(workspace) as connection:
+        with self._write_connect(workspace) as connection:
             _ = connection.execute(
                 "UPDATE sessions SET pending_approval_json = NULL WHERE workspace = ? AND session_id = ?",  # noqa: E501
                 (str(workspace), session_id),
@@ -944,7 +1022,7 @@ class SqliteSessionStore:
         response: RuntimeResponse,
         pending_question: PendingQuestion,
     ) -> None:
-        with self._connect(workspace) as connection:
+        with self._write_connect(workspace) as connection:
             updated_at = self._write_session_snapshot(
                 connection=connection,
                 workspace=workspace,
@@ -1025,7 +1103,7 @@ class SqliteSessionStore:
         )
 
     def clear_pending_question(self, *, workspace: Path, session_id: str) -> None:
-        with self._connect(workspace) as connection:
+        with self._write_connect(workspace) as connection:
             _ = connection.execute(
                 (
                     "UPDATE sessions SET pending_question_json = NULL "
@@ -1067,7 +1145,7 @@ class SqliteSessionStore:
         payload: dict[str, object],
         dedupe_key: str | None = None,
     ) -> EventEnvelope | None:
-        with self._connect(workspace) as connection:
+        with self._write_connect(workspace) as connection:
             payload = self._enriched_background_task_event_payload(
                 connection=connection,
                 workspace=workspace,
@@ -1450,7 +1528,7 @@ class SqliteSessionStore:
     ) -> None:
         task_id = validate_background_task_id(task.task.id)
         routing = task.routing_identity
-        with self._connect(workspace) as connection:
+        with self._write_connect(workspace) as connection:
             linked_session_id = task.session_id or task.request.session_id
             initial_runtime_state = self._linked_session_background_task_runtime_state(
                 connection=connection,
@@ -1559,7 +1637,7 @@ class SqliteSessionStore:
         session_id: str,
     ) -> BackgroundTaskState:
         task_id = validate_background_task_id(task_id)
-        with self._connect(workspace) as connection:
+        with self._write_connect(workspace) as connection:
             current = self._background_task_runtime_row(
                 connection=connection,
                 workspace=workspace,
@@ -1609,7 +1687,7 @@ class SqliteSessionStore:
                 "background task terminal status must be completed, failed, or cancelled"
             )
         task_id = validate_background_task_id(task_id)
-        with self._connect(workspace) as connection:
+        with self._write_connect(workspace) as connection:
             current = self._background_task_runtime_row(
                 connection=connection,
                 workspace=workspace,
@@ -1660,7 +1738,7 @@ class SqliteSessionStore:
         task_id: str,
     ) -> BackgroundTaskState:
         task_id = validate_background_task_id(task_id)
-        with self._connect(workspace) as connection:
+        with self._write_connect(workspace) as connection:
             current = self._background_task_runtime_row(
                 connection=connection,
                 workspace=workspace,
@@ -1735,7 +1813,7 @@ class SqliteSessionStore:
             if include_queued
             else "background_tasks.status = 'running'"
         )
-        with self._connect(workspace) as connection:
+        with self._write_connect(workspace) as connection:
             rows = cast(
                 list[sqlite3.Row],
                 connection.execute(
@@ -1826,7 +1904,7 @@ class SqliteSessionStore:
         cancellation_cause: str | None = None,
     ) -> BackgroundTaskState:
         task_id = validate_background_task_id(task_id)
-        with self._connect(workspace) as connection:
+        with self._write_connect(workspace) as connection:
             current = self._background_task_runtime_row(
                 connection=connection,
                 workspace=workspace,
@@ -1922,13 +2000,7 @@ class SqliteSessionStore:
         return row
 
     def _next_background_task_timestamp(self, *, connection: sqlite3.Connection) -> int:
-        row = cast(
-            sqlite3.Row,
-            connection.execute(
-                "SELECT COALESCE(MAX(updated_at), 0) + 1 AS next_ts FROM background_tasks"
-            ).fetchone(),
-        )
-        return cast(int, row["next_ts"])
+        return self._next_sequence_value(connection=connection, scope="background_tasks")
 
     def _linked_session_background_task_runtime_state(
         self,
@@ -1955,7 +2027,7 @@ class SqliteSessionStore:
     def acknowledge_notification(
         self, *, workspace: Path, notification_id: str
     ) -> RuntimeNotification:
-        with self._connect(workspace) as connection:
+        with self._write_connect(workspace) as connection:
             existing_row = cast(
                 sqlite3.Row | None,
                 connection.execute(
@@ -2000,6 +2072,336 @@ class SqliteSessionStore:
                 ).fetchone(),
             )
         return self._notification_from_row(row)
+
+    def storage_diagnostics(self, *, workspace: Path) -> dict[str, object]:
+        database_path = self._resolve_database_path(workspace)
+        with self._connect(workspace) as connection:
+            journal_mode = self._pragma_scalar(connection=connection, name="journal_mode")
+            synchronous = self._pragma_scalar(connection=connection, name="synchronous")
+            busy_timeout = self._pragma_scalar(connection=connection, name="busy_timeout")
+            foreign_keys = self._pragma_scalar(connection=connection, name="foreign_keys")
+            wal_autocheckpoint = self._pragma_scalar(
+                connection=connection,
+                name="wal_autocheckpoint",
+            )
+            checkpoint = self._wal_checkpoint(connection=connection, mode="PASSIVE")
+            counts = self._storage_table_counts(connection=connection, workspace=workspace)
+            task_status_counts = self._background_task_status_counts(
+                connection=connection,
+                workspace=workspace,
+            )
+            pending_counts = self._pending_state_counts(
+                connection=connection,
+                workspace=workspace,
+            )
+        return {
+            "database_path": str(database_path),
+            "database_exists": database_path.exists(),
+            "sqlite_version": sqlite3.sqlite_version,
+            "connection_policy": {
+                "journal_mode": journal_mode,
+                "synchronous": synchronous,
+                "busy_timeout_ms": busy_timeout,
+                "foreign_keys": foreign_keys,
+                "wal_autocheckpoint_pages": wal_autocheckpoint,
+            },
+            "checkpoint": checkpoint,
+            "file_sizes": self._database_file_sizes(database_path),
+            "counts": counts,
+            "background_task_status_counts": task_status_counts,
+            "pending_counts": pending_counts,
+        }
+
+    def prune_runtime_storage(
+        self,
+        *,
+        workspace: Path,
+        keep_sessions: int | None = None,
+        keep_background_tasks: int | None = None,
+        older_than: int | None = None,
+    ) -> dict[str, int]:
+        if keep_sessions is not None and keep_sessions < 0:
+            raise ValueError("keep_sessions must be non-negative when provided")
+        if keep_background_tasks is not None and keep_background_tasks < 0:
+            raise ValueError("keep_background_tasks must be non-negative when provided")
+        if older_than is not None and older_than < 0:
+            raise ValueError("older_than must be non-negative when provided")
+        with self._write_connect(workspace) as connection:
+            session_ids = self._prunable_session_ids(
+                connection=connection,
+                workspace=workspace,
+                keep_sessions=keep_sessions,
+                older_than=older_than,
+            )
+            task_ids = self._prunable_background_task_ids(
+                connection=connection,
+                workspace=workspace,
+                keep_background_tasks=keep_background_tasks,
+                older_than=older_than,
+            )
+            counts = {
+                "session_events": self._delete_for_ids(
+                    connection=connection,
+                    table="session_events",
+                    column="session_id",
+                    ids=session_ids,
+                ),
+                "session_event_deliveries": self._delete_for_ids(
+                    connection=connection,
+                    table="session_event_deliveries",
+                    column="session_id",
+                    ids=session_ids,
+                    workspace=workspace,
+                ),
+                "session_notifications": self._delete_for_ids(
+                    connection=connection,
+                    table="session_notifications",
+                    column="session_id",
+                    ids=session_ids,
+                    workspace=workspace,
+                ),
+                "sessions": self._delete_for_ids(
+                    connection=connection,
+                    table="sessions",
+                    column="session_id",
+                    ids=session_ids,
+                    workspace=workspace,
+                ),
+                "background_tasks": self._delete_for_ids(
+                    connection=connection,
+                    table="background_tasks",
+                    column="task_id",
+                    ids=task_ids,
+                    workspace=workspace,
+                ),
+            }
+            connection.commit()
+            _ = self._wal_checkpoint(connection=connection, mode="PASSIVE")
+        return counts
+
+    def reset_runtime_storage(self, *, workspace: Path) -> dict[str, object]:
+        database_path = self._resolve_database_path(workspace)
+        removed: list[str] = []
+        for path in (
+            database_path,
+            database_path.with_name(f"{database_path.name}-wal"),
+            database_path.with_name(f"{database_path.name}-shm"),
+        ):
+            if path.exists():
+                path.unlink()
+                removed.append(str(path))
+        return {
+            "database_path": str(database_path),
+            "removed": removed,
+            "reset": bool(removed),
+        }
+
+    @staticmethod
+    def _pragma_scalar(*, connection: sqlite3.Connection, name: str) -> object:
+        row = connection.execute(f"PRAGMA {name}").fetchone()
+        return None if row is None else cast(object, row[0])
+
+    @staticmethod
+    def _wal_checkpoint(*, connection: sqlite3.Connection, mode: str) -> dict[str, int]:
+        row = connection.execute(f"PRAGMA wal_checkpoint({mode})").fetchone()
+        if row is None:
+            return {"busy": 0, "log_pages": 0, "checkpointed_pages": 0}
+        return {
+            "busy": int(row[0]),
+            "log_pages": int(row[1]),
+            "checkpointed_pages": int(row[2]),
+        }
+
+    @staticmethod
+    def _database_file_sizes(database_path: Path) -> dict[str, int]:
+        candidates = {
+            "database": database_path,
+            "wal": database_path.with_name(f"{database_path.name}-wal"),
+            "shm": database_path.with_name(f"{database_path.name}-shm"),
+        }
+        return {
+            name: path.stat().st_size if path.exists() else 0 for name, path in candidates.items()
+        }
+
+    @staticmethod
+    def _storage_table_counts(*, connection: sqlite3.Connection, workspace: Path) -> dict[str, int]:
+        scoped_tables = ("sessions", "background_tasks", "session_notifications")
+        counts = {
+            table: int(
+                connection.execute(
+                    f"SELECT COUNT(*) FROM {table} WHERE workspace = ?",
+                    (str(workspace),),
+                ).fetchone()[0]
+            )
+            for table in scoped_tables
+        }
+        session_ids = tuple(
+            cast(str, row["session_id"])
+            for row in cast(
+                list[sqlite3.Row],
+                connection.execute(
+                    "SELECT session_id FROM sessions WHERE workspace = ?",
+                    (str(workspace),),
+                ).fetchall(),
+            )
+        )
+        counts["session_events"] = SqliteSessionStore._count_for_ids(
+            connection=connection,
+            table="session_events",
+            column="session_id",
+            ids=session_ids,
+        )
+        counts["session_event_deliveries"] = SqliteSessionStore._count_for_ids(
+            connection=connection,
+            table="session_event_deliveries",
+            column="session_id",
+            ids=session_ids,
+        )
+        return counts
+
+    @staticmethod
+    def _background_task_status_counts(
+        *, connection: sqlite3.Connection, workspace: Path
+    ) -> dict[str, int]:
+        return {
+            cast(str, row["status"]): cast(int, row["count"])
+            for row in cast(
+                list[sqlite3.Row],
+                connection.execute(
+                    """
+                    SELECT status, COUNT(*) AS count
+                    FROM background_tasks
+                    WHERE workspace = ?
+                    GROUP BY status
+                    ORDER BY status ASC
+                    """,
+                    (str(workspace),),
+                ).fetchall(),
+            )
+        }
+
+    @staticmethod
+    def _pending_state_counts(*, connection: sqlite3.Connection, workspace: Path) -> dict[str, int]:
+        row = connection.execute(
+            """
+            SELECT
+                SUM(CASE WHEN pending_approval_json IS NOT NULL THEN 1 ELSE 0 END) AS approvals,
+                SUM(CASE WHEN pending_question_json IS NOT NULL THEN 1 ELSE 0 END) AS questions
+            FROM sessions
+            WHERE workspace = ?
+            """,
+            (str(workspace),),
+        ).fetchone()
+        if row is None:
+            return {"pending_approvals": 0, "pending_questions": 0}
+        return {
+            "pending_approvals": int(row[0] or 0),
+            "pending_questions": int(row[1] or 0),
+        }
+
+    @staticmethod
+    def _count_for_ids(
+        *, connection: sqlite3.Connection, table: str, column: str, ids: tuple[str, ...]
+    ) -> int:
+        if not ids:
+            return 0
+        placeholders = ", ".join("?" for _ in ids)
+        return int(
+            connection.execute(
+                f"SELECT COUNT(*) FROM {table} WHERE {column} IN ({placeholders})",
+                ids,
+            ).fetchone()[0]
+        )
+
+    @staticmethod
+    def _delete_for_ids(
+        *,
+        connection: sqlite3.Connection,
+        table: str,
+        column: str,
+        ids: tuple[str, ...],
+        workspace: Path | None = None,
+    ) -> int:
+        if not ids:
+            return 0
+        placeholders = ", ".join("?" for _ in ids)
+        workspace_clause = " AND workspace = ?" if workspace is not None else ""
+        parameters: tuple[object, ...] = (*ids, str(workspace)) if workspace is not None else ids
+        cursor = connection.execute(
+            f"DELETE FROM {table} WHERE {column} IN ({placeholders}){workspace_clause}",
+            parameters,
+        )
+        return cursor.rowcount
+
+    @staticmethod
+    def _prunable_session_ids(
+        *,
+        connection: sqlite3.Connection,
+        workspace: Path,
+        keep_sessions: int | None,
+        older_than: int | None,
+    ) -> tuple[str, ...]:
+        conditions = ["workspace = ?", "status IN ('completed', 'failed')"]
+        parameters: list[object] = [str(workspace)]
+        if older_than is not None:
+            conditions.append("updated_at < ?")
+            parameters.append(older_than)
+        keep_clause = ""
+        if keep_sessions is not None:
+            keep_clause = (
+                "AND session_id NOT IN ("
+                "SELECT session_id FROM sessions "
+                "WHERE workspace = ? AND status IN ('completed', 'failed') "
+                "ORDER BY updated_at DESC, session_id ASC LIMIT ?"
+                ")"
+            )
+            parameters.extend([str(workspace), keep_sessions])
+        rows = connection.execute(
+            f"""
+            SELECT session_id
+            FROM sessions
+            WHERE {" AND ".join(conditions)}
+              {keep_clause}
+            ORDER BY updated_at ASC, session_id ASC
+            """,
+            tuple(parameters),
+        ).fetchall()
+        return tuple(cast(str, row["session_id"]) for row in cast(list[sqlite3.Row], rows))
+
+    @staticmethod
+    def _prunable_background_task_ids(
+        *,
+        connection: sqlite3.Connection,
+        workspace: Path,
+        keep_background_tasks: int | None,
+        older_than: int | None,
+    ) -> tuple[str, ...]:
+        conditions = ["workspace = ?", "status IN ('completed', 'failed', 'cancelled')"]
+        parameters: list[object] = [str(workspace)]
+        if older_than is not None:
+            conditions.append("updated_at < ?")
+            parameters.append(older_than)
+        keep_clause = ""
+        if keep_background_tasks is not None:
+            keep_clause = (
+                "AND task_id NOT IN ("
+                "SELECT task_id FROM background_tasks "
+                "WHERE workspace = ? AND status IN ('completed', 'failed', 'cancelled') "
+                "ORDER BY updated_at DESC, task_id ASC LIMIT ?"
+                ")"
+            )
+            parameters.extend([str(workspace), keep_background_tasks])
+        rows = connection.execute(
+            f"""
+            SELECT task_id
+            FROM background_tasks
+            WHERE {" AND ".join(conditions)}
+              {keep_clause}
+            ORDER BY updated_at ASC, task_id ASC
+            """,
+            tuple(parameters),
+        ).fetchall()
+        return tuple(cast(str, row["task_id"]) for row in cast(list[sqlite3.Row], rows))
 
     @staticmethod
     def _result_summary(*, response: RuntimeResponse, prompt: str) -> tuple[str, str | None]:
@@ -2295,11 +2697,23 @@ class SqliteSessionStore:
             return cast(int, row["created_at"])
         return self._next_timestamp(connection=connection)
 
-    def _next_timestamp(self, *, connection: sqlite3.Connection) -> int:
+    @staticmethod
+    def _next_sequence_value(*, connection: sqlite3.Connection, scope: str) -> int:
         row = cast(
-            sqlite3.Row,
+            sqlite3.Row | None,
             connection.execute(
-                "SELECT COALESCE(MAX(updated_at), 0) + 1 AS next_ts FROM sessions"
+                """
+                UPDATE storage_sequences
+                SET value = value + 1
+                WHERE scope = ?
+                RETURNING value
+                """,
+                (scope,),
             ).fetchone(),
         )
-        return cast(int, row["next_ts"])
+        if row is None:
+            raise RuntimeError(f"runtime storage sequence is missing: {scope}")
+        return cast(int, row["value"])
+
+    def _next_timestamp(self, *, connection: sqlite3.Connection) -> int:
+        return self._next_sequence_value(connection=connection, scope="sessions")

--- a/src/voidcode/runtime/storage.py
+++ b/src/voidcode/runtime/storage.py
@@ -430,6 +430,9 @@ class SqliteSessionStore:
         _ = connection.execute(
             "INSERT OR IGNORE INTO storage_sequences (scope, value) VALUES ('background_tasks', 0)"
         )
+        _ = connection.execute(
+            "INSERT OR IGNORE INTO storage_sequences (scope, value) VALUES ('auxiliary', 0)"
+        )
 
     @classmethod
     def _assert_canonical_schema(
@@ -1168,7 +1171,7 @@ class SqliteSessionStore:
             if sequence_row is None:
                 raise UnknownSessionError(f"unknown session: {session_id}")
             if dedupe_key is not None:
-                delivered_at = self._next_timestamp(connection=connection)
+                delivered_at = self._next_auxiliary_timestamp(connection=connection)
                 inserted_delivery = connection.execute(
                     """
                     INSERT OR IGNORE INTO session_event_deliveries (
@@ -2002,6 +2005,9 @@ class SqliteSessionStore:
     def _next_background_task_timestamp(self, *, connection: sqlite3.Connection) -> int:
         return self._next_sequence_value(connection=connection, scope="background_tasks")
 
+    def _next_auxiliary_timestamp(self, *, connection: sqlite3.Connection) -> int:
+        return self._next_sequence_value(connection=connection, scope="auxiliary")
+
     def _linked_session_background_task_runtime_state(
         self,
         *,
@@ -2044,7 +2050,7 @@ class SqliteSessionStore:
                 raise ValueError(f"unknown notification: {notification_id}")
             acknowledged_at = cast(int | None, existing_row["acknowledged_at"])
             if acknowledged_at is None:
-                acknowledged_at = self._next_timestamp(connection=connection)
+                acknowledged_at = self._next_auxiliary_timestamp(connection=connection)
                 _ = connection.execute(
                     """
                     UPDATE session_notifications
@@ -2127,17 +2133,23 @@ class SqliteSessionStore:
         if older_than is not None and older_than < 0:
             raise ValueError("older_than must be non-negative when provided")
         with self._write_connect(workspace) as connection:
-            session_ids = self._prunable_session_ids(
-                connection=connection,
-                workspace=workspace,
-                keep_sessions=keep_sessions,
-                older_than=older_than,
-            )
             task_ids = self._prunable_background_task_ids(
                 connection=connection,
                 workspace=workspace,
                 keep_background_tasks=keep_background_tasks,
                 older_than=older_than,
+            )
+            retained_background_task_session_ids = self._retained_background_task_session_ids(
+                connection=connection,
+                workspace=workspace,
+                pruned_task_ids=task_ids,
+            )
+            session_ids = self._prunable_session_ids(
+                connection=connection,
+                workspace=workspace,
+                keep_sessions=keep_sessions,
+                older_than=older_than,
+                protected_session_ids=retained_background_task_session_ids,
             )
             counts = {
                 "session_events": self._delete_for_ids(
@@ -2340,12 +2352,18 @@ class SqliteSessionStore:
         workspace: Path,
         keep_sessions: int | None,
         older_than: int | None,
+        protected_session_ids: tuple[str, ...] = (),
     ) -> tuple[str, ...]:
         conditions = ["workspace = ?", "status IN ('completed', 'failed')"]
         parameters: list[object] = [str(workspace)]
         if older_than is not None:
             conditions.append("updated_at < ?")
             parameters.append(older_than)
+        protected_clause = ""
+        if protected_session_ids:
+            protected_placeholders = ", ".join("?" for _ in protected_session_ids)
+            protected_clause = f"AND session_id NOT IN ({protected_placeholders})"
+            parameters.extend(protected_session_ids)
         keep_clause = ""
         if keep_sessions is not None:
             keep_clause = (
@@ -2361,8 +2379,34 @@ class SqliteSessionStore:
             SELECT session_id
             FROM sessions
             WHERE {" AND ".join(conditions)}
+              {protected_clause}
               {keep_clause}
             ORDER BY updated_at ASC, session_id ASC
+            """,
+            tuple(parameters),
+        ).fetchall()
+        return tuple(cast(str, row["session_id"]) for row in cast(list[sqlite3.Row], rows))
+
+    @staticmethod
+    def _retained_background_task_session_ids(
+        *,
+        connection: sqlite3.Connection,
+        workspace: Path,
+        pruned_task_ids: tuple[str, ...],
+    ) -> tuple[str, ...]:
+        pruned_clause = ""
+        parameters: list[object] = [str(workspace)]
+        if pruned_task_ids:
+            pruned_placeholders = ", ".join("?" for _ in pruned_task_ids)
+            pruned_clause = f"AND task_id NOT IN ({pruned_placeholders})"
+            parameters.extend(pruned_task_ids)
+        rows = connection.execute(
+            f"""
+            SELECT DISTINCT session_id
+            FROM background_tasks
+            WHERE workspace = ?
+              AND session_id IS NOT NULL
+              {pruned_clause}
             """,
             tuple(parameters),
         ).fetchall()
@@ -2464,7 +2508,7 @@ class SqliteSessionStore:
                   AND status = 'unread'
                 """,
                 (
-                    self._next_timestamp(connection=connection),
+                    self._next_auxiliary_timestamp(connection=connection),
                     str(workspace),
                     session_id,
                 ),
@@ -2482,7 +2526,7 @@ class SqliteSessionStore:
                   AND notification_id != ?
                 """,
                 (
-                    self._next_timestamp(connection=connection),
+                    self._next_auxiliary_timestamp(connection=connection),
                     str(workspace),
                     session_id,
                     notification["notification_id"],
@@ -2500,7 +2544,7 @@ class SqliteSessionStore:
                   AND status = 'unread'
                 """,
                 (
-                    self._next_timestamp(connection=connection),
+                    self._next_auxiliary_timestamp(connection=connection),
                     str(workspace),
                     session_id,
                 ),
@@ -2518,7 +2562,7 @@ class SqliteSessionStore:
                   AND notification_id != ?
                 """,
                 (
-                    self._next_timestamp(connection=connection),
+                    self._next_auxiliary_timestamp(connection=connection),
                     str(workspace),
                     session_id,
                     notification["notification_id"],
@@ -2543,7 +2587,7 @@ class SqliteSessionStore:
                 json.dumps(notification["payload"], sort_keys=True),
                 notification["event_sequence"],
                 notification["dedupe_key"],
-                self._next_timestamp(connection=connection),
+                self._next_auxiliary_timestamp(connection=connection),
                 None,
             ),
         )
@@ -2695,7 +2739,7 @@ class SqliteSessionStore:
         )
         if row is not None:
             return cast(int, row["created_at"])
-        return self._next_timestamp(connection=connection)
+        return self._next_auxiliary_timestamp(connection=connection)
 
     @staticmethod
     def _next_sequence_value(*, connection: sqlite3.Connection, scope: str) -> int:

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -261,6 +261,56 @@ def test_top_level_help_includes_examples() -> None:
     assert "voidcode commands list" in result.stdout
 
 
+def test_storage_diagnostics_outputs_json() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        env = with_src_pythonpath(os.environ.copy())
+
+        result = _run_module_cli(
+            "storage",
+            "diagnostics",
+            "--workspace",
+            str(workspace),
+            env=env,
+        )
+
+    payload = json.loads(result.stdout)
+    assert result.returncode == 0
+    assert payload["workspace"] == str(workspace)
+    assert payload["storage"]["connection_policy"]["journal_mode"] == "wal"
+    assert payload["storage"]["connection_policy"]["busy_timeout_ms"] == 5000
+
+
+def test_storage_reset_removes_local_database_files() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        (workspace / "sample.txt").write_text("sample\n", encoding="utf-8")
+        env = with_src_pythonpath(os.environ.copy())
+        setup_result = _run_module_cli(
+            "run",
+            "read sample.txt",
+            "--workspace",
+            str(workspace),
+            "--session-id",
+            "reset-session",
+            env=env,
+        )
+        reset_result = _run_module_cli(
+            "storage",
+            "reset",
+            "--workspace",
+            str(workspace),
+            env=env,
+        )
+        database_path = workspace / ".voidcode" / "sessions.sqlite3"
+
+    payload = json.loads(reset_result.stdout)
+    assert setup_result.returncode == 0
+    assert reset_result.returncode == 0
+    assert str(database_path) in payload["storage"]["removed"]
+    assert database_path.exists() is False
+
+
 def test_web_command_forwards_runtime_config_and_server_entry() -> None:
     cli = importlib.import_module("voidcode.cli")
     workspace = Path("/tmp/web-workspace")

--- a/tests/unit/runtime/test_background_task_storage.py
+++ b/tests/unit/runtime/test_background_task_storage.py
@@ -209,6 +209,81 @@ def test_background_task_storage_prunes_only_terminal_tasks(tmp_path: Path) -> N
         _ = store.load_background_task(workspace=tmp_path, task_id="task-old")
 
 
+def test_background_task_storage_prune_retains_sessions_referenced_by_kept_tasks(
+    tmp_path: Path,
+) -> None:
+    store = SqliteSessionStore()
+    old_request = RuntimeRequest(prompt="old child", session_id="child-old")
+    old_response = RuntimeResponse(
+        session=SessionState(session=SessionRef(id="child-old"), status="completed", turn=1),
+        events=(
+            EventEnvelope(
+                session_id="child-old",
+                sequence=1,
+                event_type="runtime.request_received",
+                source="runtime",
+                payload={"prompt": "old child"},
+            ),
+        ),
+        output="old child output",
+    )
+    new_request = RuntimeRequest(prompt="new child", session_id="child-new")
+    new_response = RuntimeResponse(
+        session=SessionState(session=SessionRef(id="child-new"), status="completed", turn=1),
+        events=(
+            EventEnvelope(
+                session_id="child-new",
+                sequence=1,
+                event_type="runtime.request_received",
+                source="runtime",
+                payload={"prompt": "new child"},
+            ),
+        ),
+        output="new child output",
+    )
+    store.save_run(workspace=tmp_path, request=old_request, response=old_response)
+    store.save_run(workspace=tmp_path, request=new_request, response=new_response)
+    store.create_background_task(
+        workspace=tmp_path,
+        task=BackgroundTaskState(
+            task=BackgroundTaskRef(id="task-old"),
+            status="completed",
+            request=BackgroundTaskRequestSnapshot(prompt="old child"),
+            session_id="child-old",
+            created_at=1,
+            updated_at=1,
+            finished_at=1,
+        ),
+    )
+    store.create_background_task(
+        workspace=tmp_path,
+        task=BackgroundTaskState(
+            task=BackgroundTaskRef(id="task-new"),
+            status="completed",
+            request=BackgroundTaskRequestSnapshot(prompt="new child"),
+            session_id="child-new",
+            created_at=2,
+            updated_at=2,
+            finished_at=2,
+        ),
+    )
+
+    counts = store.prune_runtime_storage(
+        workspace=tmp_path,
+        keep_sessions=1,
+        keep_background_tasks=2,
+    )
+
+    assert counts["background_tasks"] == 0
+    assert counts["sessions"] == 0
+    assert store.load_session_result(workspace=tmp_path, session_id="child-old").output == (
+        "old child output"
+    )
+    assert store.load_session_result(workspace=tmp_path, session_id="child-new").output == (
+        "new child output"
+    )
+
+
 def test_background_task_storage_lists_by_parent_session_and_preserves_order(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_background_task_storage.py
+++ b/tests/unit/runtime/test_background_task_storage.py
@@ -177,6 +177,38 @@ def test_background_task_storage_create_assigns_store_timestamps_and_orders_by_l
     assert [task.task.id for task in listed] == ["task-ts-2", "task-ts-1"]
 
 
+def test_background_task_storage_prunes_only_terminal_tasks(tmp_path: Path) -> None:
+    store = SqliteSessionStore()
+    for task_id in ("task-old", "task-new", "task-running"):
+        store.create_background_task(workspace=tmp_path, task=_task(task_id=task_id))
+    _ = store.mark_background_task_terminal(
+        workspace=tmp_path,
+        task_id="task-old",
+        status="completed",
+    )
+    _ = store.mark_background_task_terminal(
+        workspace=tmp_path,
+        task_id="task-new",
+        status="failed",
+        error="boom",
+    )
+    _ = store.mark_background_task_running(
+        workspace=tmp_path,
+        task_id="task-running",
+        session_id="session-running",
+    )
+
+    counts = store.prune_runtime_storage(workspace=tmp_path, keep_background_tasks=1)
+
+    assert counts["background_tasks"] == 1
+    assert [task.task.id for task in store.list_background_tasks(workspace=tmp_path)] == [
+        "task-running",
+        "task-new",
+    ]
+    with pytest.raises(ValueError, match="unknown background task: task-old"):
+        _ = store.load_background_task(workspace=tmp_path, task_id="task-old")
+
+
 def test_background_task_storage_lists_by_parent_session_and_preserves_order(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_session_storage.py
+++ b/tests/unit/runtime/test_session_storage.py
@@ -4,7 +4,7 @@ import sqlite3
 import threading
 from contextlib import closing
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -118,6 +118,32 @@ def test_session_storage_bootstraps_canonical_schema_for_fresh_database(tmp_path
     assert any(row[2] == 1 and row[3] == "u" for row in notification_indexes)
 
 
+def test_session_storage_configures_sqlite_operability_pragmas(tmp_path: Path) -> None:
+    database_path = tmp_path / "operability.sqlite3"
+    store = SqliteSessionStore(database_path=database_path)
+
+    store.list_sessions(workspace=tmp_path)
+
+    diagnostics = store.storage_diagnostics(workspace=tmp_path)
+
+    assert diagnostics["database_path"] == str(database_path)
+    assert diagnostics["database_exists"] is True
+    assert diagnostics["connection_policy"] == {
+        "journal_mode": "wal",
+        "synchronous": 1,
+        "busy_timeout_ms": 5000,
+        "foreign_keys": 1,
+        "wal_autocheckpoint_pages": 1000,
+    }
+    assert diagnostics["counts"] == {
+        "sessions": 0,
+        "background_tasks": 0,
+        "session_notifications": 0,
+        "session_events": 0,
+        "session_event_deliveries": 0,
+    }
+
+
 def test_session_storage_rejects_non_canonical_schema_missing_runtime_columns(
     tmp_path: Path,
 ) -> None:
@@ -196,7 +222,9 @@ def test_session_storage_rejects_non_canonical_schema_missing_runtime_columns(
         RuntimeError,
         match=(
             r"table 'sessions' missing columns: .*"
-            r"Remove '.*[\\/]invalid-sessions\.sqlite3' and rerun to reset local runtime storage\."
+            r"This pre-MVP build does not migrate old schemas\. "
+            r"Reset local runtime storage with: remove '.*[\\/]invalid-sessions\.sqlite3' "
+            r"plus matching -wal/-shm files\."
         ),
     ):
         store.list_sessions(workspace=tmp_path)
@@ -314,7 +342,9 @@ def test_session_storage_rejects_non_canonical_schema_with_wrong_existing_table_
         RuntimeError,
         match=(
             r"table 'session_event_deliveries' missing columns: dedupe_key.*"
-            r"Remove '.*[\\/]wrong-table-shape\.sqlite3' and rerun to reset local runtime storage\."
+            r"This pre-MVP build does not migrate old schemas\. "
+            r"Reset local runtime storage with: remove '.*[\\/]wrong-table-shape\.sqlite3' "
+            r"plus matching -wal/-shm files\."
         ),
     ):
         store.list_notifications(workspace=tmp_path)
@@ -582,6 +612,49 @@ def test_session_storage_append_session_event_allocates_sequences_atomically(
     assert len(events) == 2
     assert {event.sequence for event in events} == {2, 3}
     assert [event.sequence for event in loaded.events[-2:]] == [2, 3]
+
+
+def test_session_storage_prunes_terminal_sessions_and_dependent_rows(tmp_path: Path) -> None:
+    store = SqliteSessionStore()
+
+    for session_id, status in (
+        ("old-terminal", "completed"),
+        ("new-terminal", "completed"),
+        ("waiting-session", "waiting"),
+    ):
+        store.save_run(
+            workspace=tmp_path,
+            request=RuntimeRequest(prompt=session_id, session_id=session_id),
+            response=RuntimeResponse(
+                session=SessionState(
+                    session=SessionRef(id=session_id),
+                    status=cast(Any, status),
+                    turn=1,
+                    metadata={},
+                ),
+                events=(
+                    EventEnvelope(
+                        session_id=session_id,
+                        sequence=1,
+                        event_type="graph.response_ready",
+                        source="graph",
+                    ),
+                ),
+                output="done" if status == "completed" else None,
+            ),
+        )
+
+    counts = store.prune_runtime_storage(workspace=tmp_path, keep_sessions=1)
+
+    assert counts["sessions"] == 1
+    assert counts["session_events"] == 1
+    assert counts["session_notifications"] == 1
+    assert [session.session.id for session in store.list_sessions(workspace=tmp_path)] == [
+        "waiting-session",
+        "new-terminal",
+    ]
+    with pytest.raises(ValueError, match="unknown session: old-terminal"):
+        _ = store.load_session_result(workspace=tmp_path, session_id="old-terminal")
 
 
 def test_session_storage_persists_pending_question_and_question_notification(

--- a/tests/unit/runtime/test_session_storage.py
+++ b/tests/unit/runtime/test_session_storage.py
@@ -118,6 +118,82 @@ def test_session_storage_bootstraps_canonical_schema_for_fresh_database(tmp_path
     assert any(row[2] == 1 and row[3] == "u" for row in notification_indexes)
 
 
+def test_session_storage_bootstraps_sequences_from_existing_timestamps(tmp_path: Path) -> None:
+    database_path = tmp_path / "sequence-bootstrap.sqlite3"
+    store = SqliteSessionStore(database_path=database_path)
+    old_request = RuntimeRequest(prompt="old", session_id="old-session")
+    old_response = RuntimeResponse(
+        session=SessionState(session=SessionRef(id="old-session"), status="completed", turn=1),
+        events=(
+            EventEnvelope(
+                session_id="old-session",
+                sequence=1,
+                event_type="graph.response_ready",
+                source="graph",
+            ),
+        ),
+        output="old output",
+    )
+    store.save_run(workspace=tmp_path, request=old_request, response=old_response)
+    store.create_background_task(
+        workspace=tmp_path,
+        task=BackgroundTaskState(
+            task=BackgroundTaskRef(id="old-task"),
+            request=BackgroundTaskRequestSnapshot(prompt="old task"),
+        ),
+    )
+    with closing(sqlite3.connect(database_path)) as connection:
+        _ = connection.execute(
+            "UPDATE sessions SET created_at = 40, updated_at = 50 WHERE session_id = ?",
+            ("old-session",),
+        )
+        _ = connection.execute(
+            "UPDATE background_tasks SET created_at = 60, updated_at = 70 WHERE task_id = ?",
+            ("old-task",),
+        )
+        _ = connection.execute("DELETE FROM storage_sequences")
+        connection.commit()
+
+    new_request = RuntimeRequest(prompt="new", session_id="new-session")
+    new_response = RuntimeResponse(
+        session=SessionState(session=SessionRef(id="new-session"), status="completed", turn=1),
+        events=(
+            EventEnvelope(
+                session_id="new-session",
+                sequence=1,
+                event_type="graph.response_ready",
+                source="graph",
+            ),
+        ),
+        output="new output",
+    )
+    store.save_run(workspace=tmp_path, request=new_request, response=new_response)
+    store.create_background_task(
+        workspace=tmp_path,
+        task=BackgroundTaskState(
+            task=BackgroundTaskRef(id="new-task"),
+            request=BackgroundTaskRequestSnapshot(prompt="new task"),
+        ),
+    )
+
+    with closing(sqlite3.connect(database_path)) as connection:
+        new_session_row = connection.execute(
+            "SELECT created_at, updated_at FROM sessions WHERE session_id = ?",
+            ("new-session",),
+        ).fetchone()
+        new_task_row = connection.execute(
+            "SELECT created_at, updated_at FROM background_tasks WHERE task_id = ?",
+            ("new-task",),
+        ).fetchone()
+
+    assert [session.session.id for session in store.list_sessions(workspace=tmp_path)] == [
+        "new-session",
+        "old-session",
+    ]
+    assert new_session_row == (41, 51)
+    assert new_task_row == (71, 71)
+
+
 def test_session_storage_configures_sqlite_operability_pragmas(tmp_path: Path) -> None:
     database_path = tmp_path / "operability.sqlite3"
     store = SqliteSessionStore(database_path=database_path)


### PR DESCRIPTION
## Summary
- Harden runtime SQLite connections with WAL, busy timeout, explicit write transactions, and monotonic storage sequences.
- Add runtime/CLI storage diagnostics, prune, and reset maintenance surfaces for local pre-MVP storage.
- Cover storage operability, pruning, and CLI maintenance behavior with focused tests.

## Verification
- uv run ruff check src/voidcode/runtime/storage.py src/voidcode/runtime/service.py src/voidcode/cli.py tests/unit/runtime/test_session_storage.py tests/unit/runtime/test_background_task_storage.py tests/unit/interface/test_cli_smoke.py
- uv run basedpyright --warnings src
- uv run python -X utf8 -m pytest tests/unit/runtime/test_session_storage.py tests/unit/runtime/test_background_task_storage.py tests/unit/interface/test_cli_smoke.py::test_storage_diagnostics_outputs_json tests/unit/interface/test_cli_smoke.py::test_storage_reset_removes_local_database_files -q
- mise run test:fast

Closes #312