### PR TITLE
feat(runtime): productize context memory compaction

### DIFF
--- a/src/voidcode/runtime/background_tasks.py
+++ b/src/voidcode/runtime/background_tasks.py
@@ -511,7 +511,10 @@ class RuntimeBackgroundTaskSupervisor:
     def background_task_result(self, *, task: BackgroundTaskState) -> BackgroundTaskResult:
         child_result = self.load_background_task_child_result(task=task)
         approval_blocked = child_result is not None and child_result.status == "waiting"
-        summary_output = child_result.summary if child_result is not None else None
+        summary_output = self._leader_safe_child_summary(
+            task=task,
+            child_result=child_result,
+        )
         error = (
             child_result.error if child_result is not None and child_result.error else task.error
         )
@@ -539,6 +542,26 @@ class RuntimeBackgroundTaskSupervisor:
             result_available=result_available,
             cancellation_cause=task.cancellation_cause,
         )
+
+    @staticmethod
+    def _leader_safe_child_summary(
+        *,
+        task: BackgroundTaskState,
+        child_result: RuntimeSessionResult | None,
+    ) -> str | None:
+        if child_result is None:
+            return None
+        child_session_id = child_result.session.session.id
+        if child_result.status == "completed":
+            return (
+                f"Completed child session {child_session_id}; full output is preserved outside "
+                "active context."
+            )
+        if child_result.status == "waiting":
+            return child_result.summary
+        if child_result.status == "failed":
+            return child_result.summary
+        return f"Background child session {child_session_id}: {child_result.status}"
 
     def _delegated_lifecycle_payloads(
         self,

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -18,6 +18,16 @@ def _empty_tool_limits() -> dict[str, int]:
 @dataclass(frozen=True, slots=True)
 class RuntimeContinuityState:
     summary_text: str | None = None
+    objective: str | None = None
+    current_goal: str | None = None
+    verbatim_user_constraints: tuple[str, ...] = ()
+    progress_completed: tuple[str, ...] = ()
+    blockers_open_questions: tuple[str, ...] = ()
+    key_decisions: tuple[str, ...] = ()
+    relevant_files_commands_errors: tuple[str, ...] = ()
+    verification_state: tuple[str, ...] = ()
+    delegated_task_summaries: tuple[str, ...] = ()
+    recent_tail: tuple[str, ...] = ()
     dropped_tool_result_count: int = 0
     retained_tool_result_count: int = 0
     source: str = "tool_result_window"
@@ -30,15 +40,25 @@ class RuntimeContinuityState:
     # semantics. This is incremented when the shape evolves and is included
     # in the serialized payload so consumers can decide how to handle newer
     # fields.
-    version: int = 1
+    version: int = 2
 
     def metadata_payload(self) -> dict[str, object]:
         payload: dict[str, object] = {
             "summary_text": self.summary_text,
+            "objective": self.objective,
+            "current_goal": self.current_goal,
+            "verbatim_user_constraints": list(self.verbatim_user_constraints),
+            "progress_completed": list(self.progress_completed),
+            "blockers_open_questions": list(self.blockers_open_questions),
+            "key_decisions": list(self.key_decisions),
+            "relevant_files_commands_errors": list(self.relevant_files_commands_errors),
+            "verification_state": list(self.verification_state),
+            "delegated_task_summaries": list(self.delegated_task_summaries),
+            "recent_tail": list(self.recent_tail),
             "dropped_tool_result_count": self.dropped_tool_result_count,
             "retained_tool_result_count": self.retained_tool_result_count,
             "source": self.source,
-            "version": self.version,
+            "version": 2,
         }
         if self.original_tool_result_tokens is not None:
             payload["original_tool_result_tokens"] = self.original_tool_result_tokens
@@ -232,6 +252,200 @@ def _tool_result_preview(result: ToolResult, *, max_preview_chars: int) -> str:
         preview_label = "content_preview" if content else "error_preview"
         parts.append(f'{preview_label}="{clipped}"')
     return " ".join(parts)
+
+
+def _metadata_string_tuple(payload: Mapping[str, object], key: str) -> tuple[str, ...]:
+    raw = payload.get(key)
+    if not isinstance(raw, list | tuple):
+        return ()
+    raw_items = cast(list[object] | tuple[object, ...], raw)
+    values: list[str] = []
+    for item in raw_items:
+        if isinstance(item, str) and item.strip():
+            values.append(item.strip())
+    return tuple(values)
+
+
+def continuity_state_from_metadata_payload(
+    payload: Mapping[str, object],
+) -> RuntimeContinuityState | None:
+    summary_text = payload.get("summary_text")
+    if summary_text is not None and not isinstance(summary_text, str):
+        return None
+    objective = payload.get("objective")
+    if objective is not None and not isinstance(objective, str):
+        objective = None
+    current_goal = payload.get("current_goal")
+    if current_goal is not None and not isinstance(current_goal, str):
+        current_goal = None
+    dropped = payload.get("dropped_tool_result_count")
+    retained = payload.get("retained_tool_result_count")
+    source = payload.get("source")
+    if not isinstance(dropped, int) or isinstance(dropped, bool):
+        return None
+    if not isinstance(retained, int) or isinstance(retained, bool):
+        return None
+    if not isinstance(source, str):
+        return None
+
+    def _optional_int(value: object) -> int | None:
+        if value is None:
+            return None
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+        raise ValueError
+
+    try:
+        original_token_count = _optional_int(payload.get("original_tool_result_tokens"))
+        retained_token_count = _optional_int(payload.get("retained_tool_result_tokens"))
+        dropped_token_count = _optional_int(payload.get("dropped_tool_result_tokens"))
+        resolved_token_budget = _optional_int(payload.get("token_budget"))
+    except ValueError:
+        return None
+    token_estimate_source = payload.get("token_estimate_source")
+    if token_estimate_source is not None and not isinstance(token_estimate_source, str):
+        return None
+    version = payload.get("version")
+    if version is not None and (not isinstance(version, int) or isinstance(version, bool)):
+        return None
+    return RuntimeContinuityState(
+        summary_text=summary_text,
+        objective=objective,
+        current_goal=current_goal,
+        verbatim_user_constraints=_metadata_string_tuple(payload, "verbatim_user_constraints"),
+        progress_completed=_metadata_string_tuple(payload, "progress_completed"),
+        blockers_open_questions=_metadata_string_tuple(payload, "blockers_open_questions"),
+        key_decisions=_metadata_string_tuple(payload, "key_decisions"),
+        relevant_files_commands_errors=_metadata_string_tuple(
+            payload,
+            "relevant_files_commands_errors",
+        ),
+        verification_state=_metadata_string_tuple(payload, "verification_state"),
+        delegated_task_summaries=_metadata_string_tuple(payload, "delegated_task_summaries"),
+        recent_tail=_metadata_string_tuple(payload, "recent_tail"),
+        dropped_tool_result_count=dropped,
+        retained_tool_result_count=retained,
+        source=source,
+        original_tool_result_tokens=original_token_count,
+        retained_tool_result_tokens=retained_token_count,
+        dropped_tool_result_tokens=dropped_token_count,
+        token_budget=resolved_token_budget,
+        token_estimate_source=token_estimate_source,
+        version=version if version is not None else 1,
+    )
+
+
+def _previous_continuity_state(
+    session_metadata: Mapping[str, object],
+) -> RuntimeContinuityState | None:
+    runtime_state = session_metadata.get("runtime_state")
+    if not isinstance(runtime_state, dict):
+        return None
+    continuity = cast(dict[str, object], runtime_state).get("continuity")
+    if not isinstance(continuity, dict):
+        return None
+    return continuity_state_from_metadata_payload(cast(dict[str, object], continuity))
+
+
+def _merge_unique_strings(*groups: tuple[str, ...], limit: int = 12) -> tuple[str, ...]:
+    merged: list[str] = []
+    seen: set[str] = set()
+    for group in groups:
+        for value in group:
+            stripped = value.strip()
+            if not stripped or stripped in seen:
+                continue
+            seen.add(stripped)
+            merged.append(stripped)
+            if len(merged) >= limit:
+                return tuple(merged)
+    return tuple(merged)
+
+
+def _line_preview(value: str, *, limit: int) -> str:
+    collapsed = " ".join(part.strip() for part in value.splitlines() if part.strip())
+    if len(collapsed) <= limit:
+        return collapsed
+    return f"{collapsed[:limit]}..."
+
+
+def _constraint_lines(prompt: str) -> tuple[str, ...]:
+    constraints: list[str] = []
+    markers = ("must", "must not", "never", "always", "do not", "don't", "forbidden")
+    for raw_line in prompt.splitlines():
+        line = raw_line.strip(" -\t")
+        lowered = line.lower()
+        if line and any(marker in lowered for marker in markers):
+            constraints.append(line)
+    return tuple(constraints[:8])
+
+
+def _facts_from_tool_results(
+    results: tuple[ToolResult, ...], *, preview_item_limit: int, preview_char_limit: int
+) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
+    progress: list[str] = []
+    blockers: list[str] = []
+    refs: list[str] = []
+    delegated: list[str] = []
+    for result in results[:preview_item_limit]:
+        preview = _tool_result_preview(result, max_preview_chars=preview_char_limit)
+        if result.status == "ok":
+            progress.append(f"Tool result compacted: {preview}")
+        else:
+            blockers.append(f"Tool error compacted: {preview}")
+        path = result.data.get("path")
+        if isinstance(path, str) and path:
+            refs.append(f"file:{path}")
+        command = result.data.get("command")
+        if isinstance(command, str) and command:
+            refs.append(f"command:{command}")
+        if result.tool_name in {"task", "background_output"}:
+            task_id = result.data.get("task_id")
+            child_session_id = result.data.get("child_session_id")
+            summary_output = result.data.get("summary_output")
+            parts = [f"tool={result.tool_name}"]
+            if isinstance(task_id, str):
+                parts.append(f"task_id={task_id}")
+            if isinstance(child_session_id, str):
+                parts.append(f"child_session_id={child_session_id}")
+            if isinstance(summary_output, str) and summary_output:
+                parts.append(f"summary={_line_preview(summary_output, limit=preview_char_limit)}")
+            delegated.append(" ".join(parts))
+    return tuple(progress), tuple(blockers), tuple(refs), tuple(delegated)
+
+
+def _continuity_summary_text(state: RuntimeContinuityState) -> str:
+    sections: list[str] = []
+
+    def add_section(title: str, values: tuple[str, ...] | str | None) -> None:
+        if isinstance(values, str):
+            value = values.strip()
+            if value:
+                sections.append(f"## {title}\n{value}")
+            return
+        if not values:
+            return
+        lines = "\n".join(f"- {value}" for value in values if value.strip())
+        if lines:
+            sections.append(f"## {title}\n{lines}")
+
+    add_section("Objective", state.objective)
+    add_section("Current Goal", state.current_goal)
+    add_section("Constraints", state.verbatim_user_constraints)
+    add_section("Progress Completed", state.progress_completed)
+    add_section("Blockers / Open Questions", state.blockers_open_questions)
+    add_section("Key Decisions", state.key_decisions)
+    add_section("Relevant Files / Commands / Errors", state.relevant_files_commands_errors)
+    add_section("Verification State", state.verification_state)
+    add_section("Delegated / Background Tasks", state.delegated_task_summaries)
+    add_section("Recent Verbatim Tail", state.recent_tail)
+    sections.append(
+        "## Compaction Metadata\n"
+        f"- Dropped tool results: {state.dropped_tool_result_count}\n"
+        f"- Retained tool results: {state.retained_tool_result_count}\n"
+        f"- Source: {state.source}"
+    )
+    return "\n\n".join(sections)
 
 
 _UNICODE_TOKEN_ESTIMATE_SOURCE = "unicode_aware_chars"
@@ -595,7 +809,10 @@ def normalize_read_file_output(content: str | None) -> str | None:
 
 def _build_continuity_state(
     *,
+    prompt: str,
+    session_metadata: Mapping[str, object],
     dropped_results: tuple[ToolResult, ...],
+    retained_results: tuple[ToolResult, ...],
     retained_count: int,
     preview_item_limit: int,
     preview_char_limit: int,
@@ -606,8 +823,41 @@ def _build_continuity_state(
     token_estimate_source: str | None = None,
 ) -> RuntimeContinuityState:
     dropped_count = len(dropped_results)
+    previous = _previous_continuity_state(session_metadata)
+    objective = previous.objective if previous is not None else None
+    if objective is None:
+        objective = _line_preview(prompt, limit=160) if prompt.strip() else None
+    current_goal = _line_preview(prompt, limit=160) if prompt.strip() else objective
+    progress, blockers, refs, delegated = _facts_from_tool_results(
+        dropped_results,
+        preview_item_limit=preview_item_limit,
+        preview_char_limit=preview_char_limit,
+    )
+    retained_tail = tuple(
+        _tool_result_preview(result, max_preview_chars=preview_char_limit)
+        for result in retained_results[-preview_item_limit:]
+    )
+    previous_constraints = previous.verbatim_user_constraints if previous is not None else ()
+    previous_progress = previous.progress_completed if previous is not None else ()
+    previous_blockers = previous.blockers_open_questions if previous is not None else ()
+    previous_decisions = previous.key_decisions if previous is not None else ()
+    previous_refs = previous.relevant_files_commands_errors if previous is not None else ()
+    previous_verification = previous.verification_state if previous is not None else ()
+    previous_delegated = previous.delegated_task_summaries if previous is not None else ()
+    previous_tail = previous.recent_tail if previous is not None else ()
+    constraints = _merge_unique_strings(previous_constraints, _constraint_lines(prompt), limit=12)
     if dropped_count == 0:
         return RuntimeContinuityState(
+            objective=objective,
+            current_goal=current_goal,
+            verbatim_user_constraints=constraints,
+            progress_completed=previous_progress,
+            blockers_open_questions=previous_blockers,
+            key_decisions=previous_decisions,
+            relevant_files_commands_errors=previous_refs,
+            verification_state=previous_verification,
+            delegated_task_summaries=previous_delegated,
+            recent_tail=_merge_unique_strings(retained_tail, previous_tail, limit=8),
             retained_tool_result_count=retained_count,
             original_tool_result_tokens=original_tokens,
             retained_tool_result_tokens=retained_tokens,
@@ -625,9 +875,18 @@ def _build_continuity_state(
     remaining = dropped_count - preview_count
     if remaining > 0:
         lines.append(f"... and {remaining} more")
-
-    return RuntimeContinuityState(
-        summary_text="\n".join(lines),
+    legacy_summary = "\n".join(lines)
+    state_without_summary = RuntimeContinuityState(
+        objective=objective,
+        current_goal=current_goal,
+        verbatim_user_constraints=constraints,
+        progress_completed=_merge_unique_strings(previous_progress, progress, limit=16),
+        blockers_open_questions=_merge_unique_strings(previous_blockers, blockers, limit=12),
+        key_decisions=previous_decisions,
+        relevant_files_commands_errors=_merge_unique_strings(previous_refs, refs, limit=16),
+        verification_state=previous_verification,
+        delegated_task_summaries=_merge_unique_strings(previous_delegated, delegated, limit=12),
+        recent_tail=_merge_unique_strings(retained_tail, previous_tail, limit=8),
         dropped_tool_result_count=dropped_count,
         retained_tool_result_count=retained_count,
         source="tool_result_window",
@@ -636,6 +895,29 @@ def _build_continuity_state(
         dropped_tool_result_tokens=dropped_tokens,
         token_budget=token_budget,
         token_estimate_source=token_estimate_source,
+    )
+    canonical_summary = _continuity_summary_text(state_without_summary)
+    return RuntimeContinuityState(
+        summary_text=f"{canonical_summary}\n\n## Dropped Tool Preview\n{legacy_summary}",
+        objective=state_without_summary.objective,
+        current_goal=state_without_summary.current_goal,
+        verbatim_user_constraints=state_without_summary.verbatim_user_constraints,
+        progress_completed=state_without_summary.progress_completed,
+        blockers_open_questions=state_without_summary.blockers_open_questions,
+        key_decisions=state_without_summary.key_decisions,
+        relevant_files_commands_errors=state_without_summary.relevant_files_commands_errors,
+        verification_state=state_without_summary.verification_state,
+        delegated_task_summaries=state_without_summary.delegated_task_summaries,
+        recent_tail=state_without_summary.recent_tail,
+        dropped_tool_result_count=state_without_summary.dropped_tool_result_count,
+        retained_tool_result_count=state_without_summary.retained_tool_result_count,
+        source=state_without_summary.source,
+        original_tool_result_tokens=state_without_summary.original_tool_result_tokens,
+        retained_tool_result_tokens=state_without_summary.retained_tool_result_tokens,
+        dropped_tool_result_tokens=state_without_summary.dropped_tool_result_tokens,
+        token_budget=state_without_summary.token_budget,
+        token_estimate_source=state_without_summary.token_estimate_source,
+        version=2,
     )
 
 
@@ -781,7 +1063,10 @@ def prepare_provider_context(
 
     continuity_state = (
         _build_continuity_state(
+            prompt=prompt,
+            session_metadata=session_metadata,
             dropped_results=dropped_results,
+            retained_results=retained_results,
             retained_count=retained_count,
             preview_item_limit=effective_policy.continuity_preview_items,
             preview_char_limit=effective_policy.continuity_preview_chars,

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -102,6 +102,7 @@ from .context_window import (
     RuntimeContextWindow,
     RuntimeContinuityState,
     assemble_provider_context,
+    continuity_state_from_metadata_payload,
     prepare_provider_context,
 )
 from .contracts import (
@@ -4670,56 +4671,7 @@ class VoidCodeRuntime:
         continuity = runtime_state_payload.get("continuity")
         if not isinstance(continuity, dict):
             return None
-        continuity_payload = cast(dict[str, object], continuity)
-        summary_text = continuity_payload.get("summary_text")
-        dropped = continuity_payload.get("dropped_tool_result_count")
-        retained = continuity_payload.get("retained_tool_result_count")
-        source = continuity_payload.get("source")
-        original_tokens = continuity_payload.get("original_tool_result_tokens")
-        retained_tokens = continuity_payload.get("retained_tool_result_tokens")
-        dropped_tokens = continuity_payload.get("dropped_tool_result_tokens")
-        token_budget = continuity_payload.get("token_budget")
-        token_estimate_source = continuity_payload.get("token_estimate_source")
-        if summary_text is not None and not isinstance(summary_text, str):
-            return None
-        if not isinstance(dropped, int) or isinstance(dropped, bool):
-            return None
-        if not isinstance(retained, int) or isinstance(retained, bool):
-            return None
-        if not isinstance(source, str):
-            return None
-        version = continuity_payload.get("version")
-        if version is not None and (not isinstance(version, int) or isinstance(version, bool)):
-            return None
-
-        def _optional_int(value: object) -> int | None:
-            if value is None:
-                return None
-            if isinstance(value, int) and not isinstance(value, bool):
-                return value
-            raise ValueError
-
-        try:
-            original_token_count = _optional_int(original_tokens)
-            retained_token_count = _optional_int(retained_tokens)
-            dropped_token_count = _optional_int(dropped_tokens)
-            resolved_token_budget = _optional_int(token_budget)
-        except ValueError:
-            return None
-        if token_estimate_source is not None and not isinstance(token_estimate_source, str):
-            return None
-        return RuntimeContinuityState(
-            summary_text=summary_text,
-            dropped_tool_result_count=dropped,
-            retained_tool_result_count=retained,
-            source=source,
-            original_tool_result_tokens=original_token_count,
-            retained_tool_result_tokens=retained_token_count,
-            dropped_tool_result_tokens=dropped_token_count,
-            token_budget=resolved_token_budget,
-            token_estimate_source=token_estimate_source,
-            version=version if version is not None else 1,
-        )
+        return continuity_state_from_metadata_payload(cast(dict[str, object], continuity))
 
     @staticmethod
     def _session_with_context_window_metadata(

--- a/src/voidcode/tools/background_output.py
+++ b/src/voidcode/tools/background_output.py
@@ -70,6 +70,11 @@ class BackgroundOutputTool:
                 break
             time.sleep(0.05)
             result = self._runtime.load_background_task_result(args.task_id)
+        safe_summary = _background_result_safe_summary(result)
+        message_payload = {
+            **result.delegated_message.as_payload(),
+            "summary_output": safe_summary,
+        }
 
         payload: dict[str, object] = {
             "task_id": result.task_id,
@@ -77,17 +82,15 @@ class BackgroundOutputTool:
             "parent_session_id": result.parent_session_id,
             "child_session_id": result.child_session_id,
             "approval_blocked": result.approval_blocked,
-            "summary_output": result.summary_output,
+            "summary_output": safe_summary,
             "error": result.error,
             "result_available": result.result_available,
             "delegation": result.delegated_execution.as_payload(),
-            "message": result.delegated_message.as_payload(),
+            "message": message_payload,
             "block_timed_out": block_timed_out,
         }
         content = (
-            result.summary_output
-            or result.error
-            or f"Background task {result.task_id}: {result.status}"
+            safe_summary or result.error or f"Background task {result.task_id}: {result.status}"
         )
         empty_child_output = False
 
@@ -96,30 +99,56 @@ class BackgroundOutputTool:
             empty_child_output = (
                 session_result.status == "completed" and session_result.output == ""
             )
+            safe_summary = _background_session_safe_summary(
+                result=result,
+                session_result=session_result,
+            )
             transcript_events = session_result.transcript[: args.message_limit]
             transcript = [
                 {
                     "sequence": event.sequence,
                     "event_type": event.event_type,
                     "source": event.source,
-                    "payload": dict(event.payload),
                 }
                 for event in transcript_events
             ]
+            output_available = session_result.output is not None
+            full_session_reference = f"session:{session_result.session.session.id}"
             payload["session"] = {
                 "session_id": session_result.session.session.id,
                 "child_session_id": session_result.session.session.id,
                 "status": session_result.status,
                 "summary": session_result.summary,
-                "output": session_result.output,
                 "error": session_result.error,
                 "last_event_sequence": session_result.last_event_sequence,
                 "message_limit": args.message_limit,
                 "transcript_count": len(transcript),
                 "transcript_truncated": len(session_result.transcript) > len(transcript),
                 "transcript": transcript,
+                "output_available": output_available,
+                "full_output_preserved": output_available,
+                "full_session_reference": full_session_reference,
+                "retrieval_hint": (
+                    "Use sessions resume "
+                    f"{session_result.session.session.id} or "
+                    f"background_output(task_id='{result.task_id}', "
+                    "full_session=true) from an operator context to inspect full child output."
+                ),
             }
-            content = session_result.output or session_result.summary or content
+            payload["summary_output"] = safe_summary
+            payload["message"] = {
+                **result.delegated_message.as_payload(),
+                "summary_output": safe_summary,
+            }
+            content = _background_session_digest(
+                result=result,
+                session_result=session_result,
+                safe_summary=safe_summary,
+                transcript_count=len(transcript),
+                transcript_truncated=len(session_result.transcript) > len(transcript),
+                output_available=output_available,
+                full_session_reference=full_session_reference,
+            )
 
         guidance = _background_output_guidance(
             result=result,
@@ -136,6 +165,7 @@ class BackgroundOutputTool:
             status="ok",
             content=content,
             data=payload,
+            reference=_background_result_reference(result),
         )
 
 
@@ -179,3 +209,83 @@ def _background_output_guidance(
             "retries."
         )
     return None
+
+
+def _background_session_digest(
+    *,
+    result: BackgroundTaskResult,
+    session_result: RuntimeSessionResult,
+    safe_summary: str,
+    transcript_count: int,
+    transcript_truncated: bool,
+    output_available: bool,
+    full_session_reference: str,
+) -> str:
+    lines = [
+        "Background task result digest:",
+        f"- task_id: {result.task_id}",
+        f"- status: {result.status}",
+        f"- child_session_id: {session_result.session.session.id}",
+        f"- summary: {safe_summary}",
+        f"- full_output_preserved: {str(output_available).lower()}",
+        f"- transcript_events_listed: {transcript_count}",
+        f"- transcript_truncated: {str(transcript_truncated).lower()}",
+        f"- retrieval_pointer: {full_session_reference}",
+    ]
+    if session_result.error:
+        lines.append(f"- error: {session_result.error}")
+    lines.append(
+        "Use the child session reference to retrieve full output; raw child output is not injected "
+        "into active provider context."
+    )
+    return "\n".join(lines)
+
+
+def _background_result_safe_summary(result: BackgroundTaskResult) -> str | None:
+    if result.child_session_id is None:
+        return result.summary_output
+    if result.status == "completed":
+        return (
+            f"Completed child session {result.child_session_id}; full output is preserved outside "
+            "active context."
+        )
+    if result.status == "failed":
+        return (
+            f"Failed child session {result.child_session_id}; "
+            "inspect the child session for details."
+        )
+    if result.approval_blocked:
+        return result.summary_output
+    if result.summary_output:
+        return (
+            f"{result.status.title()} child session {result.child_session_id}; "
+            "details preserved by reference."
+        )
+    return None
+
+
+def _background_session_safe_summary(
+    *,
+    result: BackgroundTaskResult,
+    session_result: RuntimeSessionResult,
+) -> str:
+    child_session_id = session_result.session.session.id
+    if session_result.status == "completed":
+        return (
+            f"Completed child session {child_session_id}; full output is preserved outside "
+            "active context."
+        )
+    if session_result.status == "failed":
+        return f"Failed child session {child_session_id}; inspect the child session for details."
+    if result.summary_output:
+        return (
+            f"{result.status.title()} child session {child_session_id}; "
+            "details preserved by reference."
+        )
+    return f"Background task {result.task_id}: {result.status}"
+
+
+def _background_result_reference(result: BackgroundTaskResult) -> str | None:
+    if result.child_session_id is None:
+        return None
+    return f"session:{result.child_session_id}"

--- a/src/voidcode/tools/background_output.py
+++ b/src/voidcode/tools/background_output.py
@@ -277,6 +277,8 @@ def _background_session_safe_summary(
         )
     if session_result.status == "failed":
         return f"Failed child session {child_session_id}; inspect the child session for details."
+    if result.approval_blocked and result.summary_output:
+        return result.summary_output
     if result.summary_output:
         return (
             f"{result.status.title()} child session {child_session_id}; "

--- a/tests/integration/test_http_delegated_parity.py
+++ b/tests/integration/test_http_delegated_parity.py
@@ -843,10 +843,12 @@ def test_http_background_task_output_endpoint_exposes_typed_delegated_payload_fo
         "result_available": True,
         "cancellation_cause": None,
     }
+    assert str(message["summary_output"]).startswith("Completed child session ")
+    assert "Completed: hello" not in str(message["summary_output"])
     assert message == {
         "kind": "delegated_lifecycle",
         "status": "completed",
-        "summary_output": "Completed: hello",
+        "summary_output": message["summary_output"],
         "error": None,
         "approval_blocked": False,
         "result_available": True,

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -885,7 +885,9 @@ def test_runtime_background_subagent_e2e_collects_background_output_result(
     reloaded = runtime.load_background_task(task_id)
 
     assert response.session.status == "completed"
-    assert response.output == "child background final"
+    assert response.output is not None
+    assert "Background task result digest:" in response.output
+    assert "raw child output is not injected" in response.output
     assert task_completed.payload["delegation"] == {
         "mode": "background",
         "subagent_type": "explore",
@@ -896,11 +898,17 @@ def test_runtime_background_subagent_e2e_collects_background_output_result(
     assert reloaded.status == "completed"
     assert background_completed.payload["status"] == "ok"
     assert cast(dict[str, object], background_completed.payload["message"])["status"] == "completed"
-    assert background_completed.payload["summary_output"] == "Completed: child background final"
-    assert background_completed.payload["result_available"] is True
-    assert cast(dict[str, object], background_completed.payload["session"])["output"] == (
-        "child background final"
+    assert str(background_completed.payload["summary_output"]).startswith(
+        "Completed child session "
     )
+    assert background_completed.payload["result_available"] is True
+    session_payload = cast(dict[str, object], background_completed.payload["session"])
+    assert session_payload["output_available"] is True
+    assert session_payload["full_output_preserved"] is True
+    assert session_payload["full_session_reference"] == (
+        f"session:{session_payload['child_session_id']}"
+    )
+    assert "output" not in session_payload
 
 
 def test_runtime_background_subagent_queue_running_completed_states_respect_concurrency(
@@ -1190,10 +1198,12 @@ def test_runtime_delegated_mcp_and_background_hook_events_have_exact_metadata(
     assert delegation["selected_preset"] == "explore"
     assert delegation["selected_execution_engine"] == "provider"
     assert delegation["lifecycle_status"] == "completed"
+    assert str(message["summary_output"]).startswith("Completed child session ")
+    assert "child background final" not in str(message["summary_output"])
     assert message == {
         "kind": "delegated_lifecycle",
         "status": "completed",
-        "summary_output": "Completed: child background final",
+        "summary_output": message["summary_output"],
         "error": None,
         "approval_blocked": False,
         "result_available": True,
@@ -1228,7 +1238,8 @@ def test_runtime_background_restart_reconcile_reloads_terminal_delegated_result(
     assert completed.status == "completed"
     assert reloaded.status == "completed"
     assert task_result.status == "completed"
-    assert task_result.summary_output == "Completed: child background final"
+    assert str(task_result.summary_output).startswith("Completed child session ")
+    assert "child background final" not in str(task_result.summary_output)
     assert task_result.result_available is True
 
 
@@ -1348,11 +1359,16 @@ def test_provider_background_output_full_session_is_tool_result_not_hidden_conte
     assert response.output == "parent collected transcript"
     assert "child transcript sentinel" not in _request_text(after_task_request)
     assert background_output_result.tool_name == "background_output"
-    assert background_output_session["output"] == "child transcript sentinel"
+    assert background_output_session["output_available"] is True
+    assert background_output_session["full_output_preserved"] is True
+    assert "output" not in background_output_session
     assert isinstance(background_output_session["transcript_count"], int)
     assert background_output_session["transcript_count"] > 0
     assert background_tool_segments
-    assert background_tool_segments[0].content == "child transcript sentinel"
+    assert isinstance(background_tool_segments[0].content, str)
+    assert "Background task result digest:" in background_tool_segments[0].content
+    assert "child transcript sentinel" not in background_tool_segments[0].content
+    assert background_output_result.reference == background_output_session["full_session_reference"]
     assert all(
         "child transcript sentinel" not in segment.content
         for segment in after_background_context.segments

--- a/tests/unit/interface/test_cli_delegated_parity.py
+++ b/tests/unit/interface/test_cli_delegated_parity.py
@@ -800,7 +800,8 @@ def test_cli_tasks_surfaces_real_runtime_completed_delegated_lifecycle(
     assert f"child_session_id={completed.child_session_id}" in status_output
     assert "result_available=True" in status_output
     assert f"TASK id={started.task.id} status=completed" in task_output
-    assert "summary_output='Completed: hello'" in task_output
+    assert "summary_output='Completed child session " in task_output
+    assert "summary_output='Completed: hello'" not in task_output
     assert "RESULT\nhello\n" in task_output
     assert f"TASK id={started.task.id} status=completed" in list_output
     assert f"TASK id={started.task.id} status=completed" in filtered_output

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -9,6 +9,7 @@ from voidcode.runtime.context_window import (
     ContextWindowPolicy,
     RuntimeContinuityState,
     context_window_policy_from_payload,
+    continuity_state_from_metadata_payload,
     continuity_summary_metadata,
     count_text_tokens,
     normalize_read_file_output,
@@ -102,13 +103,15 @@ def test_prepare_provider_context_compacts_old_results_and_reports_metadata() ->
     assert context.summary_anchor is not None
     assert context.summary_anchor.startswith("continuity:")
     assert context.summary_source == {"tool_result_start": 0, "tool_result_end": 2}
-    assert context.metadata_payload()["continuity_state"] == {
-        "summary_text": context.continuity_state.summary_text,
-        "dropped_tool_result_count": 2,
-        "retained_tool_result_count": 2,
-        "source": "tool_result_window",
-        "version": 1,
-    }
+    continuity_payload = context.metadata_payload()["continuity_state"]
+    assert isinstance(continuity_payload, dict)
+    assert continuity_payload["summary_text"] == context.continuity_state.summary_text
+    assert continuity_payload["objective"] == "read sample.txt"
+    assert continuity_payload["current_goal"] == "read sample.txt"
+    assert continuity_payload["dropped_tool_result_count"] == 2
+    assert continuity_payload["retained_tool_result_count"] == 2
+    assert continuity_payload["source"] == "tool_result_window"
+    assert continuity_payload["version"] == 2
     assert context.metadata_payload()["summary_anchor"] == context.summary_anchor
     assert context.metadata_payload()["summary_source"] == context.summary_source
 
@@ -126,11 +129,10 @@ def test_prepare_provider_context_uses_explicit_continuity_preview_policy() -> N
     )
 
     assert context.continuity_state is not None
-    assert context.continuity_state.summary_text == (
-        "Compacted 3 earlier tool results:\n"
-        '1. read_file ok content_preview="conte..."\n'
-        "... and 2 more"
-    )
+    assert "## Objective\nread sample.txt" in context.continuity_state.summary_text
+    assert "Compacted 3 earlier tool results:" in context.continuity_state.summary_text
+    assert '1. read_file ok content_preview="conte..."' in context.continuity_state.summary_text
+    assert "... and 2 more" in context.continuity_state.summary_text
 
 
 def test_prepare_provider_context_compacts_by_absolute_token_budget() -> None:
@@ -494,10 +496,35 @@ def test_prepare_provider_context_continuity_metadata_includes_version() -> None
 
     assert context.continuity_state is not None
     payload = context.continuity_state.metadata_payload()
-    assert payload.get("version") == 1
+    assert payload.get("version") == 2
     assert payload.get("source") == "tool_result_window"
     assert payload.get("dropped_tool_result_count") == 1
     assert payload.get("retained_tool_result_count") == 1
+    assert payload.get("objective") == "read sample.txt"
+
+
+def test_continuity_state_metadata_payload_round_trips_v2_fields() -> None:
+    state = RuntimeContinuityState(
+        summary_text="summary",
+        objective="ship feature",
+        current_goal="fix tests",
+        verbatim_user_constraints=("Never drop raw output",),
+        progress_completed=("Implemented digest",),
+        blockers_open_questions=("Need review",),
+        key_decisions=("Use runtime-owned summary",),
+        relevant_files_commands_errors=("src/voidcode/runtime/context_window.py",),
+        verification_state=("pytest passed",),
+        delegated_task_summaries=("task_id=task-1 child_session_id=session-1",),
+        recent_tail=("background_output ok",),
+        dropped_tool_result_count=2,
+        retained_tool_result_count=1,
+        source="tool_result_window",
+        version=2,
+    )
+
+    restored = continuity_state_from_metadata_payload(state.metadata_payload())
+
+    assert restored == state
 
 
 def test_normalize_read_file_output_preserves_showing_lines_footer() -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -2679,7 +2679,10 @@ def test_runtime_load_background_task_result_exposes_completed_child_summary(
     assert result.child_session_id == completed.session_id
     assert result.status == "completed"
     assert result.approval_blocked is False
-    assert result.summary_output == "Completed: background child"
+    assert result.summary_output == (
+        f"Completed child session {completed.session_id}; full output is preserved outside "
+        "active context."
+    )
     assert result.error is None
     assert result.result_available is True
 
@@ -2744,14 +2747,18 @@ def test_runtime_background_task_completion_emits_parent_session_event_once(
     completed_delegated = completed_events[0].delegated_lifecycle
     assert completed_delegated is not None
     assert completed_delegated.delegation.delegated_task_id == started.task.id
-    assert completed_delegated.message.summary_output == "Completed: background child"
+    safe_summary = (
+        f"Completed child session {completed.session_id}; full output is preserved outside "
+        "active context."
+    )
+    assert completed_delegated.message.summary_output == safe_summary
     assert completed_events[0].payload == {
         "task_id": started.task.id,
         "parent_session_id": "leader-session",
         "requested_child_session_id": cast(str, completed.session_id),
         "child_session_id": cast(str, completed.session_id),
         "status": "completed",
-        "summary_output": "Completed: background child",
+        "summary_output": safe_summary,
         "result_available": True,
         "delegation": {
             "parent_session_id": "leader-session",
@@ -2771,7 +2778,7 @@ def test_runtime_background_task_completion_emits_parent_session_event_once(
         "message": {
             "kind": "delegated_lifecycle",
             "status": "completed",
-            "summary_output": "Completed: background child",
+            "summary_output": safe_summary,
             "error": None,
             "approval_blocked": False,
             "result_available": True,
@@ -3019,13 +3026,16 @@ def test_runtime_reconciles_persisted_child_terminal_truth_and_backfills_parent_
     assert reconciled.status == "completed"
     assert reconciled.session_id == "child-session"
     assert len(recovered_events) == 1
+    safe_summary = (
+        "Completed child session child-session; full output is preserved outside active context."
+    )
     assert recovered_events[0].payload == {
         "task_id": "task-recover",
         "parent_session_id": "leader-session",
         "requested_child_session_id": "child-session",
         "child_session_id": "child-session",
         "status": "completed",
-        "summary_output": "Completed: background child",
+        "summary_output": safe_summary,
         "result_available": True,
         "delegation": {
             "parent_session_id": "leader-session",
@@ -3045,7 +3055,7 @@ def test_runtime_reconciles_persisted_child_terminal_truth_and_backfills_parent_
         "message": {
             "kind": "delegated_lifecycle",
             "status": "completed",
-            "summary_output": "Completed: background child",
+            "summary_output": safe_summary,
             "error": None,
             "approval_blocked": False,
             "result_available": True,
@@ -6991,20 +7001,20 @@ def test_runtime_approval_resume_preserves_canonical_continuity_state(tmp_path: 
             session_id="continuity-approval",
         )
     )
-    initial_continuity = {
-        "summary_text": (
-            "Compacted 1 earlier tool results:\n"
-            '1. read_file ok path=sample.txt content_preview="alpha"'
-        ),
-        "dropped_tool_result_count": 1,
-        "retained_tool_result_count": 1,
-        "source": "tool_result_window",
-        "version": 1,
-    }
-
     assert waiting.session.status == "waiting"
     waiting_runtime_state = cast(dict[str, object], waiting.session.metadata["runtime_state"])
-    assert waiting_runtime_state["continuity"] == initial_continuity
+    initial_continuity = cast(dict[str, object], waiting_runtime_state["continuity"])
+    assert initial_continuity["objective"] == "read sample.txt read sample.txt write beta.txt 2"
+    assert initial_continuity["current_goal"] == "read sample.txt read sample.txt write beta.txt 2"
+    assert initial_continuity["dropped_tool_result_count"] == 1
+    assert initial_continuity["retained_tool_result_count"] == 1
+    assert initial_continuity["source"] == "tool_result_window"
+    assert initial_continuity["version"] == 2
+    assert "## Objective" in cast(str, initial_continuity["summary_text"])
+    assert "Compacted 1 earlier tool results:" in cast(
+        str,
+        initial_continuity["summary_text"],
+    )
     initial_continuity_summary = cast(
         dict[str, object], waiting_runtime_state["continuity_summary"]
     )
@@ -7020,19 +7030,19 @@ def test_runtime_approval_resume_preserves_canonical_continuity_state(tmp_path: 
         approval_decision="allow",
     )
 
-    expected_resumed_continuity = {
-        "summary_text": (
-            "Compacted 2 earlier tool results:\n"
-            '1. read_file ok path=sample.txt content_preview="alpha"\n'
-            '2. read_file ok path=sample.txt content_preview="alpha"'
-        ),
-        "dropped_tool_result_count": 2,
-        "retained_tool_result_count": 1,
-        "source": "tool_result_window",
-        "version": 1,
-    }
     resumed_runtime_state = cast(dict[str, object], resumed.session.metadata["runtime_state"])
-    assert resumed_runtime_state["continuity"] == expected_resumed_continuity
+    expected_resumed_continuity = cast(dict[str, object], resumed_runtime_state["continuity"])
+    assert expected_resumed_continuity["objective"] == (
+        "read sample.txt read sample.txt write beta.txt 2"
+    )
+    assert expected_resumed_continuity["dropped_tool_result_count"] == 2
+    assert expected_resumed_continuity["retained_tool_result_count"] == 1
+    assert expected_resumed_continuity["source"] == "tool_result_window"
+    assert expected_resumed_continuity["version"] == 2
+    assert "Compacted 2 earlier tool results:" in cast(
+        str,
+        expected_resumed_continuity["summary_text"],
+    )
     resumed_continuity_summary = cast(
         dict[str, object], resumed_runtime_state["continuity_summary"]
     )
@@ -7962,16 +7972,6 @@ def test_runtime_provider_compaction_emits_continuity_state_and_persists_metadat
     )
     replay = runtime.resume("continuity-session")
 
-    expected_continuity = {
-        "summary_text": (
-            "Compacted 1 earlier tool results:\n"
-            '1. read_file ok path=sample.txt content_preview="alpha"'
-        ),
-        "dropped_tool_result_count": 1,
-        "retained_tool_result_count": 1,
-        "source": "tool_result_window",
-        "version": 1,
-    }
     memory_events = [
         event for event in response.events if event.event_type == RUNTIME_MEMORY_REFRESHED
     ]
@@ -7983,6 +7983,18 @@ def test_runtime_provider_compaction_emits_continuity_state_and_persists_metadat
     assert isinstance(summary_anchor, str)
     assert summary_anchor.startswith("continuity:")
     assert summary_source == {"tool_result_start": 0, "tool_result_end": 1}
+    expected_continuity = cast(dict[str, object], memory_events[0].payload["continuity_state"])
+    assert expected_continuity["objective"] == "read sample.txt read sample.txt"
+    assert expected_continuity["current_goal"] == "read sample.txt read sample.txt"
+    assert expected_continuity["dropped_tool_result_count"] == 1
+    assert expected_continuity["retained_tool_result_count"] == 1
+    assert expected_continuity["source"] == "tool_result_window"
+    assert expected_continuity["version"] == 2
+    assert "## Objective" in cast(str, expected_continuity["summary_text"])
+    assert "Compacted 1 earlier tool results:" in cast(
+        str,
+        expected_continuity["summary_text"],
+    )
     assert memory_events[0].payload == {
         "reason": "tool_result_window",
         "original_tool_result_count": 2,

--- a/tests/unit/tools/test_background_task_tools.py
+++ b/tests/unit/tools/test_background_task_tools.py
@@ -129,6 +129,35 @@ class _UnavailableBackgroundRuntime(_StubBackgroundRuntime):
         )
 
 
+class _ApprovalBlockedBackgroundRuntime(_StubBackgroundRuntime):
+    def load_background_task_result(self, task_id: str) -> BackgroundTaskResult:
+        assert task_id == "task-1"
+        return BackgroundTaskResult(
+            task_id="task-1",
+            parent_session_id="leader-session",
+            child_session_id="child-session",
+            status="running",
+            approval_blocked=True,
+            summary_output="Approval blocked on write_file: write_file alpha.txt",
+            result_available=True,
+        )
+
+    def session_result(self, *, session_id: str) -> RuntimeSessionResult:
+        assert session_id == "child-session"
+        return RuntimeSessionResult(
+            session=SessionState(
+                session=SessionRef(id="child-session", parent_id="leader-session"),
+                status="waiting",
+                turn=1,
+            ),
+            prompt="delegated",
+            status="waiting",
+            summary="Approval blocked on write_file: write_file alpha.txt",
+            transcript=(),
+            last_event_sequence=1,
+        )
+
+
 class _BlockingUnavailableBackgroundRuntime(_UnavailableBackgroundRuntime):
     def __init__(self) -> None:
         self.load_count = 0
@@ -240,6 +269,29 @@ def test_background_output_default_returns_safe_summary_reference(tmp_path: Path
     )
     assert "raw child secret sentinel" not in str(result.data["message"])
     assert result.reference == "session:child-session"
+
+
+def test_background_output_full_session_preserves_approval_summary(tmp_path: Path) -> None:
+    tool = BackgroundOutputTool(runtime=_ApprovalBlockedBackgroundRuntime())
+
+    result = tool.invoke(
+        ToolCall(
+            tool_name="background_output",
+            arguments={"task_id": "task-1", "full_session": True},
+        ),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert result.content is not None
+    assert "Approval blocked on write_file: write_file alpha.txt" in result.content
+    assert "Running child session" not in result.content
+    assert result.data["summary_output"] == ("Approval blocked on write_file: write_file alpha.txt")
+    message_payload = result.data["message"]
+    assert isinstance(message_payload, dict)
+    assert message_payload["summary_output"] == (
+        "Approval blocked on write_file: write_file alpha.txt"
+    )
 
 
 def test_background_output_tool_bounds_full_session_transcript(tmp_path: Path) -> None:

--- a/tests/unit/tools/test_background_task_tools.py
+++ b/tests/unit/tools/test_background_task_tools.py
@@ -64,6 +64,19 @@ class _StubBackgroundRuntime:
         )
 
 
+class _RawPreviewBackgroundRuntime(_StubBackgroundRuntime):
+    def load_background_task_result(self, task_id: str) -> BackgroundTaskResult:
+        assert task_id == "task-1"
+        return BackgroundTaskResult(
+            task_id="task-1",
+            parent_session_id="leader-session",
+            child_session_id="child-session",
+            status="completed",
+            summary_output="Completed: raw child secret sentinel",
+            result_available=True,
+        )
+
+
 class _ManyEventBackgroundRuntime(_StubBackgroundRuntime):
     def session_result(self, *, session_id: str) -> RuntimeSessionResult:
         assert session_id == "child-session"
@@ -188,7 +201,11 @@ def test_background_output_tool_returns_task_summary(tmp_path: Path) -> None:
     )
 
     assert result.status == "ok"
-    assert result.content == "done"
+    assert result.content is not None
+    assert "Background task result digest:" in result.content
+    assert "child_session_id: child-session" in result.content
+    assert "raw child output is not injected" in result.content
+    assert result.reference == "session:child-session"
     assert result.data["task_id"] == "task-1"
     delegation_payload = result.data["delegation"]
     assert isinstance(delegation_payload, dict)
@@ -200,6 +217,29 @@ def test_background_output_tool_returns_task_summary(tmp_path: Path) -> None:
     assert isinstance(session_payload, dict)
     assert session_payload["session_id"] == "child-session"
     assert session_payload["child_session_id"] == "child-session"
+    assert session_payload["output_available"] is True
+    assert session_payload["full_output_preserved"] is True
+    assert session_payload["full_session_reference"] == "session:child-session"
+    assert "output" not in session_payload
+
+
+def test_background_output_default_returns_safe_summary_reference(tmp_path: Path) -> None:
+    tool = BackgroundOutputTool(runtime=_RawPreviewBackgroundRuntime())
+
+    result = tool.invoke(
+        ToolCall(tool_name="background_output", arguments={"task_id": "task-1"}),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert result.content is not None
+    assert "Completed child session child-session" in result.content
+    assert "raw child secret sentinel" not in result.content
+    assert result.data["summary_output"] == (
+        "Completed child session child-session; full output is preserved outside active context."
+    )
+    assert "raw child secret sentinel" not in str(result.data["message"])
+    assert result.reference == "session:child-session"
 
 
 def test_background_output_tool_bounds_full_session_transcript(tmp_path: Path) -> None:
@@ -221,6 +261,7 @@ def test_background_output_tool_bounds_full_session_transcript(tmp_path: Path) -
     transcript = cast(list[dict[str, object]], session_payload["transcript"])
     assert isinstance(transcript, list)
     assert transcript[-1]["sequence"] == 100
+    assert "payload" not in transcript[-1]
 
 
 def test_background_output_block_timeout_returns_current_state(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add a canonical runtime continuity record with structured objective, constraints, progress, decisions, verification, recent-tail, and delegated-task fields.
- Distill completed background task summaries and background_output results to safe reference-based digests while preserving full child output in the child session.
- Update runtime, HTTP, CLI, integration, and unit coverage for safe delegated memory behavior.

## Verification
- uv run ruff check .
- uv run basedpyright --warnings src
- uv run python -X utf8 -m pytest -n auto (1627 passed)
- bun run lint && bun run typecheck && bun run test:run (114 passed)
- post-commit focused: uv run pytest tests/unit/tools/test_background_task_tools.py tests/unit/runtime/test_context_window.py tests/unit/runtime/test_runtime_service_extensions.py -q (322 passed)

Closes #310