### PR TITLE
feat(runtime): add portable session bundles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ voidcode/
 | Delegated/background task contract | `docs/contracts/background-task-delegation.md` | runtime-owned subagent routing, result retrieval, retry/cancel notes |
 | Session persistence | `src/voidcode/runtime/storage.py` | SQLite-backed local session store |
 | Runtime contracts | `src/voidcode/runtime/contracts.py` | request/response boundary types |
+| Portable session bundles | `src/voidcode/runtime/bundle.py` | schema-versioned import/export artifact with redaction defaults |
 | Graph planning/finalization | `src/voidcode/graph/read_only_slice.py` | current deterministic slice |
 | Tool behavior | `src/voidcode/tools/` | builtin tools include read/write/edit/glob/grep/list/web_fetch/web_search/apply_patch/code_search/multi_edit/todo_write/lsp |
 | Unit tests | `tests/unit/` | contracts, metadata, import, CLI smoke |
@@ -68,6 +69,7 @@ voidcode/
 - Session recovery is local and SQLite-backed under `.voidcode/`.
 - The backend now exposes a broader tool surface including read/write/edit/search/web and patch workflows under `src/voidcode/tools/`.
 - Runtime-owned delegated child execution exists for supported child presets through background task and child session surfaces; it is not an arbitrary multi-agent topology.
+- Portable session import/export is runtime-owned through `src/voidcode/runtime/bundle.py`; CLI import/export must not read or write SQLite bundle rows directly.
 - Agent manifest `skill_refs` select catalog-visible skills by default, while request `force_load_skills` and delegated `load_skills` inject full skill bodies only into the targeted runtime context.
 - MCP is runtime/session-scoped and config-gated; do not describe workspace-scoped MCP, marketplace, dynamic agents, or direct agent-to-agent bus behavior as implemented.
 - Frontend source is intentionally small and flatter than the aspirational structure described in `frontend/README.md`.
@@ -78,6 +80,8 @@ voidcode/
 mise install
 uv sync --extra dev
 uv run voidcode --help
+uv run voidcode sessions export <session-id> --workspace . --output session.vcsession.zip --support
+uv run voidcode sessions import session.vcsession.zip --workspace . --dry-run
 mise run lint
 mise run typecheck
 mise run test

--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -42,6 +42,12 @@ from .doctor import (
     format_report_json,
 )
 from .provider.snapshot import resolved_provider_snapshot
+from .runtime.bundle import (
+    SessionBundleError,
+    SessionBundleFormat,
+    SessionBundleOptions,
+    write_session_bundle,
+)
 from .runtime.config import (
     RUNTIME_CONFIG_FILE_NAME,
     RuntimeConfig,
@@ -796,9 +802,24 @@ def _serialize_session_debug_snapshot(snapshot: RuntimeSessionDebugSnapshot) -> 
 def _handle_sessions_resume_command(args: argparse.Namespace) -> int:
     workspace = cast(Path, args.workspace)
     session_id = cast(str, args.session_id)
+    dry_run = cast(bool, getattr(args, "dry_run", False))
     approval_decision = cast(PermissionResolution | None, getattr(args, "approval_decision", None))
     runtime = VoidCodeRuntime(workspace=workspace)
     try:
+        if dry_run:
+            try:
+                snapshot = runtime.session_debug_snapshot(session_id=session_id)
+            except ValueError as exc:
+                raise SystemExit(f"error: {exc}") from None
+            print_json(
+                {
+                    "workspace": str(workspace),
+                    "session_id": session_id,
+                    "dry_run": True,
+                    "debug": _serialize_session_debug_snapshot(snapshot),
+                }
+            )
+            return 0
         try:
             result = runtime.resume(
                 session_id,
@@ -811,6 +832,74 @@ def _handle_sessions_resume_command(args: argparse.Namespace) -> int:
         _close_runtime(runtime)
 
     _print_runtime_response(result)
+    return 0
+
+
+def _session_bundle_options_from_args(args: argparse.Namespace) -> SessionBundleOptions:
+    if cast(bool, getattr(args, "support", False)):
+        return SessionBundleOptions.support_artifact()
+    return SessionBundleOptions(
+        redact=cast(bool, getattr(args, "redact", True)),
+        include_tool_output=cast(bool, getattr(args, "include_tool_output", False)),
+        include_raw_provider_messages=cast(
+            bool,
+            getattr(args, "include_raw_provider_messages", False),
+        ),
+        include_reasoning_text=cast(bool, getattr(args, "include_reasoning_text", False)),
+    )
+
+
+def _handle_sessions_export_command(args: argparse.Namespace) -> int:
+    workspace = cast(Path, args.workspace)
+    session_id = cast(str, args.session_id)
+    output_path = cast(Path | None, getattr(args, "output", None))
+    fmt = cast(SessionBundleFormat, getattr(args, "format", "zip"))
+    options = _session_bundle_options_from_args(args)
+    runtime = VoidCodeRuntime(workspace=workspace)
+    try:
+        try:
+            bundle = runtime.export_session_bundle(session_id=session_id, options=options)
+        except (ValueError, SessionBundleError) as exc:
+            raise SystemExit(f"error: {exc}") from None
+    finally:
+        _close_runtime(runtime)
+
+    if output_path is None and fmt == "json":
+        print(json.dumps(bundle.to_payload(), sort_keys=True))
+        return 0
+
+    if output_path is None:
+        output_path = Path(f"{session_id}.vcsession.zip")
+    written = write_session_bundle(bundle, path=output_path, fmt=fmt)
+    print_json(
+        {
+            "workspace": str(workspace),
+            "session_id": session_id,
+            "output": str(written),
+            "format": fmt,
+            "schema": bundle.to_payload()["schema"],
+            "manifest": bundle.to_payload()["manifest"],
+        }
+    )
+    return 0
+
+
+def _handle_sessions_import_command(args: argparse.Namespace) -> int:
+    workspace = cast(Path, args.workspace)
+    bundle_path = cast(Path, args.bundle_path)
+    dry_run = cast(bool, getattr(args, "dry_run", False))
+    runtime = VoidCodeRuntime(workspace=workspace)
+    try:
+        try:
+            result = runtime.import_session_bundle_file(
+                bundle_path=bundle_path,
+                dry_run=dry_run,
+            )
+        except (ValueError, SessionBundleError) as exc:
+            raise SystemExit(f"error: {exc}") from None
+    finally:
+        _close_runtime(runtime)
+    print_json({"workspace": str(workspace), "import": result.to_payload()})
     return 0
 
 
@@ -1991,7 +2080,90 @@ def build_parser() -> argparse.ArgumentParser:
         choices=("allow", "deny"),
         help="Optional approval decision applied to the pending request during resume.",
     )
+    _ = resume_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Inspect the persisted session without resuming execution.",
+    )
     resume_parser.set_defaults(handler=_handle_sessions_resume_command)
+
+    export_parser = sessions_subparsers.add_parser(
+        "export", help="Export a portable redacted session bundle."
+    )
+    _ = export_parser.add_argument("session_id", help="Persisted session identifier to export.")
+    _ = export_parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd(),
+        help="Workspace root used to resolve the local session database.",
+    )
+    _ = export_parser.add_argument(
+        "--output",
+        type=Path,
+        help="Bundle output path. Defaults to <session-id>.vcsession.zip for zip output.",
+    )
+    _ = export_parser.add_argument(
+        "--format",
+        choices=("zip", "json"),
+        default="zip",
+        help="Bundle output format. JSON without --output prints the artifact to stdout.",
+    )
+    redaction_group = export_parser.add_mutually_exclusive_group()
+    _ = redaction_group.add_argument(
+        "--redact",
+        dest="redact",
+        action="store_true",
+        help="Redact secrets and sensitive fields (default).",
+    )
+    _ = redaction_group.add_argument(
+        "--no-redact",
+        dest="redact",
+        action="store_false",
+        help="Do not redact bundle payloads. Use only for private artifacts.",
+    )
+    export_parser.set_defaults(redact=True)
+    _ = export_parser.add_argument(
+        "--include-tool-output",
+        action="store_true",
+        help="Include full raw tool output instead of bounded previews.",
+    )
+    _ = export_parser.add_argument(
+        "--include-raw-provider-messages",
+        action="store_true",
+        help="Include raw provider request/response payload events when present.",
+    )
+    _ = export_parser.add_argument(
+        "--include-reasoning-text",
+        action="store_true",
+        help="Include full reasoning/thinking text when present.",
+    )
+    _ = export_parser.add_argument(
+        "--support",
+        action="store_true",
+        help="Use support-artifact defaults: redacted, bounded, diagnostics-first.",
+    )
+    export_parser.set_defaults(handler=_handle_sessions_export_command)
+
+    import_parser = sessions_subparsers.add_parser(
+        "import", help="Import a portable session bundle for local inspection."
+    )
+    _ = import_parser.add_argument(
+        "bundle_path",
+        type=Path,
+        help="Session bundle zip or JSON file.",
+    )
+    _ = import_parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd(),
+        help="Workspace root used to resolve the local session database.",
+    )
+    _ = import_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and summarize the bundle without persisting imported sessions.",
+    )
+    import_parser.set_defaults(handler=_handle_sessions_import_command)
 
     debug_parser = sessions_subparsers.add_parser(
         "debug", help="Show a minimal runtime-owned debug snapshot for one session."

--- a/src/voidcode/runtime/bundle.py
+++ b/src/voidcode/runtime/bundle.py
@@ -36,6 +36,7 @@ from .contracts import (
     RuntimeResponse,
     UnknownSessionError,
     validate_session_id,
+    validate_session_reference_id,
 )
 from .events import EventEnvelope, EventSource
 from .session import SessionRef, SessionState, SessionStatus
@@ -763,10 +764,16 @@ def _optional_dict(value: object) -> dict[str, object] | None:
 def _parse_session_payload(
     payload: dict[str, object], *, index: int
 ) -> SessionBundleSessionPayload:
-    session_id = _ensure_str(payload.get("id"), where=f"sessions[{index}].id")
+    session_id = _validate_bundle_session_id(
+        _ensure_str(payload.get("id"), where=f"sessions[{index}].id"),
+        where=f"sessions[{index}].id",
+    )
     parent_raw = payload.get("parent_id")
     parent_id = (
-        _ensure_str(parent_raw, where=f"sessions[{index}].parent_id")
+        _validate_bundle_parent_id(
+            _ensure_str(parent_raw, where=f"sessions[{index}].parent_id"),
+            where=f"sessions[{index}].parent_id",
+        )
         if isinstance(parent_raw, str)
         else None
     )
@@ -815,6 +822,20 @@ def _normalize_event_payload(event: dict[str, object], *, label: str) -> dict[st
         "source": source,
         "payload": payload,
     }
+
+
+def _validate_bundle_session_id(value: str, *, where: str) -> str:
+    try:
+        return validate_session_id(value)
+    except ValueError as exc:
+        raise SessionBundleError(f"session bundle {where} is invalid: {exc}") from exc
+
+
+def _validate_bundle_parent_id(value: str, *, where: str) -> str:
+    try:
+        return validate_session_reference_id(value, field_name="parent_id")
+    except ValueError as exc:
+        raise SessionBundleError(f"session bundle {where} is invalid: {exc}") from exc
 
 
 def _parse_task_payload(
@@ -1034,24 +1055,16 @@ def apply_session_bundle(
     """Persist ``bundle`` into ``session_store``; never overwrites existing ids by default."""
 
     resolver = session_id_resolver or _default_id_collision_resolver(session_store, workspace)
-    imported_ids: list[str] = []
-    skipped_ids: list[str] = []
-    rebound_id_for: dict[str, str] = {}
+    rebound_id_for = _resolve_import_session_ids(
+        bundle.sessions,
+        session_store=session_store,
+        workspace=workspace,
+        resolver=resolver,
+    )
+    imported_ids = tuple(rebound_id_for[session.id] for session in bundle.sessions)
+    skipped_ids: tuple[str, ...] = ()
     for session in bundle.sessions:
-        try:
-            target_id = _resolve_target_id(
-                session_store=session_store,
-                workspace=workspace,
-                bundle_session_id=session.id,
-                resolver=resolver,
-            )
-        except SessionBundleError:
-            if dry_run:
-                skipped_ids.append(session.id)
-                continue
-            raise
-        rebound_id_for[session.id] = target_id
-        imported_ids.append(target_id)
+        target_id = rebound_id_for[session.id]
         if dry_run:
             continue
         rebound_session = SessionBundleSessionPayload(
@@ -1092,8 +1105,8 @@ def apply_session_bundle(
         session_count=bundle.manifest.session_count,
         event_count=bundle.manifest.event_count,
         background_task_count=bundle.manifest.background_task_count,
-        imported_session_ids=tuple(imported_ids),
-        skipped_session_ids=tuple(skipped_ids),
+        imported_session_ids=imported_ids,
+        skipped_session_ids=skipped_ids,
         skipped_background_task_count=skipped_tasks,
         dry_run=dry_run,
     )
@@ -1122,20 +1135,52 @@ def _default_id_collision_resolver(
     return resolve
 
 
+def _resolve_import_session_ids(
+    sessions: tuple[SessionBundleSessionPayload, ...],
+    *,
+    session_store: SessionStore,
+    workspace: Path,
+    resolver: Callable[[str], str],
+) -> dict[str, str]:
+    rebound: dict[str, str] = {}
+    reserved: set[str] = set()
+    for session in sessions:
+        if session.id in rebound:
+            raise SessionBundleError(f"duplicate session id in bundle: {session.id!r}")
+        target_id = _resolve_target_id(
+            session_store=session_store,
+            workspace=workspace,
+            bundle_session_id=session.id,
+            resolver=resolver,
+            reserved=reserved,
+        )
+        rebound[session.id] = target_id
+        reserved.add(target_id)
+    return rebound
+
+
 def _resolve_target_id(
     *,
     session_store: SessionStore,
     workspace: Path,
     bundle_session_id: str,
     resolver: Callable[[str], str],
+    reserved: set[str],
 ) -> str:
-    if not session_store.has_session(workspace=workspace, session_id=bundle_session_id):
+    validate_session_id(bundle_session_id)
+    if bundle_session_id not in reserved and not session_store.has_session(
+        workspace=workspace, session_id=bundle_session_id
+    ):
         return bundle_session_id
     candidate = resolver(bundle_session_id)
-    if session_store.has_session(workspace=workspace, session_id=candidate):
-        raise SessionBundleError(
-            f"session id resolver returned an id that still collides: {candidate!r}"
-        )
+    attempt = 1
+    while candidate in reserved or session_store.has_session(
+        workspace=workspace,
+        session_id=candidate,
+    ):
+        attempt += 1
+        candidate = f"{bundle_session_id}-imported-{attempt}"
+    validate_session_id(candidate)
     return candidate
 
 

--- a/src/voidcode/runtime/bundle.py
+++ b/src/voidcode/runtime/bundle.py
@@ -1,0 +1,1144 @@
+"""Portable session bundle schema, redaction, and import/export helpers.
+
+The bundle is intentionally an inert artifact:
+
+- Importing it does not auto-resume execution; it only persists the session
+  for ``sessions debug`` / ``sessions resume --dry-run`` style inspection.
+- Default export redacts secrets, raw provider messages, full reasoning text,
+  and oversized tool output. Opt-in flags can include them when the operator
+  knows the destination is private.
+- The schema is versioned (``voidcode.session.bundle.v1``); incompatible
+  schemas fail fast on import with a clear migration message.
+
+The on-disk format is either a JSON file or a zip archive containing a
+single ``bundle.json`` entry. The zip wrapper exists so future revisions can
+add bounded log files or screenshots without breaking the JSON entry.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import platform
+import re
+import sys
+import time
+import zipfile
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Final, Literal, cast, final
+
+from .. import __version__ as VOIDCODE_VERSION
+from .contracts import (
+    RuntimeRequest,
+    RuntimeResponse,
+    UnknownSessionError,
+    validate_session_id,
+)
+from .events import EventEnvelope, EventSource
+from .session import SessionRef, SessionState, SessionStatus
+from .storage import SessionStore
+from .task import StoredBackgroundTaskSummary
+
+SESSION_BUNDLE_SCHEMA_NAME: Final[str] = "voidcode.session.bundle.v1"
+SESSION_BUNDLE_SCHEMA_VERSION: Final[int] = 1
+SESSION_BUNDLE_FILE_NAME: Final[str] = "bundle.json"
+SESSION_BUNDLE_DEFAULT_EXTENSION: Final[str] = ".vcsession.zip"
+SESSION_BUNDLE_REDACTED_PLACEHOLDER: Final[str] = "<redacted>"
+
+type SessionBundleFormat = Literal["zip", "json"]
+
+
+_REDACTED_KEY_FRAGMENTS: Final[tuple[str, ...]] = (
+    "api_key",
+    "apikey",
+    "auth",
+    "authorization",
+    "bearer",
+    "cookie",
+    "credential",
+    "password",
+    "secret",
+    "session_token",
+    "token",
+)
+
+
+_REDACTED_VALUE_PATTERNS: Final[tuple[re.Pattern[str], ...]] = (
+    re.compile(r"sk-[A-Za-z0-9_\-]{6,}"),
+    re.compile(r"Bearer\s+[A-Za-z0-9._\-]{6,}", re.IGNORECASE),
+    re.compile(r"(?i)(api[_-]?key|token|secret|password)=([^\s&]+)"),
+)
+
+
+_RAW_PROVIDER_EVENT_TYPES: Final[frozenset[str]] = frozenset(
+    {
+        "provider.request_payload",
+        "provider.response_payload",
+        "provider.raw_message",
+        "provider.raw_messages",
+    }
+)
+
+
+_REASONING_TEXT_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "reasoning",
+        "reasoning_text",
+        "reasoning_content",
+        "thinking",
+        "thinking_text",
+        "thoughts",
+    }
+)
+
+
+_TOOL_OUTPUT_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "content",
+        "output",
+        "stdout",
+        "stderr",
+        "result_text",
+    }
+)
+
+
+_DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS: Final[int] = 2_000
+
+
+class SessionBundleError(ValueError):
+    """Raised when a session bundle is malformed or incompatible."""
+
+
+@dataclass(frozen=True, slots=True)
+class SessionBundleOptions:
+    """Operator-facing knobs that control export verbosity and redaction."""
+
+    redact: bool = True
+    include_tool_output: bool = False
+    include_raw_provider_messages: bool = False
+    include_reasoning_text: bool = False
+    support_mode: bool = False
+    tool_output_preview_chars: int = _DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS
+
+    @classmethod
+    def support_artifact(cls) -> SessionBundleOptions:
+        """Return an options preset tuned for bug-report style support bundles."""
+
+        return cls(
+            redact=True,
+            include_tool_output=False,
+            include_raw_provider_messages=False,
+            include_reasoning_text=False,
+            support_mode=True,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SessionBundleSessionPayload:
+    id: str
+    parent_id: str | None
+    status: str
+    turn: int
+    prompt: str
+    output: str | None
+    metadata: dict[str, object]
+    last_event_sequence: int
+    events: tuple[dict[str, object], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SessionBundleBackgroundTaskPayload:
+    task_id: str
+    status: str
+    parent_session_id: str | None
+    child_session_id: str | None
+    prompt: str
+    error: str | None
+    created_at: int
+    updated_at: int
+
+
+@dataclass(frozen=True, slots=True)
+class SessionBundleDiagnostics:
+    storage: dict[str, object] | None = None
+    config_summary: dict[str, object] | None = None
+    provider_summary: dict[str, object] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SessionBundleManifest:
+    schema_version: int
+    voidcode_version: str
+    created_at: int
+    workspace_hash: str
+    platform: dict[str, object]
+    redaction: dict[str, object]
+    support_mode: bool
+    session_count: int
+    event_count: int
+    background_task_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class SessionBundle:
+    manifest: SessionBundleManifest
+    sessions: tuple[SessionBundleSessionPayload, ...]
+    background_tasks: tuple[SessionBundleBackgroundTaskPayload, ...]
+    diagnostics: SessionBundleDiagnostics
+
+    def to_payload(self) -> dict[str, object]:
+        """Return the canonical JSON-serializable bundle payload."""
+
+        return {
+            "schema": SESSION_BUNDLE_SCHEMA_NAME,
+            "manifest": _manifest_payload(self.manifest),
+            "sessions": [_session_payload(session) for session in self.sessions],
+            "background_tasks": [_task_payload(task) for task in self.background_tasks],
+            "diagnostics": _diagnostics_payload(self.diagnostics),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SessionBundleImportResult:
+    schema: str
+    schema_version: int
+    voidcode_version: str
+    created_at: int
+    support_mode: bool
+    redaction: dict[str, object]
+    workspace_hash: str
+    session_count: int
+    event_count: int
+    background_task_count: int
+    imported_session_ids: tuple[str, ...]
+    skipped_session_ids: tuple[str, ...]
+    skipped_background_task_count: int
+    dry_run: bool
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "schema": self.schema,
+            "schema_version": self.schema_version,
+            "voidcode_version": self.voidcode_version,
+            "created_at": self.created_at,
+            "support_mode": self.support_mode,
+            "redaction": dict(self.redaction),
+            "workspace_hash": self.workspace_hash,
+            "session_count": self.session_count,
+            "event_count": self.event_count,
+            "background_task_count": self.background_task_count,
+            "imported_session_ids": list(self.imported_session_ids),
+            "skipped_session_ids": list(self.skipped_session_ids),
+            "skipped_background_task_count": self.skipped_background_task_count,
+            "dry_run": self.dry_run,
+        }
+
+
+def _manifest_payload(manifest: SessionBundleManifest) -> dict[str, object]:
+    return {
+        "schema_version": manifest.schema_version,
+        "voidcode_version": manifest.voidcode_version,
+        "created_at": manifest.created_at,
+        "workspace_hash": manifest.workspace_hash,
+        "platform": dict(manifest.platform),
+        "redaction": dict(manifest.redaction),
+        "support_mode": manifest.support_mode,
+        "session_count": manifest.session_count,
+        "event_count": manifest.event_count,
+        "background_task_count": manifest.background_task_count,
+    }
+
+
+def _session_payload(session: SessionBundleSessionPayload) -> dict[str, object]:
+    return {
+        "id": session.id,
+        "parent_id": session.parent_id,
+        "status": session.status,
+        "turn": session.turn,
+        "prompt": session.prompt,
+        "output": session.output,
+        "metadata": session.metadata,
+        "last_event_sequence": session.last_event_sequence,
+        "events": [dict(event) for event in session.events],
+    }
+
+
+def _task_payload(task: SessionBundleBackgroundTaskPayload) -> dict[str, object]:
+    return {
+        "task_id": task.task_id,
+        "status": task.status,
+        "parent_session_id": task.parent_session_id,
+        "child_session_id": task.child_session_id,
+        "prompt": task.prompt,
+        "error": task.error,
+        "created_at": task.created_at,
+        "updated_at": task.updated_at,
+    }
+
+
+def _diagnostics_payload(diagnostics: SessionBundleDiagnostics) -> dict[str, object]:
+    payload: dict[str, object] = {}
+    if diagnostics.storage is not None:
+        payload["storage"] = dict(diagnostics.storage)
+    if diagnostics.config_summary is not None:
+        payload["config_summary"] = dict(diagnostics.config_summary)
+    if diagnostics.provider_summary is not None:
+        payload["provider_summary"] = dict(diagnostics.provider_summary)
+    return payload
+
+
+def _looks_like_secret_key(key: str) -> bool:
+    lowered = key.lower()
+    return any(fragment in lowered for fragment in _REDACTED_KEY_FRAGMENTS)
+
+
+def _scrub_secret_text(value: str) -> str:
+    scrubbed = value
+    for pattern in _REDACTED_VALUE_PATTERNS:
+        scrubbed = pattern.sub(SESSION_BUNDLE_REDACTED_PLACEHOLDER, scrubbed)
+    return scrubbed
+
+
+def _redact_object(value: object) -> object:
+    if isinstance(value, dict):
+        result: dict[str, object] = {}
+        for raw_key, raw_item in cast(Mapping[object, object], value).items():
+            key = str(raw_key)
+            if _looks_like_secret_key(key):
+                result[key] = SESSION_BUNDLE_REDACTED_PLACEHOLDER
+            else:
+                result[key] = _redact_object(raw_item)
+        return result
+    if isinstance(value, list):
+        return [_redact_object(item) for item in cast(list[object], value)]
+    if isinstance(value, tuple):
+        return tuple(_redact_object(item) for item in cast(tuple[object, ...], value))
+    if isinstance(value, str):
+        return _scrub_secret_text(value)
+    return value
+
+
+def _redact_dict(value: dict[str, object]) -> dict[str, object]:
+    return cast(dict[str, object], _redact_object(value))
+
+
+def _truncate_string(value: str, *, limit: int) -> str:
+    if limit <= 0 or len(value) <= limit:
+        return value
+    suffix = f"\n... [truncated by session bundle: kept first {limit} of {len(value)} chars]"
+    return value[:limit] + suffix
+
+
+def _strip_reasoning_payload(payload: dict[str, object]) -> dict[str, object]:
+    cleaned: dict[str, object] = {}
+    for key, value in payload.items():
+        if key in _REASONING_TEXT_KEYS and isinstance(value, str):
+            cleaned[key] = SESSION_BUNDLE_REDACTED_PLACEHOLDER
+            continue
+        if isinstance(value, dict):
+            cleaned[key] = _strip_reasoning_payload(cast(dict[str, object], value))
+        elif isinstance(value, list):
+            cleaned_items: list[object] = []
+            for item in cast(list[object], value):
+                if isinstance(item, dict):
+                    cleaned_items.append(_strip_reasoning_payload(cast(dict[str, object], item)))
+                else:
+                    cleaned_items.append(item)
+            cleaned[key] = cleaned_items
+        else:
+            cleaned[key] = value
+    return cleaned
+
+
+def _truncate_tool_output_payload(
+    payload: dict[str, object],
+    *,
+    limit: int,
+) -> dict[str, object]:
+    cleaned: dict[str, object] = {}
+    for key, value in payload.items():
+        if key in _TOOL_OUTPUT_KEYS and isinstance(value, str):
+            cleaned[key] = _truncate_string(value, limit=limit)
+            continue
+        if isinstance(value, dict):
+            cleaned[key] = _truncate_tool_output_payload(
+                cast(dict[str, object], value), limit=limit
+            )
+        elif isinstance(value, list):
+            cleaned_items: list[object] = []
+            for item in cast(list[object], value):
+                if isinstance(item, dict):
+                    cleaned_items.append(
+                        _truncate_tool_output_payload(cast(dict[str, object], item), limit=limit)
+                    )
+                else:
+                    cleaned_items.append(item)
+            cleaned[key] = cleaned_items
+        else:
+            cleaned[key] = value
+    return cleaned
+
+
+def _drop_raw_provider_event(event: EventEnvelope) -> bool:
+    return event.event_type in _RAW_PROVIDER_EVENT_TYPES
+
+
+def _apply_payload_options(
+    payload: dict[str, object],
+    *,
+    options: SessionBundleOptions,
+) -> dict[str, object]:
+    cleaned = payload
+    if not options.include_reasoning_text:
+        cleaned = _strip_reasoning_payload(cleaned)
+    if not options.include_tool_output:
+        cleaned = _truncate_tool_output_payload(cleaned, limit=options.tool_output_preview_chars)
+    if options.redact:
+        cleaned = _redact_dict(cleaned)
+    return cleaned
+
+
+def _workspace_hash(workspace: Path) -> str:
+    digest = hashlib.sha256(str(workspace.resolve()).encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _platform_summary() -> dict[str, object]:
+    return {
+        "python_version": platform.python_version(),
+        "system": platform.system(),
+        "machine": platform.machine(),
+        "implementation": sys.implementation.name,
+    }
+
+
+def _redaction_summary(options: SessionBundleOptions) -> dict[str, object]:
+    notes: list[str] = []
+    if options.redact:
+        notes.append("Secret-looking keys and bearer tokens are masked.")
+    if not options.include_raw_provider_messages:
+        notes.append("Raw provider request/response payloads are dropped.")
+    if not options.include_reasoning_text:
+        notes.append("Reasoning/thinking text is redacted; metadata is kept.")
+    if not options.include_tool_output:
+        notes.append(
+            f"Tool output text is truncated to {options.tool_output_preview_chars} characters."
+        )
+    return {
+        "redacted": options.redact,
+        "include_tool_output": options.include_tool_output,
+        "include_raw_provider_messages": options.include_raw_provider_messages,
+        "include_reasoning_text": options.include_reasoning_text,
+        "tool_output_preview_chars": options.tool_output_preview_chars,
+        "notes": notes,
+    }
+
+
+@final
+class _SessionBundleBuilder:
+    def __init__(
+        self,
+        *,
+        session_store: SessionStore,
+        workspace: Path,
+        options: SessionBundleOptions,
+        storage_diagnostics: dict[str, object] | None,
+        config_summary: dict[str, object] | None,
+        provider_summary: dict[str, object] | None,
+        clock: Callable[[], int] | None = None,
+    ) -> None:
+        self._session_store = session_store
+        self._workspace = workspace
+        self._options = options
+        self._storage_diagnostics = storage_diagnostics
+        self._config_summary = config_summary
+        self._provider_summary = provider_summary
+        self._clock = clock or (lambda: int(time.time() * 1000))
+
+    def build(self, session_id: str) -> SessionBundle:
+        validate_session_id(session_id)
+        sessions, event_count = self._collect_sessions(session_id=session_id)
+        background_tasks = self._collect_background_tasks(session_id=session_id)
+        manifest = SessionBundleManifest(
+            schema_version=SESSION_BUNDLE_SCHEMA_VERSION,
+            voidcode_version=VOIDCODE_VERSION,
+            created_at=self._clock(),
+            workspace_hash=_workspace_hash(self._workspace),
+            platform=_platform_summary(),
+            redaction=_redaction_summary(self._options),
+            support_mode=self._options.support_mode,
+            session_count=len(sessions),
+            event_count=event_count,
+            background_task_count=len(background_tasks),
+        )
+        diagnostics = SessionBundleDiagnostics(
+            storage=self._sanitize_diagnostics_block(self._storage_diagnostics),
+            config_summary=self._sanitize_diagnostics_block(self._config_summary),
+            provider_summary=self._sanitize_diagnostics_block(self._provider_summary),
+        )
+        return SessionBundle(
+            manifest=manifest,
+            sessions=sessions,
+            background_tasks=background_tasks,
+            diagnostics=diagnostics,
+        )
+
+    def _sanitize_diagnostics_block(
+        self, payload: dict[str, object] | None
+    ) -> dict[str, object] | None:
+        if payload is None:
+            return None
+        if not self._options.redact:
+            return dict(payload)
+        return _redact_dict(payload)
+
+    def _collect_sessions(
+        self, *, session_id: str
+    ) -> tuple[tuple[SessionBundleSessionPayload, ...], int]:
+        primary = self._load_session_response(session_id=session_id)
+        sessions: list[SessionBundleSessionPayload] = [self._build_session_payload(primary)]
+        event_total = len(sessions[0].events)
+        for child_id in self._child_session_ids(parent_session_id=session_id):
+            try:
+                child_response = self._load_session_response(session_id=child_id)
+            except UnknownSessionError:
+                continue
+            child_payload = self._build_session_payload(child_response)
+            sessions.append(child_payload)
+            event_total += len(child_payload.events)
+        return tuple(sessions), event_total
+
+    def _load_session_response(self, *, session_id: str) -> RuntimeResponse:
+        return self._session_store.load_session(
+            workspace=self._workspace,
+            session_id=session_id,
+        )
+
+    def _build_session_payload(self, response: RuntimeResponse) -> SessionBundleSessionPayload:
+        prompt = self._session_prompt(session_id=response.session.session.id)
+        raw_events = tuple(self._build_event_payload(event) for event in response.events)
+        events = tuple(payload for payload in raw_events if payload is not None)
+        metadata = _apply_payload_options(response.session.metadata, options=self._options)
+        output = response.output
+        if output is not None and not self._options.include_tool_output:
+            output = _truncate_string(output, limit=self._options.tool_output_preview_chars)
+        return SessionBundleSessionPayload(
+            id=response.session.session.id,
+            parent_id=response.session.session.parent_id,
+            status=response.session.status,
+            turn=response.session.turn,
+            prompt=prompt,
+            output=output,
+            metadata=metadata,
+            last_event_sequence=(response.events[-1].sequence if response.events else 0),
+            events=events,
+        )
+
+    def _session_prompt(self, *, session_id: str) -> str:
+        try:
+            result = self._session_store.load_session_result(
+                workspace=self._workspace,
+                session_id=session_id,
+            )
+        except UnknownSessionError:
+            return ""
+        return result.prompt
+
+    def _build_event_payload(self, event: EventEnvelope) -> dict[str, object] | None:
+        if not self._options.include_raw_provider_messages and _drop_raw_provider_event(event):
+            return None
+        payload = _apply_payload_options(event.payload, options=self._options)
+        return {
+            "sequence": event.sequence,
+            "event_type": event.event_type,
+            "source": event.source,
+            "payload": payload,
+        }
+
+    def _child_session_ids(self, *, parent_session_id: str) -> tuple[str, ...]:
+        try:
+            tasks = self._session_store.list_background_tasks_by_parent_session(
+                workspace=self._workspace,
+                parent_session_id=parent_session_id,
+            )
+        except ValueError:
+            return ()
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for task in tasks:
+            child_id = task.session_id
+            if child_id is None or child_id in seen:
+                continue
+            seen.add(child_id)
+            ordered.append(child_id)
+        return tuple(ordered)
+
+    def _collect_background_tasks(
+        self, *, session_id: str
+    ) -> tuple[SessionBundleBackgroundTaskPayload, ...]:
+        try:
+            tasks = self._session_store.list_background_tasks_by_parent_session(
+                workspace=self._workspace,
+                parent_session_id=session_id,
+            )
+        except ValueError:
+            return ()
+        return tuple(self._build_task_payload(task) for task in tasks)
+
+    def _build_task_payload(
+        self, task: StoredBackgroundTaskSummary
+    ) -> SessionBundleBackgroundTaskPayload:
+        try:
+            full = self._session_store.load_background_task(
+                workspace=self._workspace,
+                task_id=task.task.id,
+            )
+            parent_session_id: str | None = full.parent_session_id
+        except (ValueError, UnknownSessionError):
+            parent_session_id = None
+        return SessionBundleBackgroundTaskPayload(
+            task_id=task.task.id,
+            status=task.status,
+            parent_session_id=parent_session_id,
+            child_session_id=task.session_id,
+            prompt=task.prompt,
+            error=task.error,
+            created_at=task.created_at,
+            updated_at=task.updated_at,
+        )
+
+
+def build_session_bundle(
+    *,
+    session_store: SessionStore,
+    workspace: Path,
+    session_id: str,
+    options: SessionBundleOptions | None = None,
+    storage_diagnostics: dict[str, object] | None = None,
+    config_summary: dict[str, object] | None = None,
+    provider_summary: dict[str, object] | None = None,
+    clock: Callable[[], int] | None = None,
+) -> SessionBundle:
+    """Build a redacted, schema-versioned session bundle for ``session_id``."""
+
+    builder = _SessionBundleBuilder(
+        session_store=session_store,
+        workspace=workspace,
+        options=options or SessionBundleOptions(),
+        storage_diagnostics=storage_diagnostics,
+        config_summary=config_summary,
+        provider_summary=provider_summary,
+        clock=clock,
+    )
+    return builder.build(session_id)
+
+
+def _ensure_dict(value: object, *, where: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise SessionBundleError(f"session bundle {where} must be an object")
+    return cast(dict[str, object], value)
+
+
+def _ensure_list(value: object, *, where: str) -> list[object]:
+    if not isinstance(value, list):
+        raise SessionBundleError(f"session bundle {where} must be an array")
+    return cast(list[object], value)
+
+
+def _ensure_str(value: object, *, where: str) -> str:
+    if not isinstance(value, str):
+        raise SessionBundleError(f"session bundle {where} must be a string")
+    return value
+
+
+def _ensure_int(value: object, *, where: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise SessionBundleError(f"session bundle {where} must be an integer")
+    return value
+
+
+def parse_session_bundle(payload: object) -> SessionBundle:
+    """Parse a JSON payload into a :class:`SessionBundle`, fail-fast on incompatible schemas."""
+
+    root = _ensure_dict(payload, where="payload")
+    schema = _ensure_str(root.get("schema"), where="schema")
+    if schema != SESSION_BUNDLE_SCHEMA_NAME:
+        raise SessionBundleError(
+            f"unsupported session bundle schema: {schema!r}; "
+            f"this build supports {SESSION_BUNDLE_SCHEMA_NAME!r}"
+        )
+    manifest_payload = _ensure_dict(root.get("manifest"), where="manifest")
+    schema_version = _ensure_int(
+        manifest_payload.get("schema_version"), where="manifest.schema_version"
+    )
+    if schema_version != SESSION_BUNDLE_SCHEMA_VERSION:
+        raise SessionBundleError(
+            f"session bundle schema version {schema_version} is not supported; "
+            f"this build supports version {SESSION_BUNDLE_SCHEMA_VERSION}"
+        )
+    manifest = SessionBundleManifest(
+        schema_version=schema_version,
+        voidcode_version=_ensure_str(
+            manifest_payload.get("voidcode_version"),
+            where="manifest.voidcode_version",
+        ),
+        created_at=_ensure_int(manifest_payload.get("created_at"), where="manifest.created_at"),
+        workspace_hash=_ensure_str(
+            manifest_payload.get("workspace_hash"), where="manifest.workspace_hash"
+        ),
+        platform=dict(
+            _ensure_dict(manifest_payload.get("platform", {}), where="manifest.platform")
+        ),
+        redaction=dict(
+            _ensure_dict(manifest_payload.get("redaction", {}), where="manifest.redaction")
+        ),
+        support_mode=bool(manifest_payload.get("support_mode", False)),
+        session_count=_ensure_int(
+            manifest_payload.get("session_count", 0), where="manifest.session_count"
+        ),
+        event_count=_ensure_int(
+            manifest_payload.get("event_count", 0), where="manifest.event_count"
+        ),
+        background_task_count=_ensure_int(
+            manifest_payload.get("background_task_count", 0),
+            where="manifest.background_task_count",
+        ),
+    )
+    sessions_raw = _ensure_list(root.get("sessions", []), where="sessions")
+    sessions: list[SessionBundleSessionPayload] = []
+    for index, raw in enumerate(sessions_raw):
+        session_dict = _ensure_dict(raw, where=f"sessions[{index}]")
+        sessions.append(_parse_session_payload(session_dict, index=index))
+    tasks_raw = _ensure_list(root.get("background_tasks", []), where="background_tasks")
+    tasks: list[SessionBundleBackgroundTaskPayload] = []
+    for index, raw in enumerate(tasks_raw):
+        task_dict = _ensure_dict(raw, where=f"background_tasks[{index}]")
+        tasks.append(_parse_task_payload(task_dict, index=index))
+    diagnostics_payload = _ensure_dict(root.get("diagnostics", {}), where="diagnostics")
+    diagnostics = SessionBundleDiagnostics(
+        storage=_optional_dict(diagnostics_payload.get("storage")),
+        config_summary=_optional_dict(diagnostics_payload.get("config_summary")),
+        provider_summary=_optional_dict(diagnostics_payload.get("provider_summary")),
+    )
+    return SessionBundle(
+        manifest=manifest,
+        sessions=tuple(sessions),
+        background_tasks=tuple(tasks),
+        diagnostics=diagnostics,
+    )
+
+
+def _optional_dict(value: object) -> dict[str, object] | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise SessionBundleError("diagnostics blocks must be objects when present")
+    return dict(cast(dict[str, object], value))
+
+
+def _parse_session_payload(
+    payload: dict[str, object], *, index: int
+) -> SessionBundleSessionPayload:
+    session_id = _ensure_str(payload.get("id"), where=f"sessions[{index}].id")
+    parent_raw = payload.get("parent_id")
+    parent_id = (
+        _ensure_str(parent_raw, where=f"sessions[{index}].parent_id")
+        if isinstance(parent_raw, str)
+        else None
+    )
+    status = _ensure_str(payload.get("status"), where=f"sessions[{index}].status")
+    turn = _ensure_int(payload.get("turn", 0), where=f"sessions[{index}].turn")
+    prompt = _ensure_str(payload.get("prompt", ""), where=f"sessions[{index}].prompt")
+    output_raw = payload.get("output")
+    output = (
+        _ensure_str(output_raw, where=f"sessions[{index}].output")
+        if isinstance(output_raw, str)
+        else None
+    )
+    metadata = dict(_ensure_dict(payload.get("metadata", {}), where=f"sessions[{index}].metadata"))
+    last_event_sequence = _ensure_int(
+        payload.get("last_event_sequence", 0),
+        where=f"sessions[{index}].last_event_sequence",
+    )
+    events_raw = _ensure_list(payload.get("events", []), where=f"sessions[{index}].events")
+    events: list[dict[str, object]] = []
+    for event_index, raw_event in enumerate(events_raw):
+        event_dict = _ensure_dict(raw_event, where=f"sessions[{index}].events[{event_index}]")
+        events.append(
+            _normalize_event_payload(event_dict, label=f"sessions[{index}].events[{event_index}]")
+        )
+    return SessionBundleSessionPayload(
+        id=session_id,
+        parent_id=parent_id,
+        status=status,
+        turn=turn,
+        prompt=prompt,
+        output=output,
+        metadata=metadata,
+        last_event_sequence=last_event_sequence,
+        events=tuple(events),
+    )
+
+
+def _normalize_event_payload(event: dict[str, object], *, label: str) -> dict[str, object]:
+    sequence = _ensure_int(event.get("sequence", 0), where=f"{label}.sequence")
+    event_type = _ensure_str(event.get("event_type", ""), where=f"{label}.event_type")
+    source = _ensure_str(event.get("source", "runtime"), where=f"{label}.source")
+    payload = dict(_ensure_dict(event.get("payload", {}), where=f"{label}.payload"))
+    return {
+        "sequence": sequence,
+        "event_type": event_type,
+        "source": source,
+        "payload": payload,
+    }
+
+
+def _parse_task_payload(
+    payload: dict[str, object], *, index: int
+) -> SessionBundleBackgroundTaskPayload:
+    task_id = _ensure_str(payload.get("task_id"), where=f"background_tasks[{index}].task_id")
+    status = _ensure_str(payload.get("status"), where=f"background_tasks[{index}].status")
+    raw_parent = payload.get("parent_session_id")
+    parent_session_id = (
+        _ensure_str(raw_parent, where=f"background_tasks[{index}].parent_session_id")
+        if isinstance(raw_parent, str)
+        else None
+    )
+    raw_child = payload.get("child_session_id")
+    child_session_id = (
+        _ensure_str(raw_child, where=f"background_tasks[{index}].child_session_id")
+        if isinstance(raw_child, str)
+        else None
+    )
+    prompt = _ensure_str(payload.get("prompt", ""), where=f"background_tasks[{index}].prompt")
+    raw_error = payload.get("error")
+    error = (
+        _ensure_str(raw_error, where=f"background_tasks[{index}].error")
+        if isinstance(raw_error, str)
+        else None
+    )
+    created_at = _ensure_int(
+        payload.get("created_at", 0), where=f"background_tasks[{index}].created_at"
+    )
+    updated_at = _ensure_int(
+        payload.get("updated_at", 0), where=f"background_tasks[{index}].updated_at"
+    )
+    return SessionBundleBackgroundTaskPayload(
+        task_id=task_id,
+        status=status,
+        parent_session_id=parent_session_id,
+        child_session_id=child_session_id,
+        prompt=prompt,
+        error=error,
+        created_at=created_at,
+        updated_at=updated_at,
+    )
+
+
+def serialize_session_bundle(
+    bundle: SessionBundle,
+    *,
+    fmt: SessionBundleFormat = "zip",
+) -> bytes:
+    """Return canonical bytes for ``bundle`` in either zip or json format."""
+
+    json_bytes = (json.dumps(bundle.to_payload(), sort_keys=True, indent=2) + "\n").encode("utf-8")
+    if fmt == "json":
+        return json_bytes
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(SESSION_BUNDLE_FILE_NAME, json_bytes)
+    return buffer.getvalue()
+
+
+def write_session_bundle(
+    bundle: SessionBundle,
+    *,
+    path: Path,
+    fmt: SessionBundleFormat | None = None,
+) -> Path:
+    """Write ``bundle`` to ``path``, defaulting to zip when extension is ``.zip``."""
+
+    resolved_format = fmt or _infer_bundle_format_from_path(path)
+    payload = serialize_session_bundle(bundle, fmt=resolved_format)
+    parent = path.parent
+    if str(parent) and not parent.exists():
+        parent.mkdir(parents=True, exist_ok=True)
+    _ = path.write_bytes(payload)
+    return path
+
+
+def _infer_bundle_format_from_path(path: Path) -> SessionBundleFormat:
+    suffix = path.suffix.lower()
+    if suffix == ".zip":
+        return "zip"
+    if suffix == ".json":
+        return "json"
+    return "zip"
+
+
+def read_session_bundle(path: Path) -> SessionBundle:
+    """Load a bundle from disk, accepting both json and zip artifacts."""
+
+    if not path.exists():
+        raise SessionBundleError(f"session bundle does not exist: {path}")
+    if not path.is_file():
+        raise SessionBundleError(f"session bundle is not a regular file: {path}")
+    raw = path.read_bytes()
+    return read_session_bundle_bytes(raw)
+
+
+def read_session_bundle_bytes(raw: bytes) -> SessionBundle:
+    """Decode a bundle from raw bytes (zip or json)."""
+
+    if raw.startswith(b"PK"):
+        return _decode_zip_bundle(raw)
+    return _decode_json_bundle(raw)
+
+
+def _decode_zip_bundle(raw: bytes) -> SessionBundle:
+    try:
+        with zipfile.ZipFile(io.BytesIO(raw)) as archive:
+            try:
+                payload_bytes = archive.read(SESSION_BUNDLE_FILE_NAME)
+            except KeyError as exc:
+                raise SessionBundleError(
+                    f"session bundle archive missing entry {SESSION_BUNDLE_FILE_NAME!r}"
+                ) from exc
+    except zipfile.BadZipFile as exc:
+        raise SessionBundleError("session bundle archive is not a valid zip file") from exc
+    return _decode_json_bundle(payload_bytes)
+
+
+def _decode_json_bundle(raw: bytes) -> SessionBundle:
+    try:
+        decoded = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SessionBundleError("session bundle JSON payload is not valid UTF-8 JSON") from exc
+    return parse_session_bundle(decoded)
+
+
+def _validate_event_source(value: str) -> EventSource:
+    allowed: set[str] = {"runtime", "graph", "tool"}
+    if value not in allowed:
+        raise SessionBundleError(
+            f"unknown event source {value!r}; expected one of {sorted(allowed)}"
+        )
+    return cast(EventSource, value)
+
+
+def _validate_session_status(value: str) -> SessionStatus:
+    allowed: set[str] = {"idle", "running", "waiting", "completed", "failed"}
+    if value not in allowed:
+        raise SessionBundleError(
+            f"unknown session status {value!r}; expected one of {sorted(allowed)}"
+        )
+    return cast(SessionStatus, value)
+
+
+def _events_from_session_payload(
+    session: SessionBundleSessionPayload,
+) -> tuple[EventEnvelope, ...]:
+    events: list[EventEnvelope] = []
+    for raw_event in session.events:
+        sequence = cast(int, raw_event.get("sequence", 0))
+        events.append(
+            EventEnvelope(
+                session_id=session.id,
+                sequence=sequence,
+                event_type=cast(str, raw_event.get("event_type", "")),
+                source=_validate_event_source(cast(str, raw_event.get("source", "runtime"))),
+                payload=cast(dict[str, object], raw_event.get("payload", {})),
+            )
+        )
+    return tuple(events)
+
+
+def _runtime_response_for_session(
+    session: SessionBundleSessionPayload,
+    *,
+    rebound_id: str,
+    workspace: Path,
+) -> RuntimeResponse:
+    state = SessionState(
+        session=SessionRef(id=rebound_id, parent_id=session.parent_id),
+        status=_validate_session_status(session.status),
+        turn=session.turn,
+        metadata=_session_metadata_with_import_marker(
+            session,
+            rebound_id=rebound_id,
+            workspace=workspace,
+        ),
+    )
+    events = tuple(
+        replace(event, session_id=rebound_id) for event in _events_from_session_payload(session)
+    )
+    return RuntimeResponse(session=state, events=events, output=session.output)
+
+
+def _session_metadata_with_import_marker(
+    session: SessionBundleSessionPayload,
+    *,
+    rebound_id: str,
+    workspace: Path,
+) -> dict[str, object]:
+    metadata = dict(session.metadata)
+    original_workspace = metadata.get("workspace")
+    marker: dict[str, object] = {
+        "version": 1,
+        "original_session_id": session.id,
+        "imported_at_session_id": rebound_id,
+    }
+    if isinstance(original_workspace, str):
+        marker["original_workspace"] = original_workspace
+    raw_existing = metadata.get("imported_bundle")
+    if isinstance(raw_existing, dict):
+        marker = {**cast(dict[str, object], raw_existing), **marker}
+    metadata["workspace"] = str(workspace)
+    metadata["imported_bundle"] = marker
+    return metadata
+
+
+def apply_session_bundle(
+    bundle: SessionBundle,
+    *,
+    session_store: SessionStore,
+    workspace: Path,
+    dry_run: bool = False,
+    session_id_resolver: Callable[[str], str] | None = None,
+) -> SessionBundleImportResult:
+    """Persist ``bundle`` into ``session_store``; never overwrites existing ids by default."""
+
+    resolver = session_id_resolver or _default_id_collision_resolver(session_store, workspace)
+    imported_ids: list[str] = []
+    skipped_ids: list[str] = []
+    rebound_id_for: dict[str, str] = {}
+    for session in bundle.sessions:
+        try:
+            target_id = _resolve_target_id(
+                session_store=session_store,
+                workspace=workspace,
+                bundle_session_id=session.id,
+                resolver=resolver,
+            )
+        except SessionBundleError:
+            if dry_run:
+                skipped_ids.append(session.id)
+                continue
+            raise
+        rebound_id_for[session.id] = target_id
+        imported_ids.append(target_id)
+        if dry_run:
+            continue
+        rebound_session = SessionBundleSessionPayload(
+            id=session.id,
+            parent_id=_remap_parent_id(session.parent_id, rebound_id_for),
+            status=session.status,
+            turn=session.turn,
+            prompt=session.prompt,
+            output=session.output,
+            metadata=session.metadata,
+            last_event_sequence=session.last_event_sequence,
+            events=session.events,
+        )
+        request = RuntimeRequest(
+            prompt=session.prompt,
+            session_id=target_id,
+            parent_session_id=rebound_session.parent_id,
+        )
+        response = _runtime_response_for_session(
+            rebound_session,
+            rebound_id=target_id,
+            workspace=workspace,
+        )
+        session_store.save_run(workspace=workspace, request=request, response=response)
+    skipped_tasks = sum(
+        1
+        for task in bundle.background_tasks
+        if task.child_session_id is not None and task.child_session_id not in rebound_id_for
+    )
+    return SessionBundleImportResult(
+        schema=SESSION_BUNDLE_SCHEMA_NAME,
+        schema_version=bundle.manifest.schema_version,
+        voidcode_version=bundle.manifest.voidcode_version,
+        created_at=bundle.manifest.created_at,
+        support_mode=bundle.manifest.support_mode,
+        redaction=dict(bundle.manifest.redaction),
+        workspace_hash=bundle.manifest.workspace_hash,
+        session_count=bundle.manifest.session_count,
+        event_count=bundle.manifest.event_count,
+        background_task_count=bundle.manifest.background_task_count,
+        imported_session_ids=tuple(imported_ids),
+        skipped_session_ids=tuple(skipped_ids),
+        skipped_background_task_count=skipped_tasks,
+        dry_run=dry_run,
+    )
+
+
+def _remap_parent_id(
+    parent_id: str | None,
+    rebound: Mapping[str, str],
+) -> str | None:
+    if parent_id is None:
+        return None
+    return rebound.get(parent_id, parent_id)
+
+
+def _default_id_collision_resolver(
+    session_store: SessionStore, workspace: Path
+) -> Callable[[str], str]:
+    def resolve(original: str) -> str:
+        candidate = f"{original}-imported"
+        attempt = 1
+        while session_store.has_session(workspace=workspace, session_id=candidate):
+            attempt += 1
+            candidate = f"{original}-imported-{attempt}"
+        return candidate
+
+    return resolve
+
+
+def _resolve_target_id(
+    *,
+    session_store: SessionStore,
+    workspace: Path,
+    bundle_session_id: str,
+    resolver: Callable[[str], str],
+) -> str:
+    if not session_store.has_session(workspace=workspace, session_id=bundle_session_id):
+        return bundle_session_id
+    candidate = resolver(bundle_session_id)
+    if session_store.has_session(workspace=workspace, session_id=candidate):
+        raise SessionBundleError(
+            f"session id resolver returned an id that still collides: {candidate!r}"
+        )
+    return candidate
+
+
+__all__ = [
+    "SESSION_BUNDLE_DEFAULT_EXTENSION",
+    "SESSION_BUNDLE_FILE_NAME",
+    "SESSION_BUNDLE_REDACTED_PLACEHOLDER",
+    "SESSION_BUNDLE_SCHEMA_NAME",
+    "SESSION_BUNDLE_SCHEMA_VERSION",
+    "SessionBundle",
+    "SessionBundleBackgroundTaskPayload",
+    "SessionBundleDiagnostics",
+    "SessionBundleError",
+    "SessionBundleFormat",
+    "SessionBundleImportResult",
+    "SessionBundleManifest",
+    "SessionBundleOptions",
+    "SessionBundleSessionPayload",
+    "apply_session_bundle",
+    "build_session_bundle",
+    "parse_session_bundle",
+    "read_session_bundle",
+    "read_session_bundle_bytes",
+    "serialize_session_bundle",
+    "write_session_bundle",
+]

--- a/src/voidcode/runtime/bundle.py
+++ b/src/voidcode/runtime/bundle.py
@@ -333,6 +333,20 @@ def _truncate_string(value: str, *, limit: int) -> str:
     return value[:limit] + suffix
 
 
+def _sanitize_export_text(
+    value: str | None,
+    *,
+    options: SessionBundleOptions,
+    truncate_when_tool_output_hidden: bool = False,
+) -> str | None:
+    if value is None:
+        return None
+    sanitized = _scrub_secret_text(value) if options.redact else value
+    if truncate_when_tool_output_hidden and not options.include_tool_output:
+        return _truncate_string(sanitized, limit=options.tool_output_preview_chars)
+    return sanitized
+
+
 def _strip_reasoning_payload(payload: dict[str, object]) -> dict[str, object]:
     cleaned: dict[str, object] = {}
     for key, value in payload.items():
@@ -519,13 +533,19 @@ class _SessionBundleBuilder:
         )
 
     def _build_session_payload(self, response: RuntimeResponse) -> SessionBundleSessionPayload:
-        prompt = self._session_prompt(session_id=response.session.session.id)
+        prompt = _sanitize_export_text(
+            self._session_prompt(session_id=response.session.session.id),
+            options=self._options,
+        )
+        assert prompt is not None
         raw_events = tuple(self._build_event_payload(event) for event in response.events)
         events = tuple(payload for payload in raw_events if payload is not None)
         metadata = _apply_payload_options(response.session.metadata, options=self._options)
-        output = response.output
-        if output is not None and not self._options.include_tool_output:
-            output = _truncate_string(output, limit=self._options.tool_output_preview_chars)
+        output = _sanitize_export_text(
+            response.output,
+            options=self._options,
+            truncate_when_tool_output_hidden=True,
+        )
         return SessionBundleSessionPayload(
             id=response.session.session.id,
             parent_id=response.session.session.parent_id,
@@ -605,8 +625,8 @@ class _SessionBundleBuilder:
             status=task.status,
             parent_session_id=parent_session_id,
             child_session_id=task.session_id,
-            prompt=task.prompt,
-            error=task.error,
+            prompt=_sanitize_export_text(task.prompt, options=self._options) or "",
+            error=_sanitize_export_text(task.error, options=self._options),
             created_at=task.created_at,
             updated_at=task.updated_at,
         )

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -72,6 +72,16 @@ from ..tools.skill import SkillTool
 from ..tools.task import TaskTool
 from .acp import AcpAdapter, AcpAdapterState, build_acp_adapter
 from .background_tasks import RuntimeBackgroundTaskSupervisor
+from .bundle import (
+    SessionBundle,
+    SessionBundleFormat,
+    SessionBundleImportResult,
+    SessionBundleOptions,
+    apply_session_bundle,
+    build_session_bundle,
+    read_session_bundle,
+    write_session_bundle,
+)
 from .config import (
     ExecutionEngineName,
     RuntimeAgentConfig,
@@ -2549,6 +2559,91 @@ class VoidCodeRuntime:
 
     def storage_diagnostics(self) -> dict[str, object]:
         return self._session_store.storage_diagnostics(workspace=self._workspace)
+
+    def export_session_bundle(
+        self,
+        *,
+        session_id: str,
+        options: SessionBundleOptions | None = None,
+    ) -> SessionBundle:
+        validate_session_id(session_id)
+        _ = self._load_session_result(session_id=session_id)
+        return build_session_bundle(
+            session_store=self._session_store,
+            workspace=self._workspace,
+            session_id=session_id,
+            options=options or SessionBundleOptions(),
+            storage_diagnostics=self.storage_diagnostics(),
+            config_summary=self._session_bundle_config_summary(session_id=session_id),
+            provider_summary=self._session_bundle_provider_summary(session_id=session_id),
+        )
+
+    def export_session_bundle_file(
+        self,
+        *,
+        session_id: str,
+        output_path: Path,
+        options: SessionBundleOptions | None = None,
+        fmt: str | None = None,
+    ) -> SessionBundle:
+        bundle = self.export_session_bundle(session_id=session_id, options=options)
+        if fmt is not None and fmt not in {"zip", "json"}:
+            raise ValueError(f"unsupported session bundle format: {fmt!r}")
+        _ = write_session_bundle(
+            bundle,
+            path=output_path,
+            fmt=cast(SessionBundleFormat | None, fmt),
+        )
+        return bundle
+
+    def import_session_bundle_file(
+        self,
+        *,
+        bundle_path: Path,
+        dry_run: bool = False,
+    ) -> SessionBundleImportResult:
+        bundle = read_session_bundle(bundle_path)
+        return apply_session_bundle(
+            bundle,
+            session_store=self._session_store,
+            workspace=self._workspace,
+            dry_run=dry_run,
+        )
+
+    def _session_bundle_config_summary(self, *, session_id: str) -> dict[str, object]:
+        effective_config = self.effective_runtime_config(session_id=session_id)
+        return {
+            "session_id": session_id,
+            "approval_mode": effective_config.approval_mode,
+            "model": effective_config.model,
+            "execution_engine": effective_config.execution_engine,
+            "max_steps": effective_config.max_steps,
+            "reasoning_effort": getattr(effective_config, "reasoning_effort", None),
+            "agent": serialize_runtime_agent_config(getattr(effective_config, "agent", None)),
+            "provider_fallback": serialize_provider_fallback_config(
+                getattr(effective_config, "provider_fallback", None)
+            ),
+            "resolved_provider": resolved_provider_snapshot(
+                getattr(effective_config, "resolved_provider", None)
+            ),
+        }
+
+    def _session_bundle_provider_summary(self, *, session_id: str) -> dict[str, object]:
+        readiness = self.provider_readiness(session_id=session_id)
+        return {
+            "provider": readiness.provider,
+            "model": readiness.model,
+            "configured": readiness.configured,
+            "ok": readiness.ok,
+            "status": readiness.status,
+            "guidance": readiness.guidance,
+            "auth_present": readiness.auth_present,
+            "streaming_configured": readiness.streaming_configured,
+            "streaming_supported": readiness.streaming_supported,
+            "context_window": readiness.context_window,
+            "max_output_tokens": readiness.max_output_tokens,
+            "fallback_chain": list(readiness.fallback_chain),
+        }
 
     def prune_runtime_storage(
         self,

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -506,6 +506,153 @@ def test_sessions_debug_outputs_json_snapshot() -> None:
     assert "Traceback" not in debug_result.stderr
 
 
+def test_sessions_resume_dry_run_outputs_debug_without_execution() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        _ = (workspace / "sample.txt").write_text("sample\n", encoding="utf-8")
+        env = with_src_pythonpath(os.environ.copy())
+
+        setup_result = _run_module_cli(
+            "run",
+            "read sample.txt",
+            "--workspace",
+            str(workspace),
+            "--session-id",
+            "dry-run-session",
+            env=env,
+        )
+        resume_result = _run_module_cli(
+            "sessions",
+            "resume",
+            "dry-run-session",
+            "--workspace",
+            str(workspace),
+            "--dry-run",
+            env=env,
+        )
+
+    payload = json.loads(resume_result.stdout)
+    assert setup_result.returncode == 0
+    assert resume_result.returncode == 0
+    assert payload["dry_run"] is True
+    assert payload["session_id"] == "dry-run-session"
+    assert payload["debug"]["prompt"] == "read sample.txt"
+    assert "RESULT" not in resume_result.stdout
+
+
+def test_sessions_export_import_bundle_roundtrip() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        source = root / "source"
+        target = root / "target"
+        source.mkdir()
+        target.mkdir()
+        _ = (source / "sample.txt").write_text("sample\n", encoding="utf-8")
+        bundle_path = root / "session.vcsession.zip"
+        env = with_src_pythonpath(os.environ.copy())
+
+        setup_result = _run_module_cli(
+            "run",
+            "read sample.txt",
+            "--workspace",
+            str(source),
+            "--session-id",
+            "export-session",
+            env=env,
+        )
+        export_result = _run_module_cli(
+            "sessions",
+            "export",
+            "export-session",
+            "--workspace",
+            str(source),
+            "--output",
+            str(bundle_path),
+            "--support",
+            env=env,
+        )
+        dry_run_result = _run_module_cli(
+            "sessions",
+            "import",
+            str(bundle_path),
+            "--workspace",
+            str(target),
+            "--dry-run",
+            env=env,
+        )
+        import_result = _run_module_cli(
+            "sessions",
+            "import",
+            str(bundle_path),
+            "--workspace",
+            str(target),
+            env=env,
+        )
+        debug_result = _run_module_cli(
+            "sessions",
+            "debug",
+            "export-session",
+            "--workspace",
+            str(target),
+            env=env,
+        )
+        bundle_exists = bundle_path.exists()
+
+    export_payload = json.loads(export_result.stdout)
+    dry_run_payload = json.loads(dry_run_result.stdout)
+    import_payload = json.loads(import_result.stdout)
+    debug_payload = json.loads(debug_result.stdout)
+    assert setup_result.returncode == 0
+    assert export_result.returncode == 0
+    assert bundle_exists
+    assert export_payload["manifest"]["support_mode"] is True
+    assert dry_run_result.returncode == 0
+    assert dry_run_payload["import"]["dry_run"] is True
+    assert dry_run_payload["import"]["imported_session_ids"] == ["export-session"]
+    assert import_result.returncode == 0
+    assert import_payload["import"]["imported_session_ids"] == ["export-session"]
+    assert debug_result.returncode == 0
+    assert debug_payload["prompt"] == "read sample.txt"
+    imported_bundle = debug_payload["session"]["metadata"]["imported_bundle"]
+    assert imported_bundle["version"] == 1
+    assert imported_bundle["original_session_id"] == "export-session"
+    assert imported_bundle["imported_at_session_id"] == "export-session"
+    assert imported_bundle["original_workspace"] == str(source)
+
+
+def test_sessions_export_json_to_stdout() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        _ = (workspace / "sample.txt").write_text("sample\n", encoding="utf-8")
+        env = with_src_pythonpath(os.environ.copy())
+
+        setup_result = _run_module_cli(
+            "run",
+            "read sample.txt",
+            "--workspace",
+            str(workspace),
+            "--session-id",
+            "json-export-session",
+            env=env,
+        )
+        export_result = _run_module_cli(
+            "sessions",
+            "export",
+            "json-export-session",
+            "--workspace",
+            str(workspace),
+            "--format",
+            "json",
+            env=env,
+        )
+
+    payload = json.loads(export_result.stdout)
+    assert setup_result.returncode == 0
+    assert export_result.returncode == 0
+    assert payload["schema"] == "voidcode.session.bundle.v1"
+    assert payload["sessions"][0]["id"] == "json-export-session"
+
+
 def test_sessions_list_outputs_json() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         workspace = Path(tmp)

--- a/tests/unit/runtime/test_session_bundle.py
+++ b/tests/unit/runtime/test_session_bundle.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from voidcode.runtime.bundle import (
+    SESSION_BUNDLE_REDACTED_PLACEHOLDER,
+    SESSION_BUNDLE_SCHEMA_NAME,
+    SessionBundleError,
+    SessionBundleOptions,
+    apply_session_bundle,
+    build_session_bundle,
+    parse_session_bundle,
+    read_session_bundle_bytes,
+    serialize_session_bundle,
+)
+from voidcode.runtime.contracts import RuntimeRequest, RuntimeResponse
+from voidcode.runtime.events import EventEnvelope
+from voidcode.runtime.session import SessionRef, SessionState
+from voidcode.runtime.storage import SqliteSessionStore
+
+
+def _save_sample_session(tmp_path: Path, *, session_id: str = "bundle-session") -> None:
+    store = SqliteSessionStore()
+    request = RuntimeRequest(prompt="inspect failure", session_id=session_id)
+    response = RuntimeResponse(
+        session=SessionState(
+            session=SessionRef(id=session_id),
+            status="completed",
+            turn=1,
+            metadata={
+                "runtime_state": {
+                    "run_id": "run-1",
+                    "api_key": "sk-test-secret",
+                    "todos": {
+                        "version": 1,
+                        "revision": 1,
+                        "todos": [],
+                        "summary": {
+                            "total": 0,
+                            "pending": 0,
+                            "in_progress": 0,
+                            "completed": 0,
+                            "cancelled": 0,
+                            "active": 0,
+                        },
+                    },
+                }
+            },
+        ),
+        events=(
+            EventEnvelope(
+                session_id=session_id,
+                sequence=1,
+                event_type="runtime.tool_completed",
+                source="runtime",
+                payload={
+                    "tool": "shell_exec",
+                    "stdout": "x" * 2200,
+                    "authorization": "Bearer abcdef123456",
+                    "reasoning": "private chain of thought",
+                },
+            ),
+            EventEnvelope(
+                session_id=session_id,
+                sequence=2,
+                event_type="provider.raw_message",
+                source="runtime",
+                payload={"messages": [{"content": "raw provider content"}]},
+            ),
+            EventEnvelope(
+                session_id=session_id,
+                sequence=3,
+                event_type="graph.response_ready",
+                source="graph",
+                payload={"summary": "done"},
+            ),
+        ),
+        output="done",
+    )
+    store.save_run(workspace=tmp_path, request=request, response=response)
+
+
+def test_session_bundle_export_redacts_and_bounds_default_payload(tmp_path: Path) -> None:
+    _save_sample_session(tmp_path)
+    store = SqliteSessionStore()
+
+    bundle = build_session_bundle(
+        session_store=store,
+        workspace=tmp_path,
+        session_id="bundle-session",
+        options=SessionBundleOptions(tool_output_preview_chars=16),
+        storage_diagnostics={"authorization": "Bearer storage-secret"},
+        config_summary={"api_key": "sk-config-secret"},
+    )
+    payload = bundle.to_payload()
+    encoded = json.dumps(payload, sort_keys=True)
+
+    assert payload["schema"] == SESSION_BUNDLE_SCHEMA_NAME
+    assert bundle.manifest.session_count == 1
+    assert bundle.manifest.event_count == 2
+    assert "raw provider content" not in encoded
+    assert "sk-test-secret" not in encoded
+    assert "private chain of thought" not in encoded
+    assert "Bearer abcdef123456" not in encoded
+    assert SESSION_BUNDLE_REDACTED_PLACEHOLDER in encoded
+    assert "truncated by session bundle" in encoded
+
+
+def test_session_bundle_json_and_zip_roundtrip(tmp_path: Path) -> None:
+    _save_sample_session(tmp_path)
+    store = SqliteSessionStore()
+    bundle = build_session_bundle(
+        session_store=store,
+        workspace=tmp_path,
+        session_id="bundle-session",
+    )
+
+    json_bundle = read_session_bundle_bytes(serialize_session_bundle(bundle, fmt="json"))
+    zip_bundle = read_session_bundle_bytes(serialize_session_bundle(bundle, fmt="zip"))
+
+    assert json_bundle.to_payload() == bundle.to_payload()
+    assert zip_bundle.to_payload() == bundle.to_payload()
+
+
+def test_session_bundle_import_roundtrip_never_overwrites_existing_session(
+    tmp_path: Path,
+) -> None:
+    source_workspace = tmp_path / "source"
+    target_workspace = tmp_path / "target"
+    source_workspace.mkdir()
+    target_workspace.mkdir()
+    _save_sample_session(source_workspace)
+    _save_sample_session(target_workspace)
+    source_store = SqliteSessionStore()
+    target_store = SqliteSessionStore()
+    bundle = build_session_bundle(
+        session_store=source_store,
+        workspace=source_workspace,
+        session_id="bundle-session",
+    )
+
+    result = apply_session_bundle(
+        bundle,
+        session_store=target_store,
+        workspace=target_workspace,
+    )
+    loaded = target_store.load_session(
+        workspace=target_workspace,
+        session_id="bundle-session-imported",
+    )
+
+    assert result.imported_session_ids == ("bundle-session-imported",)
+    assert loaded.session.metadata["imported_bundle"] == {
+        "version": 1,
+        "original_session_id": "bundle-session",
+        "imported_at_session_id": "bundle-session-imported",
+    }
+    assert loaded.events[-1].sequence == 3
+
+
+def test_session_bundle_unknown_schema_fails_fast() -> None:
+    with pytest.raises(SessionBundleError, match="unsupported session bundle schema"):
+        parse_session_bundle({"schema": "voidcode.session.bundle.v999", "manifest": {}})
+
+
+def test_session_bundle_dry_run_import_does_not_persist(tmp_path: Path) -> None:
+    source_workspace = tmp_path / "source"
+    target_workspace = tmp_path / "target"
+    source_workspace.mkdir()
+    target_workspace.mkdir()
+    _save_sample_session(source_workspace)
+    source_store = SqliteSessionStore()
+    target_store = SqliteSessionStore()
+    bundle = build_session_bundle(
+        session_store=source_store,
+        workspace=source_workspace,
+        session_id="bundle-session",
+    )
+
+    result = apply_session_bundle(
+        bundle,
+        session_store=target_store,
+        workspace=target_workspace,
+        dry_run=True,
+    )
+
+    assert result.dry_run is True
+    assert result.imported_session_ids == ("bundle-session",)
+    assert not target_store.has_session(workspace=target_workspace, session_id="bundle-session")

--- a/tests/unit/runtime/test_session_bundle.py
+++ b/tests/unit/runtime/test_session_bundle.py
@@ -109,6 +109,54 @@ def _save_background_task_with_secrets(tmp_path: Path) -> None:
     )
 
 
+def _minimal_bundle_payload(sessions: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "schema": "voidcode.session.bundle.v1",
+        "manifest": {
+            "schema_version": 1,
+            "voidcode_version": "0.1.0",
+            "created_at": 1,
+            "workspace_hash": "sha256:test",
+            "platform": {},
+            "redaction": {"redacted": True},
+            "support_mode": False,
+            "session_count": len(sessions),
+            "event_count": sum(
+                len(cast(list[object], session.get("events", []))) for session in sessions
+            ),
+            "background_task_count": 0,
+        },
+        "sessions": sessions,
+        "background_tasks": [],
+        "diagnostics": {},
+    }
+
+
+def _minimal_session_payload(
+    session_id: str,
+    *,
+    parent_id: str | None = None,
+) -> dict[str, object]:
+    return {
+        "id": session_id,
+        "parent_id": parent_id,
+        "status": "completed",
+        "turn": 1,
+        "prompt": f"prompt {session_id}",
+        "output": f"output {session_id}",
+        "metadata": {},
+        "last_event_sequence": 1,
+        "events": [
+            {
+                "sequence": 1,
+                "event_type": "graph.response_ready",
+                "source": "graph",
+                "payload": {"summary": session_id},
+            }
+        ],
+    }
+
+
 def test_session_bundle_export_redacts_and_bounds_default_payload(tmp_path: Path) -> None:
     _save_sample_session(tmp_path)
     store = SqliteSessionStore()
@@ -215,6 +263,45 @@ def test_session_bundle_import_roundtrip_never_overwrites_existing_session(
 def test_session_bundle_unknown_schema_fails_fast() -> None:
     with pytest.raises(SessionBundleError, match="unsupported session bundle schema"):
         parse_session_bundle({"schema": "voidcode.session.bundle.v999", "manifest": {}})
+
+
+def test_session_bundle_parse_rejects_invalid_session_ids() -> None:
+    invalid_id_payload = _minimal_bundle_payload([_minimal_session_payload("")])
+    invalid_parent_payload = _minimal_bundle_payload(
+        [_minimal_session_payload("child", parent_id="bad/parent")]
+    )
+
+    with pytest.raises(SessionBundleError, match=r"sessions\[0\]\.id is invalid"):
+        parse_session_bundle(invalid_id_payload)
+    with pytest.raises(SessionBundleError, match=r"sessions\[0\]\.parent_id is invalid"):
+        parse_session_bundle(invalid_parent_payload)
+
+
+def test_session_bundle_import_remaps_child_parent_after_full_id_resolution(
+    tmp_path: Path,
+) -> None:
+    target_store = SqliteSessionStore()
+    _save_sample_session(tmp_path, session_id="parent")
+    bundle = parse_session_bundle(
+        _minimal_bundle_payload(
+            [
+                _minimal_session_payload("child", parent_id="parent"),
+                _minimal_session_payload("parent"),
+            ]
+        )
+    )
+
+    result = apply_session_bundle(
+        bundle,
+        session_store=target_store,
+        workspace=tmp_path,
+    )
+    imported_child = target_store.load_session(workspace=tmp_path, session_id="child")
+    imported_parent = target_store.load_session(workspace=tmp_path, session_id="parent-imported")
+
+    assert result.imported_session_ids == ("child", "parent-imported")
+    assert imported_child.session.session.parent_id == "parent-imported"
+    assert imported_parent.session.session.id == "parent-imported"
 
 
 def test_session_bundle_dry_run_import_does_not_persist(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_session_bundle.py
+++ b/tests/unit/runtime/test_session_bundle.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -20,11 +21,19 @@ from voidcode.runtime.contracts import RuntimeRequest, RuntimeResponse
 from voidcode.runtime.events import EventEnvelope
 from voidcode.runtime.session import SessionRef, SessionState
 from voidcode.runtime.storage import SqliteSessionStore
+from voidcode.runtime.task import (
+    BackgroundTaskRef,
+    BackgroundTaskRequestSnapshot,
+    BackgroundTaskState,
+)
 
 
 def _save_sample_session(tmp_path: Path, *, session_id: str = "bundle-session") -> None:
     store = SqliteSessionStore()
-    request = RuntimeRequest(prompt="inspect failure", session_id=session_id)
+    request = RuntimeRequest(
+        prompt="inspect failure with api_key=prompt-secret",
+        session_id=session_id,
+    )
     response = RuntimeResponse(
         session=SessionState(
             session=SessionRef(id=session_id),
@@ -78,9 +87,26 @@ def _save_sample_session(tmp_path: Path, *, session_id: str = "bundle-session") 
                 payload={"summary": "done"},
             ),
         ),
-        output="done",
+        output="done with sk-output-secret",
     )
     store.save_run(workspace=tmp_path, request=request, response=response)
+
+
+def _save_background_task_with_secrets(tmp_path: Path) -> None:
+    store = SqliteSessionStore()
+    store.create_background_task(
+        workspace=tmp_path,
+        task=BackgroundTaskState(
+            task=BackgroundTaskRef(id="secret-task"),
+            status="failed",
+            request=BackgroundTaskRequestSnapshot(
+                prompt="delegate with api_key=task-prompt-secret",
+                parent_session_id="bundle-session",
+            ),
+            session_id="child-secret-session",
+            error="failed with Bearer taskerrorsecret",
+        ),
+    )
 
 
 def test_session_bundle_export_redacts_and_bounds_default_payload(tmp_path: Path) -> None:
@@ -103,10 +129,35 @@ def test_session_bundle_export_redacts_and_bounds_default_payload(tmp_path: Path
     assert bundle.manifest.event_count == 2
     assert "raw provider content" not in encoded
     assert "sk-test-secret" not in encoded
+    assert "prompt-secret" not in encoded
+    assert "sk-output-secret" not in encoded
     assert "private chain of thought" not in encoded
     assert "Bearer abcdef123456" not in encoded
     assert SESSION_BUNDLE_REDACTED_PLACEHOLDER in encoded
     assert "truncated by session bundle" in encoded
+
+
+def test_session_bundle_export_redacts_background_task_prompt_and_error(
+    tmp_path: Path,
+) -> None:
+    _save_sample_session(tmp_path)
+    _save_background_task_with_secrets(tmp_path)
+    store = SqliteSessionStore()
+
+    bundle = build_session_bundle(
+        session_store=store,
+        workspace=tmp_path,
+        session_id="bundle-session",
+    )
+    payload = bundle.to_payload()
+    encoded = json.dumps(payload, sort_keys=True)
+
+    assert bundle.manifest.background_task_count == 1
+    assert "task-prompt-secret" not in encoded
+    assert "taskerrorsecret" not in encoded
+    background_tasks = cast(list[dict[str, object]], payload["background_tasks"])
+    assert background_tasks[0]["prompt"] == "delegate with <redacted>"
+    assert background_tasks[0]["error"] == "failed with <redacted>"
 
 
 def test_session_bundle_json_and_zip_roundtrip(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add schema-versioned portable session bundles with redaction defaults, diagnostics, JSON/ZIP serialization, and safe import collision handling.
- Add `voidcode sessions export/import` plus `sessions resume --dry-run` for support/debug workflows.
- Cover runtime redaction/round-trip/import behavior and CLI export/import smoke flows.

## Verification
- `mise run lint`
- `mise run typecheck`
- `mise run test:fast` (1205 passed)
- `mise run build`

Closes #336