### PR TITLE
feat(runtime): make todo state runtime-owned

### DIFF
--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -9,6 +9,7 @@ from functools import lru_cache
 from typing import Any, Literal, NamedTuple, cast
 
 from ..tools.contracts import ToolResult
+from .todos import render_provider_todo_state
 
 
 def _empty_tool_limits() -> dict[str, int]:
@@ -1137,6 +1138,9 @@ def assemble_provider_context(
     for segment_content in preserved_system_segments:
         _append_system_segment(segment_content)
     _append_system_segment(skill_prompt_context)
+    todo_prompt_context = render_provider_todo_state(session_metadata)
+    if todo_prompt_context is not None:
+        _append_system_segment(todo_prompt_context)
     continuity_state = preserved_continuity_state or context_window.continuity_state
     metadata_payload = context_window.metadata_payload()
     if continuity_state is not None and "continuity_state" not in metadata_payload:

--- a/src/voidcode/runtime/events.py
+++ b/src/voidcode/runtime/events.py
@@ -62,6 +62,7 @@ type PrototypeAdditiveEventType = Literal[
     "runtime.background_task_result_read",
     "runtime.delegated_result_available",
     "runtime.skill_loaded",
+    "runtime.todo_updated",
 ]
 type DelegatedBackgroundTaskEventType = Literal[
     "runtime.background_task_waiting_approval",
@@ -157,6 +158,7 @@ RUNTIME_DELEGATED_RESULT_AVAILABLE: Final[PrototypeAdditiveEventType] = (
     "runtime.delegated_result_available"
 )
 RUNTIME_SKILL_LOADED: Final[PrototypeAdditiveEventType] = "runtime.skill_loaded"
+RUNTIME_TODO_UPDATED: Final[PrototypeAdditiveEventType] = "runtime.todo_updated"
 
 EMITTED_EVENT_TYPES: Final[tuple[ExistingEventType, ...]] = (
     RUNTIME_REQUEST_RECEIVED,
@@ -214,6 +216,7 @@ PROTOTYPE_ADDITIVE_EVENT_TYPES: Final[tuple[PrototypeAdditiveEventType, ...]] = 
     RUNTIME_BACKGROUND_TASK_RESULT_READ,
     RUNTIME_DELEGATED_RESULT_AVAILABLE,
     RUNTIME_SKILL_LOADED,
+    RUNTIME_TODO_UPDATED,
 )
 KNOWN_EVENT_TYPES: Final[tuple[KnownEventType, ...]] = (
     *EMITTED_EVENT_TYPES,

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -34,6 +34,7 @@ from .events import (
     RUNTIME_MEMORY_REFRESHED,
     RUNTIME_QUESTION_REQUESTED,
     RUNTIME_SKILL_LOADED,
+    RUNTIME_TODO_UPDATED,
     RUNTIME_TOOL_STARTED,
     EventEnvelope,
 )
@@ -112,6 +113,8 @@ class RuntimeRunLoopCoordinator:
             preserved_system_segments: list[str] = []
             for segment in graph_request.assembled_context.segments:
                 if segment.role != "system" or not isinstance(segment.content, str):
+                    continue
+                if segment.content.startswith("Runtime-managed todo state is active"):
                     continue
                 preserved_system_segments.append(segment.content)
                 if segment.content.startswith("Runtime-managed skills are active for this turn."):
@@ -644,6 +647,7 @@ class RuntimeRunLoopCoordinator:
                     },
                 )
 
+            runtime_tool_result_data = dict(tool_result.data)
             sanitized_arguments = sanitize_tool_arguments(dict(plan_tool_call.arguments))
             tool_result = cap_tool_result_output(tool_result, workspace=runtime._workspace)
             tool_result = replace(
@@ -763,6 +767,26 @@ class RuntimeRunLoopCoordinator:
                             },
                         ),
                     )
+
+            if plan_tool_call.tool_name == "todo_write" and tool_result.status == "ok":
+                revision = sequence + 1
+                session, todo_payload = runtime._session_with_todo_state(
+                    session,
+                    raw_todos=runtime_tool_result_data.get("todos"),
+                    revision=revision,
+                )
+                sequence = revision
+                yield RuntimeStreamChunk(
+                    kind="event",
+                    session=session,
+                    event=EventEnvelope(
+                        session_id=session.session.id,
+                        sequence=sequence,
+                        event_type=RUNTIME_TODO_UPDATED,
+                        source="runtime",
+                        payload=todo_payload,
+                    ),
+                )
 
             if tool_result.status == "ok":
                 post_hook_outcome = runtime._run_tool_hooks(

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -203,6 +203,11 @@ from .task import (
     supported_subagent_categories,
     validate_background_task_id,
 )
+from .todos import (
+    runtime_todos_from_tool_payload,
+    todo_event_payload,
+    todo_state_payload,
+)
 from .tool_provider import BuiltinToolProvider
 
 if TYPE_CHECKING:
@@ -4795,6 +4800,38 @@ class VoidCodeRuntime:
                 },
             },
         )
+
+    @staticmethod
+    def _session_with_todo_state(
+        session: SessionState,
+        *,
+        raw_todos: object,
+        revision: int,
+    ) -> tuple[SessionState, dict[str, object]]:
+        raw_runtime_state = session.metadata.get("runtime_state")
+        runtime_state = (
+            dict(cast(dict[str, object], raw_runtime_state))
+            if isinstance(raw_runtime_state, dict)
+            else {}
+        )
+        todos = runtime_todos_from_tool_payload(raw_todos, updated_at=revision)
+        state_payload = todo_state_payload(todos, revision=revision)
+        runtime_state["todos"] = state_payload
+        next_session = SessionState(
+            session=session.session,
+            status=session.status,
+            turn=session.turn,
+            metadata={
+                **session.metadata,
+                "runtime_state": runtime_state,
+            },
+        )
+        event_payload = todo_event_payload(
+            session_id=session.session.id,
+            todos=todos,
+            revision=revision,
+        )
+        return next_session, event_payload
 
     @staticmethod
     def _session_with_provider_usage_metadata(

--- a/src/voidcode/runtime/storage.py
+++ b/src/voidcode/runtime/storage.py
@@ -38,6 +38,7 @@ from .task import (
     is_background_task_transition_allowed,
     validate_background_task_id,
 )
+from .todos import runtime_todos_from_state_payload, todo_state_payload
 
 
 @runtime_checkable
@@ -223,6 +224,14 @@ class SqliteSessionStore:
             ("source", "TEXT", 1, None, 0),
             ("payload_json", "TEXT", 1, None, 0),
         ),
+        "session_todos": (
+            ("session_id", "TEXT", 1, None, 1),
+            ("position", "INTEGER", 1, None, 2),
+            ("content", "TEXT", 1, None, 0),
+            ("status", "TEXT", 1, None, 0),
+            ("priority", "TEXT", 1, None, 0),
+            ("updated_at", "INTEGER", 1, None, 0),
+        ),
         "background_tasks": (
             ("task_id", "TEXT", 0, None, 1),
             ("workspace", "TEXT", 1, None, 0),
@@ -277,6 +286,7 @@ class SqliteSessionStore:
     _CANONICAL_UNIQUE_INDEXES: dict[str, frozenset[tuple[str, ...]]] = {
         "sessions": frozenset(),
         "session_events": frozenset(),
+        "session_todos": frozenset(),
         "background_tasks": frozenset(),
         "session_notifications": frozenset({("workspace", "dedupe_key")}),
         "session_event_deliveries": frozenset(),
@@ -358,6 +368,19 @@ class SqliteSessionStore:
                 source TEXT NOT NULL,
                 payload_json TEXT NOT NULL,
                 PRIMARY KEY (session_id, sequence)
+            )
+            """
+        )
+        _ = connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS session_todos (
+                session_id TEXT NOT NULL,
+                position INTEGER NOT NULL,
+                content TEXT NOT NULL,
+                status TEXT NOT NULL,
+                priority TEXT NOT NULL,
+                updated_at INTEGER NOT NULL,
+                PRIMARY KEY (session_id, position)
             )
             """
         )
@@ -713,6 +736,118 @@ class SqliteSessionStore:
             self._session_events_payload(events),
         )
 
+    @staticmethod
+    def _todo_state_from_metadata(metadata: dict[str, object]) -> dict[str, object] | None:
+        raw_runtime_state = metadata.get("runtime_state")
+        if not isinstance(raw_runtime_state, dict):
+            return None
+        runtime_state = cast(dict[str, object], raw_runtime_state)
+        raw_todo_state = runtime_state.get("todos")
+        if not isinstance(raw_todo_state, dict):
+            return None
+        todo_state = cast(dict[str, object], raw_todo_state)
+        revision = todo_state.get("revision")
+        return todo_state_payload(
+            runtime_todos_from_state_payload(todo_state.get("todos")),
+            revision=revision if isinstance(revision, int) and revision >= 0 else 0,
+        )
+
+    def _replace_session_todos(
+        self,
+        *,
+        connection: sqlite3.Connection,
+        session_id: str,
+        metadata: dict[str, object],
+    ) -> None:
+        todo_state = self._todo_state_from_metadata(metadata)
+        _ = connection.execute("DELETE FROM session_todos WHERE session_id = ?", (session_id,))
+        if todo_state is None:
+            return
+        todos = runtime_todos_from_state_payload(todo_state.get("todos"))
+        _ = connection.executemany(
+            """
+            INSERT INTO session_todos (
+                session_id, position, content, status, priority, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    session_id,
+                    todo["position"],
+                    todo["content"],
+                    todo["status"],
+                    todo["priority"],
+                    todo["updated_at"],
+                )
+                for todo in todos
+            ],
+        )
+
+    def _todo_state_from_rows(
+        self,
+        *,
+        connection: sqlite3.Connection,
+        session_id: str,
+    ) -> dict[str, object] | None:
+        rows = cast(
+            list[sqlite3.Row],
+            connection.execute(
+                """
+                SELECT position, content, status, priority, updated_at
+                FROM session_todos
+                WHERE session_id = ?
+                ORDER BY position ASC
+                """,
+                (session_id,),
+            ).fetchall(),
+        )
+        if not rows:
+            return None
+        todos = runtime_todos_from_state_payload(
+            [
+                {
+                    "position": cast(int, row["position"]),
+                    "content": cast(str, row["content"]),
+                    "status": cast(str, row["status"]),
+                    "priority": cast(str, row["priority"]),
+                    "updated_at": cast(int, row["updated_at"]),
+                }
+                for row in rows
+            ]
+        )
+        revision = max((todo["updated_at"] for todo in todos), default=0)
+        return todo_state_payload(todos, revision=revision)
+
+    @classmethod
+    def _metadata_with_todo_state(
+        cls,
+        metadata: dict[str, object],
+        todo_state: dict[str, object] | None,
+    ) -> dict[str, object]:
+        if todo_state is None:
+            return metadata
+        raw_runtime_state = metadata.get("runtime_state")
+        runtime_state = (
+            dict(cast(dict[str, object], raw_runtime_state))
+            if isinstance(raw_runtime_state, dict)
+            else {}
+        )
+        runtime_state["todos"] = todo_state
+        return {**metadata, "runtime_state": runtime_state}
+
+    @staticmethod
+    def _todo_state_from_events(events: tuple[EventEnvelope, ...]) -> dict[str, object] | None:
+        for event in reversed(events):
+            if event.event_type != "runtime.todo_updated":
+                continue
+            todos = runtime_todos_from_state_payload(event.payload.get("todos"))
+            revision = event.payload.get("revision")
+            return todo_state_payload(
+                todos,
+                revision=revision if isinstance(revision, int) and revision >= 0 else 0,
+            )
+        return None
+
     def _write_session_snapshot(
         self,
         *,
@@ -757,6 +892,11 @@ class SqliteSessionStore:
             connection=connection,
             session_id=session_id,
             events=response.events,
+        )
+        self._replace_session_todos(
+            connection=connection,
+            session_id=session_id,
+            metadata=response.session.metadata,
         )
         return updated_at
 
@@ -1536,6 +1676,14 @@ class SqliteSessionStore:
                     (session_id,),
                 ).fetchall(),
             )
+            stored_todo_state = self._todo_state_from_rows(
+                connection=connection,
+                session_id=session_id,
+            )
+        metadata = self._metadata_with_todo_state(
+            cast(dict[str, object], json.loads(cast(str, session_row["metadata_json"]))),
+            stored_todo_state,
+        )
         session = SessionState(
             session=SessionRef(
                 id=cast(str, session_row["session_id"]),
@@ -1543,7 +1691,7 @@ class SqliteSessionStore:
             ),
             status=self._parse_session_status(cast(str, session_row["status"])),
             turn=cast(int, session_row["turn"]),
-            metadata=cast(dict[str, object], json.loads(cast(str, session_row["metadata_json"]))),
+            metadata=metadata,
         )
         events = tuple(
             EventEnvelope(
@@ -1563,7 +1711,7 @@ class SqliteSessionStore:
                 session=session.session,
                 status=session.status,
                 turn=session.turn,
-                metadata=self._active_revert_metadata(session.metadata),
+                metadata=self._active_revert_metadata(session.metadata, events=events),
             )
             output = None
         return RuntimeResponse(session=session, events=events, output=output)
@@ -1632,14 +1780,23 @@ class SqliteSessionStore:
         }
         return next_metadata
 
-    @staticmethod
-    def _active_revert_metadata(metadata: dict[str, object]) -> dict[str, object]:
+    def _active_revert_metadata(
+        self,
+        metadata: dict[str, object],
+        *,
+        events: tuple[EventEnvelope, ...],
+    ) -> dict[str, object]:
         next_metadata = dict(metadata)
         raw_runtime_state = next_metadata.get("runtime_state")
         if not isinstance(raw_runtime_state, dict):
             return next_metadata
         runtime_state = dict(cast(dict[str, object], raw_runtime_state))
         runtime_state.pop("continuity", None)
+        todo_state = self._todo_state_from_events(events)
+        if todo_state is None:
+            runtime_state.pop("todos", None)
+        else:
+            runtime_state["todos"] = todo_state
         next_metadata["runtime_state"] = runtime_state
         return next_metadata
 
@@ -2448,6 +2605,12 @@ class SqliteSessionStore:
                     column="session_id",
                     ids=session_ids,
                 ),
+                "session_todos": self._delete_for_ids(
+                    connection=connection,
+                    table="session_todos",
+                    column="session_id",
+                    ids=session_ids,
+                ),
                 "session_event_deliveries": self._delete_for_ids(
                     connection=connection,
                     table="session_event_deliveries",
@@ -2550,6 +2713,12 @@ class SqliteSessionStore:
         counts["session_events"] = SqliteSessionStore._count_for_ids(
             connection=connection,
             table="session_events",
+            column="session_id",
+            ids=session_ids,
+        )
+        counts["session_todos"] = SqliteSessionStore._count_for_ids(
+            connection=connection,
+            table="session_todos",
             column="session_id",
             ids=session_ids,
         )

--- a/src/voidcode/runtime/todos.py
+++ b/src/voidcode/runtime/todos.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from typing import Literal, TypedDict, cast
+
+type TodoStatus = Literal["pending", "in_progress", "completed", "cancelled"]
+type TodoPriority = Literal["high", "medium", "low"]
+
+TODO_STATUSES: tuple[TodoStatus, ...] = ("pending", "in_progress", "completed", "cancelled")
+TODO_PRIORITIES: tuple[TodoPriority, ...] = ("high", "medium", "low")
+
+
+class RuntimeTodoItem(TypedDict):
+    content: str
+    status: TodoStatus
+    priority: TodoPriority
+    position: int
+    updated_at: int
+
+
+class RuntimeTodoSummary(TypedDict):
+    total: int
+    pending: int
+    in_progress: int
+    completed: int
+    cancelled: int
+    active: int
+
+
+def todo_summary(todos: tuple[RuntimeTodoItem, ...]) -> RuntimeTodoSummary:
+    pending = sum(1 for todo in todos if todo["status"] == "pending")
+    in_progress = sum(1 for todo in todos if todo["status"] == "in_progress")
+    completed = sum(1 for todo in todos if todo["status"] == "completed")
+    cancelled = sum(1 for todo in todos if todo["status"] == "cancelled")
+    return {
+        "total": len(todos),
+        "pending": pending,
+        "in_progress": in_progress,
+        "completed": completed,
+        "cancelled": cancelled,
+        "active": pending + in_progress,
+    }
+
+
+def runtime_todos_from_tool_payload(
+    raw_todos: object,
+    *,
+    updated_at: int,
+) -> tuple[RuntimeTodoItem, ...]:
+    if not isinstance(raw_todos, list):
+        return ()
+    todos: list[RuntimeTodoItem] = []
+    for position, raw_item in enumerate(cast(list[object], raw_todos), start=1):
+        if not isinstance(raw_item, dict):
+            continue
+        item = cast(dict[object, object], raw_item)
+        content = item.get("content")
+        status = item.get("status")
+        priority = item.get("priority")
+        if not isinstance(content, str) or not content.strip():
+            continue
+        if status not in TODO_STATUSES or priority not in TODO_PRIORITIES:
+            continue
+        todos.append(
+            {
+                "content": content.strip(),
+                "status": status,
+                "priority": priority,
+                "position": position,
+                "updated_at": updated_at,
+            }
+        )
+    return tuple(todos)
+
+
+def runtime_todos_from_state_payload(raw_todos: object) -> tuple[RuntimeTodoItem, ...]:
+    if not isinstance(raw_todos, list):
+        return ()
+    todos: list[RuntimeTodoItem] = []
+    for fallback_position, raw_item in enumerate(cast(list[object], raw_todos), start=1):
+        if not isinstance(raw_item, dict):
+            continue
+        item = cast(dict[object, object], raw_item)
+        content = item.get("content")
+        status = item.get("status")
+        priority = item.get("priority")
+        raw_position = item.get("position")
+        raw_updated_at = item.get("updated_at")
+        if not isinstance(content, str) or not content.strip():
+            continue
+        if status not in TODO_STATUSES or priority not in TODO_PRIORITIES:
+            continue
+        position = (
+            raw_position
+            if isinstance(raw_position, int) and raw_position > 0
+            else fallback_position
+        )
+        updated_at = (
+            raw_updated_at if isinstance(raw_updated_at, int) and raw_updated_at >= 0 else 0
+        )
+        todos.append(
+            {
+                "content": content.strip(),
+                "status": status,
+                "priority": priority,
+                "position": position,
+                "updated_at": updated_at,
+            }
+        )
+    return tuple(sorted(todos, key=lambda todo: todo["position"]))
+
+
+def todo_state_payload(
+    todos: tuple[RuntimeTodoItem, ...],
+    *,
+    revision: int,
+) -> dict[str, object]:
+    return {
+        "version": 1,
+        "revision": revision,
+        "todos": [dict(todo) for todo in todos],
+        "summary": todo_summary(todos),
+    }
+
+
+def todo_event_payload(
+    *,
+    session_id: str,
+    todos: tuple[RuntimeTodoItem, ...],
+    revision: int,
+) -> dict[str, object]:
+    summary = todo_summary(todos)
+    return {
+        "session_id": session_id,
+        "todo_count": summary["total"],
+        "active_count": summary["active"],
+        "pending_count": summary["pending"],
+        "in_progress_count": summary["in_progress"],
+        "completed_count": summary["completed"],
+        "cancelled_count": summary["cancelled"],
+        "revision": revision,
+        "todos": [dict(todo) for todo in todos],
+        "summary": dict(summary),
+    }
+
+
+def todo_state_from_session_metadata(
+    session_metadata: dict[str, object],
+) -> dict[str, object] | None:
+    raw_runtime_state = session_metadata.get("runtime_state")
+    if not isinstance(raw_runtime_state, dict):
+        return None
+    runtime_state = cast(dict[str, object], raw_runtime_state)
+    raw_todo_state = runtime_state.get("todos")
+    if not isinstance(raw_todo_state, dict):
+        return None
+    todo_state = cast(dict[str, object], raw_todo_state)
+    todos = runtime_todos_from_state_payload(todo_state.get("todos"))
+    revision = todo_state.get("revision")
+    return todo_state_payload(
+        todos,
+        revision=revision if isinstance(revision, int) and revision >= 0 else 0,
+    )
+
+
+def render_provider_todo_state(session_metadata: dict[str, object]) -> str | None:
+    todo_state = todo_state_from_session_metadata(session_metadata)
+    if todo_state is None:
+        return None
+    todos = runtime_todos_from_state_payload(todo_state.get("todos"))
+    active_todos = tuple(todo for todo in todos if todo["status"] in {"pending", "in_progress"})
+    if not active_todos:
+        return None
+    lines = [
+        "Runtime-managed todo state is active for this session.",
+        "Use this as the current plan truth; do not recreate it from older tool results.",
+        "Current active todos:",
+    ]
+    for todo in active_todos:
+        lines.append(f"{todo['position']}. [{todo['status']}/{todo['priority']}] {todo['content']}")
+    return "\n".join(lines)

--- a/src/voidcode/tools/todo_write.py
+++ b/src/voidcode/tools/todo_write.py
@@ -59,6 +59,15 @@ def _parse_todo_item(item: object, *, idx: int) -> dict[str, str]:
     }
 
 
+def _render_todo_content(todos: list[dict[str, str]]) -> str:
+    if not todos:
+        return "Updated 0 todos"
+    lines = [f"Updated {len(todos)} todos"]
+    for position, todo in enumerate(todos, start=1):
+        lines.append(f"{position}. [{todo['status']}/{todo['priority']}] {todo['content']}")
+    return "\n".join(lines)
+
+
 class TodoWriteTool:
     definition: ClassVar[ToolDefinition] = ToolDefinition(
         name="todo_write",
@@ -91,7 +100,7 @@ class TodoWriteTool:
         return ToolResult(
             tool_name=self.definition.name,
             status="ok",
-            content=f"Updated {len(normalized)} todos",
+            content=_render_todo_content(normalized),
             data={
                 "todos": normalized,
                 "summary": summary,

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -119,6 +119,8 @@ class RuntimeRunner(Protocol):
 
     def list_sessions(self) -> tuple[StoredSessionSummaryLike, ...]: ...
 
+    def session_result(self, *, session_id: str) -> RuntimeResponseLike: ...
+
     def resume(
         self,
         session_id: str,
@@ -1083,6 +1085,127 @@ def test_runtime_delegated_skill_loaded_child_records_exact_skill_metadata(
         isinstance(content, str) and "Use the delegated integration skill body." in content
         for content in system_contents
     )
+
+
+def test_provider_runtime_persists_and_injects_runtime_todo_state(tmp_path: Path) -> None:
+    contracts_module = importlib.import_module("voidcode.runtime.contracts")
+    config_module = importlib.import_module("voidcode.runtime.config")
+    model_provider_module = importlib.import_module("voidcode.provider.registry")
+    permission_module = importlib.import_module("voidcode.runtime.permission")
+    provider_protocol_module = importlib.import_module("voidcode.runtime.provider_protocol")
+    service_module = importlib.import_module("voidcode.runtime.service")
+    tool_contracts_module = importlib.import_module("voidcode.tools.contracts")
+    runtime_request = cast(Callable[..., RuntimeRequestLike], contracts_module.RuntimeRequest)
+    requests: list[object] = []
+
+    class _TodoModelProvider:
+        def turn_provider(self) -> object:
+            class _Provider:
+                name = "opencode"
+
+                def propose_turn(self, request: object) -> object:
+                    requests.append(request)
+                    if len(requests) == 1:
+                        return provider_protocol_module.ProviderTurnResult(
+                            tool_call=tool_contracts_module.ToolCall(
+                                tool_name="todo_write",
+                                arguments={
+                                    "todos": [
+                                        {
+                                            "content": "make todo runtime-owned",
+                                            "status": "in_progress",
+                                            "priority": "high",
+                                        },
+                                        {
+                                            "content": "document completed setup",
+                                            "status": "completed",
+                                            "priority": "low",
+                                        },
+                                    ]
+                                },
+                            )
+                        )
+                    if len(requests) == 2:
+                        return provider_protocol_module.ProviderTurnResult(
+                            tool_call=tool_contracts_module.ToolCall(
+                                tool_name="todo_write",
+                                arguments={
+                                    "todos": [
+                                        {
+                                            "content": "verify latest todo context only",
+                                            "status": "pending",
+                                            "priority": "medium",
+                                        }
+                                    ]
+                                },
+                            )
+                        )
+                    return provider_protocol_module.ProviderTurnResult(output="done")
+
+            return _Provider()
+
+    runtime = cast(
+        RuntimeRunner,
+        service_module.VoidCodeRuntime(
+            workspace=tmp_path,
+            config=config_module.RuntimeConfig(
+                approval_mode="allow",
+                execution_engine="provider",
+                model="opencode/gpt-5.4",
+                context_window=config_module.RuntimeContextWindowConfig(max_tool_results=1),
+            ),
+            permission_policy=permission_module.PermissionPolicy(mode="allow"),
+            model_provider_registry=model_provider_module.ModelProviderRegistry(
+                providers={"opencode": _TodoModelProvider()}
+            ),
+        ),
+    )
+
+    response = runtime.run(
+        runtime_request(prompt="track todo state", session_id="runtime-todo-session")
+    )
+    loaded = runtime.session_result(session_id="runtime-todo-session")
+    todo_events = tuple(
+        event for event in response.events if event.event_type == "runtime.todo_updated"
+    )
+    second_request_system_segments = [
+        segment.content
+        for segment in _assembled_context(requests[1]).segments
+        if segment.role == "system"
+    ]
+    third_request_system_segments = [
+        segment.content
+        for segment in _assembled_context(requests[2]).segments
+        if segment.role == "system"
+    ]
+
+    assert response.session.status == "completed"
+    assert len(todo_events) == 2
+    todo_event = todo_events[0]
+    latest_todo_event = todo_events[1]
+    assert todo_event.payload["active_count"] == 1
+    assert todo_event.payload["pending_count"] == 0
+    assert todo_event.payload["in_progress_count"] == 1
+    assert todo_event.payload["completed_count"] == 1
+    assert latest_todo_event.payload["pending_count"] == 1
+    assert any(
+        isinstance(content, str)
+        and "Runtime-managed todo state is active" in content
+        and "make todo runtime-owned" in content
+        and "document completed setup" not in content
+        for content in second_request_system_segments
+    )
+    latest_todo_segments = [
+        content
+        for content in third_request_system_segments
+        if isinstance(content, str) and content.startswith("Runtime-managed todo state is active")
+    ]
+    assert len(latest_todo_segments) == 1
+    assert "verify latest todo context only" in latest_todo_segments[0]
+    assert "make todo runtime-owned" not in latest_todo_segments[0]
+    raw_runtime_state = loaded.session.metadata["runtime_state"]
+    assert isinstance(raw_runtime_state, dict)
+    assert "todos" in raw_runtime_state
 
 
 def test_runtime_delegated_mcp_and_background_hook_events_have_exact_metadata(

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from voidcode.runtime.context_window import (
     ContextWindowPolicy,
     RuntimeContinuityState,
+    assemble_provider_context,
     context_window_policy_from_payload,
     continuity_state_from_metadata_payload,
     continuity_summary_metadata,
@@ -76,6 +77,50 @@ def test_prepare_provider_context_keeps_results_within_limit() -> None:
     assert context.retained_tool_result_count == 2
     assert context.max_tool_result_count == 3
     assert context.continuity_state is None
+
+
+def test_assemble_provider_context_injects_active_runtime_todos() -> None:
+    assembled = assemble_provider_context(
+        prompt="continue",
+        tool_results=(),
+        session_metadata={
+            "runtime_state": {
+                "todos": {
+                    "version": 1,
+                    "revision": 12,
+                    "todos": [
+                        {
+                            "content": "implement runtime todo state",
+                            "status": "in_progress",
+                            "priority": "high",
+                            "position": 1,
+                            "updated_at": 12,
+                        },
+                        {
+                            "content": "old finished task",
+                            "status": "completed",
+                            "priority": "low",
+                            "position": 2,
+                            "updated_at": 12,
+                        },
+                    ],
+                }
+            }
+        },
+        policy=ContextWindowPolicy(max_tool_results=0),
+    )
+
+    system_segments = [
+        segment.content for segment in assembled.segments if segment.role == "system"
+    ]
+
+    assert any(
+        isinstance(content, str)
+        and "Runtime-managed todo state is active" in content
+        and "implement runtime todo state" in content
+        and "old finished task" not in content
+        for content in system_segments
+    )
 
 
 def test_prepare_provider_context_compacts_old_results_and_reports_metadata() -> None:

--- a/tests/unit/runtime/test_runtime_events.py
+++ b/tests/unit/runtime/test_runtime_events.py
@@ -31,6 +31,7 @@ from voidcode.runtime.events import (
     RUNTIME_SKILL_LOADED,
     RUNTIME_SKILLS_APPLIED,
     RUNTIME_SKILLS_BINDING_MISMATCH,
+    RUNTIME_TODO_UPDATED,
     RUNTIME_TOOL_STARTED,
     DelegatedExecutionPayload,
     DelegatedLifecycleEventPayload,
@@ -75,6 +76,7 @@ def test_future_additive_event_types_cover_async_lifecycle_surfaces() -> None:
         RUNTIME_BACKGROUND_TASK_RESULT_READ,
         RUNTIME_DELEGATED_RESULT_AVAILABLE,
         RUNTIME_SKILL_LOADED,
+        RUNTIME_TODO_UPDATED,
     )
 
 

--- a/tests/unit/runtime/test_session_storage.py
+++ b/tests/unit/runtime/test_session_storage.py
@@ -122,6 +122,91 @@ def test_session_storage_revert_marker_filters_active_view_only(tmp_path: Path) 
     ] == [1, 2, 3]
 
 
+def test_session_storage_persists_runtime_todos_and_filters_reverted_state(
+    tmp_path: Path,
+) -> None:
+    store = SqliteSessionStore()
+    request = RuntimeRequest(prompt="track todos", session_id="todo-session")
+    response = RuntimeResponse(
+        session=SessionState(
+            session=SessionRef(id="todo-session"),
+            status="completed",
+            turn=1,
+            metadata={
+                "runtime_state": {
+                    "todos": {
+                        "version": 1,
+                        "revision": 3,
+                        "todos": [
+                            {
+                                "content": "persist me",
+                                "status": "in_progress",
+                                "priority": "high",
+                                "position": 1,
+                                "updated_at": 3,
+                            }
+                        ],
+                        "summary": {
+                            "total": 1,
+                            "pending": 0,
+                            "in_progress": 1,
+                            "completed": 0,
+                            "cancelled": 0,
+                            "active": 1,
+                        },
+                    }
+                }
+            },
+        ),
+        events=(
+            EventEnvelope(
+                session_id="todo-session",
+                sequence=1,
+                event_type="runtime.request_received",
+                source="runtime",
+                payload={"prompt": "track todos"},
+            ),
+            EventEnvelope(
+                session_id="todo-session",
+                sequence=3,
+                event_type="runtime.todo_updated",
+                source="runtime",
+                payload={
+                    "session_id": "todo-session",
+                    "revision": 3,
+                    "todos": [
+                        {
+                            "content": "persist me",
+                            "status": "in_progress",
+                            "priority": "high",
+                            "position": 1,
+                            "updated_at": 3,
+                        }
+                    ],
+                },
+            ),
+        ),
+        output="done",
+    )
+
+    store.save_run(workspace=tmp_path, request=request, response=response)
+
+    loaded = store.load_session(workspace=tmp_path, session_id="todo-session")
+
+    raw_runtime_state = loaded.session.metadata["runtime_state"]
+    assert isinstance(raw_runtime_state, dict)
+    todos_state = cast(dict[str, object], raw_runtime_state)["todos"]
+    assert isinstance(todos_state, dict)
+    assert cast(list[dict[str, object]], todos_state["todos"])[0]["content"] == "persist me"
+
+    store.revert_session(workspace=tmp_path, session_id="todo-session", sequence=3)
+    reverted = store.load_session(workspace=tmp_path, session_id="todo-session")
+
+    raw_reverted_runtime_state = reverted.session.metadata["runtime_state"]
+    assert isinstance(raw_reverted_runtime_state, dict)
+    assert "todos" not in raw_reverted_runtime_state
+
+
 def test_session_storage_undo_uses_latest_visible_user_turn(tmp_path: Path) -> None:
     store = SqliteSessionStore()
     request = RuntimeRequest(prompt="second", session_id="multi-turn-session")
@@ -198,6 +283,9 @@ def test_session_storage_bootstraps_canonical_schema_for_fresh_database(tmp_path
         session_columns = [
             row[1] for row in connection.execute("PRAGMA table_info(sessions)").fetchall()
         ]
+        todo_columns = [
+            row[1] for row in connection.execute("PRAGMA table_info(session_todos)").fetchall()
+        ]
         delivery_columns = [
             row[1]
             for row in connection.execute("PRAGMA table_info(session_event_deliveries)").fetchall()
@@ -221,6 +309,14 @@ def test_session_storage_bootstraps_canonical_schema_for_fresh_database(tmp_path
         "created_at",
         "updated_at",
         "last_event_sequence",
+    ]
+    assert todo_columns == [
+        "session_id",
+        "position",
+        "content",
+        "status",
+        "priority",
+        "updated_at",
     ]
     assert delivery_columns == ["workspace", "session_id", "dedupe_key", "delivered_at"]
     assert any(row[2] == 1 and row[3] == "u" for row in notification_indexes)
@@ -324,6 +420,7 @@ def test_session_storage_configures_sqlite_operability_pragmas(tmp_path: Path) -
         "background_tasks": 0,
         "session_notifications": 0,
         "session_events": 0,
+        "session_todos": 0,
         "session_event_deliveries": 0,
     }
 

--- a/tests/unit/tools/test_todo_write_tool.py
+++ b/tests/unit/tools/test_todo_write_tool.py
@@ -31,6 +31,7 @@ def test_todo_write_returns_session_metadata_without_workspace_artifact(tmp_path
     assert payload[0]["content"] == "task-a"
     assert payload[1]["status"] == "completed"
     assert result.status == "ok"
+    assert result.content == "Updated 2 todos\n1. [pending/high] task-a\n2. [completed/low] task-b"
     summary_raw = result.data["summary"]
     assert isinstance(summary_raw, dict)
     summary = cast(dict[str, object], summary_raw)


### PR DESCRIPTION
## Summary
- Store `todo_write` state as runtime-owned session todo state with durable SQLite rows and revert-aware metadata hydration.
- Emit `runtime.todo_updated` and inject active todos into provider context from session state instead of retained tool results.
- Add regression coverage for persistence, provider context injection, event registration, and sequential todo updates.

## Verification
- `uv run ruff check .`
- `uv run basedpyright --warnings src/voidcode/runtime/todos.py src/voidcode/runtime/context_window.py src/voidcode/runtime/events.py src/voidcode/runtime/run_loop.py src/voidcode/runtime/service.py src/voidcode/runtime/storage.py src/voidcode/tools/todo_write.py`
- `uv run pytest tests/unit/tools/test_todo_write_tool.py tests/unit/runtime/test_context_window.py tests/unit/runtime/test_session_storage.py tests/unit/runtime/test_runtime_events.py tests/integration/test_tool_workflows_integration.py tests/integration/test_read_only_slice.py -q`
- `uv run pytest -n auto` (first rerun hit two unrelated flakes; exact failures passed on rerun)
- `uv run pytest tests/integration/test_http_transport.py::test_transport_status_preserves_mcp_failed_state_across_fresh_requests tests/unit/tools/fuzz/test_grep_tool_fuzz.py::test_grep_tool_reports_exact_literal_line_and_column_matches -q`

Closes #328