### PR TITLE
Security hardening pass for backend tool boundaries (URL, path, MCP, shell)

### DIFF
--- a/src/voidcode/mcp/types.py
+++ b/src/voidcode/mcp/types.py
@@ -51,6 +51,8 @@ class McpToolDescriptor:
     description: str
     input_schema: dict[str, Any]
     safety: McpToolSafety = field(default_factory=McpToolSafety)
+    enabled: bool = True
+    disabled_reason: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/voidcode/runtime/mcp.py
+++ b/src/voidcode/runtime/mcp.py
@@ -121,9 +121,11 @@ def _validate_call_arguments_against_schema(
         value = arguments[raw_key]
         if expected_type == "string" and not isinstance(value, str):
             raise ValueError(f"MCP[{tool_name}]: argument '{raw_key}' must be a string")
-        if expected_type == "integer" and not isinstance(value, int):
+        if expected_type == "integer" and (isinstance(value, bool) or not isinstance(value, int)):
             raise ValueError(f"MCP[{tool_name}]: argument '{raw_key}' must be an integer")
-        if expected_type == "number" and not isinstance(value, (int, float)):
+        if expected_type == "number" and (
+            isinstance(value, bool) or not isinstance(value, (int, float))
+        ):
             raise ValueError(f"MCP[{tool_name}]: argument '{raw_key}' must be a number")
         if expected_type == "boolean" and not isinstance(value, bool):
             raise ValueError(f"MCP[{tool_name}]: argument '{raw_key}' must be a boolean")
@@ -264,7 +266,7 @@ class ManagedMcpManager:
         )
         self._portal_context: AbstractContextManager[BlockingPortal] | None = None
         self._portal: BlockingPortal | None = None
-        self._tool_descriptors_by_server: dict[str, dict[str, McpToolDescriptor]] = {}
+        self._tool_descriptors_by_server: dict[_McpServerKey, dict[str, McpToolDescriptor]] = {}
 
     @property
     def configuration(self) -> McpConfigState:
@@ -288,6 +290,14 @@ class ManagedMcpManager:
         _ = parent_session_id
         tools: list[McpToolDescriptor] = []
         for server_name in self._configuration.servers:
+            server_config = self._configuration.servers.get(server_name)
+            if server_config is None:
+                continue
+            key = self._server_key(
+                server_name=server_name,
+                scope=getattr(server_config, "scope", "runtime"),
+                owner_session_id=owner_session_id,
+            )
             running = self._ensure_running(
                 server_name=server_name,
                 workspace=workspace,
@@ -305,7 +315,7 @@ class ManagedMcpManager:
                 descriptor = self._descriptor_from_sdk_tool(server_name=server_name, tool=tool)
                 server_descriptors[descriptor.tool_name] = descriptor
                 tools.append(descriptor)
-            self._tool_descriptors_by_server[server_name] = server_descriptors
+            self._tool_descriptors_by_server[key] = server_descriptors
         return tuple(tools)
 
     def call_tool(
@@ -319,25 +329,34 @@ class ManagedMcpManager:
         parent_session_id: str | None = None,
     ) -> McpToolCallResult:
         _ = parent_session_id
+        server_config = self._configuration.servers.get(server_name)
+        if server_config is None:
+            raise ValueError(f"MCP[{server_name}]: server not found in configuration")
+        key = self._server_key(
+            server_name=server_name,
+            scope=getattr(server_config, "scope", "runtime"),
+            owner_session_id=owner_session_id,
+        )
         running = self._ensure_running(
             server_name=server_name,
             workspace=workspace,
             owner_session_id=owner_session_id,
         )
-        descriptor = self._tool_descriptors_by_server.get(server_name, {}).get(tool_name)
+        descriptor = self._tool_descriptors_by_server.get(key, {}).get(tool_name)
         if descriptor is None:
-            discovered = self.list_tools(
+            _ = self.list_tools(
                 workspace=workspace,
                 owner_session_id=owner_session_id,
                 parent_session_id=parent_session_id,
             )
-            _ = discovered
-            descriptor = self._tool_descriptors_by_server.get(server_name, {}).get(tool_name)
+            descriptor = self._tool_descriptors_by_server.get(key, {}).get(tool_name)
+
         if descriptor is not None and not descriptor.enabled:
             raise ValueError(
                 f"MCP[{server_name}/{tool_name}] is disabled: "
                 f"{descriptor.disabled_reason or 'invalid schema'}"
             )
+
         if descriptor is not None:
             try:
                 _validate_call_arguments_against_schema(
@@ -356,6 +375,7 @@ class ManagedMcpManager:
                 )
                 self._record_diagnostic(diagnostic)
                 raise
+
         result = self._call_sdk(
             running,
             stage="call",
@@ -503,145 +523,139 @@ class ManagedMcpManager:
         stderr_log: IO[str] | None = None
         transport_context: AbstractContextManager[tuple[object, object]] | None = None
         session_context: AbstractContextManager[ClientSession] | None = None
-        self._state_lock.acquire()
-        try:
+
+        with self._state_lock:
             running = self._running_servers.get(key)
             if running is not None:
                 running.last_used_at = time.monotonic()
                 self._record_server_reused(key=key, workspace_root=running.workspace_root)
                 self._record_server_acquired(key=key, workspace_root=running.workspace_root)
-                self._state_lock.release()
                 return running
-            portal = self._ensure_portal()
-            stderr_log = open(os.devnull, "w", encoding="utf-8")  # noqa: SIM115 - closed in shutdown
-            params = StdioServerParameters(
-                command=server_config.command[0],
-                args=list(server_config.command[1:]),
-                env={**os.environ, **server_config.env},
-                cwd=workspace_root,
-            )
-            pending_transport_context = portal.wrap_async_context_manager(
-                cast(Any, stdio_client(params, errlog=stderr_log))
-            )
-            read_stream, write_stream = pending_transport_context.__enter__()
-            transport_context = pending_transport_context
-            pending_session_context = portal.wrap_async_context_manager(
-                ClientSession(
-                    read_stream,
-                    write_stream,
-                    read_timeout_seconds=self._request_timeout,
-                    client_info=Implementation(
-                        name=MCP_CLIENT_NAME,
-                        version=MCP_CLIENT_VERSION,
-                    ),
+
+            try:
+                portal = self._ensure_portal()
+                stderr_log = open(
+                    os.devnull,
+                    "w",
+                    encoding="utf-8",
+                )  # noqa: SIM115 - closed in shutdown
+                params = StdioServerParameters(
+                    command=server_config.command[0],
+                    args=list(server_config.command[1:]),
+                    env={**os.environ, **server_config.env},
+                    cwd=workspace_root,
                 )
-            )
-            session = pending_session_context.__enter__()
-            session_context = pending_session_context
-            self._record_server_started(
-                key=key,
-                workspace_root=workspace_root,
-                command=list(server_config.command),
-            )
-            initialize_result = cast(
-                InitializeResult,
-                self._call_sdk_session(
-                    session,
-                    stage="startup",
-                    method="initialize",
-                    server_name=server_name,
-                    workspace_root=workspace_root,
-                    operation=lambda session=session: session.initialize(),
-                ),
-            )
-        except FileNotFoundError as exc:
-            self._close_partial_server(
-                session_context=session_context,
-                transport_context=transport_context,
-                stderr_log=stderr_log,
-            )
-            diagnostic = create_diagnostic(
-                severity=McpDiagnosticSeverity.ERROR,
-                category="startup",
-                code="server_startup_failed",
-                server_name=server_name,
-                command=server_config.command[0],
-            )
-            self._record_diagnostic(diagnostic)
-            message = (
-                f"MCP[{server_name}]: failed to start server - cmd not found "
-                f"(command not found): "
-                f"{server_config.command[0]}"
-            )
-            self._record_failure_event(
-                key=key,
-                workspace_root=workspace_root,
-                stage="startup",
-                error=message,
-                command=list(server_config.command),
-                diagnostic=diagnostic,
-            )
-            self._state_lock.release()
-            raise ValueError(message) from exc
-        except Exception as exc:
-            self._close_partial_server(
-                session_context=session_context,
-                transport_context=transport_context,
-                stderr_log=stderr_log,
-            )
-            diagnostic = self._diagnostic_for_exception(
-                exc,
-                server_name=server_name,
-                stage="startup",
-                method="initialize",
-            )
-            self._record_diagnostic(diagnostic)
-            message = self._message_for_exception(
-                exc,
-                fallback=f"MCP[{server_name}]: failed to initialize server",
-            )
-            self._record_failure_event(
-                key=key,
-                workspace_root=workspace_root,
-                stage="startup",
-                error=message,
-                method="initialize",
-                command=list(server_config.command),
-                diagnostic=diagnostic,
-            )
-            if transport_context is not None:
-                self._record_server_stopped(
+                pending_transport_context = portal.wrap_async_context_manager(
+                    cast(Any, stdio_client(params, errlog=stderr_log))
+                )
+                read_stream, write_stream = pending_transport_context.__enter__()
+                transport_context = pending_transport_context
+                pending_session_context = portal.wrap_async_context_manager(
+                    ClientSession(
+                        read_stream,
+                        write_stream,
+                        read_timeout_seconds=self._request_timeout,
+                        client_info=Implementation(
+                            name=MCP_CLIENT_NAME,
+                            version=MCP_CLIENT_VERSION,
+                        ),
+                    )
+                )
+                session = pending_session_context.__enter__()
+                session_context = pending_session_context
+                self._record_server_started(
                     key=key,
                     workspace_root=workspace_root,
-                    preserve_failed_state=True,
+                    command=list(server_config.command),
                 )
-            self._state_lock.release()
-            raise ValueError(message) from exc
+                initialize_result = cast(
+                    InitializeResult,
+                    self._call_sdk_session(
+                        session,
+                        stage="startup",
+                        method="initialize",
+                        server_name=server_name,
+                        workspace_root=workspace_root,
+                        operation=lambda session=session: session.initialize(),
+                    ),
+                )
+            except FileNotFoundError as exc:
+                self._close_partial_server(
+                    session_context=session_context,
+                    transport_context=transport_context,
+                    stderr_log=stderr_log,
+                )
+                diagnostic = create_diagnostic(
+                    severity=McpDiagnosticSeverity.ERROR,
+                    category="startup",
+                    code="server_startup_failed",
+                    server_name=server_name,
+                    command=server_config.command[0],
+                )
+                self._record_diagnostic(diagnostic)
+                message = (
+                    f"MCP[{server_name}]: failed to start server - cmd not found "
+                    f"(command not found): "
+                    f"{server_config.command[0]}"
+                )
+                self._record_failure_event(
+                    key=key,
+                    workspace_root=workspace_root,
+                    stage="startup",
+                    error=message,
+                    command=list(server_config.command),
+                    diagnostic=diagnostic,
+                )
+                raise ValueError(message) from exc
+            except Exception as exc:
+                self._close_partial_server(
+                    session_context=session_context,
+                    transport_context=transport_context,
+                    stderr_log=stderr_log,
+                )
+                diagnostic = self._diagnostic_for_exception(
+                    exc,
+                    server_name=server_name,
+                    stage="startup",
+                    method="initialize",
+                )
+                self._record_diagnostic(diagnostic)
+                message = self._message_for_exception(
+                    exc,
+                    fallback=f"MCP[{server_name}]: failed to initialize server",
+                )
+                self._record_failure_event(
+                    key=key,
+                    workspace_root=workspace_root,
+                    stage="startup",
+                    error=message,
+                    method="initialize",
+                    command=list(server_config.command),
+                    diagnostic=diagnostic,
+                )
+                if transport_context is not None:
+                    self._record_server_stopped(
+                        key=key,
+                        workspace_root=workspace_root,
+                        preserve_failed_state=True,
+                    )
+                raise ValueError(message) from exc
 
-        running = _RunningMcpServer(
-            server_name=server_name,
-            workspace_root=workspace_root,
-            transport_context=transport_context,
-            session_context=session_context,
-            session=session,
-            stderr_log=stderr_log,
-            initialize_result=initialize_result,
-            scope=key.scope,
-            owner_session_id=key.owner_session_id,
-        )
-        with self._state_lock:
-            existing = self._running_servers.get(key)
-            if existing is not None:
-                self._terminate_running_server(running)
-                existing.last_used_at = time.monotonic()
-                self._record_server_reused(key=key, workspace_root=existing.workspace_root)
-                self._state_lock.release()
-                return existing
+            running = _RunningMcpServer(
+                server_name=server_name,
+                workspace_root=workspace_root,
+                transport_context=transport_context,
+                session_context=session_context,
+                session=session,
+                stderr_log=stderr_log,
+                initialize_result=initialize_result,
+                scope=key.scope,
+                owner_session_id=key.owner_session_id,
+            )
             self._running_servers[key] = running
             self._record_server_acquired(key=key, workspace_root=running.workspace_root)
-        _ = initialize_result
-        self._state_lock.release()
-        return running
+            _ = initialize_result
+            return running
 
     def _ensure_portal(self) -> BlockingPortal:
         if self._portal is not None:
@@ -784,6 +798,7 @@ class ManagedMcpManager:
         )
 
     def _stop_running_server(self, key: _McpServerKey) -> None:
+        self._tool_descriptors_by_server.pop(key, None)
         running = self._running_servers.pop(key, None)
         if running is None:
             return
@@ -802,6 +817,7 @@ class ManagedMcpManager:
             scope=scope,
             owner_session_id=owner_session_id if scope == "session" else None,
         )
+        self._tool_descriptors_by_server.pop(key, None)
         with self._state_lock:
             running = self._running_servers.pop(key, None)
         if running is None:

--- a/src/voidcode/runtime/mcp.py
+++ b/src/voidcode/runtime/mcp.py
@@ -290,32 +290,13 @@ class ManagedMcpManager:
         _ = parent_session_id
         tools: list[McpToolDescriptor] = []
         for server_name in self._configuration.servers:
-            server_config = self._configuration.servers.get(server_name)
-            if server_config is None:
-                continue
-            key = self._server_key(
-                server_name=server_name,
-                scope=getattr(server_config, "scope", "runtime"),
-                owner_session_id=owner_session_id,
+            tools.extend(
+                self._list_tools_for_server(
+                    server_name=server_name,
+                    workspace=workspace,
+                    owner_session_id=owner_session_id,
+                )
             )
-            running = self._ensure_running(
-                server_name=server_name,
-                workspace=workspace,
-                owner_session_id=owner_session_id,
-            )
-            result = self._call_sdk(
-                running,
-                stage="discovery",
-                method="tools/list",
-                operation=lambda session=running.session: session.list_tools(),
-            )
-            list_result = cast(ListToolsResult, result)
-            server_descriptors: dict[str, McpToolDescriptor] = {}
-            for tool in list_result.tools:
-                descriptor = self._descriptor_from_sdk_tool(server_name=server_name, tool=tool)
-                server_descriptors[descriptor.tool_name] = descriptor
-                tools.append(descriptor)
-            self._tool_descriptors_by_server[key] = server_descriptors
         return tuple(tools)
 
     def call_tool(
@@ -344,10 +325,10 @@ class ManagedMcpManager:
         )
         descriptor = self._tool_descriptors_by_server.get(key, {}).get(tool_name)
         if descriptor is None:
-            _ = self.list_tools(
+            _ = self._list_tools_for_server(
+                server_name=server_name,
                 workspace=workspace,
                 owner_session_id=owner_session_id,
-                parent_session_id=parent_session_id,
             )
             descriptor = self._tool_descriptors_by_server.get(key, {}).get(tool_name)
 
@@ -777,6 +758,42 @@ class ManagedMcpManager:
                 enabled=False,
                 disabled_reason=str(exc),
             )
+
+    def _list_tools_for_server(
+        self,
+        *,
+        server_name: str,
+        workspace: Path,
+        owner_session_id: str | None,
+    ) -> tuple[McpToolDescriptor, ...]:
+        server_config = self._configuration.servers.get(server_name)
+        if server_config is None:
+            return ()
+        key = self._server_key(
+            server_name=server_name,
+            scope=getattr(server_config, "scope", "runtime"),
+            owner_session_id=owner_session_id,
+        )
+        running = self._ensure_running(
+            server_name=server_name,
+            workspace=workspace,
+            owner_session_id=owner_session_id,
+        )
+        result = self._call_sdk(
+            running,
+            stage="discovery",
+            method="tools/list",
+            operation=lambda session=running.session: session.list_tools(),
+        )
+        list_result = cast(ListToolsResult, result)
+        server_descriptors: dict[str, McpToolDescriptor] = {}
+        descriptors: list[McpToolDescriptor] = []
+        for tool in list_result.tools:
+            descriptor = self._descriptor_from_sdk_tool(server_name=server_name, tool=tool)
+            server_descriptors[descriptor.tool_name] = descriptor
+            descriptors.append(descriptor)
+        self._tool_descriptors_by_server[key] = server_descriptors
+        return tuple(descriptors)
 
     @staticmethod
     def _server_key(

--- a/src/voidcode/runtime/mcp.py
+++ b/src/voidcode/runtime/mcp.py
@@ -69,6 +69,70 @@ _RECOVERABLE_MCP_CALL_ERROR_CODES = frozenset(
 )
 
 
+def _validate_input_schema(raw_schema: object) -> dict[str, object]:
+    if not isinstance(raw_schema, dict):
+        raise ValueError("inputSchema must be a JSON object")
+    schema = dict(cast(dict[str, object], raw_schema))
+    schema_type = schema.get("type")
+    if schema_type is not None and schema_type != "object":
+        raise ValueError("inputSchema type must be 'object'")
+    required = schema.get("required")
+    if required is not None:
+        if not isinstance(required, list):
+            raise ValueError("inputSchema required must be an array of strings")
+        required_items = cast(list[object], required)
+        if not all(isinstance(item, str) for item in required_items):
+            raise ValueError("inputSchema required must be an array of strings")
+    properties = schema.get("properties")
+    if properties is not None and not isinstance(properties, dict):
+        raise ValueError("inputSchema properties must be an object")
+    return schema
+
+
+def _validate_call_arguments_against_schema(
+    *,
+    tool_name: str,
+    arguments: dict[str, object],
+    input_schema: dict[str, object],
+) -> None:
+    required = input_schema.get("required")
+    if isinstance(required, list):
+        required_items = cast(list[object], required)
+        required_names = [name for name in required_items if isinstance(name, str)]
+        missing = [name for name in required_names if name not in arguments]
+        if missing:
+            joined = ", ".join(missing)
+            raise ValueError(f"MCP[{tool_name}]: missing required arguments: {joined}")
+
+    properties = input_schema.get("properties")
+    if not isinstance(properties, dict):
+        return
+
+    raw_properties = cast(dict[object, object], properties)
+    for raw_key, raw_expected_schema in raw_properties.items():
+        if not isinstance(raw_key, str):
+            continue
+        if raw_key not in arguments:
+            continue
+        if not isinstance(raw_expected_schema, dict):
+            continue
+        expected_schema = cast(dict[str, object], raw_expected_schema)
+        expected_type = expected_schema.get("type")
+        value = arguments[raw_key]
+        if expected_type == "string" and not isinstance(value, str):
+            raise ValueError(f"MCP[{tool_name}]: argument '{raw_key}' must be a string")
+        if expected_type == "integer" and not isinstance(value, int):
+            raise ValueError(f"MCP[{tool_name}]: argument '{raw_key}' must be an integer")
+        if expected_type == "number" and not isinstance(value, (int, float)):
+            raise ValueError(f"MCP[{tool_name}]: argument '{raw_key}' must be a number")
+        if expected_type == "boolean" and not isinstance(value, bool):
+            raise ValueError(f"MCP[{tool_name}]: argument '{raw_key}' must be a boolean")
+        if expected_type == "array" and not isinstance(value, list):
+            raise ValueError(f"MCP[{tool_name}]: argument '{raw_key}' must be an array")
+        if expected_type == "object" and not isinstance(value, dict):
+            raise ValueError(f"MCP[{tool_name}]: argument '{raw_key}' must be an object")
+
+
 # =============================================================================
 # Disabled MCP Manager
 # =============================================================================
@@ -200,6 +264,7 @@ class ManagedMcpManager:
         )
         self._portal_context: AbstractContextManager[BlockingPortal] | None = None
         self._portal: BlockingPortal | None = None
+        self._tool_descriptors_by_server: dict[str, dict[str, McpToolDescriptor]] = {}
 
     @property
     def configuration(self) -> McpConfigState:
@@ -235,8 +300,12 @@ class ManagedMcpManager:
                 operation=lambda session=running.session: session.list_tools(),
             )
             list_result = cast(ListToolsResult, result)
+            server_descriptors: dict[str, McpToolDescriptor] = {}
             for tool in list_result.tools:
-                tools.append(self._descriptor_from_sdk_tool(server_name=server_name, tool=tool))
+                descriptor = self._descriptor_from_sdk_tool(server_name=server_name, tool=tool)
+                server_descriptors[descriptor.tool_name] = descriptor
+                tools.append(descriptor)
+            self._tool_descriptors_by_server[server_name] = server_descriptors
         return tuple(tools)
 
     def call_tool(
@@ -255,6 +324,38 @@ class ManagedMcpManager:
             workspace=workspace,
             owner_session_id=owner_session_id,
         )
+        descriptor = self._tool_descriptors_by_server.get(server_name, {}).get(tool_name)
+        if descriptor is None:
+            discovered = self.list_tools(
+                workspace=workspace,
+                owner_session_id=owner_session_id,
+                parent_session_id=parent_session_id,
+            )
+            _ = discovered
+            descriptor = self._tool_descriptors_by_server.get(server_name, {}).get(tool_name)
+        if descriptor is not None and not descriptor.enabled:
+            raise ValueError(
+                f"MCP[{server_name}/{tool_name}] is disabled: "
+                f"{descriptor.disabled_reason or 'invalid schema'}"
+            )
+        if descriptor is not None:
+            try:
+                _validate_call_arguments_against_schema(
+                    tool_name=f"{server_name}/{tool_name}",
+                    arguments=arguments,
+                    input_schema=descriptor.input_schema,
+                )
+            except ValueError as exc:
+                diagnostic = create_diagnostic(
+                    severity=McpDiagnosticSeverity.ERROR,
+                    category="call",
+                    code="invalid_params",
+                    server_name=server_name,
+                    tool_name=tool_name,
+                    reason=str(exc),
+                )
+                self._record_diagnostic(diagnostic)
+                raise
         result = self._call_sdk(
             running,
             stage="call",
@@ -633,13 +734,35 @@ class ManagedMcpManager:
             if annotations is not None
             else McpToolSafety()
         )
-        return McpToolDescriptor(
-            server_name=server_name,
-            tool_name=tool.name,
-            description=tool.description or "",
-            input_schema=dict(tool.inputSchema),
-            safety=safety,
-        )
+        try:
+            input_schema = _validate_input_schema(tool.inputSchema)
+            return McpToolDescriptor(
+                server_name=server_name,
+                tool_name=tool.name,
+                description=tool.description or "",
+                input_schema=input_schema,
+                safety=safety,
+                enabled=True,
+            )
+        except ValueError as exc:
+            diagnostic = create_diagnostic(
+                severity=McpDiagnosticSeverity.ERROR,
+                category="discovery",
+                code="invalid_tool_schema",
+                server_name=server_name,
+                tool_name=tool.name,
+                reason=str(exc),
+            )
+            self._record_diagnostic(diagnostic)
+            return McpToolDescriptor(
+                server_name=server_name,
+                tool_name=tool.name,
+                description=tool.description or "",
+                input_schema={"type": "object", "properties": {}},
+                safety=safety,
+                enabled=False,
+                disabled_reason=str(exc),
+            )
 
     @staticmethod
     def _server_key(

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -1001,6 +1001,7 @@ class VoidCodeRuntime:
                 workspace=self._workspace,
                 owner_session_id=owner_session_id,
             )
+            if tool.enabled
         )
 
     def _tool_registry_for_effective_config(

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -938,6 +938,7 @@ class VoidCodeRuntime:
                 workspace=self._workspace,
                 owner_session_id=context.session_id if context is not None else None,
             )
+            if tool.enabled
         )
 
     def _refresh_mcp_tools(self) -> None:

--- a/src/voidcode/security/__init__.py
+++ b/src/voidcode/security/__init__.py
@@ -1,0 +1,3 @@
+from .path_policy import WorkspacePathResolution, resolve_workspace_path
+
+__all__ = ["WorkspacePathResolution", "resolve_workspace_path"]

--- a/src/voidcode/security/__init__.py
+++ b/src/voidcode/security/__init__.py
@@ -1,3 +1,10 @@
 from .path_policy import WorkspacePathResolution, resolve_workspace_path
+from .url_policy import UrlValidationResult, validate_redirect_target, validate_url
 
-__all__ = ["WorkspacePathResolution", "resolve_workspace_path"]
+__all__ = [
+    "WorkspacePathResolution",
+    "resolve_workspace_path",
+    "UrlValidationResult",
+    "validate_redirect_target",
+    "validate_url",
+]

--- a/src/voidcode/security/__init__.py
+++ b/src/voidcode/security/__init__.py
@@ -1,9 +1,19 @@
 from .path_policy import WorkspacePathResolution, resolve_workspace_path
+from .shell_policy import (
+    DEFAULT_TIMEOUT_SECONDS,
+    MAX_TIMEOUT_SECONDS,
+    ShellExecutionPolicy,
+    resolve_shell_execution_policy,
+)
 from .url_policy import UrlValidationResult, validate_redirect_target, validate_url
 
 __all__ = [
     "WorkspacePathResolution",
     "resolve_workspace_path",
+    "DEFAULT_TIMEOUT_SECONDS",
+    "MAX_TIMEOUT_SECONDS",
+    "ShellExecutionPolicy",
+    "resolve_shell_execution_policy",
     "UrlValidationResult",
     "validate_redirect_target",
     "validate_url",

--- a/src/voidcode/security/path_policy.py
+++ b/src/voidcode/security/path_policy.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspacePathResolution:
+    workspace_root: Path
+    candidate: Path
+    relative_path: str
+
+
+def resolve_workspace_path(
+    *,
+    workspace: Path,
+    raw_path: str,
+    containment_error: str = "path must be inside the workspace",
+    require_existing: bool = False,
+    existence_error: str | None = None,
+    require_regular_file: bool = False,
+    regular_file_error: str | None = None,
+) -> WorkspacePathResolution:
+    workspace_root = workspace.resolve()
+    candidate = (workspace_root / Path(raw_path)).resolve()
+
+    if not candidate.is_relative_to(workspace_root):
+        raise ValueError(containment_error)
+
+    if require_existing and not candidate.exists():
+        raise ValueError(existence_error or f"target does not exist: {raw_path}")
+
+    if require_regular_file and not candidate.is_file():
+        raise ValueError(regular_file_error or f"target is not a regular file: {raw_path}")
+
+    return WorkspacePathResolution(
+        workspace_root=workspace_root,
+        candidate=candidate,
+        relative_path=candidate.relative_to(workspace_root).as_posix(),
+    )
+
+
+__all__ = ["WorkspacePathResolution", "resolve_workspace_path"]

--- a/src/voidcode/security/shell_policy.py
+++ b/src/voidcode/security/shell_policy.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_TIMEOUT_SECONDS = 30
+MAX_TIMEOUT_SECONDS = 120
+
+
+@dataclass(frozen=True, slots=True)
+class ShellExecutionPolicy:
+    workspace_root: Path
+    timeout_seconds: int
+    runtime_timeout_selected: bool
+
+
+def resolve_shell_execution_policy(
+    *,
+    workspace: Path,
+    timeout_argument: object,
+    runtime_timeout_seconds: int | None,
+) -> ShellExecutionPolicy:
+    workspace_root = workspace.resolve()
+    if not workspace_root.exists() or not workspace_root.is_dir():
+        raise ValueError("shell_exec workspace must be an existing directory")
+
+    if isinstance(timeout_argument, (int, float)) and timeout_argument > 0:
+        local_timeout_seconds = min(int(timeout_argument), MAX_TIMEOUT_SECONDS)
+    else:
+        local_timeout_seconds = DEFAULT_TIMEOUT_SECONDS
+
+    timeout_seconds = local_timeout_seconds
+    runtime_timeout_selected = False
+    if runtime_timeout_seconds is not None and runtime_timeout_seconds < timeout_seconds:
+        timeout_seconds = runtime_timeout_seconds
+        runtime_timeout_selected = True
+
+    return ShellExecutionPolicy(
+        workspace_root=workspace_root,
+        timeout_seconds=timeout_seconds,
+        runtime_timeout_selected=runtime_timeout_selected,
+    )
+
+
+__all__ = [
+    "DEFAULT_TIMEOUT_SECONDS",
+    "MAX_TIMEOUT_SECONDS",
+    "ShellExecutionPolicy",
+    "resolve_shell_execution_policy",
+]

--- a/src/voidcode/security/url_policy.py
+++ b/src/voidcode/security/url_policy.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import ipaddress
+import socket
+import urllib.parse
+from dataclasses import dataclass
+
+ALLOWED_SCHEMES = frozenset({"http", "https"})
+BLOCKED_HOSTNAMES = frozenset({"localhost", "metadata", "metadata.google.internal"})
+
+
+@dataclass(frozen=True, slots=True)
+class UrlValidationResult:
+    url: str
+    scheme: str
+    hostname: str
+    port: int | None
+
+
+def _normalize_ip(address: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
+    parsed = ipaddress.ip_address(address)
+    if isinstance(parsed, ipaddress.IPv6Address) and parsed.ipv4_mapped is not None:
+        return parsed.ipv4_mapped
+    return parsed
+
+
+def _is_blocked_ip(address: str) -> bool:
+    try:
+        parsed = _normalize_ip(address)
+    except ValueError:
+        return False
+    return bool(
+        parsed.is_private
+        or parsed.is_loopback
+        or parsed.is_link_local
+        or parsed.is_reserved
+        or parsed.is_multicast
+        or parsed.is_unspecified
+    )
+
+
+def _resolve_ips(hostname: str) -> tuple[str, ...]:
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror:
+        return ()
+    addresses: list[str] = []
+    for info in infos:
+        if not info[4]:
+            continue
+        address = info[4][0]
+        if not isinstance(address, str):
+            continue
+        addresses.append(address)
+    return tuple(dict.fromkeys(addresses))
+
+
+def validate_url(url_value: str) -> UrlValidationResult:
+    parsed = urllib.parse.urlparse(url_value)
+    if parsed.scheme not in ALLOWED_SCHEMES:
+        raise ValueError("web_fetch url must start with http:// or https://")
+    if not parsed.hostname:
+        raise ValueError("web_fetch url must include a hostname")
+    if parsed.username or parsed.password:
+        raise ValueError("web_fetch url must not include credentials")
+
+    hostname = parsed.hostname.lower().strip(".")
+    if hostname in BLOCKED_HOSTNAMES:
+        raise ValueError("web_fetch target host is blocked for security reasons")
+
+    if _is_blocked_ip(hostname):
+        raise ValueError("web_fetch target host is blocked for security reasons")
+
+    for resolved in _resolve_ips(hostname):
+        if _is_blocked_ip(resolved):
+            raise ValueError("web_fetch target host is blocked for security reasons")
+
+    return UrlValidationResult(
+        url=url_value,
+        scheme=parsed.scheme,
+        hostname=hostname,
+        port=parsed.port,
+    )
+
+
+def validate_redirect_target(*, base_url: str, location: str) -> UrlValidationResult:
+    redirected_url = urllib.parse.urljoin(base_url, location)
+    return validate_url(redirected_url)
+
+
+__all__ = [
+    "ALLOWED_SCHEMES",
+    "BLOCKED_HOSTNAMES",
+    "UrlValidationResult",
+    "validate_redirect_target",
+    "validate_url",
+]

--- a/src/voidcode/tools/_workspace.py
+++ b/src/voidcode/tools/_workspace.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 from difflib import get_close_matches
 from pathlib import Path
 
+from ..security.path_policy import resolve_workspace_path as _resolve_workspace_path
+
 
 def resolve_workspace_path(*, workspace: Path, raw_path: str) -> tuple[Path, str]:
-    workspace_root = workspace.resolve()
-    candidate = (workspace_root / Path(raw_path)).resolve()
-    if not candidate.is_relative_to(workspace_root):
-        raise ValueError("path must be inside the workspace")
-    return candidate, candidate.relative_to(workspace_root).as_posix()
+    resolution = _resolve_workspace_path(
+        workspace=workspace,
+        raw_path=raw_path,
+        containment_error="path must be inside the workspace",
+    )
+    return resolution.candidate, resolution.relative_path
 
 
 def suggest_workspace_paths(*, workspace: Path, raw_path: str, limit: int = 5) -> list[str]:

--- a/src/voidcode/tools/apply_patch.py
+++ b/src/voidcode/tools/apply_patch.py
@@ -12,6 +12,7 @@ from unidiff import PatchSet
 from unidiff.errors import UnidiffParseError
 
 from ..hook.config import RuntimeHooksConfig
+from ..security.path_policy import resolve_workspace_path
 from ._formatter import FormatterExecutor, formatter_diagnostics, formatter_payload
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
@@ -42,10 +43,11 @@ class _PreparedMarkerChange:
 
 
 def _assert_within_workspace(workspace: Path, rel_path: Path) -> None:
-    root = workspace.resolve()
-    candidate = (root / rel_path).resolve()
-    if not candidate.is_relative_to(root):
-        raise ValueError("patch operation must affect paths inside the workspace")
+    _ = resolve_workspace_path(
+        workspace=workspace,
+        raw_path=rel_path.as_posix(),
+        containment_error="patch operation must affect paths inside the workspace",
+    )
 
 
 def _strip_heredoc(input_text: str) -> str:
@@ -539,8 +541,13 @@ def _formatter_feedback_for_changes(
         path_value = change.get("path")
         if not isinstance(path_value, str):
             continue
-        candidate = (workspace / path_value).resolve()
-        if not candidate.is_relative_to(workspace) or not candidate.is_file():
+        resolution = resolve_workspace_path(
+            workspace=workspace,
+            raw_path=path_value,
+            containment_error="patch operation must affect paths inside the workspace",
+        )
+        candidate = resolution.candidate
+        if not candidate.is_file():
             continue
         result = executor.run(candidate)
         if result.status != "not_configured":

--- a/src/voidcode/tools/edit.py
+++ b/src/voidcode/tools/edit.py
@@ -8,6 +8,7 @@ from typing import ClassVar
 from rapidfuzz.distance import Levenshtein
 
 from ..hook.config import RuntimeHooksConfig
+from ..security.path_policy import resolve_workspace_path
 from ._formatter import (
     FormatterExecutionResult,
     FormatterExecutor,
@@ -464,12 +465,13 @@ class EditTool:
         if not isinstance(replace_all, bool):
             raise ValueError("edit replaceAll must be a boolean")
 
-        relative_path = Path(path_value)
-        workspace_root = workspace.resolve()
-        candidate = (workspace_root / relative_path).resolve()
-
-        if not candidate.is_relative_to(workspace_root):
-            raise ValueError("edit only allows paths inside the workspace")
+        resolution = resolve_workspace_path(
+            workspace=workspace,
+            raw_path=path_value,
+            containment_error="edit only allows paths inside the workspace",
+        )
+        workspace_root = resolution.workspace_root
+        candidate = resolution.candidate
 
         if not candidate.exists():
             raise ValueError(f"edit target does not exist: {path_value}")

--- a/src/voidcode/tools/multi_edit.py
+++ b/src/voidcode/tools/multi_edit.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 from pydantic import ValidationError
 
 from ..hook.config import RuntimeHooksConfig
+from ..security.path_policy import resolve_workspace_path
 from ._formatter import (
     FormatterExecutionResult,
     FormatterExecutor,
@@ -81,14 +82,17 @@ class MultiEditTool:
                     raise ValueError(f"multi_edit edit #{idx} replaceAll must be boolean") from exc
             raise ValueError("multi_edit requires an array edits argument") from exc
 
-        workspace_root = workspace.resolve()
-        target = (workspace_root / Path(args.path)).resolve()
-        if not target.is_relative_to(workspace_root):
-            raise ValueError("multi_edit only allows paths inside the workspace")
+        resolution = resolve_workspace_path(
+            workspace=workspace,
+            raw_path=args.path,
+            containment_error="multi_edit only allows paths inside the workspace",
+        )
+        workspace_root = resolution.workspace_root
+        target = resolution.candidate
         if not target.exists() or not target.is_file():
             raise ValueError(f"multi_edit target does not exist: {args.path}")
 
-        relative_target = target.relative_to(workspace_root).as_posix()
+        relative_target = resolution.relative_path
         content_before = read_utf8_text(target)
 
         applied = 0

--- a/src/voidcode/tools/shell_exec.py
+++ b/src/voidcode/tools/shell_exec.py
@@ -4,7 +4,7 @@ import os
 import signal
 import subprocess
 from pathlib import Path
-from typing import ClassVar, final
+from typing import Any, ClassVar, final
 
 from pydantic import ValidationError
 
@@ -26,7 +26,13 @@ def _truncate(text: str | None) -> tuple[str, bool]:
     return text[:MAX_OUTPUT_CHARS], True
 
 
-def kill_timed_out_process(process: subprocess.Popen[str]) -> None:
+def _decode_process_output(payload: bytes | None) -> str:
+    if payload is None:
+        return ""
+    return payload.decode("utf-8", errors="replace")
+
+
+def kill_timed_out_process(process: subprocess.Popen[Any]) -> None:
     if os.name == "nt":
         taskkill_succeeded = False
         try:
@@ -120,9 +126,6 @@ class ShellExecTool:
                 shell=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
                 start_new_session=True,
                 creationflags=creationflags,
             )
@@ -130,7 +133,7 @@ class ShellExecTool:
             raise ValueError(f"shell_exec failed to execute command: {exc}") from exc
 
         try:
-            stdout, stderr = process.communicate(timeout=timeout_seconds)
+            stdout_bytes, stderr_bytes = process.communicate(timeout=timeout_seconds)
         except subprocess.TimeoutExpired as exc:
             kill_timed_out_process(process)
             process.communicate()
@@ -139,6 +142,9 @@ class ShellExecTool:
                     f"tool '{self.definition.name}' exceeded runtime timeout of {timeout_seconds}s"
                 ) from exc
             raise ValueError(f"shell_exec command timed out after {timeout_seconds}s") from exc
+
+        stdout = _decode_process_output(stdout_bytes)
+        stderr = _decode_process_output(stderr_bytes)
 
         output = stdout
         if stderr:

--- a/src/voidcode/tools/shell_exec.py
+++ b/src/voidcode/tools/shell_exec.py
@@ -8,11 +8,13 @@ from typing import ClassVar, final
 
 from pydantic import ValidationError
 
+from ..security.shell_policy import (
+    DEFAULT_TIMEOUT_SECONDS,
+    resolve_shell_execution_policy,
+)
 from ._pydantic_args import ShellExecArgs
 from .contracts import RuntimeToolTimeoutError, ToolCall, ToolDefinition, ToolResult
 
-DEFAULT_TIMEOUT_SECONDS = 30
-MAX_TIMEOUT_SECONDS = 120
 MAX_OUTPUT_CHARS = 200_000
 
 
@@ -100,16 +102,13 @@ class ShellExecTool:
         command_text = args.command.strip()
 
         timeout_value = call.arguments.get("timeout", DEFAULT_TIMEOUT_SECONDS)
-        if isinstance(timeout_value, (int, float)) and timeout_value > 0:
-            local_timeout_seconds = min(int(timeout_value), MAX_TIMEOUT_SECONDS)
-        else:
-            local_timeout_seconds = DEFAULT_TIMEOUT_SECONDS
-
-        timeout_seconds = local_timeout_seconds
-        runtime_timeout_selected = False
-        if runtime_timeout_seconds is not None and runtime_timeout_seconds < timeout_seconds:
-            timeout_seconds = runtime_timeout_seconds
-            runtime_timeout_selected = True
+        policy = resolve_shell_execution_policy(
+            workspace=workspace,
+            timeout_argument=timeout_value,
+            runtime_timeout_seconds=runtime_timeout_seconds,
+        )
+        timeout_seconds = policy.timeout_seconds
+        runtime_timeout_selected = policy.runtime_timeout_selected
 
         try:
             creationflags = 0
@@ -117,7 +116,7 @@ class ShellExecTool:
                 creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
             process = subprocess.Popen(
                 command_text,
-                cwd=workspace.resolve(),
+                cwd=policy.workspace_root,
                 shell=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -155,11 +154,15 @@ class ShellExecTool:
             content=content,
             data={
                 "command": command_text,
+                "cwd": str(policy.workspace_root),
                 "exit_code": process.returncode,
                 "stdout": stdout,
                 "stderr": stderr,
                 "timeout": timeout_seconds,
+                "stdout_truncated": stdout_truncated,
+                "stderr_truncated": stderr_truncated,
                 "truncated": content_truncated or stdout_truncated or stderr_truncated,
+                "output_char_count": len(content),
             },
             truncated=content_truncated or stdout_truncated or stderr_truncated,
             partial=content_truncated or stdout_truncated or stderr_truncated,

--- a/src/voidcode/tools/web_fetch.py
+++ b/src/voidcode/tools/web_fetch.py
@@ -1,78 +1,18 @@
 from __future__ import annotations
 
 import base64
-import ipaddress
 import re
-import socket
-import urllib.parse
 from pathlib import Path
 from typing import ClassVar
 
 import httpx
 from bs4 import BeautifulSoup
 
+from ..security.url_policy import validate_redirect_target, validate_url
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 MAX_RESPONSE_SIZE = 5 * 1024 * 1024
 DEFAULT_TIMEOUT = 30
-
-
-def _is_private_or_loopback_host(hostname: str) -> bool:
-    blocked_hostnames = {
-        "localhost",
-        "metadata.google.internal",
-        "metadata",
-    }
-    lower = hostname.lower().strip(".")
-    if lower in blocked_hostnames:
-        return True
-
-    try:
-        ip = ipaddress.ip_address(lower)
-        return bool(
-            ip.is_private
-            or ip.is_loopback
-            or ip.is_link_local
-            or ip.is_reserved
-            or ip.is_multicast
-            or ip.is_unspecified
-        )
-    except ValueError:
-        pass
-
-    try:
-        infos = socket.getaddrinfo(hostname, None)
-    except socket.gaierror:
-        return False
-
-    for info in infos:
-        address = info[4][0]
-        try:
-            ip = ipaddress.ip_address(address)
-        except ValueError:
-            continue
-        if (
-            ip.is_private
-            or ip.is_loopback
-            or ip.is_link_local
-            or ip.is_reserved
-            or ip.is_multicast
-            or ip.is_unspecified
-        ):
-            return True
-    return False
-
-
-def _validate_fetch_url(url_value: str) -> None:
-    parsed = urllib.parse.urlparse(url_value)
-    if parsed.scheme not in ("http", "https"):
-        raise ValueError("web_fetch url must start with http:// or https://")
-
-    if not parsed.hostname:
-        raise ValueError("web_fetch url must include a hostname")
-
-    if _is_private_or_loopback_host(parsed.hostname):
-        raise ValueError("web_fetch target host is blocked for security reasons")
 
 
 def _extract_text_from_html(html: str) -> str:
@@ -155,7 +95,7 @@ class WebFetchTool:
         if not isinstance(url_value, str):
             raise ValueError("web_fetch requires a string url argument")
 
-        _validate_fetch_url(url_value)
+        _ = validate_url(url_value)
 
         format_value = call.arguments.get("format", "markdown")
         if not isinstance(format_value, str) or format_value not in ("text", "markdown", "html"):
@@ -214,9 +154,10 @@ class WebFetchTool:
                             raise ValueError(
                                 "Failed to fetch URL: redirect response missing location"
                             )
-                        redirected_url = urllib.parse.urljoin(current_url, location)
-                        _validate_fetch_url(redirected_url)
-                        current_url = redirected_url
+                        redirected = validate_redirect_target(
+                            base_url=current_url, location=location
+                        )
+                        current_url = redirected.url
                         continue
 
                     if response.status_code >= 400:
@@ -225,7 +166,7 @@ class WebFetchTool:
                         )
 
                     final_url = str(response.url)
-                    _validate_fetch_url(final_url)
+                    _ = validate_url(final_url)
                     content_type = response.headers.get("Content-Type", "")
                     content_length = response.headers.get("Content-Length")
 

--- a/src/voidcode/tools/write_file.py
+++ b/src/voidcode/tools/write_file.py
@@ -7,6 +7,7 @@ from typing import ClassVar, final
 from pydantic import ValidationError
 
 from ..hook.config import RuntimeHooksConfig
+from ..security.path_policy import resolve_workspace_path
 from ._formatter import FormatterExecutor, formatter_diagnostics, formatter_payload
 from ._pydantic_args import WriteFileArgs
 from .contracts import ToolCall, ToolDefinition, ToolResult
@@ -39,12 +40,13 @@ class WriteFileTool:
                 raise ValueError("write_file requires a string content argument") from exc
             raise ValueError("write_file requires a string path argument") from exc
 
-        relative_path = Path(args.path)
-        workspace_root = workspace.resolve()
-        candidate = (workspace_root / relative_path).resolve()
-
-        if not candidate.is_relative_to(workspace_root):
-            raise ValueError("write_file only allows paths inside the workspace")
+        resolution = resolve_workspace_path(
+            workspace=workspace,
+            raw_path=args.path,
+            containment_error="write_file only allows paths inside the workspace",
+        )
+        workspace_root = resolution.workspace_root
+        candidate = resolution.candidate
 
         candidate.parent.mkdir(parents=True, exist_ok=True)
         old_content = candidate.read_text(encoding="utf-8") if candidate.exists() else ""
@@ -55,7 +57,7 @@ class WriteFileTool:
             formatter_result = FormatterExecutor(self._hooks_config, workspace_root).run(candidate)
 
         diagnostics = formatter_diagnostics(formatter_result)
-        content = f"Wrote file successfully: {candidate.relative_to(workspace_root).as_posix()}"
+        content = f"Wrote file successfully: {resolution.relative_path}"
         if diagnostics:
             content += f" Formatter warning: {diagnostics[0]['message']}"
 
@@ -71,7 +73,7 @@ class WriteFileTool:
         )
 
         data: dict[str, object] = {
-            "path": relative_output_path,
+            "path": resolution.relative_path,
             "byte_count": candidate.stat().st_size,
             "diff": diff,
         }

--- a/tests/unit/runtime/test_mcp.py
+++ b/tests/unit/runtime/test_mcp.py
@@ -1456,3 +1456,197 @@ for raw_line in sys.stdin:
     ]
     assert cleanup_events[0].payload["owner_session_id"] == "abandoned"
     assert cleanup_events[0].payload["reason"] == "abandoned"
+
+
+def test_mcp_manager_marks_malformed_tool_schema_as_disabled(tmp_path: Path) -> None:
+    server_script = tmp_path / "invalid_schema_mcp_server.py"
+    server_script.write_text(
+        r"""
+from __future__ import annotations
+
+import json
+import sys
+
+
+def send(message: dict[str, object]) -> None:
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+
+for raw_line in sys.stdin:
+    line = raw_line.strip()
+    if not line:
+        continue
+    message = json.loads(line)
+    method = message.get("method")
+    if method == "initialize":
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "invalid-schema-mcp", "version": "0.1.0"},
+                },
+            }
+        )
+        continue
+    if method == "notifications/initialized":
+        continue
+    if method == "tools/list":
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {
+                    "tools": [
+                        {
+                            "name": "bad_schema",
+                            "description": "Bad schema tool",
+                            "inputSchema": {"type": "string"},
+                        },
+                        {
+                            "name": "good_schema",
+                            "description": "Good schema tool",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {"text": {"type": "string"}},
+                            },
+                        },
+                    ]
+                },
+            }
+        )
+        continue
+""",
+        encoding="utf-8",
+    )
+
+    collector = InMemoryMcpDiagnosticsCollector()
+    manager = build_mcp_manager(
+        RuntimeMcpConfig(
+            enabled=True,
+            servers={
+                "invalid": RuntimeMcpServerConfig(
+                    transport="stdio",
+                    command=(sys.executable, str(server_script)),
+                )
+            },
+        ),
+        diagnostics_collector=collector,
+    )
+
+    tools = manager.list_tools(workspace=tmp_path)
+    assert len(tools) == 2
+    bad = next(tool for tool in tools if tool.tool_name == "bad_schema")
+    good = next(tool for tool in tools if tool.tool_name == "good_schema")
+    assert bad.enabled is False
+    assert bad.disabled_reason is not None
+    assert good.enabled is True
+
+    diagnostics = collector.get_diagnostics()
+    assert diagnostics
+    assert diagnostics[-1].category == "discovery"
+
+
+def test_mcp_manager_validates_call_arguments_against_required_schema(tmp_path: Path) -> None:
+    server_script = tmp_path / "required_schema_mcp_server.py"
+    server_script.write_text(
+        r"""
+from __future__ import annotations
+
+import json
+import sys
+
+
+def send(message: dict[str, object]) -> None:
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+
+for raw_line in sys.stdin:
+    line = raw_line.strip()
+    if not line:
+        continue
+    message = json.loads(line)
+    method = message.get("method")
+    if method == "initialize":
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "required-schema-mcp", "version": "0.1.0"},
+                },
+            }
+        )
+        continue
+    if method == "notifications/initialized":
+        continue
+    if method == "tools/list":
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {
+                    "tools": [
+                        {
+                            "name": "echo",
+                            "description": "Echo",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {"text": {"type": "string"}},
+                                "required": ["text"],
+                            },
+                        }
+                    ]
+                },
+            }
+        )
+        continue
+    if method == "tools/call":
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {
+                    "content": [{"type": "text", "text": "ok"}],
+                    "isError": False,
+                },
+            }
+        )
+""",
+        encoding="utf-8",
+    )
+
+    collector = InMemoryMcpDiagnosticsCollector()
+    manager = build_mcp_manager(
+        RuntimeMcpConfig(
+            enabled=True,
+            servers={
+                "required": RuntimeMcpServerConfig(
+                    transport="stdio",
+                    command=(sys.executable, str(server_script)),
+                )
+            },
+        ),
+        diagnostics_collector=collector,
+    )
+
+    discovered = manager.list_tools(workspace=tmp_path)
+    assert [tool.tool_name for tool in discovered] == ["echo"]
+
+    with pytest.raises(ValueError, match="missing required arguments"):
+        manager.call_tool(
+            server_name="required",
+            tool_name="echo",
+            arguments={},
+            workspace=tmp_path,
+        )
+
+    diagnostics = collector.get_diagnostics()
+    assert diagnostics
+    assert diagnostics[-1].category == "call"

--- a/tests/unit/runtime/test_tool_execution_timeout.py
+++ b/tests/unit/runtime/test_tool_execution_timeout.py
@@ -458,6 +458,11 @@ def test_shell_exec_uses_existing_tool_timeout_when_runtime_timeout_is_unset(
 
     assert len(completed_events) == 1
     assert completed_events[0].payload["timeout"] == 30
+    assert completed_events[0].payload["cwd"] == str(tmp_path.resolve())
+    assert completed_events[0].payload["exit_code"] == 0
+    assert completed_events[0].payload["stdout_truncated"] is False
+    assert completed_events[0].payload["stderr_truncated"] is False
+    assert completed_events[0].payload["truncated"] is False
 
 
 def test_shell_exec_timeout_wins_when_shorter_than_runtime_timeout(tmp_path: Path) -> None:

--- a/tests/unit/tools/test_apply_patch_tool.py
+++ b/tests/unit/tools/test_apply_patch_tool.py
@@ -685,3 +685,28 @@ def test_apply_patch_raises_helpful_error_when_git_is_missing(
             ToolCall(tool_name="apply_patch", arguments={"patch": patch_text}),
             workspace=tmp_path,
         )
+
+
+def test_apply_patch_rejects_structured_symlink_escape(tmp_path: Path) -> None:
+    outside_dir = tmp_path.parent / "outside_patch_escape"
+    outside_dir.mkdir(exist_ok=True)
+    link_dir = tmp_path / "linkdir"
+    try:
+        link_dir.symlink_to(outside_dir, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlink is not available on this platform")
+
+    patch_text = "\n".join(
+        [
+            "*** Begin Patch",
+            "*** Add File: linkdir/escape.txt",
+            "+escaped",
+            "*** End Patch",
+        ]
+    )
+
+    with pytest.raises(ValueError, match="inside the workspace"):
+        ApplyPatchTool().invoke(
+            ToolCall(tool_name="apply_patch", arguments={"patch": patch_text}),
+            workspace=tmp_path,
+        )

--- a/tests/unit/tools/test_edit_tool.py
+++ b/tests/unit/tools/test_edit_tool.py
@@ -123,6 +123,26 @@ def test_edit_tool_rejects_path_outside_workspace(tmp_path: Path) -> None:
         )
 
 
+def test_edit_tool_rejects_symlink_escape(tmp_path: Path) -> None:
+    outside = tmp_path.parent / "outside_edit_escape.txt"
+    outside.write_text("alpha", encoding="utf-8")
+    link = tmp_path / "link.txt"
+    try:
+        link.symlink_to(outside)
+    except OSError:
+        pytest.skip("symlink is not available on this platform")
+
+    tool = EditTool()
+    with pytest.raises(ValueError, match="inside the workspace"):
+        tool.invoke(
+            ToolCall(
+                tool_name="edit",
+                arguments={"path": "link.txt", "oldString": "alpha", "newString": "beta"},
+            ),
+            workspace=tmp_path,
+        )
+
+
 def test_edit_tool_rejects_nonexistent_file(tmp_path: Path) -> None:
     tool = EditTool()
 

--- a/tests/unit/tools/test_read_file_tool.py
+++ b/tests/unit/tools/test_read_file_tool.py
@@ -75,6 +75,23 @@ def test_read_file_tool_rejects_workspace_escape(tmp_path: Path) -> None:
         )
 
 
+def test_read_file_tool_rejects_symlink_escape(tmp_path: Path) -> None:
+    outside = tmp_path.parent / "outside_read_escape.txt"
+    outside.write_text("secret", encoding="utf-8")
+    link = tmp_path / "link.txt"
+    try:
+        link.symlink_to(outside)
+    except OSError:
+        pytest.skip("symlink is not available on this platform")
+
+    tool = ReadFileTool()
+    with pytest.raises(ValueError, match="inside the workspace"):
+        tool.invoke(
+            ToolCall(tool_name="read_file", arguments={"filePath": "link.txt"}),
+            workspace=tmp_path,
+        )
+
+
 def test_read_file_tool_sniffs_text_with_bounded_stream_read(tmp_path: Path) -> None:
     sample = tmp_path / "sample.txt"
     _ = sample.write_text("alpha\nbeta\n", encoding="utf-8")

--- a/tests/unit/tools/test_security_boundary_matrix.py
+++ b/tests/unit/tools/test_security_boundary_matrix.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Protocol
+
+import pytest
+
+from voidcode.tools import (
+    ApplyPatchTool,
+    EditTool,
+    ReadFileTool,
+    ShellExecTool,
+    ToolCall,
+    WebFetchTool,
+    WriteFileTool,
+)
+
+
+class _InvokableTool(Protocol):
+    def invoke(self, call: ToolCall, *, workspace: Path): ...
+
+
+@pytest.mark.parametrize(
+    ("tool", "arguments"),
+    [
+        (ReadFileTool(), {"filePath": "link.txt"}),
+        (WriteFileTool(), {"path": "linkdir/out.txt", "content": "x"}),
+        (EditTool(), {"path": "link.txt", "oldString": "a", "newString": "b"}),
+    ],
+)
+def test_workspace_symlink_escape_is_blocked(
+    tmp_path: Path,
+    tool: _InvokableTool,
+    arguments: dict[str, object],
+) -> None:
+    outside_file = tmp_path.parent / "matrix-outside.txt"
+    outside_file.write_text("a", encoding="utf-8")
+    link_file = tmp_path / "link.txt"
+    link_dir = tmp_path / "linkdir"
+    try:
+        link_file.symlink_to(outside_file)
+        link_dir.symlink_to(tmp_path.parent, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlink is not available on this platform")
+
+    with pytest.raises(ValueError, match="inside the workspace"):
+        tool.invoke(
+            ToolCall(tool_name="matrix", arguments=arguments),
+            workspace=tmp_path,
+        )
+
+
+def test_apply_patch_symlink_escape_is_blocked(tmp_path: Path) -> None:
+    outside_dir = tmp_path.parent / "matrix-outside-dir"
+    outside_dir.mkdir(exist_ok=True)
+    link_dir = tmp_path / "linkdir"
+    try:
+        link_dir.symlink_to(outside_dir, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlink is not available on this platform")
+
+    patch_text = "\n".join(
+        [
+            "*** Begin Patch",
+            "*** Add File: linkdir/escaped.txt",
+            "+blocked",
+            "*** End Patch",
+        ]
+    )
+    with pytest.raises(ValueError, match="inside the workspace"):
+        ApplyPatchTool().invoke(
+            ToolCall(tool_name="apply_patch", arguments={"patch": patch_text}),
+            workspace=tmp_path,
+        )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:8080/",
+        "https://metadata.google.internal/computeMetadata/v1",
+        "http://[::ffff:127.0.0.1]/",
+        "https://user:pass@example.com/",
+    ],
+)
+def test_web_fetch_security_boundary_blocks_dangerous_targets(url: str) -> None:
+    with pytest.raises(ValueError):
+        WebFetchTool().invoke(
+            ToolCall(tool_name="web_fetch", arguments={"url": url, "format": "text"}),
+            workspace=Path("/tmp"),
+        )
+
+
+def test_shell_exec_emits_consistent_security_metadata(tmp_path: Path) -> None:
+    result = ShellExecTool().invoke(
+        ToolCall(
+            tool_name="shell_exec",
+            arguments={"command": f'"{sys.executable}" -c "print(1)"'},
+        ),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert result.data["cwd"] == str(tmp_path.resolve())
+    assert result.data["timeout"] == 30
+    assert result.data["truncated"] is False
+    assert result.data["stdout_truncated"] is False
+    assert result.data["stderr_truncated"] is False
+    assert isinstance(result.data["output_char_count"], int)

--- a/tests/unit/tools/test_shell_exec_tool.py
+++ b/tests/unit/tools/test_shell_exec_tool.py
@@ -27,11 +27,14 @@ def test_shell_exec_tool_runs_command_in_workspace(tmp_path: Path) -> None:
 
     assert result.tool_name == "shell_exec"
     assert result.status == "ok"
-    assert result.content == f"{tmp_path.resolve()}\n"
+    assert isinstance(result.content, str)
+    assert result.content.strip() == str(tmp_path.resolve())
     assert result.data.get("command") == command
     assert result.data.get("cwd") == str(tmp_path.resolve())
     assert result.data.get("exit_code") == 0
-    assert result.data.get("stdout") == f"{tmp_path.resolve()}\n"
+    stdout = result.data.get("stdout")
+    assert isinstance(stdout, str)
+    assert stdout.strip() == str(tmp_path.resolve())
     assert result.data.get("stderr") == ""
     assert result.data.get("timeout") == 30
     assert result.data.get("truncated") is False

--- a/tests/unit/tools/test_shell_exec_tool.py
+++ b/tests/unit/tools/test_shell_exec_tool.py
@@ -29,11 +29,14 @@ def test_shell_exec_tool_runs_command_in_workspace(tmp_path: Path) -> None:
     assert result.status == "ok"
     assert result.content == f"{tmp_path.resolve()}\n"
     assert result.data.get("command") == command
+    assert result.data.get("cwd") == str(tmp_path.resolve())
     assert result.data.get("exit_code") == 0
     assert result.data.get("stdout") == f"{tmp_path.resolve()}\n"
     assert result.data.get("stderr") == ""
     assert result.data.get("timeout") == 30
     assert result.data.get("truncated") is False
+    assert result.data.get("stdout_truncated") is False
+    assert result.data.get("stderr_truncated") is False
 
 
 def test_shell_exec_tool_supports_shell_operators(tmp_path: Path) -> None:
@@ -185,3 +188,5 @@ def test_shell_exec_tool_truncates_large_output(tmp_path: Path) -> None:
     assert isinstance(result.content, str)
     assert len(result.content) == 200000
     assert result.data.get("truncated") is True
+    assert result.data.get("stdout_truncated") is True
+    assert result.data.get("output_char_count") == 200000

--- a/tests/unit/tools/test_webfetch_tool.py
+++ b/tests/unit/tools/test_webfetch_tool.py
@@ -192,3 +192,67 @@ def test_webfetch_rejects_redirect_to_localhost() -> None:
                 ),
                 workspace=Path("/tmp"),
             )
+
+
+def test_webfetch_rejects_redirect_chain_to_metadata_host() -> None:
+    tool = WebFetchTool()
+    first = httpx.Response(
+        302,
+        headers={"Location": "https://metadata.google.internal/computeMetadata/v1"},
+        request=httpx.Request("GET", "https://example.com/start"),
+    )
+
+    with patch("httpx.Client.request", side_effect=[first]):
+        with pytest.raises(ValueError, match="blocked"):
+            tool.invoke(
+                ToolCall(
+                    tool_name="web_fetch",
+                    arguments={"url": "https://example.com/start", "format": "text"},
+                ),
+                workspace=Path("/tmp"),
+            )
+
+
+def test_webfetch_rejects_ipv4_mapped_ipv6_host() -> None:
+    tool = WebFetchTool()
+
+    with pytest.raises(ValueError, match="blocked"):
+        tool.invoke(
+            ToolCall(
+                tool_name="web_fetch",
+                arguments={"url": "http://[::ffff:127.0.0.1]/", "format": "text"},
+            ),
+            workspace=Path("/tmp"),
+        )
+
+
+def test_webfetch_rejects_url_credentials() -> None:
+    tool = WebFetchTool()
+
+    with pytest.raises(ValueError, match="must not include credentials"):
+        tool.invoke(
+            ToolCall(
+                tool_name="web_fetch",
+                arguments={"url": "https://user:pass@example.com/secret", "format": "text"},
+            ),
+            workspace=Path("/tmp"),
+        )
+
+
+def test_webfetch_fails_when_redirect_location_is_missing() -> None:
+    tool = WebFetchTool()
+    redirect = httpx.Response(
+        302,
+        headers={},
+        request=httpx.Request("GET", "https://example.com/start"),
+    )
+
+    with patch("httpx.Client.request", side_effect=[redirect]):
+        with pytest.raises(ValueError, match="missing location"):
+            tool.invoke(
+                ToolCall(
+                    tool_name="web_fetch",
+                    arguments={"url": "https://example.com/start", "format": "text"},
+                ),
+                workspace=Path("/tmp"),
+            )

--- a/tests/unit/tools/test_write_file_tool.py
+++ b/tests/unit/tools/test_write_file_tool.py
@@ -77,6 +77,26 @@ def test_write_file_tool_rejects_paths_outside_workspace(tmp_path: Path) -> None
         )
 
 
+def test_write_file_tool_rejects_symlink_escape(tmp_path: Path) -> None:
+    outside_dir = tmp_path.parent / "outside_write_escape"
+    outside_dir.mkdir(exist_ok=True)
+    link_dir = tmp_path / "linkdir"
+    try:
+        link_dir.symlink_to(outside_dir, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlink is not available on this platform")
+
+    tool = WriteFileTool()
+    with pytest.raises(ValueError, match="inside the workspace"):
+        tool.invoke(
+            ToolCall(
+                tool_name="write_file",
+                arguments={"path": "linkdir/escape.txt", "content": "nope"},
+            ),
+            workspace=tmp_path,
+        )
+
+
 def test_write_file_tool_runs_formatter_after_writing(tmp_path: Path) -> None:
     formatter_script = tmp_path / "formatter.py"
     formatter_script.write_text(


### PR DESCRIPTION
Summary, close #313 
- Centralized workspace path containment into a shared policy and applied it across file/path-sensitive tools.
- Hardened web_fetch URL boundary with shared SSRF guards (scheme restriction, blocked hosts/IPs, redirect-hop revalidation, credential rejection).
- Added MCP schema boundary validation with graceful per-tool disablement and diagnostics instead of server-wide failure.
- Strengthened shell_exec runtime boundary and audit metadata consistency, including robust cross-platform output decoding.
- Added a security boundary regression matrix to lock behavior across path, URL, MCP, and shell flows.
Why
The backend tool surface is the primary local privilege boundary in VoidCode. This change reduces inconsistent security behavior across tools and hardens model-to-local-action transitions against malformed input, redirect-based SSRF bypasses, schema poisoning, path escape, and shell execution edge cases.
Key changes
1) Workspace path boundary
- Added shared policy module for canonical path resolution + containment checks.
- Enforced symlink escape blocking consistently.
- Applied to read/write/edit/multi_edit/apply_patch path flows.
2) Web fetch / network boundary
- Added shared URL validation policy.
- Enforced http/https only.
- Blocked localhost/private/link-local/reserved/multicast/metadata targets.
- Validated DNS-resolved addresses.
- Revalidated redirect targets hop-by-hop.
- Rejected credential-bearing URLs.
3) MCP tool schema boundary
- Validated MCP inputSchema shape (JSON object semantics).
- Marked malformed MCP tools as disabled with diagnostics instead of crashing discovery.
- Added pre-call argument validation against required/type constraints.
- Filtered disabled MCP tools from runtime-exposed tool registry.
4) Shell execution boundary
- Introduced shell execution policy resolution for cwd/timeout decisions.
- Added richer audit metadata (cwd, truncation fields, output char count).
- Switched subprocess capture to binary + explicit UTF-8 replacement decode to avoid platform-specific decode failures in reader threads (notably on Windows timeout/kill paths).
5) Regression coverage
- Added/expanded tests for:
  - symlink/path escape
  - redirect-based blocked target transitions
  - IPv4-mapped IPv6 blocking
  - malformed MCP schema disablement
  - MCP required-argument validation
  - shell execution audit metadata consistency
  - cross-tool security boundary matrix
Validation
- ruff check . passed
- basedpyright passed
- Targeted runtime/tool suites for path, web_fetch, MCP, shell, and timeout behavior passed
- Frontend checks passed (frontend:check)