### PR TITLE
feat(runtime): add active run interruption

### DIFF
--- a/src/voidcode/acp/stdio.py
+++ b/src/voidcode/acp/stdio.py
@@ -49,6 +49,7 @@ class AcpRuntime(Protocol):
 class AcpSessionBinding:
     acp_session_id: str
     runtime_session_id: str | None = None
+    active_run_id: str | None = None
     active: bool = False
     cancel_requested: bool = False
     tool_call_ids_by_tool: dict[str, str] = field(default_factory=dict)
@@ -196,6 +197,7 @@ class StdioAcpServer:
                 raise ValueError("another ACP prompt is already running")
             self._runtime_prompt_active = True
         binding.active = True
+        binding.active_run_id = None
         binding.cancel_requested = False
         thread = threading.Thread(
             target=self._handle_session_prompt,
@@ -251,6 +253,8 @@ class StdioAcpServer:
                     break
                 if binding.runtime_session_id is None:
                     binding.runtime_session_id = chunk.session.session.id
+                if binding.active_run_id is None:
+                    binding.active_run_id = _session_run_id(chunk.session)
                 final_session_status = getattr(chunk.session, "status", None)
                 if chunk.event is not None:
                     if _optional_attr(chunk.event, "event_type") == "runtime.failed":
@@ -292,6 +296,7 @@ class StdioAcpServer:
             self._write_error(request_id, _ERROR_INTERNAL, "runtime execution failed")
         finally:
             binding.active = False
+            binding.active_run_id = None
             with self._runtime_lock:
                 self._runtime_prompt_active = False
 
@@ -302,11 +307,17 @@ class StdioAcpServer:
             raise ValueError(f"unknown ACP session id: {acp_session_id}")
         binding.cancel_requested = True
         cancel_payload: dict[str, object] | None = None
-        if binding.runtime_session_id is not None:
+        can_cancel_runtime = (
+            binding.active
+            and binding.runtime_session_id is not None
+            and binding.active_run_id is not None
+        )
+        if can_cancel_runtime:
             cancel_session = getattr(self.runtime, "cancel_session", None)
             if callable(cancel_session):
                 result = cancel_session(
                     binding.runtime_session_id,
+                    run_id=binding.active_run_id,
                     reason="acp session/cancel",
                 )
                 as_payload = getattr(result, "as_payload", None)
@@ -496,6 +507,16 @@ def _mapping_attr(value: object, name: str) -> JsonObject:
     if isinstance(raw, dict):
         return cast(JsonObject, raw)
     return {}
+
+
+def _session_run_id(session: object) -> str | None:
+    metadata = _mapping_attr(session, "metadata")
+    runtime_state = metadata.get("runtime_state")
+    if not isinstance(runtime_state, dict):
+        return None
+    typed_runtime_state = cast(dict[str, object], runtime_state)
+    run_id = typed_runtime_state.get("run_id")
+    return run_id if isinstance(run_id, str) and run_id else None
 
 
 def _string_payload(payload: Mapping[str, object], key: str, *, default: str = "") -> str:

--- a/src/voidcode/acp/stdio.py
+++ b/src/voidcode/acp/stdio.py
@@ -36,6 +36,14 @@ type JsonRpcId = str | int | None
 class AcpRuntime(Protocol):
     def run_stream(self, request: RuntimeRequest) -> Iterator[RuntimeStreamChunk]: ...
 
+    def cancel_session(
+        self,
+        session_id: str,
+        *,
+        run_id: str | None = None,
+        reason: str | None = None,
+    ) -> object: ...
+
 
 @dataclass(slots=True)
 class AcpSessionBinding:
@@ -293,16 +301,29 @@ class StdioAcpServer:
         if binding is None:
             raise ValueError(f"unknown ACP session id: {acp_session_id}")
         binding.cancel_requested = True
+        cancel_payload: dict[str, object] | None = None
+        if binding.runtime_session_id is not None:
+            cancel_session = getattr(self.runtime, "cancel_session", None)
+            if callable(cancel_session):
+                result = cancel_session(
+                    binding.runtime_session_id,
+                    reason="acp session/cancel",
+                )
+                as_payload = getattr(result, "as_payload", None)
+                if callable(as_payload):
+                    cancel_payload = cast(dict[str, object], as_payload())
+                elif isinstance(result, dict):
+                    cancel_payload = cast(dict[str, object], result)
+        interrupted = (
+            bool(cancel_payload.get("interrupted")) if cancel_payload is not None else False
+        )
         return {
             "sessionId": acp_session_id,
             "runtimeSessionId": binding.runtime_session_id,
-            "cancelled": False,
-            "stopReason": "cancelled" if binding.active else "not_active",
-            "supported": False,
-            "message": (
-                "No active interrupt is available for the minimal stdio ACP facade; "
-                "cancellation is best-effort and currently limited."
-            ),
+            "cancelled": interrupted,
+            "stopReason": "cancelled" if interrupted or binding.active else "not_active",
+            "supported": cancel_payload is not None,
+            "runtimeCancel": cancel_payload,
         }
 
     def _write_runtime_event_update(

--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -168,8 +168,9 @@ def _run_with_inline_approval(
     result = _consume_runtime_stream(
         runtime.run_stream(request),
         emit_events=emit_events,
-        on_interrupt=lambda session_id: runtime.cancel_session(
+        on_interrupt=lambda session_id, run_id: runtime.cancel_session(
             session_id,
+            run_id=run_id,
             reason="cli KeyboardInterrupt",
         ),
     )
@@ -185,8 +186,9 @@ def _run_with_inline_approval(
                 approval_decision=_prompt_for_approval(approval_event),
             ),
             emit_events=emit_events,
-            on_interrupt=lambda session_id: runtime.cancel_session(
+            on_interrupt=lambda session_id, run_id: runtime.cancel_session(
                 session_id,
+                run_id=run_id,
                 reason="cli KeyboardInterrupt",
             ),
         )
@@ -208,7 +210,7 @@ def _consume_runtime_stream(
     chunks: Iterator[RuntimeStreamChunk],
     *,
     emit_events: bool,
-    on_interrupt: Callable[[str], object] | None = None,
+    on_interrupt: Callable[[str, str | None], object] | None = None,
 ) -> RuntimeStreamResult:
     output: str | None = None
     final_session: SessionState | None = None
@@ -232,13 +234,25 @@ def _consume_runtime_stream(
                 output = chunk.output
     except KeyboardInterrupt:
         if final_session is not None and on_interrupt is not None:
-            on_interrupt(final_session.session.id)
+            on_interrupt(
+                final_session.session.id,
+                _run_id_from_session_metadata(final_session.metadata),
+            )
         raise
 
     if final_session is None:
         raise ValueError("runtime stream emitted no chunks")
 
     return RuntimeStreamResult(output=output, session=final_session, events=tuple(events))
+
+
+def _run_id_from_session_metadata(metadata: dict[str, object]) -> str | None:
+    runtime_state = metadata.get("runtime_state")
+    if not isinstance(runtime_state, dict):
+        return None
+    typed_runtime_state = cast(dict[str, object], runtime_state)
+    raw_run_id = typed_runtime_state.get("run_id")
+    return raw_run_id if isinstance(raw_run_id, str) and raw_run_id else None
 
 
 def _last_event(result: RuntimeStreamResult) -> EventEnvelope | None:

--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -123,6 +123,9 @@ def _handle_run_command(args: argparse.Namespace) -> int:
                 interactive=interactive,
                 emit_events=interactive and not json_output,
             )
+        except KeyboardInterrupt:
+            print("Interrupted current run.", file=sys.stderr)
+            return 130
         except ValueError as exc:
             raise SystemExit(f"error: {exc}") from None
 
@@ -162,7 +165,14 @@ def _run_with_inline_approval(
     interactive: bool,
     emit_events: bool,
 ) -> RuntimeStreamResult:
-    result = _consume_runtime_stream(runtime.run_stream(request), emit_events=emit_events)
+    result = _consume_runtime_stream(
+        runtime.run_stream(request),
+        emit_events=emit_events,
+        on_interrupt=lambda session_id: runtime.cancel_session(
+            session_id,
+            reason="cli KeyboardInterrupt",
+        ),
+    )
 
     while interactive:
         approval_event = _pending_approval_event(result.session, _last_event(result))
@@ -175,6 +185,10 @@ def _run_with_inline_approval(
                 approval_decision=_prompt_for_approval(approval_event),
             ),
             emit_events=emit_events,
+            on_interrupt=lambda session_id: runtime.cancel_session(
+                session_id,
+                reason="cli KeyboardInterrupt",
+            ),
         )
         result = RuntimeStreamResult(
             output=resumed_result.output,
@@ -194,22 +208,32 @@ def _consume_runtime_stream(
     chunks: Iterator[RuntimeStreamChunk],
     *,
     emit_events: bool,
+    on_interrupt: Callable[[str], object] | None = None,
 ) -> RuntimeStreamResult:
     output: str | None = None
     final_session: SessionState | None = None
     events: list[EventEnvelope] = []
 
-    for chunk in chunks:
-        final_session = chunk.session
-        if chunk.event is not None:
-            if emit_events:
-                print(
-                    format_event(chunk.event.event_type, chunk.event.source, chunk.event.payload),
-                    flush=True,
-                )
-            events.append(chunk.event)
-        if chunk.kind == "output":
-            output = chunk.output
+    try:
+        for chunk in chunks:
+            final_session = chunk.session
+            if chunk.event is not None:
+                if emit_events:
+                    print(
+                        format_event(
+                            chunk.event.event_type,
+                            chunk.event.source,
+                            chunk.event.payload,
+                        ),
+                        flush=True,
+                    )
+                events.append(chunk.event)
+            if chunk.kind == "output":
+                output = chunk.output
+    except KeyboardInterrupt:
+        if final_session is not None and on_interrupt is not None:
+            on_interrupt(final_session.session.id)
+        raise
 
     if final_session is None:
         raise ValueError("runtime stream emitted no chunks")

--- a/src/voidcode/graph/contracts.py
+++ b/src/voidcode/graph/contracts.py
@@ -4,7 +4,7 @@ import operator
 from dataclasses import dataclass, field
 from typing import Annotated, Protocol, TypedDict, runtime_checkable
 
-from ..provider.protocol import ProviderAssembledContext, ProviderContextWindow
+from ..provider.protocol import ProviderAbortSignal, ProviderAssembledContext, ProviderContextWindow
 from ..runtime.events import EventSource
 from ..runtime.session import SessionState
 from ..tools.contracts import ToolCall, ToolDefinition, ToolResult
@@ -43,6 +43,7 @@ class GraphRunRequest:
     available_tools: tuple[ToolDefinition, ...] = ()
     context_window: ProviderContextWindow | None = None
     metadata: dict[str, object] = field(default_factory=dict)
+    abort_signal: ProviderAbortSignal | None = None
 
 
 @runtime_checkable

--- a/src/voidcode/graph/provider_graph.py
+++ b/src/voidcode/graph/provider_graph.py
@@ -115,13 +115,21 @@ class ProviderGraph:
             ),
         )
 
+        abort_signal = request.abort_signal or cast(ProviderAbortSignal, self._abort_signal)
         abort_requested = request.metadata.get("abort_requested", False)
         if isinstance(abort_requested, bool):
-            self._abort_signal.set_cancelled(abort_requested)
+            if abort_requested and hasattr(abort_signal, "set_cancelled"):
+                cast(_GraphAbortSignal, abort_signal).set_cancelled(True)
         else:
-            self._abort_signal.set_cancelled(
-                str(abort_requested).strip().lower() not in {"false", "0", "no", "off", ""}
-            )
+            should_abort = str(abort_requested).strip().lower() not in {
+                "false",
+                "0",
+                "no",
+                "off",
+                "",
+            }
+            if should_abort and hasattr(abort_signal, "set_cancelled"):
+                cast(_GraphAbortSignal, abort_signal).set_cancelled(True)
         turn_request = ProviderTurnRequest(
             assembled_context=request.assembled_context,
             bounded_context_window=request.context_window,
@@ -132,7 +140,7 @@ class ProviderGraph:
             agent_preset=cast(dict[str, object] | None, request.metadata.get("agent_preset")),
             reasoning_effort=cast(str | None, request.metadata.get("reasoning_effort")),
             attempt=cast(int, request.metadata.get("provider_attempt", 0)),
-            abort_signal=cast(ProviderAbortSignal, self._abort_signal),
+            abort_signal=abort_signal,
         )
 
         if streaming_enabled and isinstance(self._provider, StreamableTurnProvider):

--- a/src/voidcode/graph/provider_graph.py
+++ b/src/voidcode/graph/provider_graph.py
@@ -115,11 +115,9 @@ class ProviderGraph:
             ),
         )
 
-        abort_signal = request.abort_signal or cast(ProviderAbortSignal, self._abort_signal)
         abort_requested = request.metadata.get("abort_requested", False)
         if isinstance(abort_requested, bool):
-            if abort_requested and hasattr(abort_signal, "set_cancelled"):
-                cast(_GraphAbortSignal, abort_signal).set_cancelled(True)
+            should_abort = abort_requested
         else:
             should_abort = str(abort_requested).strip().lower() not in {
                 "false",
@@ -128,6 +126,12 @@ class ProviderGraph:
                 "off",
                 "",
             }
+
+        if request.abort_signal is None:
+            self._abort_signal.set_cancelled(should_abort)
+            abort_signal = cast(ProviderAbortSignal, self._abort_signal)
+        else:
+            abort_signal = request.abort_signal
             if should_abort and hasattr(abort_signal, "set_cancelled"):
                 cast(_GraphAbortSignal, abort_signal).set_cancelled(True)
         turn_request = ProviderTurnRequest(

--- a/src/voidcode/runtime/http.py
+++ b/src/voidcode/runtime/http.py
@@ -46,7 +46,7 @@ from .contracts import (
 from .events import DelegatedLifecycleEventPayload, EventEnvelope
 from .permission import PermissionResolution
 from .question import QuestionResponse
-from .service import VoidCodeRuntime
+from .service import ActiveRunInterruptResult, VoidCodeRuntime
 from .session import SessionRef, SessionState, StoredSessionSummary
 from .task import (
     BackgroundTaskRequestSnapshot,
@@ -76,6 +76,14 @@ class RuntimeTransport(Protocol):
     ) -> tuple[StoredBackgroundTaskSummary, ...]: ...
 
     def cancel_background_task(self, task_id: str) -> BackgroundTaskState: ...
+
+    def cancel_session(
+        self,
+        session_id: str,
+        *,
+        run_id: str | None = None,
+        reason: str | None = None,
+    ) -> ActiveRunInterruptResult: ...
 
     def list_sessions(self) -> tuple[StoredSessionSummary, ...]: ...
 
@@ -206,6 +214,21 @@ class _ApprovalResolutionRequestPayload(_HttpBoundaryModel):
         if value not in ("allow", "deny"):
             raise ValueError("must be 'allow' or 'deny'")
         return cast(str, value)
+
+
+class _SessionCancelRequestPayload(_HttpBoundaryModel):
+    run_id: str | None = None
+    reason: str | None = None
+
+    @field_validator("run_id", "reason", mode="before")
+    @classmethod
+    def _validate_optional_string(cls, value: object) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise ValueError("must be a string when provided")
+        stripped = value.strip()
+        return stripped or None
 
 
 class _SettingsRequestPayload(BaseModel):
@@ -608,6 +631,9 @@ class RuntimeTransportApp:
             is_undo_route = session_path.endswith("/undo")
             is_revert_route = session_path.endswith("/revert")
             is_unrevert_route = session_path.endswith("/unrevert")
+            is_cancel_route = session_path.endswith("/cancel") or session_path.endswith(
+                "/interrupt"
+            )
             session_id = (
                 session_path.removesuffix("/tasks")
                 if is_task_list_route
@@ -625,6 +651,10 @@ class RuntimeTransportApp:
                 if is_revert_route
                 else session_path.removesuffix("/unrevert")
                 if is_unrevert_route
+                else session_path.removesuffix("/cancel")
+                if session_path.endswith("/cancel")
+                else session_path.removesuffix("/interrupt")
+                if session_path.endswith("/interrupt")
                 else session_path
             )
             try:
@@ -664,8 +694,22 @@ class RuntimeTransportApp:
                 if is_revert_route
                 else session_path.removesuffix("/unrevert")
                 if is_unrevert_route
+                else session_path.removesuffix("/cancel")
+                if session_path.endswith("/cancel")
+                else session_path.removesuffix("/interrupt")
+                if session_path.endswith("/interrupt")
                 else session_path
             )
+            if is_cancel_route:
+                if method != "POST":
+                    await self._json_response(
+                        send,
+                        status=405,
+                        payload={"error": "method not allowed"},
+                    )
+                    return
+                await self._handle_cancel_session(session_id=session_id, receive=receive, send=send)
+                return
             if is_approval_route:
                 if method != "POST":
                     await self._json_response(
@@ -1115,6 +1159,31 @@ class RuntimeTransportApp:
             status=200,
             payload=self._serialize_background_task_state(task),
         )
+
+    async def _handle_cancel_session(
+        self,
+        *,
+        session_id: str,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        try:
+            body = await self._read_body(receive)
+            payload = self._parse_session_cancel_request(body)
+        except ValueError as exc:
+            await self._json_response(send, status=400, payload={"error": str(exc)})
+            return
+        with self._active_request_scope():
+            runtime = self._runtime_factory()
+            try:
+                result = runtime.cancel_session(
+                    session_id,
+                    run_id=payload.run_id,
+                    reason=payload.reason,
+                )
+            finally:
+                self._close_runtime(runtime, workspace_coordinator=self._workspace_coordinator)
+        await self._json_response(send, status=200, payload=result.as_payload())
 
     async def _handle_list_notifications(self, send: Send) -> None:
         with self._active_request_scope():
@@ -1569,6 +1638,18 @@ class RuntimeTransportApp:
             raise ValueError(_format_http_validation_error(error)) from exc
 
         return cast(str, payload.request_id), cast(PermissionResolution, payload.decision)
+
+    def _parse_session_cancel_request(self, body: bytes) -> _SessionCancelRequestPayload:
+        if not body.strip():
+            return _SessionCancelRequestPayload()
+        raw_payload = _parse_json_body(body)
+        if not isinstance(raw_payload, dict):
+            raise ValueError("request body must be a JSON object")
+        try:
+            return _SessionCancelRequestPayload.model_validate(raw_payload)
+        except ValidationError as exc:
+            error = cast(dict[str, object], exc.errors(include_url=False)[0])
+            raise ValueError(_format_http_validation_error(error)) from exc
 
     def _parse_settings_request(self, body: bytes) -> dict[str, str | None]:
         raw_payload = _parse_json_body(body)

--- a/src/voidcode/runtime/resume.py
+++ b/src/voidcode/runtime/resume.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 from ..graph.contracts import GraphRunRequest
+from ..provider.protocol import ProviderAbortSignal
 from ..tools.contracts import ToolResult, ToolResultStatus
 from ..tools.output import sanitize_tool_result_data
 from ..tools.question import QuestionTool
@@ -44,6 +45,21 @@ class PersistedResumeCheckpointEnvelope:
     payload: dict[str, object]
 
 
+def _metadata_with_resume_run_id(
+    metadata: dict[str, object], *, run_id: str | None
+) -> dict[str, object]:
+    if run_id is None:
+        return metadata
+    raw_runtime_state = metadata.get("runtime_state")
+    runtime_state = (
+        dict(cast(dict[str, object], raw_runtime_state))
+        if isinstance(raw_runtime_state, dict)
+        else {}
+    )
+    runtime_state["run_id"] = run_id
+    return {**metadata, "runtime_state": runtime_state}
+
+
 class RuntimeResumeCoordinator:
     def __init__(self, runtime: VoidCodeRuntime) -> None:
         self._runtime = runtime
@@ -54,6 +70,8 @@ class RuntimeResumeCoordinator:
         session_id: str,
         approval_request_id: str,
         approval_decision: PermissionResolution,
+        run_id: str | None = None,
+        abort_signal: ProviderAbortSignal | None = None,
         finalize_background_task: bool = False,
     ) -> Iterator[RuntimeStreamChunk]:
         stored_response, pending, checkpoint = self._load_pending_approval_context(
@@ -68,6 +86,8 @@ class RuntimeResumeCoordinator:
             pending=pending,
             approval_decision=approval_decision,
             checkpoint=checkpoint,
+            run_id=run_id,
+            abort_signal=abort_signal,
         ):
             final_session = chunk.session
             if chunk.event is not None:
@@ -123,6 +143,8 @@ class RuntimeResumeCoordinator:
         session_id: str,
         question_request_id: str,
         responses: tuple[QuestionResponse, ...],
+        run_id: str | None = None,
+        abort_signal: ProviderAbortSignal | None = None,
         finalize_background_task: bool = False,
     ) -> Iterator[RuntimeStreamChunk]:
         stored_response, pending, checkpoint, normalized_responses = (
@@ -140,6 +162,8 @@ class RuntimeResumeCoordinator:
             pending=pending,
             responses=normalized_responses,
             checkpoint=checkpoint,
+            run_id=run_id,
+            abort_signal=abort_signal,
         ):
             final_session = chunk.session
             if chunk.event is not None:
@@ -199,6 +223,8 @@ class RuntimeResumeCoordinator:
         pending: PendingQuestion,
         responses: tuple[QuestionResponse, ...],
         checkpoint: dict[str, object] | None,
+        run_id: str | None = None,
+        abort_signal: ProviderAbortSignal | None = None,
     ) -> Iterator[RuntimeStreamChunk]:
         runtime = self._runtime
         session = SessionState(
@@ -228,6 +254,12 @@ class RuntimeResumeCoordinator:
             prompt, tool_results = self._resume_prompt_and_tool_results_from_stored_events(
                 stored.events
             )
+        session = SessionState(
+            session=session.session,
+            status=session.status,
+            turn=session.turn,
+            metadata=_metadata_with_resume_run_id(session.metadata, run_id=run_id),
+        )
         runtime._validate_session_workspace(session, session_id=stored.session.session.id)
         tool_results.append(question_answer_result)
 
@@ -307,6 +339,7 @@ class RuntimeResumeCoordinator:
                     else {}
                 ),
             },
+            abort_signal=abort_signal,
         )
         graph = runtime._graph_for_session_metadata(session.metadata)
         output: str | None = None
@@ -463,6 +496,8 @@ class RuntimeResumeCoordinator:
         pending: PendingApproval,
         approval_decision: PermissionResolution,
         checkpoint: dict[str, object] | None,
+        run_id: str | None = None,
+        abort_signal: ProviderAbortSignal | None = None,
     ) -> Iterator[RuntimeStreamChunk]:
         runtime = self._runtime
         session = SessionState(
@@ -519,6 +554,12 @@ class RuntimeResumeCoordinator:
                 stored.events
             )
 
+        session = SessionState(
+            session=session.session,
+            status=session.status,
+            turn=session.turn,
+            metadata=_metadata_with_resume_run_id(session.metadata, run_id=run_id),
+        )
         runtime._validate_session_workspace(session, session_id=stored.session.session.id)
         session = runtime._session_with_current_acp_metadata(session)
         preserved_continuity_state = runtime._continuity_state_from_session_metadata(
@@ -574,6 +615,7 @@ class RuntimeResumeCoordinator:
                     else {}
                 ),
             },
+            abort_signal=abort_signal,
         )
         provider_attempt = runtime._provider_attempt_from_metadata(graph_request.metadata)
         graph = runtime._graph_for_session_metadata(session.metadata)

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -55,6 +55,15 @@ def _is_tool_timeout_like_exception(exc: Exception) -> bool:
     return "timeout" in message or "timed out" in message
 
 
+def _is_abort_requested(request: GraphRunRequest) -> bool:
+    return bool(request.abort_signal is not None and request.abort_signal.cancelled)
+
+
+def _abort_reason(request: GraphRunRequest) -> str | None:
+    reason = getattr(request.abort_signal, "reason", None)
+    return reason if isinstance(reason, str) and reason else None
+
+
 class RuntimeRunLoopCoordinator:
     def __init__(self, runtime: VoidCodeRuntime) -> None:
         self._runtime = runtime
@@ -132,6 +141,7 @@ class RuntimeRunLoopCoordinator:
                     preserved_system_segments=tuple(preserved_system_segments),
                 ),
                 metadata=graph_request.metadata,
+                abort_signal=graph_request.abort_signal,
             )
             effective_runtime_config = runtime._effective_runtime_config_from_metadata(
                 session.metadata
@@ -230,6 +240,19 @@ class RuntimeRunLoopCoordinator:
                 effective_runtime_config.execution_engine == "provider"
             )
             try:
+                if _is_abort_requested(graph_request):
+                    yield runtime._failed_chunk(
+                        session=session,
+                        sequence=sequence + 1,
+                        error="run interrupted",
+                        payload={
+                            "kind": "interrupted",
+                            "cancelled": True,
+                            "run_id": runtime._run_id_from_session_metadata(session.metadata),
+                            "reason": _abort_reason(graph_request),
+                        },
+                    )
+                    return
                 graph_step = graph.step(
                     graph_request,
                     tool_results=tuple(tool_results),
@@ -338,6 +361,7 @@ class RuntimeRunLoopCoordinator:
                                 **graph_request.metadata,
                                 "provider_attempt": provider_attempt,
                             },
+                            abort_signal=graph_request.abort_signal,
                         )
                         continue
                     if provider_error.kind in {
@@ -405,6 +429,19 @@ class RuntimeRunLoopCoordinator:
                 getattr(graph_step, "is_finished", False)
                 or getattr(graph_step, "output", None) is not None
             )
+            if _is_abort_requested(graph_request):
+                yield runtime._failed_chunk(
+                    session=session,
+                    sequence=sequence + 1,
+                    error="run interrupted",
+                    payload={
+                        "kind": "interrupted",
+                        "cancelled": True,
+                        "run_id": runtime._run_id_from_session_metadata(session.metadata),
+                        "reason": _abort_reason(graph_request),
+                    },
+                )
+                return
             session = runtime._session_with_provider_usage_metadata(
                 session,
                 getattr(graph_step, "provider_usage", None),
@@ -585,6 +622,19 @@ class RuntimeRunLoopCoordinator:
                     payload={"tool": plan_tool_call.tool_name},
                 ),
             )
+            if _is_abort_requested(graph_request):
+                yield runtime._failed_chunk(
+                    session=session,
+                    sequence=sequence + 1,
+                    error="run interrupted",
+                    payload={
+                        "kind": "interrupted",
+                        "cancelled": True,
+                        "run_id": runtime._run_id_from_session_metadata(session.metadata),
+                        "reason": _abort_reason(graph_request),
+                    },
+                )
+                return
             try:
                 with bind_runtime_tool_context(
                     RuntimeToolInvocationContext(
@@ -594,6 +644,7 @@ class RuntimeRunLoopCoordinator:
                         remaining_spawn_budget=runtime._remaining_spawn_budget_from_metadata(
                             session.metadata
                         ),
+                        abort_signal=graph_request.abort_signal,
                     )
                 ):
                     if tool_timeout is None:
@@ -648,6 +699,20 @@ class RuntimeRunLoopCoordinator:
                 )
 
             runtime_tool_result_data = dict(tool_result.data)
+            if _is_abort_requested(graph_request):
+                yield runtime._failed_chunk(
+                    session=session,
+                    sequence=sequence + 1,
+                    error="run interrupted",
+                    payload={
+                        "kind": "interrupted",
+                        "cancelled": True,
+                        "run_id": runtime._run_id_from_session_metadata(session.metadata),
+                        "reason": _abort_reason(graph_request),
+                    },
+                )
+                return
+
             sanitized_arguments = sanitize_tool_arguments(dict(plan_tool_call.arguments))
             tool_result = cap_tool_result_output(tool_result, workspace=runtime._workspace)
             tool_result = replace(

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -353,8 +353,14 @@ def _provider_target_label(target: ResolvedProviderModel) -> str:
 
 class _ActiveSessionRegistry:
     def __init__(self) -> None:
-        self._runs: dict[_ActiveSessionKey, _ActiveRunHandle] = {}
+        self._runs: dict[_ActiveSessionKey, dict[str, _ActiveRunHandle]] = {}
         self._lock = threading.Lock()
+
+    @staticmethod
+    def _latest_handle(handles: dict[str, _ActiveRunHandle]) -> _ActiveRunHandle | None:
+        if not handles:
+            return None
+        return next(reversed(handles.values()))
 
     def register(
         self,
@@ -367,7 +373,8 @@ class _ActiveSessionRegistry:
         key = _ActiveSessionKey(workspace=workspace, session_id=session_id)
         abort_signal = _ActiveRunAbortSignal()
         with self._lock:
-            self._runs[key] = _ActiveRunHandle(
+            handles = self._runs.setdefault(key, {})
+            handles[run_id] = _ActiveRunHandle(
                 run_id=run_id,
                 abort_signal=abort_signal,
                 metadata=dict(metadata),
@@ -384,18 +391,26 @@ class _ActiveSessionRegistry:
     ) -> None:
         key = _ActiveSessionKey(workspace=workspace, session_id=session_id)
         with self._lock:
-            handle = self._runs.get(key)
-            if handle is None or (run_id is not None and handle.run_id != run_id):
+            handles = self._runs.get(key)
+            if handles is None:
+                return
+            handle = handles.get(run_id) if run_id is not None else self._latest_handle(handles)
+            if handle is None:
                 return
             handle.metadata = dict(metadata)
 
     def unregister(self, *, workspace: Path, session_id: str, run_id: str | None = None) -> None:
         key = _ActiveSessionKey(workspace=workspace, session_id=session_id)
         with self._lock:
-            handle = self._runs.get(key)
-            if handle is None or (run_id is not None and handle.run_id != run_id):
+            handles = self._runs.get(key)
+            if handles is None:
                 return
-            self._runs.pop(key, None)
+            if run_id is None:
+                self._runs.pop(key, None)
+                return
+            handles.pop(run_id, None)
+            if not handles:
+                self._runs.pop(key, None)
 
     def contains(self, *, workspace: Path, session_id: str) -> bool:
         key = _ActiveSessionKey(workspace=workspace, session_id=session_id)
@@ -405,7 +420,8 @@ class _ActiveSessionRegistry:
     def metadata(self, *, workspace: Path, session_id: str) -> dict[str, object] | None:
         key = _ActiveSessionKey(workspace=workspace, session_id=session_id)
         with self._lock:
-            handle = self._runs.get(key)
+            handles = self._runs.get(key)
+            handle = self._latest_handle(handles) if handles is not None else None
             return dict(handle.metadata) if handle is not None else None
 
     def abort_signal(
@@ -417,8 +433,11 @@ class _ActiveSessionRegistry:
     ) -> ProviderAbortSignal | None:
         key = _ActiveSessionKey(workspace=workspace, session_id=session_id)
         with self._lock:
-            handle = self._runs.get(key)
-            if handle is None or handle.run_id != run_id:
+            handles = self._runs.get(key)
+            if handles is None:
+                return None
+            handle = handles.get(run_id)
+            if handle is None:
                 return None
             return handle.abort_signal
 
@@ -432,7 +451,8 @@ class _ActiveSessionRegistry:
     ) -> ActiveRunInterruptResult:
         key = _ActiveSessionKey(workspace=workspace, session_id=session_id)
         with self._lock:
-            handle = self._runs.get(key)
+            handles = self._runs.get(key)
+            handle = self._latest_handle(handles) if handles is not None else None
             if handle is None:
                 return ActiveRunInterruptResult(
                     session_id=session_id,
@@ -440,6 +460,16 @@ class _ActiveSessionRegistry:
                     run_id=run_id,
                     reason=reason,
                 )
+            if run_id is not None:
+                requested_handle = handles.get(run_id) if handles is not None else None
+                if requested_handle is None:
+                    return ActiveRunInterruptResult(
+                        session_id=session_id,
+                        status="stale",
+                        run_id=handle.run_id,
+                        reason=reason,
+                    )
+                handle = requested_handle
             if run_id is not None and handle.run_id != run_id:
                 return ActiveRunInterruptResult(
                     session_id=session_id,

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -49,7 +49,7 @@ from ..provider.models import (
     ResolvedProviderConfig,
     ResolvedProviderModel,
 )
-from ..provider.protocol import ProviderTokenUsage
+from ..provider.protocol import ProviderAbortSignal, ProviderTokenUsage
 from ..provider.registry import ModelProviderRegistry
 from ..provider.resolution import resolve_provider_config
 from ..provider.snapshot import (
@@ -291,6 +291,54 @@ class _ActiveSessionKey:
     session_id: str
 
 
+@dataclass(slots=True)
+class _ActiveRunAbortSignal:
+    _cancelled: bool = False
+    _reason: str | None = None
+
+    @property
+    def cancelled(self) -> bool:
+        return self._cancelled
+
+    @property
+    def reason(self) -> str | None:
+        return self._reason
+
+    def set_cancelled(self, value: bool, *, reason: str | None = None) -> None:
+        self._cancelled = value
+        if value:
+            self._reason = reason
+
+
+@dataclass(frozen=True, slots=True)
+class ActiveRunInterruptResult:
+    session_id: str
+    status: Literal["interrupted", "not_active", "stale"]
+    run_id: str | None = None
+    reason: str | None = None
+
+    @property
+    def interrupted(self) -> bool:
+        return self.status == "interrupted"
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "session_id": self.session_id,
+            "status": self.status,
+            "interrupted": self.interrupted,
+            "cancelled": self.interrupted,
+            "run_id": self.run_id,
+            "reason": self.reason,
+        }
+
+
+@dataclass(slots=True)
+class _ActiveRunHandle:
+    run_id: str
+    abort_signal: _ActiveRunAbortSignal
+    metadata: dict[str, object]
+
+
 def _provider_target_label(target: ResolvedProviderModel) -> str:
     provider = target.selection.provider
     model = target.selection.model
@@ -305,14 +353,26 @@ def _provider_target_label(target: ResolvedProviderModel) -> str:
 
 class _ActiveSessionRegistry:
     def __init__(self) -> None:
-        self._counts: dict[_ActiveSessionKey, int] = {}
-        self._metadata: dict[_ActiveSessionKey, dict[str, object]] = {}
+        self._runs: dict[_ActiveSessionKey, _ActiveRunHandle] = {}
         self._lock = threading.Lock()
 
-    def register(self, *, workspace: Path, session_id: str) -> None:
+    def register(
+        self,
+        *,
+        workspace: Path,
+        session_id: str,
+        run_id: str,
+        metadata: dict[str, object],
+    ) -> ProviderAbortSignal:
         key = _ActiveSessionKey(workspace=workspace, session_id=session_id)
+        abort_signal = _ActiveRunAbortSignal()
         with self._lock:
-            self._counts[key] = self._counts.get(key, 0) + 1
+            self._runs[key] = _ActiveRunHandle(
+                run_id=run_id,
+                abort_signal=abort_signal,
+                metadata=dict(metadata),
+            )
+        return abort_signal
 
     def remember_metadata(
         self,
@@ -320,35 +380,80 @@ class _ActiveSessionRegistry:
         workspace: Path,
         session_id: str,
         metadata: dict[str, object],
+        run_id: str | None = None,
     ) -> None:
         key = _ActiveSessionKey(workspace=workspace, session_id=session_id)
         with self._lock:
-            if key not in self._counts:
+            handle = self._runs.get(key)
+            if handle is None or (run_id is not None and handle.run_id != run_id):
                 return
-            self._metadata[key] = dict(metadata)
+            handle.metadata = dict(metadata)
 
-    def unregister(self, *, workspace: Path, session_id: str) -> None:
+    def unregister(self, *, workspace: Path, session_id: str, run_id: str | None = None) -> None:
         key = _ActiveSessionKey(workspace=workspace, session_id=session_id)
         with self._lock:
-            count = self._counts.get(key)
-            if count is None:
+            handle = self._runs.get(key)
+            if handle is None or (run_id is not None and handle.run_id != run_id):
                 return
-            if count <= 1:
-                self._counts.pop(key, None)
-                self._metadata.pop(key, None)
-                return
-            self._counts[key] = count - 1
+            self._runs.pop(key, None)
 
     def contains(self, *, workspace: Path, session_id: str) -> bool:
         key = _ActiveSessionKey(workspace=workspace, session_id=session_id)
         with self._lock:
-            return key in self._counts
+            return key in self._runs
 
     def metadata(self, *, workspace: Path, session_id: str) -> dict[str, object] | None:
         key = _ActiveSessionKey(workspace=workspace, session_id=session_id)
         with self._lock:
-            metadata = self._metadata.get(key)
-            return dict(metadata) if metadata is not None else None
+            handle = self._runs.get(key)
+            return dict(handle.metadata) if handle is not None else None
+
+    def abort_signal(
+        self,
+        *,
+        workspace: Path,
+        session_id: str,
+        run_id: str,
+    ) -> ProviderAbortSignal | None:
+        key = _ActiveSessionKey(workspace=workspace, session_id=session_id)
+        with self._lock:
+            handle = self._runs.get(key)
+            if handle is None or handle.run_id != run_id:
+                return None
+            return handle.abort_signal
+
+    def interrupt(
+        self,
+        *,
+        workspace: Path,
+        session_id: str,
+        run_id: str | None = None,
+        reason: str | None = None,
+    ) -> ActiveRunInterruptResult:
+        key = _ActiveSessionKey(workspace=workspace, session_id=session_id)
+        with self._lock:
+            handle = self._runs.get(key)
+            if handle is None:
+                return ActiveRunInterruptResult(
+                    session_id=session_id,
+                    status="not_active",
+                    run_id=run_id,
+                    reason=reason,
+                )
+            if run_id is not None and handle.run_id != run_id:
+                return ActiveRunInterruptResult(
+                    session_id=session_id,
+                    status="stale",
+                    run_id=handle.run_id,
+                    reason=reason,
+                )
+            handle.abort_signal.set_cancelled(True, reason=reason)
+            return ActiveRunInterruptResult(
+                session_id=session_id,
+                status="interrupted",
+                run_id=handle.run_id,
+                reason=reason,
+            )
 
 
 _ACTIVE_SESSION_REGISTRY = _ActiveSessionRegistry()
@@ -1412,8 +1517,9 @@ class VoidCodeRuntime:
         )
         session_id = self._resolve_session_id(request)
         run_id = os.urandom(8).hex()
-        self._register_active_session_id(
+        abort_signal = self._register_active_session_id(
             session_id,
+            run_id=run_id,
             metadata={
                 "prompt": request.prompt,
                 "run_id": run_id,
@@ -1427,7 +1533,12 @@ class VoidCodeRuntime:
             final_session: SessionState | None = None
 
             try:
-                for chunk in self._stream_chunks(request, session_id=session_id, run_id=run_id):
+                for chunk in self._stream_chunks(
+                    request,
+                    session_id=session_id,
+                    run_id=run_id,
+                    abort_signal=abort_signal,
+                ):
                     final_session = chunk.session
                     if chunk.event is not None:
                         events.append(chunk.event)
@@ -1459,7 +1570,7 @@ class VoidCodeRuntime:
             response = RuntimeResponse(session=final_session, events=tuple(events), output=output)
             self._persist_response(request=request, response=response)
         finally:
-            self._unregister_active_session_id(session_id)
+            self._unregister_active_session_id(session_id, run_id=run_id)
 
     def run(self, request: RuntimeRequest) -> RuntimeResponse:
         events: list[EventEnvelope] = []
@@ -1550,6 +1661,7 @@ class VoidCodeRuntime:
         *,
         session_id: str | None = None,
         run_id: str | None = None,
+        abort_signal: ProviderAbortSignal | None = None,
     ) -> Iterator[RuntimeStreamChunk]:
         resolved_session_id = session_id or self._resolve_session_id(request)
         effective_config = self._runtime_config_for_request(request)
@@ -1766,6 +1878,7 @@ class VoidCodeRuntime:
                     else {}
                 ),
             },
+            abort_signal=abort_signal,
         )
         tool_results: list[ToolResult] = []
         graph = self._graph_for_session_metadata(session.metadata)
@@ -6178,24 +6291,65 @@ class VoidCodeRuntime:
     def _register_active_session_id(
         self,
         session_id: str,
+        *,
+        run_id: str,
         metadata: dict[str, object] | None = None,
-    ) -> None:
-        _ACTIVE_SESSION_REGISTRY.register(workspace=self._workspace, session_id=session_id)
-        if metadata is not None:
-            _ACTIVE_SESSION_REGISTRY.remember_metadata(
-                workspace=self._workspace,
-                session_id=session_id,
-                metadata=metadata,
-            )
+    ) -> ProviderAbortSignal:
+        return _ACTIVE_SESSION_REGISTRY.register(
+            workspace=self._workspace,
+            session_id=session_id,
+            run_id=run_id,
+            metadata=metadata or {},
+        )
 
-    def _unregister_active_session_id(self, session_id: str) -> None:
-        _ACTIVE_SESSION_REGISTRY.unregister(workspace=self._workspace, session_id=session_id)
+    def _unregister_active_session_id(self, session_id: str, *, run_id: str | None = None) -> None:
+        _ACTIVE_SESSION_REGISTRY.unregister(
+            workspace=self._workspace,
+            session_id=session_id,
+            run_id=run_id,
+        )
 
     def _active_session_metadata(self, session_id: str) -> dict[str, object] | None:
         return _ACTIVE_SESSION_REGISTRY.metadata(
             workspace=self._workspace,
             session_id=session_id,
         )
+
+    def _active_run_abort_signal(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+    ) -> ProviderAbortSignal | None:
+        return _ACTIVE_SESSION_REGISTRY.abort_signal(
+            workspace=self._workspace,
+            session_id=session_id,
+            run_id=run_id,
+        )
+
+    def interrupt_active_run(
+        self,
+        session_id: str,
+        *,
+        run_id: str | None = None,
+        reason: str | None = None,
+    ) -> ActiveRunInterruptResult:
+        validate_session_id(session_id)
+        return _ACTIVE_SESSION_REGISTRY.interrupt(
+            workspace=self._workspace,
+            session_id=session_id,
+            run_id=run_id,
+            reason=reason,
+        )
+
+    def cancel_session(
+        self,
+        session_id: str,
+        *,
+        run_id: str | None = None,
+        reason: str | None = None,
+    ) -> ActiveRunInterruptResult:
+        return self.interrupt_active_run(session_id, run_id=run_id, reason=reason)
 
     def _session_belongs_to_workspace(self, session_id: str) -> bool:
         try:

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -3971,12 +3971,28 @@ class VoidCodeRuntime:
             session_id=session_id,
             approval_request_id=approval_request_id,
         )
-        yield from self._resume_pending_approval_stream(
-            session_id=session_id,
-            approval_request_id=approval_request_id,
-            approval_decision=approval_decision,
-            finalize_background_task=True,
+        run_id = os.urandom(8).hex()
+        abort_signal = self._register_active_session_id(
+            session_id,
+            run_id=run_id,
+            metadata={
+                "resume": True,
+                "resume_kind": "approval",
+                "approval_request_id": approval_request_id,
+                "run_id": run_id,
+            },
         )
+        try:
+            yield from self._resume_pending_approval_stream(
+                session_id=session_id,
+                approval_request_id=approval_request_id,
+                approval_decision=approval_decision,
+                run_id=run_id,
+                abort_signal=abort_signal,
+                finalize_background_task=True,
+            )
+        finally:
+            self._unregister_active_session_id(session_id, run_id=run_id)
 
     def _validate_resume_targets_owned_request(
         self,
@@ -4093,12 +4109,28 @@ class VoidCodeRuntime:
             session_id=session_id,
             question_request_id=question_request_id,
         )
-        yield from self._answer_pending_question_stream(
-            session_id=session_id,
-            question_request_id=question_request_id,
-            responses=responses,
-            finalize_background_task=True,
+        run_id = os.urandom(8).hex()
+        abort_signal = self._register_active_session_id(
+            session_id,
+            run_id=run_id,
+            metadata={
+                "resume": True,
+                "resume_kind": "question",
+                "question_request_id": question_request_id,
+                "run_id": run_id,
+            },
         )
+        try:
+            yield from self._answer_pending_question_stream(
+                session_id=session_id,
+                question_request_id=question_request_id,
+                responses=responses,
+                run_id=run_id,
+                abort_signal=abort_signal,
+                finalize_background_task=True,
+            )
+        finally:
+            self._unregister_active_session_id(session_id, run_id=run_id)
 
     def _pending_approval_from_response(self, response: RuntimeResponse) -> PendingApproval:
         approval_event = next(
@@ -4355,12 +4387,16 @@ class VoidCodeRuntime:
         session_id: str,
         approval_request_id: str,
         approval_decision: PermissionResolution,
+        run_id: str | None = None,
+        abort_signal: ProviderAbortSignal | None = None,
         finalize_background_task: bool = False,
     ) -> Iterator[RuntimeStreamChunk]:
         yield from self._resume_coordinator.resume_pending_approval_stream(
             session_id=session_id,
             approval_request_id=approval_request_id,
             approval_decision=approval_decision,
+            run_id=run_id,
+            abort_signal=abort_signal,
             finalize_background_task=finalize_background_task,
         )
 
@@ -4383,12 +4419,16 @@ class VoidCodeRuntime:
         session_id: str,
         question_request_id: str,
         responses: tuple[QuestionResponse, ...],
+        run_id: str | None = None,
+        abort_signal: ProviderAbortSignal | None = None,
         finalize_background_task: bool = False,
     ) -> Iterator[RuntimeStreamChunk]:
         yield from self._resume_coordinator.answer_pending_question_stream(
             session_id=session_id,
             question_request_id=question_request_id,
             responses=responses,
+            run_id=run_id,
+            abort_signal=abort_signal,
             finalize_background_task=finalize_background_task,
         )
 

--- a/src/voidcode/tools/runtime_context.py
+++ b/src/voidcode/tools/runtime_context.py
@@ -5,6 +5,8 @@ from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
 
+from ..provider.protocol import ProviderAbortSignal
+
 
 @dataclass(frozen=True, slots=True)
 class RuntimeToolInvocationContext:
@@ -12,6 +14,7 @@ class RuntimeToolInvocationContext:
     parent_session_id: str | None = None
     delegation_depth: int = 0
     remaining_spawn_budget: int | None = None
+    abort_signal: ProviderAbortSignal | None = None
 
 
 _CURRENT_RUNTIME_TOOL_CONTEXT: ContextVar[RuntimeToolInvocationContext | None] = ContextVar(

--- a/src/voidcode/tools/shell_exec.py
+++ b/src/voidcode/tools/shell_exec.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import signal
 import subprocess
+import time
 from pathlib import Path
 from typing import Any, ClassVar, final
 
@@ -14,6 +15,7 @@ from ..security.shell_policy import (
 )
 from ._pydantic_args import ShellExecArgs
 from .contracts import RuntimeToolTimeoutError, ToolCall, ToolDefinition, ToolResult
+from .runtime_context import current_runtime_tool_context
 
 MAX_OUTPUT_CHARS = 200_000
 
@@ -132,16 +134,37 @@ class ShellExecTool:
         except OSError as exc:
             raise ValueError(f"shell_exec failed to execute command: {exc}") from exc
 
-        try:
-            stdout_bytes, stderr_bytes = process.communicate(timeout=timeout_seconds)
-        except subprocess.TimeoutExpired as exc:
-            kill_timed_out_process(process)
-            process.communicate()
+        runtime_context = current_runtime_tool_context()
+        abort_signal = runtime_context.abort_signal if runtime_context is not None else None
+        deadline = time.monotonic() + timeout_seconds
+        stdout_bytes = b""
+        stderr_bytes = b""
+        timed_out = False
+        aborted = False
+        while True:
+            if abort_signal is not None and abort_signal.cancelled:
+                aborted = True
+                kill_timed_out_process(process)
+                stdout_bytes, stderr_bytes = process.communicate()
+                break
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                timed_out = True
+                kill_timed_out_process(process)
+                stdout_bytes, stderr_bytes = process.communicate()
+                break
+            try:
+                stdout_bytes, stderr_bytes = process.communicate(timeout=min(0.05, remaining))
+                break
+            except subprocess.TimeoutExpired:
+                continue
+
+        if timed_out:
             if runtime_timeout_selected:
                 raise RuntimeToolTimeoutError(
                     f"tool '{self.definition.name}' exceeded runtime timeout of {timeout_seconds}s"
-                ) from exc
-            raise ValueError(f"shell_exec command timed out after {timeout_seconds}s") from exc
+                )
+            raise ValueError(f"shell_exec command timed out after {timeout_seconds}s")
 
         stdout = _decode_process_output(stdout_bytes)
         stderr = _decode_process_output(stderr_bytes)
@@ -153,6 +176,30 @@ class ShellExecTool:
         content, content_truncated = _truncate(output)
         stdout, stdout_truncated = _truncate(stdout)
         stderr, stderr_truncated = _truncate(stderr)
+
+        if aborted:
+            reason = getattr(abort_signal, "reason", None)
+            content = "User aborted the command."
+            return ToolResult(
+                tool_name=self.definition.name,
+                status="error",
+                content=content,
+                error=content,
+                data={
+                    "command": command_text,
+                    "exit_code": process.returncode,
+                    "stdout": stdout,
+                    "stderr": stderr,
+                    "timeout": timeout_seconds,
+                    "truncated": stdout_truncated or stderr_truncated,
+                    "interrupted": True,
+                    "cancelled": True,
+                    "reason": reason if isinstance(reason, str) else None,
+                },
+                truncated=stdout_truncated or stderr_truncated,
+                partial=stdout_truncated or stderr_truncated,
+                timeout_seconds=timeout_seconds,
+            )
 
         return ToolResult(
             tool_name=self.definition.name,

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -347,6 +347,64 @@ def test_transport_agents_endpoint_serializes_stable_summary_fields() -> None:
     ]
 
 
+def test_transport_session_cancel_endpoint_calls_runtime_cancel_session() -> None:
+    runtime_http = importlib.import_module("voidcode.runtime.http")
+    RuntimeTransportApp = runtime_http.RuntimeTransportApp
+    ActiveRunInterruptResult = runtime_http.ActiveRunInterruptResult
+
+    class SessionCancelRuntime:
+        calls: list[tuple[str, str | None, str | None]] = []
+
+        def cancel_session(
+            self,
+            session_id: str,
+            *,
+            run_id: str | None = None,
+            reason: str | None = None,
+        ) -> object:
+            self.calls.append((session_id, run_id, reason))
+            return ActiveRunInterruptResult(
+                session_id=session_id,
+                status="interrupted",
+                run_id=run_id,
+                reason=reason,
+            )
+
+    app = RuntimeTransportApp(runtime_factory=SessionCancelRuntime)
+
+    response = _run_app(
+        app,
+        method="POST",
+        path="/api/sessions/session-cancel/cancel",
+        body=json.dumps({"run_id": "run-1", "reason": "operator"}).encode("utf-8"),
+    )
+
+    assert response.status == 200
+    assert response.json() == {
+        "session_id": "session-cancel",
+        "status": "interrupted",
+        "interrupted": True,
+        "cancelled": True,
+        "run_id": "run-1",
+        "reason": "operator",
+    }
+    assert SessionCancelRuntime.calls == [("session-cancel", "run-1", "operator")]
+
+
+def test_transport_session_cancel_endpoint_rejects_non_post() -> None:
+    runtime_http = importlib.import_module("voidcode.runtime.http")
+    RuntimeTransportApp = runtime_http.RuntimeTransportApp
+
+    class SessionCancelRuntime:
+        pass
+
+    app = RuntimeTransportApp(runtime_factory=SessionCancelRuntime)
+
+    response = _run_app(app, method="GET", path="/api/sessions/session-cancel/cancel")
+
+    assert response.status == 405
+
+
 def _parse_sse_payloads(response: _TransportResponse) -> list[dict[str, object]]:
     frames = [frame for frame in response.body.decode("utf-8").split("\n\n") if frame]
     payloads: list[dict[str, object]] = []

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -3199,11 +3199,23 @@ def test_transport_allows_parent_session_while_parent_stream_request_is_active(
 
     original_register = active_registry.register
 
-    def _register_and_signal(*, workspace: Path, session_id: str) -> None:
-        original_register(workspace=workspace, session_id=session_id)
+    def _register_and_signal(
+        *,
+        workspace: Path,
+        session_id: str,
+        run_id: str,
+        metadata: dict[str, object],
+    ) -> object:
+        result = original_register(
+            workspace=workspace,
+            session_id=session_id,
+            run_id=run_id,
+            metadata=metadata,
+        )
         if session_id == "leader-session":
             parent_started.set()
             allow_parent_to_finish.wait(timeout=5)
+        return result
 
     parent_response_holder: dict[str, object] = {}
 

--- a/tests/unit/acp/test_stdio.py
+++ b/tests/unit/acp/test_stdio.py
@@ -33,6 +33,7 @@ class _StubSessionRef:
 class _StubSession:
     session: _StubSessionRef
     status: str = "running"
+    metadata: dict[str, object] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -48,6 +49,7 @@ class _StubRuntime:
         self.chunks = chunks or []
         self.fail = fail
         self.requests: list[RuntimeRequest] = []
+        self.cancel_calls: list[tuple[str, str | None, str | None]] = []
 
     def run_stream(self, request: RuntimeRequest) -> Iterator[Any]:
         self.requests.append(request)
@@ -63,23 +65,29 @@ class _StubRuntime:
         run_id: str | None = None,
         reason: str | None = None,
     ) -> dict[str, object]:
-        _ = run_id
+        self.cancel_calls.append((session_id, run_id, reason))
         return {
             "session_id": session_id,
             "status": "interrupted",
             "interrupted": True,
             "cancelled": True,
-            "run_id": "run-1",
+            "run_id": run_id,
             "reason": reason,
         }
 
 
 class _SlowRuntime:
+    def __init__(self) -> None:
+        self.cancel_calls: list[tuple[str, str | None, str | None]] = []
+
     def run_stream(self, request: RuntimeRequest) -> Iterator[Any]:
         _ = request
         yield _StubChunk(
             kind="event",
-            session=_StubSession(_StubSessionRef("runtime-1")),
+            session=_StubSession(
+                _StubSessionRef("runtime-1"),
+                metadata={"runtime_state": {"run_id": "run-1"}},
+            ),
             event=_StubEvent(
                 session_id="runtime-1",
                 sequence=1,
@@ -94,6 +102,23 @@ class _SlowRuntime:
             session=_StubSession(_StubSessionRef("runtime-1"), status="completed"),
             output="late output",
         )
+
+    def cancel_session(
+        self,
+        session_id: str,
+        *,
+        run_id: str | None = None,
+        reason: str | None = None,
+    ) -> dict[str, object]:
+        self.cancel_calls.append((session_id, run_id, reason))
+        return {
+            "session_id": session_id,
+            "status": "interrupted",
+            "interrupted": True,
+            "cancelled": True,
+            "run_id": run_id,
+            "reason": reason,
+        }
 
 
 def _request(method: str, request_id: int, params: dict[str, object] | None = None) -> str:
@@ -294,11 +319,32 @@ def test_cancel_returns_limited_success_without_crashing() -> None:
 
 
 def test_cancel_delegates_to_runtime_when_runtime_session_exists() -> None:
+    runtime = _SlowRuntime()
+    with patch("voidcode.acp.stdio.uuid4", return_value=SimpleNamespace(hex="abc")):
+        messages, _ = _run_server(
+            runtime,
+            _request("session/new", 1),
+            _request("session/prompt", 2, {"sessionId": "acp-session-abc", "prompt": "hello"}),
+            _request("session/cancel", 3, {"sessionId": "acp-session-abc"}),
+        )
+
+    cancel_result = next(message["result"] for message in messages if message.get("id") == 3)
+    assert cancel_result["cancelled"] is True
+    assert cancel_result["supported"] is True
+    assert cancel_result["runtimeCancel"]["session_id"] == "runtime-1"
+    assert cancel_result["runtimeCancel"]["run_id"] == "run-1"
+    assert runtime.cancel_calls == [("runtime-1", "run-1", "acp session/cancel")]
+
+
+def test_cancel_does_not_touch_runtime_when_binding_is_inactive() -> None:
     runtime = _StubRuntime(
         [
             _StubChunk(
                 kind="event",
-                session=_StubSession(_StubSessionRef("runtime-1")),
+                session=_StubSession(
+                    _StubSessionRef("runtime-1"),
+                    metadata={"runtime_state": {"run_id": "completed-run"}},
+                ),
                 event=_StubEvent(
                     session_id="runtime-1",
                     sequence=1,
@@ -306,6 +352,11 @@ def test_cancel_delegates_to_runtime_when_runtime_session_exists() -> None:
                     source="runtime",
                     payload={"prompt": "hello"},
                 ),
+            ),
+            _StubChunk(
+                kind="output",
+                session=_StubSession(_StubSessionRef("runtime-1"), status="completed"),
+                output="done",
             ),
         ]
     )
@@ -317,10 +368,13 @@ def test_cancel_delegates_to_runtime_when_runtime_session_exists() -> None:
             _request("session/cancel", 3, {"sessionId": "acp-session-abc"}),
         )
 
-    cancel_result = messages[-1]["result"]
-    assert cancel_result["cancelled"] is True
-    assert cancel_result["supported"] is True
-    assert cancel_result["runtimeCancel"]["session_id"] == "runtime-1"
+    cancel_result = next(message["result"] for message in messages if message.get("id") == 3)
+    assert cancel_result["runtimeSessionId"] == "runtime-1"
+    assert cancel_result["cancelled"] is False
+    assert cancel_result["supported"] is False
+    assert cancel_result["stopReason"] == "not_active"
+    assert cancel_result["runtimeCancel"] is None
+    assert runtime.cancel_calls == []
 
 
 def test_cancel_notification_writes_no_response() -> None:

--- a/tests/unit/acp/test_stdio.py
+++ b/tests/unit/acp/test_stdio.py
@@ -56,6 +56,23 @@ class _StubRuntime:
         print("runtime debug should go to stderr")
         yield from self.chunks
 
+    def cancel_session(
+        self,
+        session_id: str,
+        *,
+        run_id: str | None = None,
+        reason: str | None = None,
+    ) -> dict[str, object]:
+        _ = run_id
+        return {
+            "session_id": session_id,
+            "status": "interrupted",
+            "interrupted": True,
+            "cancelled": True,
+            "run_id": "run-1",
+            "reason": reason,
+        }
+
 
 class _SlowRuntime:
     def run_stream(self, request: RuntimeRequest) -> Iterator[Any]:
@@ -273,7 +290,37 @@ def test_cancel_returns_limited_success_without_crashing() -> None:
     assert messages[1]["result"]["cancelled"] is False
     assert messages[1]["result"]["stopReason"] == "not_active"
     assert messages[1]["result"]["supported"] is False
-    assert "limited" in messages[1]["result"]["message"]
+    assert messages[1]["result"]["runtimeCancel"] is None
+
+
+def test_cancel_delegates_to_runtime_when_runtime_session_exists() -> None:
+    runtime = _StubRuntime(
+        [
+            _StubChunk(
+                kind="event",
+                session=_StubSession(_StubSessionRef("runtime-1")),
+                event=_StubEvent(
+                    session_id="runtime-1",
+                    sequence=1,
+                    event_type="runtime.request_received",
+                    source="runtime",
+                    payload={"prompt": "hello"},
+                ),
+            ),
+        ]
+    )
+    with patch("voidcode.acp.stdio.uuid4", return_value=SimpleNamespace(hex="abc")):
+        messages, _ = _run_server(
+            runtime,
+            _request("session/new", 1),
+            _request("session/prompt", 2, {"sessionId": "acp-session-abc", "prompt": "hello"}),
+            _request("session/cancel", 3, {"sessionId": "acp-session-abc"}),
+        )
+
+    cancel_result = messages[-1]["result"]
+    assert cancel_result["cancelled"] is True
+    assert cancel_result["supported"] is True
+    assert cancel_result["runtimeCancel"]["session_id"] == "runtime-1"
 
 
 def test_cancel_notification_writes_no_response() -> None:

--- a/tests/unit/graph/test_single_agent_slice.py
+++ b/tests/unit/graph/test_single_agent_slice.py
@@ -88,6 +88,15 @@ class _CapturingTurnProvider:
         return ProviderTurnResult(output="done")
 
 
+class _AbortSignal:
+    def __init__(self, *, cancelled: bool = False) -> None:
+        self._cancelled = cancelled
+
+    @property
+    def cancelled(self) -> bool:
+        return self._cancelled
+
+
 class _MixedNonStreamingTurnProvider:
     name = "opencode"
 
@@ -357,6 +366,33 @@ def test_provider_provider_graph_requests_tool_on_first_turn() -> None:
         "streaming": False,
         "prompt": "read sample.txt",
     }
+
+
+def test_provider_graph_passes_runtime_abort_signal_to_provider() -> None:
+    provider = _CapturingTurnProvider()
+    provider_model = resolve_provider_model(
+        "opencode/gpt-5.4",
+        registry=ModelProviderRegistry.with_defaults(),
+    )
+    graph = ProviderGraph(provider=provider, provider_model=provider_model)
+    request_context = RuntimeContextWindow(prompt="stop")
+    abort_signal = _AbortSignal(cancelled=True)
+
+    _ = graph.step(
+        request=GraphRunRequest(
+            session=_session(),
+            prompt="stop",
+            available_tools=_tool_definitions(),
+            context_window=request_context,
+            assembled_context=_assembled_from_context_window(request_context),
+            abort_signal=abort_signal,
+        ),
+        tool_results=(),
+        session=_session(),
+    )
+
+    assert provider.requests[0].abort_signal is abort_signal
+    assert provider.requests[0].abort_signal.cancelled is True
 
 
 def test_provider_provider_graph_finalizes_after_tool_result() -> None:

--- a/tests/unit/graph/test_single_agent_slice.py
+++ b/tests/unit/graph/test_single_agent_slice.py
@@ -82,9 +82,13 @@ class _CapturingTurnProvider:
 
     def __init__(self) -> None:
         self.requests: list[ProviderTurnRequest] = []
+        self.abort_cancelled_values: list[bool | None] = []
 
     def propose_turn(self, request: ProviderTurnRequest) -> ProviderTurnResult:
         self.requests.append(request)
+        self.abort_cancelled_values.append(
+            request.abort_signal.cancelled if request.abort_signal is not None else None
+        )
         return ProviderTurnResult(output="done")
 
 
@@ -393,6 +397,41 @@ def test_provider_graph_passes_runtime_abort_signal_to_provider() -> None:
 
     assert provider.requests[0].abort_signal is abort_signal
     assert provider.requests[0].abort_signal.cancelled is True
+
+
+def test_provider_graph_resets_internal_abort_signal_between_requests() -> None:
+    provider = _CapturingTurnProvider()
+    provider_model = resolve_provider_model(
+        "opencode/gpt-5.4",
+        registry=ModelProviderRegistry.with_defaults(),
+    )
+    graph = ProviderGraph(provider=provider, provider_model=provider_model)
+    cancelled_context = RuntimeContextWindow(prompt="cancel")
+    next_context = RuntimeContextWindow(prompt="continue")
+
+    _ = graph.step(
+        request=GraphRunRequest(
+            session=_session(),
+            prompt="cancel",
+            context_window=cancelled_context,
+            assembled_context=_assembled_from_context_window(cancelled_context),
+            metadata={"abort_requested": True},
+        ),
+        tool_results=(),
+        session=_session(),
+    )
+    _ = graph.step(
+        request=GraphRunRequest(
+            session=_session(),
+            prompt="continue",
+            context_window=next_context,
+            assembled_context=_assembled_from_context_window(next_context),
+        ),
+        tool_results=(),
+        session=_session(),
+    )
+
+    assert provider.abort_cancelled_values == [True, False]
 
 
 def test_provider_provider_graph_finalizes_after_tool_result() -> None:

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -191,11 +191,20 @@ def _runtime_event(
 
 
 def _make_chunk(
-    *, session_id: str, status: str, event: _StubEvent | None = None, output: str | None = None
+    *,
+    session_id: str,
+    status: str,
+    event: _StubEvent | None = None,
+    output: str | None = None,
+    metadata: dict[str, object] | None = None,
 ) -> _StubChunk:
     return _StubChunk(
         kind="output" if output is not None else "event",
-        session=_StubSession(session=_StubSessionRef(id=session_id), status=status),
+        session=_StubSession(
+            session=_StubSessionRef(id=session_id),
+            status=status,
+            metadata=metadata,
+        ),
         event=event,
         output=output,
     )
@@ -645,6 +654,7 @@ def test_run_command_ctrl_c_cancels_active_runtime_session(capsys: Any) -> None:
             session_id="interrupt-session",
             status="running",
             event=_runtime_event("runtime.request_received", prompt="slow"),
+            metadata={"runtime_state": {"run_id": "cli-run-1"}},
         )
         raise KeyboardInterrupt
 
@@ -656,6 +666,7 @@ def test_run_command_ctrl_c_cancels_active_runtime_session(capsys: Any) -> None:
     assert result == 130
     runtime_class.return_value.cancel_session.assert_called_once_with(
         "interrupt-session",
+        run_id="cli-run-1",
         reason="cli KeyboardInterrupt",
     )
     assert "Interrupted current run." in capsys.readouterr().err

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -635,6 +635,32 @@ def test_run_command_loads_config_and_forwards_it_to_runtime() -> None:
     runtime_class.return_value.resume.assert_not_called()
 
 
+def test_run_command_ctrl_c_cancels_active_runtime_session(capsys: Any) -> None:
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/demo-workspace")
+    config = SimpleNamespace(approval_mode="allow")
+
+    def _interrupted_stream() -> Iterable[_StubChunk]:
+        yield _make_chunk(
+            session_id="interrupt-session",
+            status="running",
+            event=_runtime_event("runtime.request_received", prompt="slow"),
+        )
+        raise KeyboardInterrupt
+
+    with patch.object(cli, "load_runtime_config", autospec=True, return_value=config):
+        with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
+            runtime_class.return_value.run_stream.return_value = _interrupted_stream()
+            result = cli.main(["run", "slow", "--workspace", str(workspace)])
+
+    assert result == 130
+    runtime_class.return_value.cancel_session.assert_called_once_with(
+        "interrupt-session",
+        reason="cli KeyboardInterrupt",
+    )
+    assert "Interrupted current run." in capsys.readouterr().err
+
+
 def test_run_command_accepts_agent_skills_max_steps_and_provider_stream_flags() -> None:
     cli = importlib.import_module("voidcode.cli")
     workspace = Path("/tmp/demo-workspace")

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1667,6 +1667,35 @@ def test_runtime_cancel_session_interrupts_active_run(tmp_path: Path) -> None:
     assert failed_events[-1].payload["reason"] == "test cancellation"
 
 
+def test_runtime_cancel_session_preserves_older_overlapping_run_after_newer_run_finishes(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+
+    first_stream = runtime.run_stream(RuntimeRequest(prompt="first", session_id="overlap-cancel"))
+    first_chunk = next(first_stream)
+    second_stream = runtime.run_stream(RuntimeRequest(prompt="second", session_id="overlap-cancel"))
+    second_chunk = next(second_stream)
+    second_remaining = list(second_stream)
+
+    result = runtime.cancel_session("overlap-cancel", reason="cancel older run")
+    first_remaining = list(first_stream)
+
+    first_failed_events = [
+        chunk.event
+        for chunk in first_remaining
+        if chunk.event is not None and chunk.event.event_type == "runtime.failed"
+    ]
+    assert first_chunk.session.status == "running"
+    assert second_chunk.session.status == "running"
+    assert second_remaining[-1].session.status == "completed"
+    assert result.status == "interrupted"
+    assert result.interrupted is True
+    assert first_failed_events
+    assert first_failed_events[-1].payload["kind"] == "interrupted"
+    assert first_failed_events[-1].payload["reason"] == "cancel older run"
+
+
 def test_runtime_cancel_session_rejects_stale_run_id(tmp_path: Path) -> None:
     runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
 

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1645,6 +1645,51 @@ def test_runtime_session_debug_snapshot_marks_active_running_session(tmp_path: P
     _ = list(stream)
 
 
+def test_runtime_cancel_session_interrupts_active_run(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+
+    stream = runtime.run_stream(RuntimeRequest(prompt="cancel me", session_id="active-cancel"))
+    first_chunk = next(stream)
+    result = runtime.cancel_session("active-cancel", reason="test cancellation")
+    remaining_chunks = list(stream)
+
+    failed_events = [
+        chunk.event
+        for chunk in remaining_chunks
+        if chunk.event is not None and chunk.event.event_type == "runtime.failed"
+    ]
+    assert first_chunk.session.status == "running"
+    assert result.status == "interrupted"
+    assert result.interrupted is True
+    assert failed_events
+    assert failed_events[-1].payload["kind"] == "interrupted"
+    assert failed_events[-1].payload["cancelled"] is True
+    assert failed_events[-1].payload["reason"] == "test cancellation"
+
+
+def test_runtime_cancel_session_rejects_stale_run_id(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+
+    stream = runtime.run_stream(RuntimeRequest(prompt="stale cancel", session_id="stale-cancel"))
+    first_chunk = next(stream)
+    result = runtime.cancel_session("stale-cancel", run_id="older-run")
+    remaining_chunks = list(stream)
+
+    assert first_chunk.session.status == "running"
+    assert result.status == "stale"
+    assert result.interrupted is False
+    assert remaining_chunks[-1].session.status == "completed"
+
+
+def test_runtime_cancel_session_returns_not_active_for_idle_session(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+
+    result = runtime.cancel_session("idle-cancel")
+
+    assert result.status == "not_active"
+    assert result.interrupted is False
+
+
 def test_runtime_session_debug_snapshot_prefers_active_state_for_reused_session_id(
     tmp_path: Path,
 ) -> None:
@@ -1700,7 +1745,8 @@ def test_runtime_session_debug_snapshot_preserves_fresh_terminal_state_while_act
     deferred_unregister_session_id: str | None = None
     original_unregister = runtime._unregister_active_session_id  # pyright: ignore[reportPrivateUsage]
 
-    def _defer_unregister(session_id: str) -> None:
+    def _defer_unregister(session_id: str, *, run_id: str | None = None) -> None:
+        _ = run_id
         nonlocal deferred_unregister_session_id
         deferred_unregister_session_id = session_id
 

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -100,6 +100,7 @@ from voidcode.runtime.service import (
     RuntimeRequest,
     RuntimeRequestMetadataPayload,
     RuntimeResponse,
+    RuntimeStreamChunk,
     SessionState,
     ToolRegistry,
     VoidCodeRuntime,
@@ -232,6 +233,31 @@ class _ApprovalThenCaptureSkillGraph:
                     tool_name="write_file", arguments={"path": "alpha.txt", "content": "1"}
                 )
             )
+        return _StubStep(output="done", is_finished=True)
+
+
+class _BlockingApprovalResumeGraph:
+    def __init__(self) -> None:
+        self.resume_started = threading.Event()
+        self.release_resume = threading.Event()
+
+    def step(
+        self,
+        request: GraphRunRequest,
+        tool_results: tuple[object, ...],
+        *,
+        session: SessionState,
+    ) -> _StubStep:
+        _ = request, session
+        if not tool_results:
+            return _StubStep(
+                tool_call=ToolCall(
+                    tool_name="write_file", arguments={"path": "alpha.txt", "content": "1"}
+                )
+            )
+        self.resume_started.set()
+        if not self.release_resume.wait(timeout=2.0):
+            raise RuntimeError("resume was not released")
         return _StubStep(output="done", is_finished=True)
 
 
@@ -1708,6 +1734,66 @@ def test_runtime_cancel_session_rejects_stale_run_id(tmp_path: Path) -> None:
     assert result.status == "stale"
     assert result.interrupted is False
     assert remaining_chunks[-1].session.status == "completed"
+
+
+def test_runtime_cancel_session_interrupts_active_approval_resume_run(tmp_path: Path) -> None:
+    graph = _BlockingApprovalResumeGraph()
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=graph,
+        config=RuntimeConfig(approval_mode="ask"),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+    waiting = runtime.run(RuntimeRequest(prompt="resume cancel", session_id="resume-cancel"))
+    approval_request_id = cast(str, waiting.events[-1].payload["request_id"])
+    chunks: list[object] = []
+    errors: list[BaseException] = []
+
+    def _consume_resume_stream() -> None:
+        try:
+            chunks.extend(
+                runtime.resume_stream(
+                    "resume-cancel",
+                    approval_request_id=approval_request_id,
+                    approval_decision="allow",
+                )
+            )
+        except BaseException as exc:  # pragma: no cover - asserted via errors list
+            errors.append(exc)
+
+    resume_thread = threading.Thread(target=_consume_resume_stream)
+    resume_thread.start()
+    assert graph.resume_started.wait(timeout=1.0) is True
+    active_metadata = _private_attr(runtime, "_active_session_metadata")("resume-cancel")
+    assert isinstance(active_metadata, dict)
+    run_id = cast(str, active_metadata["run_id"])
+
+    result = runtime.cancel_session("resume-cancel", run_id=run_id, reason="resume cancellation")
+    graph.release_resume.set()
+    resume_thread.join(timeout=2.0)
+
+    failed_events = [
+        chunk.event
+        for chunk in chunks
+        if isinstance(chunk, RuntimeStreamChunk)
+        and chunk.event is not None
+        and chunk.event.event_type == "runtime.failed"
+    ]
+    resumed_runtime_states = [
+        cast(dict[str, object], chunk.session.metadata.get("runtime_state", {}))
+        for chunk in chunks
+        if isinstance(chunk, RuntimeStreamChunk)
+    ]
+    assert errors == []
+    assert resume_thread.is_alive() is False
+    assert result.status == "interrupted"
+    assert result.interrupted is True
+    assert failed_events
+    assert failed_events[-1].payload["kind"] == "interrupted"
+    assert failed_events[-1].payload["cancelled"] is True
+    assert failed_events[-1].payload["run_id"] == run_id
+    assert failed_events[-1].payload["reason"] == "resume cancellation"
+    assert any(state.get("run_id") == run_id for state in resumed_runtime_states)
 
 
 def test_runtime_cancel_session_returns_not_active_for_idle_session(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_tool_execution_timeout.py
+++ b/tests/unit/runtime/test_tool_execution_timeout.py
@@ -11,6 +11,17 @@ from voidcode.runtime.contracts import RuntimeRequest
 from voidcode.runtime.service import ToolRegistry, VoidCodeRuntime
 from voidcode.tools import ShellExecTool
 from voidcode.tools.contracts import ToolCall, ToolDefinition, ToolResult
+from voidcode.tools.runtime_context import RuntimeToolInvocationContext, bind_runtime_tool_context
+
+
+class _AbortSignal:
+    def __init__(self, *, cancelled: bool = False, reason: str | None = None) -> None:
+        self._cancelled = cancelled
+        self.reason = reason
+
+    @property
+    def cancelled(self) -> bool:
+        return self._cancelled
 
 
 class _InstantTool:
@@ -198,6 +209,27 @@ def test_tool_completes_normally_within_timeout(tmp_path: Path) -> None:
     assert "runtime.tool_completed" in event_types
     assert "runtime.tool_timeout" not in event_types
     assert "runtime.failed" not in event_types
+
+
+def test_shell_exec_returns_interrupted_result_when_runtime_abort_is_set(tmp_path: Path) -> None:
+    tool = ShellExecTool()
+    command = f'"{sys.executable}" -c "import time; time.sleep(10)"'
+
+    with bind_runtime_tool_context(
+        RuntimeToolInvocationContext(
+            session_id="shell-abort",
+            abort_signal=_AbortSignal(cancelled=True, reason="test abort"),
+        )
+    ):
+        result = tool.invoke(
+            ToolCall(tool_name="shell_exec", arguments={"command": command, "timeout": 30}),
+            workspace=tmp_path,
+        )
+
+    assert result.status == "error"
+    assert result.data["interrupted"] is True
+    assert result.data["cancelled"] is True
+    assert result.data["reason"] == "test abort"
 
 
 def test_slow_tool_that_finishes_within_timeout_is_not_interrupted(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add runtime-owned active run interruption with per-run abort signals, stale run guards, and failed/interrupted terminal events.
- Thread abort signals through provider graph requests, runtime tool context, shell subprocess execution, HTTP session cancel, ACP session/cancel, and CLI Ctrl-C handling.
- Cover cancellation behavior across runtime, HTTP, ACP, CLI, provider graph, shell execution, and active-session registry tests.

## Verification
- `uv run ruff check .`
- `uv run basedpyright --warnings src`
- `uv run pytest -n auto` (1676 passed)
- `uv build`

Closes #324