### PR TITLE
feat(runtime): add provider context inspector

### DIFF
--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -61,6 +61,7 @@ from .runtime.contracts import (
     ProviderInspectResult,
     ProviderModelMetadata,
     ProviderReadinessResult,
+    RuntimeProviderContextSnapshot,
     RuntimeRequest,
     RuntimeSessionDebugSnapshot,
     RuntimeSessionRevertMarker,
@@ -788,8 +789,62 @@ def _serialize_session_debug_snapshot(snapshot: RuntimeSessionDebugSnapshot) -> 
             if snapshot.last_tool is not None
             else None
         ),
+        "provider_context": _serialize_provider_context_snapshot(snapshot.provider_context),
         "suggested_operator_action": snapshot.suggested_operator_action,
         "operator_guidance": snapshot.operator_guidance,
+    }
+
+
+def _serialize_provider_context_snapshot(
+    snapshot: RuntimeProviderContextSnapshot | None,
+) -> dict[str, object] | None:
+    if snapshot is None:
+        return None
+    return {
+        "provider": snapshot.provider,
+        "model": snapshot.model,
+        "execution_engine": snapshot.execution_engine,
+        "segment_count": snapshot.segment_count,
+        "message_count": snapshot.message_count,
+        "context_window": snapshot.context_window,
+        "segments": [
+            {
+                "index": segment.index,
+                "role": segment.role,
+                "source": segment.source,
+                "content": segment.content,
+                "content_truncated": segment.content_truncated,
+                "tool_call_id": segment.tool_call_id,
+                "tool_name": segment.tool_name,
+                "tool_arguments": segment.tool_arguments,
+                "metadata": segment.metadata,
+            }
+            for segment in snapshot.segments
+        ],
+        "provider_messages": [
+            {
+                "index": message.index,
+                "role": message.role,
+                "source": message.source,
+                "content": message.content,
+                "content_truncated": message.content_truncated,
+                "tool_call_id": message.tool_call_id,
+                "tool_calls": list(message.tool_calls),
+            }
+            for message in snapshot.provider_messages
+        ],
+        "diagnostics": [
+            {
+                "severity": diagnostic.severity,
+                "code": diagnostic.code,
+                "message": diagnostic.message,
+                "source": diagnostic.source,
+                "segment_indices": list(diagnostic.segment_indices),
+                "suggested_fix": diagnostic.suggested_fix,
+                "details": diagnostic.details,
+            }
+            for diagnostic in snapshot.diagnostics
+        ],
     }
 
 

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -1127,20 +1127,26 @@ def assemble_provider_context(
     segments: list[RuntimeContextSegment] = []
     seen_system_contents: set[str] = set()
 
-    def _append_system_segment(content: str) -> None:
+    def _append_system_segment(content: str, *, source: str) -> None:
         normalized = content.strip()
         if not normalized or normalized in seen_system_contents:
             return
         seen_system_contents.add(normalized)
-        segments.append(RuntimeContextSegment(role="system", content=normalized))
+        segments.append(
+            RuntimeContextSegment(
+                role="system",
+                content=normalized,
+                metadata={"source": source},
+            )
+        )
 
-    _append_system_segment(agent_prompt_context)
+    _append_system_segment(agent_prompt_context, source="agent_prompt")
     for segment_content in preserved_system_segments:
-        _append_system_segment(segment_content)
-    _append_system_segment(skill_prompt_context)
+        _append_system_segment(segment_content, source="preserved_system_segment")
+    _append_system_segment(skill_prompt_context, source="skill_prompt")
     todo_prompt_context = render_provider_todo_state(session_metadata)
     if todo_prompt_context is not None:
-        _append_system_segment(todo_prompt_context)
+        _append_system_segment(todo_prompt_context, source="runtime_todo_state")
     continuity_state = preserved_continuity_state or context_window.continuity_state
     metadata_payload = context_window.metadata_payload()
     if continuity_state is not None and "continuity_state" not in metadata_payload:
@@ -1148,8 +1154,17 @@ def assemble_provider_context(
     if continuity_state is not None:
         summary_text = continuity_state.summary_text
         if isinstance(summary_text, str) and summary_text.strip():
-            _append_system_segment(f"Runtime continuity summary:\n{summary_text.strip()}")
-    segments.append(RuntimeContextSegment(role="user", content=prompt))
+            _append_system_segment(
+                f"Runtime continuity summary:\n{summary_text.strip()}",
+                source="continuity_summary",
+            )
+    segments.append(
+        RuntimeContextSegment(
+            role="user",
+            content=prompt,
+            metadata={"source": "current_user_prompt"},
+        )
+    )
     for index, result in enumerate(context_window.tool_results, start=1):
         raw_tool_call_id = result.data.get("tool_call_id")
         tool_call_id = (
@@ -1170,6 +1185,7 @@ def assemble_provider_context(
                 tool_call_id=tool_call_id,
                 tool_name=result.tool_name,
                 tool_arguments=tool_arguments,
+                metadata={"source": "retained_tool_result"},
             )
         )
         segments.append(
@@ -1179,6 +1195,7 @@ def assemble_provider_context(
                 tool_call_id=tool_call_id,
                 tool_name=result.tool_name,
                 metadata={
+                    "source": "retained_tool_result",
                     "status": result.status,
                     "error": result.error,
                     "data": result.data,

--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -731,6 +731,54 @@ class RuntimeSessionDebugFailure:
 
 
 @dataclass(frozen=True, slots=True)
+class RuntimeProviderContextDiagnostic:
+    severity: Literal["info", "warning", "error"]
+    code: str
+    message: str
+    source: str | None = None
+    segment_indices: tuple[int, ...] = ()
+    suggested_fix: str | None = None
+    details: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeProviderContextSegmentSnapshot:
+    index: int
+    role: str
+    source: str
+    content: str | None = None
+    content_truncated: bool = False
+    tool_call_id: str | None = None
+    tool_name: str | None = None
+    tool_arguments: dict[str, object] = field(default_factory=dict)
+    metadata: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeProviderMessageSnapshot:
+    index: int
+    role: str
+    source: str
+    content: str | None = None
+    content_truncated: bool = False
+    tool_call_id: str | None = None
+    tool_calls: tuple[dict[str, object], ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeProviderContextSnapshot:
+    provider: str
+    model: str
+    execution_engine: str
+    segment_count: int
+    message_count: int
+    context_window: dict[str, object] = field(default_factory=dict)
+    segments: tuple[RuntimeProviderContextSegmentSnapshot, ...] = ()
+    provider_messages: tuple[RuntimeProviderMessageSnapshot, ...] = ()
+    diagnostics: tuple[RuntimeProviderContextDiagnostic, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
 class RuntimeSessionDebugSnapshot:
     session: SessionState
     prompt: str
@@ -749,6 +797,7 @@ class RuntimeSessionDebugSnapshot:
     last_failure_event: RuntimeSessionDebugEvent | None = None
     failure: RuntimeSessionDebugFailure | None = None
     last_tool: RuntimeSessionDebugToolSummary | None = None
+    provider_context: RuntimeProviderContextSnapshot | None = None
     suggested_operator_action: str = "inspect_session"
     operator_guidance: str = "Inspect the persisted session state."
 

--- a/src/voidcode/runtime/http.py
+++ b/src/voidcode/runtime/http.py
@@ -28,6 +28,7 @@ from .contracts import (
     ReviewFileDiff,
     ReviewTreeNode,
     RuntimeNotification,
+    RuntimeProviderContextSnapshot,
     RuntimeRequest,
     RuntimeRequestError,
     RuntimeResponse,
@@ -1877,8 +1878,64 @@ class RuntimeTransportApp:
                 if snapshot.last_tool is not None
                 else None
             ),
+            "provider_context": RuntimeTransportApp._serialize_provider_context_snapshot(
+                snapshot.provider_context
+            ),
             "suggested_operator_action": snapshot.suggested_operator_action,
             "operator_guidance": snapshot.operator_guidance,
+        }
+
+    @staticmethod
+    def _serialize_provider_context_snapshot(
+        snapshot: RuntimeProviderContextSnapshot | None,
+    ) -> dict[str, object] | None:
+        if snapshot is None:
+            return None
+        return {
+            "provider": snapshot.provider,
+            "model": snapshot.model,
+            "execution_engine": snapshot.execution_engine,
+            "segment_count": snapshot.segment_count,
+            "message_count": snapshot.message_count,
+            "context_window": snapshot.context_window,
+            "segments": [
+                {
+                    "index": segment.index,
+                    "role": segment.role,
+                    "source": segment.source,
+                    "content": segment.content,
+                    "content_truncated": segment.content_truncated,
+                    "tool_call_id": segment.tool_call_id,
+                    "tool_name": segment.tool_name,
+                    "tool_arguments": segment.tool_arguments,
+                    "metadata": segment.metadata,
+                }
+                for segment in snapshot.segments
+            ],
+            "provider_messages": [
+                {
+                    "index": message.index,
+                    "role": message.role,
+                    "source": message.source,
+                    "content": message.content,
+                    "content_truncated": message.content_truncated,
+                    "tool_call_id": message.tool_call_id,
+                    "tool_calls": list(message.tool_calls),
+                }
+                for message in snapshot.provider_messages
+            ],
+            "diagnostics": [
+                {
+                    "severity": diagnostic.severity,
+                    "code": diagnostic.code,
+                    "message": diagnostic.message,
+                    "source": diagnostic.source,
+                    "segment_indices": list(diagnostic.segment_indices),
+                    "suggested_fix": diagnostic.suggested_fix,
+                    "details": diagnostic.details,
+                }
+                for diagnostic in snapshot.diagnostics
+            ],
         }
 
     @staticmethod

--- a/src/voidcode/runtime/provider_context.py
+++ b/src/voidcode/runtime/provider_context.py
@@ -16,7 +16,18 @@ from .contracts import (
 
 _MAX_DEBUG_CONTENT_CHARS = 2_000
 _OVERSIZED_TOOL_FEEDBACK_CHARS = 8_000
-_SECRET_KEYS = frozenset({"api_key", "apikey", "authorization", "token", "password", "secret"})
+_SECRET_KEYS = frozenset(
+    {
+        "access_token",
+        "api_key",
+        "apikey",
+        "authorization",
+        "client_secret",
+        "password",
+        "secret",
+        "token",
+    }
+)
 _SECRET_TEXT_PATTERNS = (
     re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]{8,}"),
     re.compile(r"(?i)(api[_-]?key\s*[=:]\s*)[^\s,;]+"),
@@ -118,7 +129,7 @@ def _segment_snapshot(
     raw_data = metadata.get("data")
     safe_metadata = {key: value for key, value in metadata.items() if key not in {"data"}}
     if isinstance(raw_data, dict):
-        safe_metadata["data"] = sanitize_tool_result_data(cast(dict[str, object], raw_data))
+        safe_metadata["data"] = _sanitize_debug_data(cast(dict[str, object], raw_data))
     return RuntimeProviderContextSegmentSnapshot(
         index=index,
         role=segment.role,
@@ -245,7 +256,7 @@ def _tool_payload_json(segment: RuntimeContextSegment) -> str:
     metadata = segment.metadata or {}
     raw_data = metadata.get("data")
     sanitized_data = (
-        sanitize_tool_result_data(cast(dict[str, object], raw_data))
+        _sanitize_debug_data(cast(dict[str, object], raw_data))
         if isinstance(raw_data, dict)
         else {}
     )
@@ -260,7 +271,7 @@ def _tool_payload_json(segment: RuntimeContextSegment) -> str:
         "arguments": sanitized_arguments,
         "status": metadata.get("status"),
         "content": _redact_debug_text(segment.content or ""),
-        "error": metadata.get("error"),
+        "error": _safe_payload(metadata.get("error")),
         "data": {
             key: value
             for key, value in sanitized_data.items()
@@ -275,6 +286,11 @@ def _tool_payload_json(segment: RuntimeContextSegment) -> str:
 
 def _sanitize_debug_arguments(arguments: dict[str, object]) -> dict[str, object]:
     sanitized = sanitize_tool_arguments(arguments)
+    return cast(dict[str, object], _safe_payload(sanitized))
+
+
+def _sanitize_debug_data(data: dict[str, object]) -> dict[str, object]:
+    sanitized = sanitize_tool_result_data(data)
     return cast(dict[str, object], _safe_payload(sanitized))
 
 

--- a/src/voidcode/runtime/provider_context.py
+++ b/src/voidcode/runtime/provider_context.py
@@ -1,0 +1,495 @@
+from __future__ import annotations
+
+import json
+import re
+from collections import defaultdict
+from typing import cast
+
+from ..tools.output import sanitize_tool_arguments, sanitize_tool_result_data
+from .context_window import RuntimeAssembledContext, RuntimeContextSegment
+from .contracts import (
+    RuntimeProviderContextDiagnostic,
+    RuntimeProviderContextSegmentSnapshot,
+    RuntimeProviderContextSnapshot,
+    RuntimeProviderMessageSnapshot,
+)
+
+_MAX_DEBUG_CONTENT_CHARS = 2_000
+_OVERSIZED_TOOL_FEEDBACK_CHARS = 8_000
+_SECRET_KEYS = frozenset({"api_key", "apikey", "authorization", "token", "password", "secret"})
+_SECRET_TEXT_PATTERNS = (
+    re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]{8,}"),
+    re.compile(r"(?i)(api[_-]?key\s*[=:]\s*)[^\s,;]+"),
+    re.compile(r"(?i)(access[_-]?token\s*[=:]\s*)[^\s,;]+"),
+    re.compile(r"(?i)(client[_-]?secret\s*[=:]\s*)[^\s,;]+"),
+)
+
+
+def inspect_provider_context(
+    *,
+    assembled_context: RuntimeAssembledContext,
+    provider: str,
+    model: str,
+    execution_engine: str,
+    available_tool_count: int,
+) -> RuntimeProviderContextSnapshot:
+    segments = tuple(
+        _segment_snapshot(index, segment)
+        for index, segment in enumerate(assembled_context.segments)
+    )
+    provider_messages = tuple(
+        _provider_message_snapshots(
+            segments=assembled_context.segments,
+            provider=provider,
+        )
+    )
+    diagnostics = tuple(
+        _diagnostics(
+            segments=assembled_context.segments,
+            context_metadata=assembled_context.metadata,
+            provider=provider,
+            available_tool_count=available_tool_count,
+        )
+    )
+    return RuntimeProviderContextSnapshot(
+        provider=provider,
+        model=model,
+        execution_engine=execution_engine,
+        segment_count=len(segments),
+        message_count=len(provider_messages),
+        context_window=dict(assembled_context.metadata),
+        segments=segments,
+        provider_messages=provider_messages,
+        diagnostics=diagnostics,
+    )
+
+
+def _source_from_metadata(segment: RuntimeContextSegment) -> str:
+    metadata = segment.metadata or {}
+    source = metadata.get("source")
+    return source if isinstance(source, str) and source else "assembled_context"
+
+
+def _clip_content(content: str | None) -> tuple[str | None, bool]:
+    if content is None:
+        return None, False
+    redacted = _redact_debug_text(content)
+    if len(redacted) <= _MAX_DEBUG_CONTENT_CHARS:
+        return redacted, False
+    return f"{redacted[:_MAX_DEBUG_CONTENT_CHARS]}…", True
+
+
+def _redact_debug_text(content: str) -> str:
+    redacted = content
+    for pattern in _SECRET_TEXT_PATTERNS:
+        redacted = pattern.sub(r"\1[redacted]", redacted)
+    return redacted
+
+
+def _normalize_tool_call_id(value: str | None, *, fallback: str) -> str:
+    raw = value if value is not None and value.strip() else fallback
+    normalized = re.sub(r"[^a-zA-Z0-9_-]", "_", raw.strip())
+    return normalized or fallback
+
+
+def _safe_payload(value: object) -> object:
+    if isinstance(value, str):
+        clipped, truncated = _clip_content(value)
+        return {"text": clipped, "truncated": True} if truncated else clipped
+    if isinstance(value, dict):
+        return {
+            str(key): _safe_payload(item)
+            for key, item in cast(dict[object, object], value).items()
+            if str(key).lower() not in _SECRET_KEYS
+        }
+    if isinstance(value, list | tuple):
+        return [_safe_payload(item) for item in cast(list[object] | tuple[object, ...], value)]
+    if isinstance(value, bool | int | float) or value is None:
+        return value
+    return str(value)
+
+
+def _segment_snapshot(
+    index: int,
+    segment: RuntimeContextSegment,
+) -> RuntimeProviderContextSegmentSnapshot:
+    content, content_truncated = _clip_content(segment.content)
+    metadata = segment.metadata or {}
+    raw_data = metadata.get("data")
+    safe_metadata = {key: value for key, value in metadata.items() if key not in {"data"}}
+    if isinstance(raw_data, dict):
+        safe_metadata["data"] = sanitize_tool_result_data(cast(dict[str, object], raw_data))
+    return RuntimeProviderContextSegmentSnapshot(
+        index=index,
+        role=segment.role,
+        source=_source_from_metadata(segment),
+        content=content,
+        content_truncated=content_truncated,
+        tool_call_id=segment.tool_call_id,
+        tool_name=segment.tool_name,
+        tool_arguments=_sanitize_debug_arguments(segment.tool_arguments or {}),
+        metadata=cast(dict[str, object], _safe_payload(safe_metadata)),
+    )
+
+
+def _provider_message_snapshots(
+    *,
+    segments: tuple[RuntimeContextSegment, ...],
+    provider: str,
+) -> list[RuntimeProviderMessageSnapshot]:
+    if provider == "opencode-go":
+        return _opencode_go_message_snapshots(segments)
+    return _standard_tool_message_snapshots(segments)
+
+
+def _standard_tool_message_snapshots(
+    segments: tuple[RuntimeContextSegment, ...],
+) -> list[RuntimeProviderMessageSnapshot]:
+    messages: list[RuntimeProviderMessageSnapshot] = []
+    for segment in segments:
+        if segment.role == "assistant" and segment.tool_name is not None:
+            messages.append(
+                RuntimeProviderMessageSnapshot(
+                    index=len(messages),
+                    role="assistant",
+                    source="provider_native_tool_call",
+                    tool_calls=(
+                        {
+                            "id": _tool_call_id(segment, fallback=segment.tool_name),
+                            "type": "function",
+                            "function": {
+                                "name": segment.tool_name,
+                                "arguments": json.dumps(
+                                    _sanitize_debug_arguments(segment.tool_arguments or {}),
+                                    ensure_ascii=False,
+                                    sort_keys=True,
+                                ),
+                            },
+                        },
+                    ),
+                )
+            )
+            continue
+        if segment.role == "tool":
+            content, content_truncated = _clip_content(_tool_payload_json(segment))
+            messages.append(
+                RuntimeProviderMessageSnapshot(
+                    index=len(messages),
+                    role="tool",
+                    source="provider_native_tool_result",
+                    content=content,
+                    content_truncated=content_truncated,
+                    tool_call_id=_tool_call_id(
+                        segment,
+                        fallback=segment.tool_name or "voidcode_tool",
+                    ),
+                )
+            )
+            continue
+        content, content_truncated = _clip_content(segment.content)
+        messages.append(
+            RuntimeProviderMessageSnapshot(
+                index=len(messages),
+                role=segment.role,
+                source=_source_from_metadata(segment),
+                content=content,
+                content_truncated=content_truncated,
+            )
+        )
+    return messages
+
+
+def _opencode_go_message_snapshots(
+    segments: tuple[RuntimeContextSegment, ...],
+) -> list[RuntimeProviderMessageSnapshot]:
+    messages: list[RuntimeProviderMessageSnapshot] = []
+    tool_feedback_lines: list[str] = []
+    for segment in segments:
+        if segment.role == "tool":
+            tool_feedback_lines.append(_tool_payload_json(segment))
+        elif segment.role != "assistant":
+            content, content_truncated = _clip_content(segment.content)
+            messages.append(
+                RuntimeProviderMessageSnapshot(
+                    index=len(messages),
+                    role=segment.role,
+                    source=_source_from_metadata(segment),
+                    content=content,
+                    content_truncated=content_truncated,
+                )
+            )
+    if tool_feedback_lines:
+        content, content_truncated = _clip_content(
+            "\n".join(
+                (
+                    "Completed tool calls for current request:",
+                    "Use these results as latest state. Do not repeat completed calls "
+                    "unless retry is required.",
+                    *tool_feedback_lines,
+                )
+            )
+        )
+        messages.append(
+            RuntimeProviderMessageSnapshot(
+                index=len(messages),
+                role="user",
+                source="opencode_go_synthetic_tool_feedback",
+                content=content,
+                content_truncated=content_truncated,
+            )
+        )
+    return messages
+
+
+def _tool_payload_json(segment: RuntimeContextSegment) -> str:
+    metadata = segment.metadata or {}
+    raw_data = metadata.get("data")
+    sanitized_data = (
+        sanitize_tool_result_data(cast(dict[str, object], raw_data))
+        if isinstance(raw_data, dict)
+        else {}
+    )
+    raw_arguments = sanitized_data.get("arguments")
+    sanitized_arguments = (
+        _sanitize_debug_arguments(cast(dict[str, object], raw_arguments))
+        if isinstance(raw_arguments, dict)
+        else {}
+    )
+    payload = {
+        "tool_name": segment.tool_name,
+        "arguments": sanitized_arguments,
+        "status": metadata.get("status"),
+        "content": _redact_debug_text(segment.content or ""),
+        "error": metadata.get("error"),
+        "data": {
+            key: value
+            for key, value in sanitized_data.items()
+            if key not in {"tool_call_id", "arguments"}
+        },
+        "truncated": metadata.get("truncated"),
+        "partial": metadata.get("partial"),
+        "reference": metadata.get("reference"),
+    }
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True)
+
+
+def _sanitize_debug_arguments(arguments: dict[str, object]) -> dict[str, object]:
+    sanitized = sanitize_tool_arguments(arguments)
+    return cast(dict[str, object], _safe_payload(sanitized))
+
+
+def _tool_call_id(segment: RuntimeContextSegment, *, fallback: str) -> str:
+    return _normalize_tool_call_id(segment.tool_call_id, fallback=fallback)
+
+
+def _diagnostics(
+    *,
+    segments: tuple[RuntimeContextSegment, ...],
+    context_metadata: dict[str, object],
+    provider: str,
+    available_tool_count: int,
+) -> list[RuntimeProviderContextDiagnostic]:
+    diagnostics: list[RuntimeProviderContextDiagnostic] = []
+    diagnostics.extend(_duplicate_system_diagnostics(segments))
+    diagnostics.extend(_tool_pair_diagnostics(segments, available_tool_count=available_tool_count))
+    diagnostics.extend(_context_window_diagnostics(context_metadata))
+    diagnostics.extend(_todo_projection_diagnostics(segments))
+    if provider == "opencode-go" and any(segment.role == "tool" for segment in segments):
+        diagnostics.append(
+            RuntimeProviderContextDiagnostic(
+                severity="info",
+                code="provider_path_uses_synthetic_tool_feedback",
+                message=(
+                    "opencode-go receives completed tool results as one synthetic user "
+                    "feedback block instead of provider-native tool-role messages."
+                ),
+                source="opencode_go_synthetic_tool_feedback",
+                suggested_fix=(
+                    "Inspect provider_messages to verify each tool result appears exactly once."
+                ),
+            )
+        )
+    return diagnostics
+
+
+def _duplicate_system_diagnostics(
+    segments: tuple[RuntimeContextSegment, ...],
+) -> list[RuntimeProviderContextDiagnostic]:
+    by_fingerprint: dict[str, list[int]] = defaultdict(list)
+    for index, segment in enumerate(segments):
+        if segment.role != "system" or not isinstance(segment.content, str):
+            continue
+        fingerprint = " ".join(segment.content.lower().split())
+        by_fingerprint[fingerprint].append(index)
+    return [
+        RuntimeProviderContextDiagnostic(
+            severity="warning",
+            code="duplicate_system_segment",
+            message="Provider context contains duplicate normalized system text.",
+            source="assembled_context",
+            segment_indices=tuple(indices),
+            suggested_fix="Check agent, skill, preserved system, and continuity injection sources.",
+        )
+        for indices in by_fingerprint.values()
+        if len(indices) > 1
+    ]
+
+
+def _tool_pair_diagnostics(
+    segments: tuple[RuntimeContextSegment, ...], *, available_tool_count: int
+) -> list[RuntimeProviderContextDiagnostic]:
+    diagnostics: list[RuntimeProviderContextDiagnostic] = []
+    assistant_ids: dict[str, list[int]] = defaultdict(list)
+    tool_ids: dict[str, list[int]] = defaultdict(list)
+    for index, segment in enumerate(segments):
+        if segment.role == "assistant" and segment.tool_name is not None:
+            assistant_ids[segment.tool_call_id or ""].append(index)
+        if segment.role == "tool":
+            tool_ids[segment.tool_call_id or ""].append(index)
+            if len(segment.content or "") > _OVERSIZED_TOOL_FEEDBACK_CHARS:
+                diagnostics.append(
+                    RuntimeProviderContextDiagnostic(
+                        severity="warning",
+                        code="oversized_tool_feedback",
+                        message=(
+                            "A retained tool result is large enough to pressure provider context."
+                        ),
+                        source=_source_from_metadata(segment),
+                        segment_indices=(index,),
+                        suggested_fix=(
+                            "Prefer runtime-owned summaries or artifacts for large tool outputs."
+                        ),
+                        details={"content_chars": len(segment.content or "")},
+                    )
+                )
+    for tool_call_id, indices in assistant_ids.items():
+        if tool_call_id not in tool_ids:
+            diagnostics.append(
+                RuntimeProviderContextDiagnostic(
+                    severity="error",
+                    code="missing_tool_result",
+                    message="Assistant tool call has no matching tool result segment.",
+                    source="assembled_context",
+                    segment_indices=tuple(indices),
+                    suggested_fix=(
+                        "Ensure every assistant tool call is followed by exactly one tool result."
+                    ),
+                    details={"tool_call_id": tool_call_id},
+                )
+            )
+    for tool_call_id, indices in tool_ids.items():
+        if tool_call_id not in assistant_ids:
+            diagnostics.append(
+                RuntimeProviderContextDiagnostic(
+                    severity="error",
+                    code="orphan_tool_result",
+                    message="Tool result segment has no matching assistant tool call segment.",
+                    source="assembled_context",
+                    segment_indices=tuple(indices),
+                    suggested_fix=(
+                        "Rebuild provider context from paired runtime.tool_completed records."
+                    ),
+                    details={"tool_call_id": tool_call_id},
+                )
+            )
+    duplicate_ids = [
+        tool_call_id for tool_call_id, indices in assistant_ids.items() if len(indices) > 1
+    ]
+    if duplicate_ids:
+        diagnostics.append(
+            RuntimeProviderContextDiagnostic(
+                severity="warning",
+                code="duplicate_tool_call_id",
+                message="Provider context reuses a tool_call_id across assistant tool calls.",
+                source="assembled_context",
+                suggested_fix="Check runtime invocation id and provider tool_call_id propagation.",
+                details={"tool_call_ids": duplicate_ids},
+            )
+        )
+    if assistant_ids and available_tool_count == 0:
+        diagnostics.append(
+            RuntimeProviderContextDiagnostic(
+                severity="warning",
+                code="provider_requires_tools_schema",
+                message=(
+                    "Provider history contains tool calls but the current request has no "
+                    "active tool schema."
+                ),
+                source="tool_registry",
+                suggested_fix=(
+                    "Keep a compatible tool schema available or inject a provider-specific "
+                    "compatibility guard."
+                ),
+            )
+        )
+    return diagnostics
+
+
+def _context_window_diagnostics(
+    context_metadata: dict[str, object],
+) -> list[RuntimeProviderContextDiagnostic]:
+    diagnostics: list[RuntimeProviderContextDiagnostic] = []
+    dropped = context_metadata.get("dropped_tool_result_count")
+    if isinstance(dropped, int) and dropped > 0:
+        diagnostics.append(
+            RuntimeProviderContextDiagnostic(
+                severity="info",
+                code="tool_feedback_not_retained",
+                message=(
+                    "Some historical tool results were dropped before provider context assembly."
+                ),
+                source="context_window",
+                suggested_fix=(
+                    "Inspect continuity_state and retained tool segments for critical state "
+                    "coverage."
+                ),
+                details={"dropped_tool_result_count": dropped},
+            )
+        )
+    continuity = context_metadata.get("continuity_state")
+    continuity_payload = (
+        cast(dict[str, object], continuity) if isinstance(continuity, dict) else None
+    )
+    if continuity_payload is not None and not continuity_payload.get("summary_text") and dropped:
+        diagnostics.append(
+            RuntimeProviderContextDiagnostic(
+                severity="warning",
+                code="compaction_boundary_missing_checkpoint",
+                message="Tool results were dropped without a continuity summary checkpoint.",
+                source="context_window",
+                suggested_fix=(
+                    "Enable continuity summarization before dropping older tool feedback."
+                ),
+            )
+        )
+    return diagnostics
+
+
+def _todo_projection_diagnostics(
+    segments: tuple[RuntimeContextSegment, ...],
+) -> list[RuntimeProviderContextDiagnostic]:
+    has_runtime_todos = any(
+        segment.role == "system" and _source_from_metadata(segment) == "runtime_todo_state"
+        for segment in segments
+    )
+    todo_tool_indices = [
+        index
+        for index, segment in enumerate(segments)
+        if segment.role == "tool" and segment.tool_name == "todo_write"
+    ]
+    if todo_tool_indices and not has_runtime_todos:
+        return [
+            RuntimeProviderContextDiagnostic(
+                severity="warning",
+                code="todo_state_only_in_droppable_feedback",
+                message=(
+                    "TODO/progress state is visible only through retained todo_write tool feedback."
+                ),
+                source="runtime_todo_state",
+                segment_indices=tuple(todo_tool_indices),
+                suggested_fix=(
+                    "Persist TODO/progress as runtime-owned state before context-window pruning."
+                ),
+            )
+        ]
+    return []

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -3833,7 +3833,7 @@ class VoidCodeRuntime:
                     tool_name=str(event.payload.get("tool", "unknown")),
                     status="error" if is_error else "ok",
                     content=str(raw_content) if raw_content is not None and not is_error else None,
-                    data=sanitize_tool_result_data(event.payload),
+                    data=VoidCodeRuntime._provider_visible_tool_result_data(event.payload),
                     error=str(error_value) if is_error else None,
                     truncated=event.payload.get("truncated") is True,
                     partial=event.payload.get("partial") is True,
@@ -3845,6 +3845,20 @@ class VoidCodeRuntime:
                 )
             )
         return prompt, tool_results
+
+    @staticmethod
+    def _provider_visible_tool_result_data(payload: dict[str, object]) -> dict[str, object]:
+        runtime_envelope_keys = {
+            "content",
+            "display",
+            "error",
+            "status",
+            "tool",
+            "tool_status",
+        }
+        return sanitize_tool_result_data(
+            {key: value for key, value in payload.items() if key not in runtime_envelope_keys}
+        )
 
     def _debug_skill_prompt_context(self, metadata: dict[str, object]) -> str:
         snapshot = self._skill_snapshot_from_metadata(metadata)

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -66,6 +66,7 @@ from ..tools.contracts import (
     ToolResult,
 )
 from ..tools.guidance import definition_with_guidance
+from ..tools.output import sanitize_tool_result_data
 from ..tools.question import QuestionTool
 from ..tools.runtime_context import current_runtime_tool_context
 from ..tools.skill import SkillTool
@@ -118,6 +119,7 @@ from .contracts import (
     ProviderValidationResult,
     ReviewFileDiff,
     RuntimeNotification,
+    RuntimeProviderContextSnapshot,
     RuntimeRequest,
     RuntimeRequestError,
     RuntimeRequestMetadataPayload,
@@ -181,6 +183,7 @@ from .permission import (
     PermissionResolution,
     resolve_permission,
 )
+from .provider_context import inspect_provider_context
 from .provider_protocol import ProviderExecutionError
 from .question import PendingQuestion, QuestionResponse
 from .resume import RuntimeResumeCoordinator
@@ -2461,6 +2464,7 @@ class VoidCodeRuntime:
             )
         )
         last_tool = self._last_tool_summary(result)
+        provider_context = self._provider_context_debug_snapshot(result)
         failure = self._debug_failure(
             result=result,
             last_failure_event=last_failure_event,
@@ -2524,6 +2528,7 @@ class VoidCodeRuntime:
             last_failure_event=last_failure_event,
             failure=failure,
             last_tool=last_tool,
+            provider_context=provider_context,
             suggested_operator_action=suggested_operator_action,
             operator_guidance=operator_guidance,
         )
@@ -3784,6 +3789,68 @@ class VoidCodeRuntime:
                 sequence=event.sequence,
             )
         return None
+
+    def _provider_context_debug_snapshot(
+        self,
+        result: RuntimeSessionResult,
+    ) -> RuntimeProviderContextSnapshot:
+        prompt, tool_results = self._prompt_and_tool_results_from_debug_events(result.transcript)
+        if not prompt:
+            prompt = result.prompt
+        assembled_context = self._assemble_provider_context(
+            prompt=prompt,
+            tool_results=tuple(tool_results),
+            session_metadata=result.session.metadata,
+            skill_prompt_context=self._debug_skill_prompt_context(result.session.metadata),
+        )
+        effective_config = self._effective_runtime_config_from_metadata(result.session.metadata)
+        active_target = effective_config.resolved_provider.active_target
+        provider = active_target.selection.provider or "unknown"
+        model = active_target.selection.model or active_target.selection.raw_model or "unknown"
+        tool_registry = self._tool_registry_for_effective_config(effective_config)
+        return inspect_provider_context(
+            assembled_context=assembled_context,
+            provider=provider,
+            model=model,
+            execution_engine=effective_config.execution_engine,
+            available_tool_count=len(tool_registry.definitions()),
+        )
+
+    @staticmethod
+    def _prompt_and_tool_results_from_debug_events(
+        events: tuple[EventEnvelope, ...],
+    ) -> tuple[str, list[ToolResult]]:
+        prompt = VoidCodeRuntime._prompt_from_events(events)
+        tool_results: list[ToolResult] = []
+        for event in events:
+            if event.event_type != "runtime.tool_completed":
+                continue
+            error_value = event.payload.get("error")
+            raw_content = event.payload.get("content")
+            is_error = error_value is not None
+            tool_results.append(
+                ToolResult(
+                    tool_name=str(event.payload.get("tool", "unknown")),
+                    status="error" if is_error else "ok",
+                    content=str(raw_content) if raw_content is not None and not is_error else None,
+                    data=sanitize_tool_result_data(event.payload),
+                    error=str(error_value) if is_error else None,
+                    truncated=event.payload.get("truncated") is True,
+                    partial=event.payload.get("partial") is True,
+                    reference=(
+                        cast(str, event.payload.get("reference"))
+                        if isinstance(event.payload.get("reference"), str)
+                        else None
+                    ),
+                )
+            )
+        return prompt, tool_results
+
+    def _debug_skill_prompt_context(self, metadata: dict[str, object]) -> str:
+        snapshot = self._skill_snapshot_from_metadata(metadata)
+        if snapshot is None:
+            return ""
+        return snapshot.skill_prompt_context
 
     @staticmethod
     def _operator_guidance(

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -958,6 +958,10 @@ def test_transport_reads_session_debug_snapshot(tmp_path: Path) -> None:
     )
     assert payload["last_failure_event"] is None
     assert payload["failure"] is None
+    provider_context = cast(dict[str, object], payload["provider_context"])
+    assert cast(int, provider_context["segment_count"]) >= 3
+    provider_segments = cast(list[dict[str, object]], provider_context["segments"])
+    assert provider_segments[-1]["tool_name"] == "read_file"
     assert payload["suggested_operator_action"] == "replay"
 
 

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -502,6 +502,8 @@ def test_sessions_debug_outputs_json_snapshot() -> None:
     assert payload["pending_approval"] is None
     assert payload["pending_question"] is None
     assert payload["last_relevant_event"]["event_type"] == "graph.response_ready"
+    assert payload["provider_context"]["segment_count"] >= 3
+    assert payload["provider_context"]["segments"][-1]["tool_name"] == "read_file"
     assert payload["suggested_operator_action"] == "replay"
     assert "Traceback" not in debug_result.stderr
 

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -203,6 +203,47 @@ def test_provider_context_inspector_redacts_secret_text_from_tool_output() -> No
     assert tool_message.tool_call_id == "call_secret"
 
 
+def test_provider_context_inspector_redacts_tool_error_and_data_fields() -> None:
+    assembled = assemble_provider_context(
+        prompt="inspect failure",
+        tool_results=(
+            ToolResult(
+                tool_name="web_fetch",
+                status="error",
+                error="request failed with access_token=tool-secret-token",
+                data={
+                    "tool_call_id": "call:error",
+                    "arguments": {"url": "https://example.com"},
+                    "headers": {"authorization": "Bearer nested-secret-token"},
+                    "access_token": "data-secret-token",
+                },
+            ),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(max_tool_results=4),
+    )
+
+    snapshot = inspect_provider_context(
+        assembled_context=assembled,
+        provider="openai",
+        model="gpt-4o",
+        execution_engine="provider",
+        available_tool_count=3,
+    )
+    tool_segment = snapshot.segments[-1]
+    tool_message_content = snapshot.provider_messages[-1].content or ""
+
+    assert "tool-secret-token" not in tool_message_content
+    assert "nested-secret-token" not in tool_message_content
+    assert "data-secret-token" not in tool_message_content
+    assert "authorization" not in tool_message_content.lower()
+    assert tool_segment.metadata["error"] == "request failed with access_token=[redacted]"
+    tool_data = tool_segment.metadata["data"]
+    assert isinstance(tool_data, dict)
+    assert "headers" in tool_data
+    assert tool_data["headers"] == {}
+
+
 def test_provider_context_inspector_reports_tool_pairing_problems() -> None:
     assembled = RuntimeAssembledContext(
         prompt="continue",

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 
 from voidcode.runtime.context_window import (
     ContextWindowPolicy,
+    RuntimeAssembledContext,
+    RuntimeContextSegment,
     RuntimeContinuityState,
     assemble_provider_context,
     context_window_policy_from_payload,
@@ -16,6 +18,7 @@ from voidcode.runtime.context_window import (
     normalize_read_file_output,
     prepare_provider_context,
 )
+from voidcode.runtime.provider_context import inspect_provider_context
 from voidcode.tools.contracts import ToolResult
 
 
@@ -121,6 +124,122 @@ def test_assemble_provider_context_injects_active_runtime_todos() -> None:
         and "old finished task" not in content
         for content in system_segments
     )
+    assert [segment.metadata for segment in assembled.segments if segment.role == "system"] == [
+        {"source": "runtime_todo_state"}
+    ]
+
+
+def test_provider_context_inspector_reports_opencode_go_synthetic_feedback() -> None:
+    assembled = assemble_provider_context(
+        prompt="continue",
+        tool_results=(
+            ToolResult(
+                tool_name="read_file",
+                content="hello",
+                status="ok",
+                data={
+                    "tool_call_id": "call:1",
+                    "arguments": {"path": "sample.txt", "api_key": "secret"},
+                    "path": "sample.txt",
+                },
+            ),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(max_tool_results=4),
+    )
+
+    snapshot = inspect_provider_context(
+        assembled_context=assembled,
+        provider="opencode-go",
+        model="glm-5",
+        execution_engine="provider",
+        available_tool_count=3,
+    )
+
+    assert snapshot.provider == "opencode-go"
+    assert snapshot.provider_messages[-1].source == "opencode_go_synthetic_tool_feedback"
+    assert snapshot.provider_messages[-1].role == "user"
+    synthetic_content = snapshot.provider_messages[-1].content or ""
+    assert "Completed tool calls for current request" in synthetic_content
+    assert "api_key" not in synthetic_content
+    assert "secret" not in synthetic_content
+    assert any(
+        diagnostic.code == "provider_path_uses_synthetic_tool_feedback"
+        for diagnostic in snapshot.diagnostics
+    )
+
+
+def test_provider_context_inspector_redacts_secret_text_from_tool_output() -> None:
+    assembled = assemble_provider_context(
+        prompt="inspect env",
+        tool_results=(
+            ToolResult(
+                tool_name="read_file",
+                content=(
+                    "OPENAI_API_KEY=sk-test-secret\n"
+                    "Authorization: Bearer abcdefghijklmnopqrstuvwxyz"
+                ),
+                status="ok",
+                data={"tool_call_id": "call:secret", "arguments": {"path": ".env"}},
+            ),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(max_tool_results=4),
+    )
+
+    snapshot = inspect_provider_context(
+        assembled_context=assembled,
+        provider="openai",
+        model="gpt-4o",
+        execution_engine="provider",
+        available_tool_count=3,
+    )
+    tool_segment = snapshot.segments[-1]
+    tool_message = snapshot.provider_messages[-1]
+
+    assert tool_segment.content == "OPENAI_API_KEY=[redacted]\nAuthorization: Bearer [redacted]"
+    assert "sk-test-secret" not in (tool_message.content or "")
+    assert "abcdefghijklmnopqrstuvwxyz" not in (tool_message.content or "")
+    assert tool_message.tool_call_id == "call_secret"
+
+
+def test_provider_context_inspector_reports_tool_pairing_problems() -> None:
+    assembled = RuntimeAssembledContext(
+        prompt="continue",
+        tool_results=(),
+        continuity_state=None,
+        metadata={},
+        segments=(
+            RuntimeContextSegment(role="user", content="continue"),
+            RuntimeContextSegment(
+                role="assistant",
+                content=None,
+                tool_call_id="missing-result",
+                tool_name="read_file",
+                tool_arguments={"path": "sample.txt"},
+            ),
+            RuntimeContextSegment(
+                role="tool",
+                content="orphan",
+                tool_call_id="orphan-result",
+                tool_name="grep",
+                metadata={"status": "ok", "data": {}},
+            ),
+        ),
+    )
+
+    snapshot = inspect_provider_context(
+        assembled_context=assembled,
+        provider="openai",
+        model="gpt-4o",
+        execution_engine="provider",
+        available_tool_count=0,
+    )
+    diagnostic_codes = {diagnostic.code for diagnostic in snapshot.diagnostics}
+
+    assert "missing_tool_result" in diagnostic_codes
+    assert "orphan_tool_result" in diagnostic_codes
+    assert "provider_requires_tools_schema" in diagnostic_codes
 
 
 def test_prepare_provider_context_compacts_old_results_and_reports_metadata() -> None:
@@ -174,10 +293,12 @@ def test_prepare_provider_context_uses_explicit_continuity_preview_policy() -> N
     )
 
     assert context.continuity_state is not None
-    assert "## Objective\nread sample.txt" in context.continuity_state.summary_text
-    assert "Compacted 3 earlier tool results:" in context.continuity_state.summary_text
-    assert '1. read_file ok content_preview="conte..."' in context.continuity_state.summary_text
-    assert "... and 2 more" in context.continuity_state.summary_text
+    summary_text = context.continuity_state.summary_text
+    assert summary_text is not None
+    assert "## Objective\nread sample.txt" in summary_text
+    assert "Compacted 3 earlier tool results:" in summary_text
+    assert '1. read_file ok content_preview="conte..."' in summary_text
+    assert "... and 2 more" in summary_text
 
 
 def test_prepare_provider_context_compacts_by_absolute_token_budget() -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1619,6 +1619,18 @@ def test_runtime_session_debug_snapshot_includes_provider_context(tmp_path: Path
     assert provider_context.segments[-1].source == "retained_tool_result"
     assert provider_context.segments[-1].tool_name == "read_file"
     assert provider_context.segments[-1].metadata["status"] == "ok"
+    reconstructed_data = provider_context.segments[-1].metadata["data"]
+    assert isinstance(reconstructed_data, dict)
+    assert "path" in reconstructed_data
+    assert "content" not in reconstructed_data
+    assert "display" not in reconstructed_data
+    assert "error" not in reconstructed_data
+    assert "status" not in reconstructed_data
+    assert "tool" not in reconstructed_data
+    assert "tool_status" not in reconstructed_data
+    provider_message_content = provider_context.provider_messages[-1].content or ""
+    assert "tool_status" not in provider_message_content
+    assert "display" not in provider_message_content
     assert all(
         diagnostic.code not in {"missing_tool_result", "orphan_tool_result"}
         for diagnostic in provider_context.diagnostics

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1603,6 +1603,59 @@ def test_runtime_session_debug_snapshot_reports_completed_state(tmp_path: Path) 
     )
 
 
+def test_runtime_session_debug_snapshot_includes_provider_context(tmp_path: Path) -> None:
+    _ = (tmp_path / "sample.txt").write_text("provider debug\n", encoding="utf-8")
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+
+    _ = runtime.run(RuntimeRequest(prompt="read sample.txt", session_id="provider-debug"))
+    snapshot = runtime.session_debug_snapshot(session_id="provider-debug")
+
+    provider_context = snapshot.provider_context
+    assert provider_context is not None
+    assert provider_context.execution_engine == "deterministic"
+    assert provider_context.segment_count == len(provider_context.segments)
+    assert provider_context.message_count == len(provider_context.provider_messages)
+    assert [segment.role for segment in provider_context.segments][-2:] == ["assistant", "tool"]
+    assert provider_context.segments[-1].source == "retained_tool_result"
+    assert provider_context.segments[-1].tool_name == "read_file"
+    assert provider_context.segments[-1].metadata["status"] == "ok"
+    assert all(
+        diagnostic.code not in {"missing_tool_result", "orphan_tool_result"}
+        for diagnostic in provider_context.diagnostics
+    )
+
+
+def test_runtime_session_debug_snapshot_reconstructs_skill_prompt_context(
+    tmp_path: Path,
+) -> None:
+    skill_dir = tmp_path / ".voidcode" / "skills" / "demo"
+    _write_demo_skill(skill_dir, content="# Demo\nAlways explain your reasoning.")
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_SkillCapturingStubGraph(),
+        config=RuntimeConfig(skills=RuntimeSkillsConfig(enabled=True)),
+    )
+
+    _ = runtime.run(
+        RuntimeRequest(
+            prompt="hello",
+            session_id="skill-debug",
+            metadata={"force_load_skills": ["demo"]},
+        )
+    )
+    snapshot = runtime.session_debug_snapshot(session_id="skill-debug")
+
+    provider_context = snapshot.provider_context
+    assert provider_context is not None
+    skill_segments = [
+        segment
+        for segment in provider_context.segments
+        if segment.role == "system" and segment.source == "skill_prompt"
+    ]
+    assert len(skill_segments) == 1
+    assert "Always explain your reasoning." in (skill_segments[0].content or "")
+
+
 def test_runtime_session_debug_snapshot_reports_pending_approval_state(tmp_path: Path) -> None:
     runtime = VoidCodeRuntime(
         workspace=tmp_path,


### PR DESCRIPTION
## Summary
- Adds runtime provider-context debug contracts with sanitized assembled segments, provider message previews, and structural diagnostics.
- Preserves segment provenance through context assembly and reconstructs provider context from persisted session debug snapshots, including skill prompt context.
- Exposes provider-context inspection through CLI and HTTP session debug surfaces.

## Verification
- `uv run ruff check .`
- `uv run basedpyright --warnings src`
- `uv run python -X utf8 -m pytest -n auto` (1729 passed)
- `bun run lint` (frontend)
- `bun run typecheck` (frontend)
- `bun run test:run` (frontend; rerun passed 162 tests after one timeout flake)

Closes #334