### PR TITLE
feat(runtime): add conversation undo

### DIFF
--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -63,6 +63,7 @@ from .runtime.contracts import (
     ProviderReadinessResult,
     RuntimeRequest,
     RuntimeSessionDebugSnapshot,
+    RuntimeSessionRevertMarker,
     RuntimeStreamChunk,
     validate_runtime_request_metadata,
 )
@@ -704,6 +705,7 @@ def _serialize_session_debug_snapshot(snapshot: RuntimeSessionDebugSnapshot) -> 
             if snapshot.pending_question is not None
             else None
         ),
+        "revert_marker": _serialize_revert_marker(snapshot.revert_marker),
         "last_event_sequence": snapshot.last_event_sequence,
         "last_relevant_event": (
             {
@@ -783,6 +785,60 @@ def _handle_sessions_debug_command(args: argparse.Namespace) -> int:
         _close_runtime(runtime)
 
     print(json.dumps(_serialize_session_debug_snapshot(snapshot), sort_keys=True))
+    return 0
+
+
+def _serialize_revert_marker(marker: RuntimeSessionRevertMarker | None) -> dict[str, object] | None:
+    if marker is None:
+        return None
+    return {"sequence": marker.sequence, "active": marker.active}
+
+
+def _handle_sessions_undo_command(args: argparse.Namespace) -> int:
+    workspace = cast(Path, args.workspace)
+    session_id = cast(str, args.session_id)
+    runtime = VoidCodeRuntime(workspace=workspace)
+    try:
+        try:
+            marker = runtime.undo_session(session_id=session_id)
+        except ValueError as exc:
+            raise SystemExit(f"error: {exc}") from None
+    finally:
+        _close_runtime(runtime)
+    print_json({"session_id": session_id, "revert_marker": _serialize_revert_marker(marker)})
+    return 0
+
+
+def _handle_sessions_revert_command(args: argparse.Namespace) -> int:
+    workspace = cast(Path, args.workspace)
+    session_id = cast(str, args.session_id)
+    runtime = VoidCodeRuntime(workspace=workspace)
+    try:
+        try:
+            marker = runtime.revert_session(
+                session_id=session_id,
+                sequence=cast(int, args.sequence),
+            )
+        except ValueError as exc:
+            raise SystemExit(f"error: {exc}") from None
+    finally:
+        _close_runtime(runtime)
+    print_json({"session_id": session_id, "revert_marker": _serialize_revert_marker(marker)})
+    return 0
+
+
+def _handle_sessions_unrevert_command(args: argparse.Namespace) -> int:
+    workspace = cast(Path, args.workspace)
+    session_id = cast(str, args.session_id)
+    runtime = VoidCodeRuntime(workspace=workspace)
+    try:
+        try:
+            marker = runtime.unrevert_session(session_id=session_id)
+        except ValueError as exc:
+            raise SystemExit(f"error: {exc}") from None
+    finally:
+        _close_runtime(runtime)
+    print_json({"session_id": session_id, "revert_marker": _serialize_revert_marker(marker)})
     return 0
 
 
@@ -1902,6 +1958,49 @@ def build_parser() -> argparse.ArgumentParser:
         help="Output JSON debug snapshot (default).",
     )
     debug_parser.set_defaults(handler=_handle_sessions_debug_command)
+
+    undo_parser = sessions_subparsers.add_parser(
+        "undo", help="Revert the latest user turn out of provider-facing context."
+    )
+    _ = undo_parser.add_argument("session_id", help="Persisted session identifier to undo.")
+    _ = undo_parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd(),
+        help="Workspace root used to resolve the local session database.",
+    )
+    undo_parser.set_defaults(handler=_handle_sessions_undo_command)
+
+    revert_parser = sessions_subparsers.add_parser(
+        "revert", help="Revert provider-facing context to an event sequence."
+    )
+    _ = revert_parser.add_argument("session_id", help="Persisted session identifier to revert.")
+    _ = revert_parser.add_argument(
+        "--to",
+        dest="sequence",
+        type=int,
+        required=True,
+        help="Event sequence to use as the revert point.",
+    )
+    _ = revert_parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd(),
+        help="Workspace root used to resolve the local session database.",
+    )
+    revert_parser.set_defaults(handler=_handle_sessions_revert_command)
+
+    unrevert_parser = sessions_subparsers.add_parser(
+        "unrevert", help="Clear an active conversation revert marker."
+    )
+    _ = unrevert_parser.add_argument("session_id", help="Persisted session identifier to unrevert.")
+    _ = unrevert_parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd(),
+        help="Workspace root used to resolve the local session database.",
+    )
+    unrevert_parser.set_defaults(handler=_handle_sessions_unrevert_command)
 
     tasks_status_parser = tasks_subparsers.add_parser(
         "status", help="Show delegated task lifecycle state."

--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -689,6 +689,12 @@ class RuntimeSessionDebugEvent:
 
 
 @dataclass(frozen=True, slots=True)
+class RuntimeSessionRevertMarker:
+    sequence: int
+    active: bool = True
+
+
+@dataclass(frozen=True, slots=True)
 class RuntimeSessionDebugPendingApproval:
     request_id: str
     tool_name: str
@@ -737,6 +743,7 @@ class RuntimeSessionDebugSnapshot:
     resume_checkpoint_kind: str | None = None
     pending_approval: RuntimeSessionDebugPendingApproval | None = None
     pending_question: RuntimeSessionDebugPendingQuestion | None = None
+    revert_marker: RuntimeSessionRevertMarker | None = None
     last_event_sequence: int = 0
     last_relevant_event: RuntimeSessionDebugEvent | None = None
     last_failure_event: RuntimeSessionDebugEvent | None = None
@@ -756,6 +763,7 @@ class RuntimeSessionResult:
     error: str | None = None
     transcript: tuple[EventEnvelope, ...] = ()
     last_event_sequence: int = 0
+    revert_marker: RuntimeSessionRevertMarker | None = None
 
     @property
     def delegated_events(self) -> tuple[DelegatedLifecycleEventPayload, ...]:

--- a/src/voidcode/runtime/http.py
+++ b/src/voidcode/runtime/http.py
@@ -33,6 +33,7 @@ from .contracts import (
     RuntimeResponse,
     RuntimeSessionDebugSnapshot,
     RuntimeSessionResult,
+    RuntimeSessionRevertMarker,
     RuntimeStatusSnapshot,
     RuntimeStreamChunk,
     WorkspaceRegistrySnapshot,
@@ -109,6 +110,12 @@ class RuntimeTransport(Protocol):
     def session_result(self, *, session_id: str) -> RuntimeSessionResult: ...
 
     def session_debug_snapshot(self, *, session_id: str) -> RuntimeSessionDebugSnapshot: ...
+
+    def revert_session(self, *, session_id: str, sequence: int) -> RuntimeSessionRevertMarker: ...
+
+    def undo_session(self, *, session_id: str) -> RuntimeSessionRevertMarker: ...
+
+    def unrevert_session(self, *, session_id: str) -> RuntimeSessionRevertMarker | None: ...
 
     def list_notifications(self) -> tuple[RuntimeNotification, ...]: ...
 
@@ -261,6 +268,17 @@ class _QuestionAnswerRequestPayload(_HttpBoundaryModel):
         if not isinstance(value, list) or not value:
             raise ValueError("must be a non-empty array")
         return cast(list[object], value)
+
+
+class _SessionRevertRequestPayload(_HttpBoundaryModel):
+    sequence: int | None = None
+
+    @field_validator("sequence", mode="before")
+    @classmethod
+    def _validate_sequence(cls, value: object) -> int:
+        if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+            raise ValueError("must be a positive integer")
+        return value
 
 
 def _parse_json_body(body: bytes) -> object:
@@ -587,6 +605,9 @@ class RuntimeTransportApp:
             is_question_route = session_path.endswith("/question")
             is_result_route = session_path.endswith("/result")
             is_debug_route = session_path.endswith("/debug")
+            is_undo_route = session_path.endswith("/undo")
+            is_revert_route = session_path.endswith("/revert")
+            is_unrevert_route = session_path.endswith("/unrevert")
             session_id = (
                 session_path.removesuffix("/tasks")
                 if is_task_list_route
@@ -598,6 +619,12 @@ class RuntimeTransportApp:
                 if is_result_route
                 else session_path.removesuffix("/debug")
                 if is_debug_route
+                else session_path.removesuffix("/undo")
+                if is_undo_route
+                else session_path.removesuffix("/revert")
+                if is_revert_route
+                else session_path.removesuffix("/unrevert")
+                if is_unrevert_route
                 else session_path
             )
             try:
@@ -631,6 +658,12 @@ class RuntimeTransportApp:
                 if is_result_route
                 else session_path.removesuffix("/debug")
                 if is_debug_route
+                else session_path.removesuffix("/undo")
+                if is_undo_route
+                else session_path.removesuffix("/revert")
+                if is_revert_route
+                else session_path.removesuffix("/unrevert")
+                if is_unrevert_route
                 else session_path
             )
             if is_approval_route:
@@ -680,6 +713,40 @@ class RuntimeTransportApp:
                     )
                     return
                 await self._handle_session_debug(session_id=session_id, send=send)
+                return
+            if is_undo_route:
+                if method != "POST":
+                    await self._json_response(
+                        send,
+                        status=405,
+                        payload={"error": "method not allowed"},
+                    )
+                    return
+                await self._handle_session_undo(session_id=session_id, send=send)
+                return
+            if is_revert_route:
+                if method != "POST":
+                    await self._json_response(
+                        send,
+                        status=405,
+                        payload={"error": "method not allowed"},
+                    )
+                    return
+                await self._handle_session_revert(
+                    session_id=session_id,
+                    receive=receive,
+                    send=send,
+                )
+                return
+            if is_unrevert_route:
+                if method != "POST":
+                    await self._json_response(
+                        send,
+                        status=405,
+                        payload={"error": "method not allowed"},
+                    )
+                    return
+                await self._handle_session_unrevert(session_id=session_id, send=send)
                 return
             if method != "GET":
                 await self._json_response(
@@ -1281,6 +1348,70 @@ class RuntimeTransportApp:
             payload=self._serialize_session_debug_snapshot(snapshot),
         )
 
+    async def _handle_session_undo(self, *, session_id: str, send: Send) -> None:
+        with self._active_request_scope():
+            runtime = self._runtime_factory()
+            try:
+                marker = runtime.undo_session(session_id=session_id)
+            except ValueError as exc:
+                await self._json_response(send, status=404, payload={"error": str(exc)})
+                return
+            finally:
+                self._close_runtime(runtime, workspace_coordinator=self._workspace_coordinator)
+        await self._json_response(
+            send,
+            status=200,
+            payload={"revert_marker": self._serialize_revert_marker(marker)},
+        )
+
+    async def _handle_session_revert(
+        self,
+        *,
+        session_id: str,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        try:
+            payload = _SessionRevertRequestPayload.model_validate_json(
+                await self._read_body(receive)
+            )
+        except (ValidationError, ValueError) as exc:
+            await self._json_response(send, status=400, payload={"error": str(exc)})
+            return
+        with self._active_request_scope():
+            runtime = self._runtime_factory()
+            try:
+                marker = runtime.revert_session(
+                    session_id=session_id,
+                    sequence=cast(int, payload.sequence),
+                )
+            except ValueError as exc:
+                await self._json_response(send, status=404, payload={"error": str(exc)})
+                return
+            finally:
+                self._close_runtime(runtime, workspace_coordinator=self._workspace_coordinator)
+        await self._json_response(
+            send,
+            status=200,
+            payload={"revert_marker": self._serialize_revert_marker(marker)},
+        )
+
+    async def _handle_session_unrevert(self, *, session_id: str, send: Send) -> None:
+        with self._active_request_scope():
+            runtime = self._runtime_factory()
+            try:
+                marker = runtime.unrevert_session(session_id=session_id)
+            except ValueError as exc:
+                await self._json_response(send, status=404, payload={"error": str(exc)})
+                return
+            finally:
+                self._close_runtime(runtime, workspace_coordinator=self._workspace_coordinator)
+        await self._json_response(
+            send,
+            status=200,
+            payload={"revert_marker": self._serialize_revert_marker(marker)},
+        )
+
     async def _handle_approval_resolution(
         self,
         *,
@@ -1579,10 +1710,25 @@ class RuntimeTransportApp:
             "output": result.output,
             "error": result.error,
             "last_event_sequence": result.last_event_sequence,
+            "revert_marker": RuntimeTransportApp._serialize_revert_marker(result.revert_marker),
             "transcript": [
-                RuntimeTransportApp._serialize_event(event) for event in result.transcript
+                {
+                    **cast(dict[str, object], RuntimeTransportApp._serialize_event(event)),
+                    "reverted": result.revert_marker is not None
+                    and result.revert_marker.active
+                    and event.sequence >= result.revert_marker.sequence,
+                }
+                for event in result.transcript
             ],
         }
+
+    @staticmethod
+    def _serialize_revert_marker(
+        marker: RuntimeSessionRevertMarker | None,
+    ) -> dict[str, object] | None:
+        if marker is None:
+            return None
+        return {"sequence": marker.sequence, "active": marker.active}
 
     @staticmethod
     def _serialize_session_debug_snapshot(
@@ -1623,6 +1769,7 @@ class RuntimeTransportApp:
                 if snapshot.pending_question is not None
                 else None
             ),
+            "revert_marker": RuntimeTransportApp._serialize_revert_marker(snapshot.revert_marker),
             "last_event_sequence": snapshot.last_event_sequence,
             "last_relevant_event": RuntimeTransportApp._serialize_session_debug_event(
                 snapshot.last_relevant_event

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -129,6 +129,7 @@ from .contracts import (
     RuntimeSessionDebugSnapshot,
     RuntimeSessionDebugToolSummary,
     RuntimeSessionResult,
+    RuntimeSessionRevertMarker,
     RuntimeStatusSnapshot,
     RuntimeStreamChunk,
     UnknownSessionError,
@@ -2127,6 +2128,52 @@ class VoidCodeRuntime:
         )
         return self._load_session_result(session_id=session_id)
 
+    def revert_session(self, *, session_id: str, sequence: int) -> RuntimeSessionRevertMarker:
+        validate_session_id(session_id)
+        marker = self._session_store.revert_session(
+            workspace=self._workspace,
+            session_id=session_id,
+            sequence=sequence,
+        )
+        self._validate_session_workspace(
+            self._session_store.load_session_result(
+                workspace=self._workspace,
+                session_id=session_id,
+            ).session,
+            session_id=session_id,
+        )
+        return marker
+
+    def undo_session(self, *, session_id: str) -> RuntimeSessionRevertMarker:
+        validate_session_id(session_id)
+        marker = self._session_store.undo_session(
+            workspace=self._workspace,
+            session_id=session_id,
+        )
+        self._validate_session_workspace(
+            self._session_store.load_session_result(
+                workspace=self._workspace,
+                session_id=session_id,
+            ).session,
+            session_id=session_id,
+        )
+        return marker
+
+    def unrevert_session(self, *, session_id: str) -> RuntimeSessionRevertMarker | None:
+        validate_session_id(session_id)
+        marker = self._session_store.unrevert_session(
+            workspace=self._workspace,
+            session_id=session_id,
+        )
+        self._validate_session_workspace(
+            self._session_store.load_session_result(
+                workspace=self._workspace,
+                session_id=session_id,
+            ).session,
+            session_id=session_id,
+        )
+        return marker
+
     def _load_session_result(self, *, session_id: str) -> RuntimeSessionResult:
         validate_session_id(session_id)
         result = self._session_store.load_session_result(
@@ -2266,6 +2313,7 @@ class VoidCodeRuntime:
                 if pending_question is not None
                 else None
             ),
+            revert_marker=result.revert_marker,
             last_event_sequence=result.last_event_sequence,
             last_relevant_event=last_relevant_event,
             last_failure_event=last_failure_event,

--- a/src/voidcode/runtime/storage.py
+++ b/src/voidcode/runtime/storage.py
@@ -15,6 +15,7 @@ from .contracts import (
     RuntimeRequest,
     RuntimeResponse,
     RuntimeSessionResult,
+    RuntimeSessionRevertMarker,
     UnknownSessionError,
 )
 from .events import (
@@ -57,6 +58,16 @@ class SessionStore(Protocol):
     def load_session(self, *, workspace: Path, session_id: str) -> RuntimeResponse: ...
 
     def load_session_result(self, *, workspace: Path, session_id: str) -> RuntimeSessionResult: ...
+
+    def revert_session(
+        self, *, workspace: Path, session_id: str, sequence: int
+    ) -> RuntimeSessionRevertMarker: ...
+
+    def undo_session(self, *, workspace: Path, session_id: str) -> RuntimeSessionRevertMarker: ...
+
+    def unrevert_session(
+        self, *, workspace: Path, session_id: str
+    ) -> RuntimeSessionRevertMarker | None: ...
 
     def list_notifications(self, *, workspace: Path) -> tuple[RuntimeNotification, ...]: ...
 
@@ -1485,6 +1496,19 @@ class SqliteSessionStore:
         return row is not None
 
     def load_session(self, *, workspace: Path, session_id: str) -> RuntimeResponse:
+        return self._load_session_response(
+            workspace=workspace,
+            session_id=session_id,
+            filter_reverted=True,
+        )
+
+    def _load_session_response(
+        self,
+        *,
+        workspace: Path,
+        session_id: str,
+        filter_reverted: bool,
+    ) -> RuntimeResponse:
         with self._connect(workspace) as connection:
             session_row = cast(
                 sqlite3.Row | None,
@@ -1530,12 +1554,25 @@ class SqliteSessionStore:
             )
             for row in event_rows
         )
-        return RuntimeResponse(
-            session=session, events=events, output=cast(str | None, session_row["output"])
-        )
+        marker = self._revert_marker_from_metadata(session.metadata)
+        output = cast(str | None, session_row["output"])
+        if filter_reverted and marker is not None and marker.active:
+            events = tuple(event for event in events if event.sequence < marker.sequence)
+            session = SessionState(
+                session=session.session,
+                status=session.status,
+                turn=session.turn,
+                metadata=self._active_revert_metadata(session.metadata),
+            )
+            output = None
+        return RuntimeResponse(session=session, events=events, output=output)
 
     def load_session_result(self, *, workspace: Path, session_id: str) -> RuntimeSessionResult:
-        response = self.load_session(workspace=workspace, session_id=session_id)
+        response = self._load_session_response(
+            workspace=workspace,
+            session_id=session_id,
+            filter_reverted=False,
+        )
         with self._connect(workspace) as connection:
             row = cast(
                 sqlite3.Row | None,
@@ -1561,7 +1598,196 @@ class SqliteSessionStore:
             error=error,
             transcript=response.events,
             last_event_sequence=response.events[-1].sequence if response.events else 0,
+            revert_marker=self._revert_marker_from_metadata(response.session.metadata),
         )
+
+    @staticmethod
+    def _revert_marker_from_metadata(
+        metadata: dict[str, object],
+    ) -> RuntimeSessionRevertMarker | None:
+        raw_marker = metadata.get("conversation_revert")
+        if not isinstance(raw_marker, dict):
+            return None
+        marker_payload = cast(dict[object, object], raw_marker)
+        raw_sequence = marker_payload.get("sequence")
+        if not isinstance(raw_sequence, int) or isinstance(raw_sequence, bool) or raw_sequence < 1:
+            return None
+        raw_active = marker_payload.get("active", True)
+        active = raw_active if isinstance(raw_active, bool) else True
+        return RuntimeSessionRevertMarker(sequence=raw_sequence, active=active)
+
+    @staticmethod
+    def _metadata_with_revert_marker(
+        metadata: dict[str, object],
+        marker: RuntimeSessionRevertMarker | None,
+    ) -> dict[str, object]:
+        next_metadata = dict(metadata)
+        if marker is None:
+            next_metadata.pop("conversation_revert", None)
+            return next_metadata
+        next_metadata["conversation_revert"] = {
+            "sequence": marker.sequence,
+            "active": marker.active,
+        }
+        return next_metadata
+
+    @staticmethod
+    def _active_revert_metadata(metadata: dict[str, object]) -> dict[str, object]:
+        next_metadata = dict(metadata)
+        raw_runtime_state = next_metadata.get("runtime_state")
+        if not isinstance(raw_runtime_state, dict):
+            return next_metadata
+        runtime_state = dict(cast(dict[str, object], raw_runtime_state))
+        runtime_state.pop("continuity", None)
+        next_metadata["runtime_state"] = runtime_state
+        return next_metadata
+
+    def _session_metadata_and_events(
+        self,
+        *,
+        connection: sqlite3.Connection,
+        workspace: Path,
+        session_id: str,
+    ) -> tuple[dict[str, object], tuple[EventEnvelope, ...]]:
+        session_row = cast(
+            sqlite3.Row | None,
+            connection.execute(
+                """
+                SELECT metadata_json
+                FROM sessions
+                WHERE workspace = ? AND session_id = ?
+                """,
+                (str(workspace), session_id),
+            ).fetchone(),
+        )
+        if session_row is None:
+            raise UnknownSessionError(f"unknown session: {session_id}")
+        event_rows = cast(
+            list[sqlite3.Row],
+            connection.execute(
+                """
+                SELECT sequence, event_type, source, payload_json
+                FROM session_events
+                WHERE session_id = ?
+                ORDER BY sequence ASC
+                """,
+                (session_id,),
+            ).fetchall(),
+        )
+        events = tuple(
+            EventEnvelope(
+                session_id=session_id,
+                sequence=cast(int, row["sequence"]),
+                event_type=cast(str, row["event_type"]),
+                source=self._parse_event_source(cast(str, row["source"])),
+                payload=cast(dict[str, object], json.loads(cast(str, row["payload_json"]))),
+            )
+            for row in event_rows
+        )
+        return cast(dict[str, object], json.loads(cast(str, session_row["metadata_json"]))), events
+
+    def _write_revert_marker(
+        self,
+        *,
+        connection: sqlite3.Connection,
+        workspace: Path,
+        session_id: str,
+        marker: RuntimeSessionRevertMarker | None,
+    ) -> None:
+        metadata, _events = self._session_metadata_and_events(
+            connection=connection,
+            workspace=workspace,
+            session_id=session_id,
+        )
+        updated_at = self._next_timestamp(connection=connection)
+        _ = connection.execute(
+            """
+            UPDATE sessions
+            SET metadata_json = ?, updated_at = ?
+            WHERE workspace = ? AND session_id = ?
+            """,
+            (
+                json.dumps(self._metadata_with_revert_marker(metadata, marker), sort_keys=True),
+                updated_at,
+                str(workspace),
+                session_id,
+            ),
+        )
+
+    def revert_session(
+        self, *, workspace: Path, session_id: str, sequence: int
+    ) -> RuntimeSessionRevertMarker:
+        if sequence < 1:
+            raise ValueError("revert sequence must be a positive integer")
+        with self._write_connect(workspace) as connection:
+            _metadata, events = self._session_metadata_and_events(
+                connection=connection,
+                workspace=workspace,
+                session_id=session_id,
+            )
+            if not any(event.sequence == sequence for event in events):
+                raise ValueError(f"session {session_id} has no event sequence {sequence}")
+            marker = RuntimeSessionRevertMarker(sequence=sequence, active=True)
+            self._write_revert_marker(
+                connection=connection,
+                workspace=workspace,
+                session_id=session_id,
+                marker=marker,
+            )
+            connection.commit()
+            return marker
+
+    def undo_session(self, *, workspace: Path, session_id: str) -> RuntimeSessionRevertMarker:
+        with self._write_connect(workspace) as connection:
+            metadata, events = self._session_metadata_and_events(
+                connection=connection,
+                workspace=workspace,
+                session_id=session_id,
+            )
+            active_marker = self._revert_marker_from_metadata(metadata)
+            active_cutoff = active_marker.sequence if active_marker is not None else None
+            candidate = next(
+                (
+                    event
+                    for event in reversed(events)
+                    if event.event_type == "runtime.request_received"
+                    and (active_cutoff is None or event.sequence < active_cutoff)
+                ),
+                None,
+            )
+            if candidate is None:
+                raise ValueError(f"session {session_id} has no user turn to undo")
+            marker = RuntimeSessionRevertMarker(sequence=candidate.sequence, active=True)
+            self._write_revert_marker(
+                connection=connection,
+                workspace=workspace,
+                session_id=session_id,
+                marker=marker,
+            )
+            connection.commit()
+            return marker
+
+    def unrevert_session(
+        self, *, workspace: Path, session_id: str
+    ) -> RuntimeSessionRevertMarker | None:
+        with self._write_connect(workspace) as connection:
+            metadata, _events = self._session_metadata_and_events(
+                connection=connection,
+                workspace=workspace,
+                session_id=session_id,
+            )
+            marker = self._revert_marker_from_metadata(metadata)
+            if marker is None:
+                connection.commit()
+                return None
+            self._write_revert_marker(
+                connection=connection,
+                workspace=workspace,
+                session_id=session_id,
+                marker=None,
+            )
+            connection.commit()
+            return marker
 
     def list_notifications(self, *, workspace: Path) -> tuple[RuntimeNotification, ...]:
         with self._connect(workspace) as connection:

--- a/tests/unit/runtime/test_session_storage.py
+++ b/tests/unit/runtime/test_session_storage.py
@@ -62,6 +62,114 @@ def test_session_storage_persists_parent_lineage_across_read_surfaces(tmp_path: 
     assert notifications[0].session.parent_id == "leader-session"
 
 
+def test_session_storage_revert_marker_filters_active_view_only(tmp_path: Path) -> None:
+    store = SqliteSessionStore()
+    request = RuntimeRequest(prompt="mistaken request", session_id="undo-session")
+    response = RuntimeResponse(
+        session=SessionState(
+            session=SessionRef(id="undo-session"),
+            status="completed",
+            turn=1,
+            metadata={"runtime_state": {"continuity": {"facts": ["bad context"]}, "run_id": "r1"}},
+        ),
+        events=(
+            EventEnvelope(
+                session_id="undo-session",
+                sequence=1,
+                event_type="runtime.request_received",
+                source="runtime",
+                payload={"prompt": "mistaken request"},
+            ),
+            EventEnvelope(
+                session_id="undo-session",
+                sequence=2,
+                event_type="runtime.tool_completed",
+                source="runtime",
+                payload={"tool": "read_file", "status": "ok", "content": "context"},
+            ),
+            EventEnvelope(
+                session_id="undo-session",
+                sequence=3,
+                event_type="graph.response_ready",
+                source="graph",
+                payload={"response": "bad branch"},
+            ),
+        ),
+        output="bad branch",
+    )
+    store.save_run(workspace=tmp_path, request=request, response=response)
+
+    marker = store.revert_session(workspace=tmp_path, session_id="undo-session", sequence=2)
+    active = store.load_session(workspace=tmp_path, session_id="undo-session")
+    result = store.load_session_result(workspace=tmp_path, session_id="undo-session")
+
+    assert marker.sequence == 2
+    assert [event.sequence for event in active.events] == [1]
+    assert active.output is None
+    assert active.session.metadata["runtime_state"] == {"run_id": "r1"}
+    assert [event.sequence for event in result.transcript] == [1, 2, 3]
+    assert result.output == "bad branch"
+    assert result.revert_marker is not None
+    assert result.revert_marker.sequence == 2
+
+    restored = store.unrevert_session(workspace=tmp_path, session_id="undo-session")
+
+    assert restored is not None
+    assert restored.sequence == 2
+    assert [
+        event.sequence
+        for event in store.load_session(workspace=tmp_path, session_id="undo-session").events
+    ] == [1, 2, 3]
+
+
+def test_session_storage_undo_uses_latest_visible_user_turn(tmp_path: Path) -> None:
+    store = SqliteSessionStore()
+    request = RuntimeRequest(prompt="second", session_id="multi-turn-session")
+    response = RuntimeResponse(
+        session=SessionState(
+            session=SessionRef(id="multi-turn-session"), status="completed", turn=2
+        ),
+        events=(
+            EventEnvelope(
+                session_id="multi-turn-session",
+                sequence=1,
+                event_type="runtime.request_received",
+                source="runtime",
+                payload={"prompt": "first"},
+            ),
+            EventEnvelope(
+                session_id="multi-turn-session",
+                sequence=2,
+                event_type="graph.response_ready",
+                source="graph",
+            ),
+            EventEnvelope(
+                session_id="multi-turn-session",
+                sequence=3,
+                event_type="runtime.request_received",
+                source="runtime",
+                payload={"prompt": "second"},
+            ),
+            EventEnvelope(
+                session_id="multi-turn-session",
+                sequence=4,
+                event_type="graph.response_ready",
+                source="graph",
+            ),
+        ),
+        output="second output",
+    )
+    store.save_run(workspace=tmp_path, request=request, response=response)
+
+    marker = store.undo_session(workspace=tmp_path, session_id="multi-turn-session")
+
+    assert marker.sequence == 3
+    assert [
+        event.sequence
+        for event in store.load_session(workspace=tmp_path, session_id="multi-turn-session").events
+    ] == [1, 2]
+
+
 def test_session_storage_bootstraps_canonical_schema_for_fresh_database(tmp_path: Path) -> None:
     database_path = tmp_path / "fresh-sessions.sqlite3"
     store = SqliteSessionStore(database_path=database_path)


### PR DESCRIPTION
## Summary
- Add marker-based conversation revert state so active session reads exclude reverted tails while retaining full audit transcripts.
- Expose `sessions undo`, `sessions revert --to`, `sessions unrevert`, plus matching HTTP session routes.
- Annotate reverted transcript events and guard active provider context from stale continuity/output leakage.

## Verification
- `uv run ruff check .`
- `uv run basedpyright --warnings src`
- `uv run python -X utf8 -m pytest -n auto` (1637 passed)
- `bun run lint && bun run typecheck && bun run test:run` (passed on retry; first run hit a Vitest timeout in `SettingsPanel.test.tsx` with jsdom canvas warnings)
- `uv build`
- `bun run build`

Closes #323