### PR TITLE
feat(runtime): add provider failure recovery checkpoints

### DIFF
--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -139,6 +139,7 @@ def _handle_run_command(args: argparse.Namespace) -> int:
                 _print_noninteractive_blocked(result, blocked_event)
                 return _blocked_exit_code(blocked_event)
             _print_plain_runtime_output(result.output)
+            _print_runtime_failure_footer(runtime, result, workspace=workspace)
     finally:
         _close_runtime(runtime)
     return EXIT_SUCCESS
@@ -343,6 +344,56 @@ def _print_plain_runtime_output(output: str | None) -> None:
     print(output, end="", flush=True)
     if not output.endswith("\n"):
         print(flush=True)
+
+
+def _print_runtime_failure_footer(
+    runtime: VoidCodeRuntime,
+    result: RuntimeStreamResult,
+    *,
+    workspace: Path,
+) -> None:
+    if result.session.status != "failed":
+        return
+    failed_event = next(
+        (event for event in reversed(result.events) if event.event_type == "runtime.failed"),
+        None,
+    )
+    if failed_event is None:
+        return
+    try:
+        snapshot = runtime.session_debug_snapshot(session_id=result.session.session.id)
+    except ValueError:
+        snapshot = None
+    workspace_arg = f"--workspace {shlex.quote(str(workspace))}"
+    provider = failed_event.payload.get("provider")
+    model = failed_event.payload.get("model")
+    provider_error_kind = failed_event.payload.get("provider_error_kind")
+    last_tool = snapshot.last_tool if snapshot is not None else None
+    resumable = snapshot.resumable if snapshot is not None else False
+    print("", file=sys.stderr, flush=True)
+    print("VoidCode runtime failure summary", file=sys.stderr, flush=True)
+    print(f"  session: {result.session.session.id}", file=sys.stderr, flush=True)
+    print(f"  status: {result.session.status}", file=sys.stderr, flush=True)
+    if isinstance(provider, str) and provider:
+        print(f"  provider: {provider}", file=sys.stderr, flush=True)
+    if isinstance(model, str) and model:
+        print(f"  model: {model}", file=sys.stderr, flush=True)
+    if isinstance(provider_error_kind, str) and provider_error_kind:
+        print(f"  provider_error_kind: {provider_error_kind}", file=sys.stderr, flush=True)
+    print(f"  resumable: {str(resumable).lower()}", file=sys.stderr, flush=True)
+    if last_tool is not None:
+        print(f"  last_successful_tool: {last_tool.tool_name}", file=sys.stderr, flush=True)
+    print(
+        f"  debug: voidcode sessions debug {result.session.session.id} {workspace_arg}",
+        file=sys.stderr,
+        flush=True,
+    )
+    if resumable:
+        print(
+            f"  resume: voidcode sessions resume {result.session.session.id} {workspace_arg}",
+            file=sys.stderr,
+            flush=True,
+        )
 
 
 def _runtime_stream_payload(result: RuntimeStreamResult, *, workspace: Path) -> dict[str, object]:

--- a/src/voidcode/runtime/resume.py
+++ b/src/voidcode/runtime/resume.py
@@ -1077,7 +1077,11 @@ class RuntimeResumeCoordinator:
         )
 
     def resume_provider_failure_response(
-        self, *, session_id: str, checkpoint: dict[str, object]
+        self,
+        *,
+        session_id: str,
+        checkpoint: dict[str, object],
+        finalize_background_task: bool = False,
     ) -> RuntimeResponse:
         output: str | None = None
         final_session: SessionState | None = None
@@ -1092,11 +1096,16 @@ class RuntimeResumeCoordinator:
             workspace=self._runtime._workspace,
             session_id=session_id,
         )
-        return RuntimeResponse(
+        response = RuntimeResponse(
             session=final_session or stored.session,
             events=stored.events,
             output=output if output is not None else stored.output,
         )
+        if finalize_background_task:
+            self._runtime._background_task_supervisor.finalize_background_task_from_session_response(
+                session_response=response
+            )
+        return response
 
     def resume_provider_failure_stream(
         self,
@@ -1105,6 +1114,7 @@ class RuntimeResumeCoordinator:
         checkpoint: dict[str, object],
         run_id: str | None = None,
         abort_signal: ProviderAbortSignal | None = None,
+        finalize_background_task: bool = False,
     ) -> Iterator[RuntimeStreamChunk]:
         runtime = self._runtime
         checkpoint_envelope = self.validated_resume_checkpoint_envelope(
@@ -1276,6 +1286,13 @@ class RuntimeResumeCoordinator:
                     final_session.session.id,
                     end_hook_outcome.failed_error,
                 )
+            release_events = runtime._release_mcp_session_events(
+                session_id=final_session.session.id,
+                start_sequence=end_hook_outcome.last_sequence + 1,
+            )
+            loop_events.extend(release_events)
+            for event in release_events:
+                yield RuntimeStreamChunk(kind="event", session=final_session, event=event)
 
         response = RuntimeResponse(
             session=final_session,
@@ -1288,6 +1305,10 @@ class RuntimeResumeCoordinator:
             parent_session_id=stored.session.session.parent_id,
         )
         runtime._persist_response(request=request, response=response)
+        if finalize_background_task:
+            runtime._background_task_supervisor.finalize_background_task_from_session_response(
+                session_response=response
+            )
 
     @staticmethod
     def tool_results_from_checkpoint(raw_tool_results: list[object]) -> tuple[ToolResult, ...]:

--- a/src/voidcode/runtime/resume.py
+++ b/src/voidcode/runtime/resume.py
@@ -1211,25 +1211,45 @@ class RuntimeResumeCoordinator:
         output: str | None = None
         final_session = session
         last_sequence = max_stored_sequence
-        for chunk in runtime._execute_graph_loop(
-            graph=graph,
-            tool_registry=tool_registry,
-            session=session,
-            sequence=max_stored_sequence,
-            graph_request=graph_request,
-            tool_results=tool_results,
-            permission_policy=runtime._permission_policy_for_session(session.metadata),
-            preserved_continuity_state=runtime._continuity_state_from_session_metadata(
-                session.metadata
-            ),
-        ):
-            final_session = chunk.session
-            if chunk.event is not None:
-                last_sequence = chunk.event.sequence
-                loop_events.append(chunk.event)
-            if chunk.kind == "output":
-                output = chunk.output
-            yield chunk
+        try:
+            for chunk in runtime._execute_graph_loop(
+                graph=graph,
+                tool_registry=tool_registry,
+                session=session,
+                sequence=max_stored_sequence,
+                graph_request=graph_request,
+                tool_results=tool_results,
+                permission_policy=runtime._permission_policy_for_session(session.metadata),
+                preserved_continuity_state=runtime._continuity_state_from_session_metadata(
+                    session.metadata
+                ),
+            ):
+                final_session = chunk.session
+                if chunk.event is not None:
+                    last_sequence = chunk.event.sequence
+                    loop_events.append(chunk.event)
+                if chunk.kind == "output":
+                    output = chunk.output
+                yield chunk
+        except Exception:
+            if final_session.status == "failed":
+                response = RuntimeResponse(
+                    session=final_session,
+                    events=stored.events + tuple(loop_events),
+                    output=output,
+                )
+                request = RuntimeRequest(
+                    prompt=prompt,
+                    session_id=stored.session.session.id,
+                    parent_session_id=stored.session.session.parent_id,
+                )
+                runtime._persist_response(request=request, response=response)
+                if finalize_background_task:
+                    runtime._background_task_supervisor.finalize_background_task_from_session_response(
+                        session_response=response
+                    )
+                return
+            raise
 
         if final_session.status == "waiting":
             final_session = runtime._disconnect_acp_for_session_state(final_session)

--- a/src/voidcode/runtime/resume.py
+++ b/src/voidcode/runtime/resume.py
@@ -1076,6 +1076,219 @@ class RuntimeResumeCoordinator:
             load_checkpoint(workspace=self._runtime._workspace, session_id=session_id),
         )
 
+    def resume_provider_failure_response(
+        self, *, session_id: str, checkpoint: dict[str, object]
+    ) -> RuntimeResponse:
+        output: str | None = None
+        final_session: SessionState | None = None
+        for chunk in self.resume_provider_failure_stream(
+            session_id=session_id,
+            checkpoint=checkpoint,
+        ):
+            final_session = chunk.session
+            if chunk.kind == "output":
+                output = chunk.output
+        stored = self._runtime._session_store.load_session(
+            workspace=self._runtime._workspace,
+            session_id=session_id,
+        )
+        return RuntimeResponse(
+            session=final_session or stored.session,
+            events=stored.events,
+            output=output if output is not None else stored.output,
+        )
+
+    def resume_provider_failure_stream(
+        self,
+        *,
+        session_id: str,
+        checkpoint: dict[str, object],
+        run_id: str | None = None,
+        abort_signal: ProviderAbortSignal | None = None,
+    ) -> Iterator[RuntimeStreamChunk]:
+        runtime = self._runtime
+        checkpoint_envelope = self.validated_resume_checkpoint_envelope(
+            checkpoint=checkpoint,
+            expected_kind="provider_failure_retryable",
+        )
+        if checkpoint_envelope is None:
+            raise ValueError("provider failure resume checkpoint is missing")
+        stored = runtime._session_store.load_session(
+            workspace=runtime._workspace,
+            session_id=session_id,
+        )
+        runtime._validate_session_workspace(stored.session, session_id=session_id)
+        payload = checkpoint_envelope.payload
+        prompt = payload.get("prompt")
+        session_metadata = payload.get("session_metadata")
+        raw_tool_results = payload.get("tool_results")
+        if not isinstance(prompt, str):
+            raise ValueError("persisted provider failure checkpoint prompt must be a string")
+        if not isinstance(session_metadata, dict):
+            raise ValueError(
+                "persisted provider failure checkpoint session_metadata must be an object"
+            )
+        if not isinstance(raw_tool_results, list):
+            raise ValueError("persisted provider failure checkpoint tool_results must be a list")
+        tool_results = list(self.tool_results_from_checkpoint(cast(list[object], raw_tool_results)))
+        session = SessionState(
+            session=stored.session.session,
+            status="running",
+            turn=stored.session.turn,
+            metadata=_metadata_with_resume_run_id(
+                cast(dict[str, object], session_metadata),
+                run_id=run_id,
+            ),
+        )
+        runtime._validate_session_workspace(session, session_id=session_id)
+        session = runtime._session_with_current_acp_metadata(session)
+        effective_config = runtime._effective_runtime_config_from_metadata(session.metadata)
+        try:
+            runtime._validate_reasoning_effort_capability(effective_config)
+        except ValueError as exc:
+            raise RuntimeRequestError(str(exc)) from exc
+        tool_registry = runtime._tool_registry_for_effective_config(effective_config)
+        skill_registry = runtime._skill_registry_for_effective_config(effective_config)
+        resumed_skill_snapshot = runtime._build_skill_snapshot(
+            skill_registry,
+            metadata=session.metadata,
+            agent=effective_config.agent,
+            source="resume",
+        )
+        graph_request = GraphRunRequest(
+            session=session,
+            prompt=prompt,
+            available_tools=tool_registry.definitions(),
+            context_window=runtime._prepare_provider_context_window(
+                prompt=prompt,
+                tool_results=tuple(tool_results),
+                session_metadata=session.metadata,
+            ),
+            assembled_context=runtime._assemble_provider_context(
+                prompt=prompt,
+                tool_results=tuple(tool_results),
+                session_metadata=session.metadata,
+                skill_prompt_context=resumed_skill_snapshot.skill_prompt_context,
+            ),
+            metadata={
+                **session.metadata,
+                "agent_preset": serialize_runtime_agent_config(effective_config.agent),
+                "provider_attempt": (
+                    session.metadata.get("provider_attempt", 0)
+                    if isinstance(session.metadata.get("provider_attempt", 0), int)
+                    else 0
+                ),
+                "provider_stream": True,
+                "provider_failure_resume": True,
+                **(
+                    {"reasoning_effort": effective_config.reasoning_effort}
+                    if effective_config.reasoning_effort is not None
+                    and "reasoning_effort" not in session.metadata
+                    else {}
+                ),
+            },
+            abort_signal=abort_signal,
+        )
+        graph = runtime._graph_for_session_metadata(session.metadata)
+        provider_attempt = runtime._provider_attempt_from_metadata(graph_request.metadata)
+        if provider_attempt > 0:
+            graph = runtime._graph_selection_for_effective_config(
+                effective_config,
+                provider_attempt=provider_attempt,
+            ).graph
+        max_stored_sequence = stored.events[-1].sequence if stored.events else 0
+        loop_events: list[EventEnvelope] = []
+        output: str | None = None
+        final_session = session
+        last_sequence = max_stored_sequence
+        for chunk in runtime._execute_graph_loop(
+            graph=graph,
+            tool_registry=tool_registry,
+            session=session,
+            sequence=max_stored_sequence,
+            graph_request=graph_request,
+            tool_results=tool_results,
+            permission_policy=runtime._permission_policy_for_session(session.metadata),
+            preserved_continuity_state=runtime._continuity_state_from_session_metadata(
+                session.metadata
+            ),
+        ):
+            final_session = chunk.session
+            if chunk.event is not None:
+                last_sequence = chunk.event.sequence
+                loop_events.append(chunk.event)
+            if chunk.kind == "output":
+                output = chunk.output
+            yield chunk
+
+        if final_session.status == "waiting":
+            final_session = runtime._disconnect_acp_for_session_state(final_session)
+            idle_hook_outcome = runtime._run_lifecycle_hooks(
+                session=final_session,
+                sequence=last_sequence,
+                surface="session_idle",
+                payload={"reason": "provider_failure_resume_waiting", "resume": True},
+            )
+            for hook_chunk in idle_hook_outcome.chunks:
+                hook_event = cast(EventEnvelope, hook_chunk.event)
+                last_sequence = hook_event.sequence
+                loop_events.append(hook_event)
+                yield hook_chunk
+            if idle_hook_outcome.failed_error is not None:
+                failed_chunk = runtime._failed_chunk(
+                    session=final_session,
+                    sequence=idle_hook_outcome.last_sequence + 1,
+                    error=idle_hook_outcome.failed_error,
+                )
+                failed_event = cast(EventEnvelope, failed_chunk.event)
+                loop_events.append(failed_event)
+                final_session = failed_chunk.session
+                yield failed_chunk
+        else:
+            final_chunks, final_session, final_sequence = runtime._finalize_run_acp(
+                session=final_session,
+                sequence=last_sequence,
+            )
+            for chunk in final_chunks:
+                if chunk.event is not None:
+                    last_sequence += 1
+                    resequenced_event = runtime._resequence_event(
+                        chunk.event,
+                        sequence=last_sequence,
+                    )
+                    loop_events.append(resequenced_event)
+                    yield RuntimeStreamChunk(
+                        kind="event", session=chunk.session, event=resequenced_event
+                    )
+            end_hook_outcome = runtime._run_lifecycle_hooks(
+                session=final_session,
+                sequence=max(last_sequence, final_sequence),
+                surface="session_end",
+                payload={"session_status": final_session.status, "resume": True},
+            )
+            for hook_chunk in end_hook_outcome.chunks:
+                hook_event = cast(EventEnvelope, hook_chunk.event)
+                loop_events.append(hook_event)
+                yield hook_chunk
+            if end_hook_outcome.failed_error is not None:
+                logger.warning(
+                    "session_end hook failed for %s during provider failure resume: %s",
+                    final_session.session.id,
+                    end_hook_outcome.failed_error,
+                )
+
+        response = RuntimeResponse(
+            session=final_session,
+            events=stored.events + tuple(loop_events),
+            output=output,
+        )
+        request = RuntimeRequest(
+            prompt=prompt,
+            session_id=stored.session.session.id,
+            parent_session_id=stored.session.session.parent_id,
+        )
+        runtime._persist_response(request=request, response=response)
+
     @staticmethod
     def tool_results_from_checkpoint(raw_tool_results: list[object]) -> tuple[ToolResult, ...]:
         parsed: list[ToolResult] = []

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -3947,6 +3947,7 @@ class VoidCodeRuntime:
                 return self._resume_provider_failure_response(
                     session_id=session_id,
                     checkpoint=checkpoint,
+                    finalize_background_task=True,
                 )
             response = self._load_stored_response(session_id=session_id)
             self._background_task_supervisor.reconcile_parent_background_task_events_for_session(
@@ -3997,6 +3998,7 @@ class VoidCodeRuntime:
                         checkpoint=checkpoint,
                         run_id=run_id,
                         abort_signal=abort_signal,
+                        finalize_background_task=True,
                     )
                 finally:
                     self._unregister_active_session_id(session_id, run_id=run_id)
@@ -4604,11 +4606,16 @@ class VoidCodeRuntime:
         return self._resume_coordinator.load_resume_checkpoint(session_id=session_id)
 
     def _resume_provider_failure_response(
-        self, *, session_id: str, checkpoint: dict[str, object]
+        self,
+        *,
+        session_id: str,
+        checkpoint: dict[str, object],
+        finalize_background_task: bool = False,
     ) -> RuntimeResponse:
         return self._resume_coordinator.resume_provider_failure_response(
             session_id=session_id,
             checkpoint=checkpoint,
+            finalize_background_task=finalize_background_task,
         )
 
     def _resume_provider_failure_stream(
@@ -4618,12 +4625,14 @@ class VoidCodeRuntime:
         checkpoint: dict[str, object],
         run_id: str | None = None,
         abort_signal: ProviderAbortSignal | None = None,
+        finalize_background_task: bool = False,
     ) -> Iterator[RuntimeStreamChunk]:
         yield from self._resume_coordinator.resume_provider_failure_stream(
             session_id=session_id,
             checkpoint=checkpoint,
             run_id=run_id,
             abort_signal=abort_signal,
+            finalize_background_task=finalize_background_task,
         )
 
     @staticmethod

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -2428,8 +2428,16 @@ class VoidCodeRuntime:
             pending_approval=pending_approval,
             pending_question=pending_question,
         )
+        checkpoint_kind = (
+            cast(str, resume_checkpoint.get("kind"))
+            if isinstance(resume_checkpoint, dict)
+            and isinstance(resume_checkpoint.get("kind"), str)
+            else None
+        )
         terminal = result.session.status in {"completed", "failed"}
-        resumable = result.session.status == "waiting"
+        resumable = result.session.status == "waiting" or (
+            result.session.status == "failed" and checkpoint_kind == "provider_failure_retryable"
+        )
         replayable = bool(result.transcript) or result.output is not None or terminal
         last_relevant_event = self._debug_event(
             next(
@@ -2475,6 +2483,7 @@ class VoidCodeRuntime:
             pending_approval=pending_approval,
             pending_question=pending_question,
             active=active,
+            resumable=resumable,
             terminal=terminal,
             failure=failure,
         )
@@ -2487,12 +2496,7 @@ class VoidCodeRuntime:
             resumable=resumable,
             replayable=replayable,
             terminal=terminal,
-            resume_checkpoint_kind=(
-                cast(str, resume_checkpoint.get("kind"))
-                if isinstance(resume_checkpoint, dict)
-                and isinstance(resume_checkpoint.get("kind"), str)
-                else None
-            ),
+            resume_checkpoint_kind=checkpoint_kind,
             pending_approval=(
                 RuntimeSessionDebugPendingApproval(
                     request_id=pending_approval.request_id,
@@ -3748,7 +3752,7 @@ class VoidCodeRuntime:
             if pending_question is not None and checkpoint_kind != "question_wait":
                 return "pending question does not match the persisted resume checkpoint"
         if result.session.status in {"completed", "failed"}:
-            if checkpoint_kind not in {None, "terminal"}:
+            if checkpoint_kind not in {None, "provider_failure_retryable", "terminal"}:
                 return "terminal session resume checkpoint does not match persisted terminal state"
             if pending_approval is not None or pending_question is not None:
                 return "terminal session still has pending approval/question state"
@@ -3792,6 +3796,7 @@ class VoidCodeRuntime:
         pending_approval: PendingApproval | None,
         pending_question: PendingQuestion | None,
         active: bool,
+        resumable: bool,
         terminal: bool,
         failure: RuntimeSessionDebugFailure | None,
     ) -> tuple[str, str]:
@@ -3814,6 +3819,16 @@ class VoidCodeRuntime:
         if active:
             return ("wait", "Session is currently active in the runtime.")
         if terminal and failure is not None:
+            if failure.classification == "provider_failure" and current_status == "failed":
+                if not resumable:
+                    return (
+                        "inspect_failure",
+                        f"Inspect {failure.classification} and rerun if needed.",
+                    )
+                return (
+                    "resume_provider_failure",
+                    "Resume this session to continue from the provider failure checkpoint.",
+                )
             return ("inspect_failure", f"Inspect {failure.classification} and rerun if needed.")
         if terminal:
             return ("replay", "Session is terminal; replay or inspect transcript if needed.")
@@ -3927,6 +3942,12 @@ class VoidCodeRuntime:
     ) -> RuntimeResponse:
         validate_session_id(session_id)
         if approval_request_id is None and approval_decision is None:
+            checkpoint = self._load_resume_checkpoint(session_id=session_id)
+            if checkpoint is not None and checkpoint.get("kind") == "provider_failure_retryable":
+                return self._resume_provider_failure_response(
+                    session_id=session_id,
+                    checkpoint=checkpoint,
+                )
             response = self._load_stored_response(session_id=session_id)
             self._background_task_supervisor.reconcile_parent_background_task_events_for_session(
                 parent_session_id=session_id
@@ -3958,6 +3979,28 @@ class VoidCodeRuntime:
     ) -> Iterator[RuntimeStreamChunk]:
         validate_session_id(session_id)
         if approval_request_id is None and approval_decision is None:
+            checkpoint = self._load_resume_checkpoint(session_id=session_id)
+            if checkpoint is not None and checkpoint.get("kind") == "provider_failure_retryable":
+                run_id = os.urandom(8).hex()
+                abort_signal = self._register_active_session_id(
+                    session_id,
+                    run_id=run_id,
+                    metadata={
+                        "resume": True,
+                        "resume_kind": "provider_failure_retryable",
+                        "run_id": run_id,
+                    },
+                )
+                try:
+                    yield from self._resume_provider_failure_stream(
+                        session_id=session_id,
+                        checkpoint=checkpoint,
+                        run_id=run_id,
+                        abort_signal=abort_signal,
+                    )
+                finally:
+                    self._unregister_active_session_id(session_id, run_id=run_id)
+                return
             response = self._load_stored_response(session_id=session_id)
             self._background_task_supervisor.reconcile_parent_background_task_events_for_session(
                 parent_session_id=session_id
@@ -4559,6 +4602,29 @@ class VoidCodeRuntime:
 
     def _load_resume_checkpoint(self, *, session_id: str) -> dict[str, object] | None:
         return self._resume_coordinator.load_resume_checkpoint(session_id=session_id)
+
+    def _resume_provider_failure_response(
+        self, *, session_id: str, checkpoint: dict[str, object]
+    ) -> RuntimeResponse:
+        return self._resume_coordinator.resume_provider_failure_response(
+            session_id=session_id,
+            checkpoint=checkpoint,
+        )
+
+    def _resume_provider_failure_stream(
+        self,
+        *,
+        session_id: str,
+        checkpoint: dict[str, object],
+        run_id: str | None = None,
+        abort_signal: ProviderAbortSignal | None = None,
+    ) -> Iterator[RuntimeStreamChunk]:
+        yield from self._resume_coordinator.resume_provider_failure_stream(
+            session_id=session_id,
+            checkpoint=checkpoint,
+            run_id=run_id,
+            abort_signal=abort_signal,
+        )
 
     @staticmethod
     def _tool_results_from_checkpoint(raw_tool_results: list[object]) -> tuple[ToolResult, ...]:

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -3944,6 +3944,9 @@ class VoidCodeRuntime:
         if approval_request_id is None and approval_decision is None:
             checkpoint = self._load_resume_checkpoint(session_id=session_id)
             if checkpoint is not None and checkpoint.get("kind") == "provider_failure_retryable":
+                self._background_task_supervisor.reconcile_parent_background_task_events_for_session(
+                    parent_session_id=session_id
+                )
                 return self._resume_provider_failure_response(
                     session_id=session_id,
                     checkpoint=checkpoint,
@@ -3982,6 +3985,9 @@ class VoidCodeRuntime:
         if approval_request_id is None and approval_decision is None:
             checkpoint = self._load_resume_checkpoint(session_id=session_id)
             if checkpoint is not None and checkpoint.get("kind") == "provider_failure_retryable":
+                self._background_task_supervisor.reconcile_parent_background_task_events_for_session(
+                    parent_session_id=session_id
+                )
                 run_id = os.urandom(8).hex()
                 abort_signal = self._register_active_session_id(
                     session_id,

--- a/src/voidcode/runtime/storage.py
+++ b/src/voidcode/runtime/storage.py
@@ -197,7 +197,9 @@ class _SQLitePolicy:
 @final
 class SqliteSessionStore:
     _database_path: Path | None
-    _RESUME_CHECKPOINT_KINDS = frozenset({"approval_wait", "question_wait", "terminal"})
+    _RESUME_CHECKPOINT_KINDS = frozenset(
+        {"approval_wait", "question_wait", "provider_failure_retryable", "terminal"}
+    )
     _sqlite_policy = _SQLitePolicy()
 
     _CANONICAL_SCHEMA: dict[str, tuple[tuple[str, str, int, str | None, int], ...]] = {
@@ -1084,7 +1086,7 @@ class SqliteSessionStore:
                     )
                 ),
                 pending_question_json=None,
-                resume_checkpoint=self._terminal_resume_checkpoint(
+                resume_checkpoint=self._run_resume_checkpoint(
                     request=request,
                     response=response,
                 ),
@@ -1586,6 +1588,36 @@ class SqliteSessionStore:
         }
 
     @staticmethod
+    def _provider_failure_retryable_resume_checkpoint(
+        *, request: RuntimeRequest, response: RuntimeResponse, failure_event: EventEnvelope
+    ) -> dict[str, object]:
+        payload = failure_event.payload
+        last_tool: dict[str, object] = next(
+            (
+                event.payload
+                for event in reversed(response.events)
+                if event.event_type == "runtime.tool_completed"
+                and event.payload.get("status") != "error"
+            ),
+            cast(dict[str, object], {}),
+        )
+        return {
+            **SqliteSessionStore._resume_checkpoint_base(
+                request=request,
+                response=response,
+                kind="provider_failure_retryable",
+            ),
+            "provider_error_kind": payload.get("provider_error_kind"),
+            "provider": payload.get("provider"),
+            "model": payload.get("model"),
+            "fallback_exhausted": payload.get("fallback_exhausted"),
+            "provider_error_details": payload.get("provider_error_details"),
+            "failure_event_sequence": failure_event.sequence,
+            "last_successful_tool": last_tool.get("tool"),
+            "last_successful_tool_call_id": last_tool.get("tool_call_id"),
+        }
+
+    @staticmethod
     def _terminal_resume_checkpoint(
         *, request: RuntimeRequest, response: RuntimeResponse
     ) -> dict[str, object]:
@@ -1593,6 +1625,43 @@ class SqliteSessionStore:
             request=request,
             response=response,
             kind="terminal",
+        )
+
+    @staticmethod
+    def _run_resume_checkpoint(
+        *, request: RuntimeRequest, response: RuntimeResponse
+    ) -> dict[str, object]:
+        if response.session.status != "failed":
+            return SqliteSessionStore._terminal_resume_checkpoint(
+                request=request,
+                response=response,
+            )
+        failure_event = next(
+            (event for event in reversed(response.events) if event.event_type == "runtime.failed"),
+            None,
+        )
+        if failure_event is None:
+            return SqliteSessionStore._terminal_resume_checkpoint(
+                request=request,
+                response=response,
+            )
+        if failure_event.payload.get("provider_error_kind") != "transient_failure":
+            return SqliteSessionStore._terminal_resume_checkpoint(
+                request=request,
+                response=response,
+            )
+        if not any(
+            event.event_type == "runtime.tool_completed" and event.payload.get("status") != "error"
+            for event in response.events
+        ):
+            return SqliteSessionStore._terminal_resume_checkpoint(
+                request=request,
+                response=response,
+            )
+        return SqliteSessionStore._provider_failure_retryable_resume_checkpoint(
+            request=request,
+            response=response,
+            failure_event=failure_event,
         )
 
     @staticmethod

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -715,6 +715,67 @@ def test_run_command_accepts_agent_skills_max_steps_and_provider_stream_flags() 
     assert request.metadata["provider_stream"] is True
 
 
+def test_run_command_prints_provider_failure_footer(capsys: Any) -> None:
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/demo-workspace")
+    config = SimpleNamespace(approval_mode="allow")
+    chunks = (
+        _make_chunk(
+            session_id="provider-failed-session",
+            status="running",
+            event=_runtime_event("runtime.request_received", prompt="go"),
+        ),
+        _make_chunk(
+            session_id="provider-failed-session",
+            status="running",
+            event=_runtime_event(
+                "runtime.tool_completed",
+                sequence=2,
+                source="tool",
+                tool="read_file",
+                status="ok",
+                content="sample",
+                arguments={"filePath": "sample.txt"},
+            ),
+        ),
+        _make_chunk(
+            session_id="provider-failed-session",
+            status="failed",
+            event=_runtime_event(
+                "runtime.failed",
+                sequence=3,
+                error="stream disconnect",
+                provider_error_kind="transient_failure",
+                provider="opencode",
+                model="glm-5",
+            ),
+        ),
+    )
+    snapshot = SimpleNamespace(
+        resumable=True,
+        last_tool=SimpleNamespace(tool_name="read_file"),
+    )
+
+    with patch.object(cli, "load_runtime_config", autospec=True, return_value=config):
+        with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
+            runtime_class.return_value.run_stream.return_value = iter(chunks)
+            runtime_class.return_value.session_debug_snapshot.return_value = snapshot
+            result = cli.main(["run", "go", "--workspace", str(workspace), "--provider-stream"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "VoidCode runtime failure summary" in captured.err
+    assert "session: provider-failed-session" in captured.err
+    assert "status: failed" in captured.err
+    assert "provider: opencode" in captured.err
+    assert "model: glm-5" in captured.err
+    assert "provider_error_kind: transient_failure" in captured.err
+    assert "resumable: true" in captured.err
+    assert "last_successful_tool: read_file" in captured.err
+    assert "voidcode sessions debug provider-failed-session" in captured.err
+    assert "voidcode sessions resume provider-failed-session" in captured.err
+
+
 def test_run_command_forwards_reasoning_effort_flag_to_metadata_and_config() -> None:
     cli = importlib.import_module("voidcode.cli")
     workspace = Path("/tmp/demo-workspace")

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -107,6 +107,7 @@ from voidcode.runtime.service import (
     VoidCodeRuntime,
 )
 from voidcode.runtime.session import SessionRef
+from voidcode.runtime.storage import SqliteSessionStore
 from voidcode.runtime.task import (
     BackgroundTaskRef,
     BackgroundTaskRequestSnapshot,
@@ -12248,6 +12249,152 @@ def test_runtime_provider_transient_failure_after_tool_is_resumable(
         event for event in resumed.events if event.event_type == "runtime.tool_completed"
     ]
     assert len(tool_completed_events) == 1
+
+
+def test_runtime_provider_failure_resume_finalizes_background_task_and_releases_mcp(
+    tmp_path: Path,
+) -> None:
+    class _RecordingMcpManager:
+        def __init__(self) -> None:
+            self.release_session_ids: list[str] = []
+
+        @property
+        def configuration(self) -> McpConfigState:
+            return McpConfigState(configured_enabled=True)
+
+        def current_state(self) -> McpManagerState:
+            return McpManagerState(mode="managed", configuration=self.configuration)
+
+        def list_tools(
+            self,
+            *,
+            workspace: Path,
+            owner_session_id: str | None = None,
+            parent_session_id: str | None = None,
+        ):
+            _ = workspace, owner_session_id, parent_session_id
+            return ()
+
+        def call_tool(
+            self,
+            *,
+            server_name: str,
+            tool_name: str,
+            arguments: dict[str, object],
+            workspace: Path,
+            owner_session_id: str | None = None,
+            parent_session_id: str | None = None,
+        ):
+            _ = server_name, tool_name, arguments, workspace, owner_session_id, parent_session_id
+            raise AssertionError("not used")
+
+        def release_session(self, *, session_id: str) -> tuple[McpRuntimeEvent, ...]:
+            self.release_session_ids.append(session_id)
+            return (
+                McpRuntimeEvent(
+                    event_type=RUNTIME_MCP_SERVER_STOPPED,
+                    payload={"server": "echo", "workspace_root": str(tmp_path)},
+                ),
+            )
+
+        def shutdown(self) -> tuple[McpRuntimeEvent, ...]:
+            return ()
+
+        def drain_events(self) -> tuple[McpRuntimeEvent, ...]:
+            return ()
+
+    (tmp_path / "sample.txt").write_text("sample contents", encoding="utf-8")
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    (
+                        ProviderStreamEvent(
+                            kind="content",
+                            channel="tool",
+                            text=(
+                                '{"tool_name":"read_file",'
+                                '"arguments":{"filePath":"sample.txt"},'
+                                '"tool_call_id":"read-sample"}'
+                            ),
+                        ),
+                        ProviderStreamEvent(kind="done", done_reason="completed"),
+                    ),
+                    (
+                        ProviderStreamEvent(
+                            kind="error",
+                            channel="error",
+                            error="stream disconnect",
+                            error_kind="transient_failure",
+                        ),
+                        ProviderStreamEvent(kind="done", done_reason="error"),
+                    ),
+                    ProviderTurnResult(output="resumed complete"),
+                ),
+            ),
+        }
+    )
+    mcp_manager = _RecordingMcpManager()
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        model_provider_registry=registry,
+        mcp_manager=mcp_manager,
+    )
+    task_id = "bg-provider-failure-resume"
+    child_session_id = "provider-retry-background-child"
+
+    _ = list(
+        runtime._run_with_persistence(  # pyright: ignore[reportPrivateUsage]
+            RuntimeRequest(
+                prompt="read sample.txt",
+                session_id=child_session_id,
+                metadata={
+                    "provider_stream": True,
+                    "background_task_id": task_id,
+                    "background_run": True,
+                },
+            ),
+            allow_internal_metadata=True,
+        )
+    )
+    runtime._session_store.create_background_task(  # pyright: ignore[reportPrivateUsage]
+        workspace=tmp_path,
+        task=BackgroundTaskState(
+            task=BackgroundTaskRef(id=task_id),
+            request=BackgroundTaskRequestSnapshot(
+                prompt="read sample.txt",
+            ),
+        ),
+    )
+    session_store = runtime._session_store  # pyright: ignore[reportPrivateUsage]
+    assert isinstance(session_store, SqliteSessionStore)
+    with session_store._write_connect(tmp_path) as connection:  # pyright: ignore[reportPrivateUsage]
+        _ = connection.execute(
+            """
+            UPDATE background_tasks
+            SET status = 'running', session_id = ?, result_available = 0,
+                error = NULL, finished_at = NULL
+            WHERE task_id = ?
+            """,
+            (child_session_id, task_id),
+        )
+        connection.commit()
+    running_task = runtime._session_store.load_background_task(  # pyright: ignore[reportPrivateUsage]
+        workspace=tmp_path,
+        task_id=task_id,
+    )
+    assert running_task.status == "running"
+    mcp_manager.release_session_ids.clear()
+
+    resumed = runtime.resume(child_session_id)
+
+    assert resumed.session.status == "completed"
+    assert resumed.output == "resumed complete"
+    assert runtime.load_background_task(task_id).status == "completed"
+    assert mcp_manager.release_session_ids == [child_session_id]
+    assert any(event.event_type == RUNTIME_MCP_SERVER_STOPPED for event in resumed.events)
 
 
 def test_runtime_fallback_event_preserves_provider_error_details(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -12397,6 +12397,126 @@ def test_runtime_provider_failure_resume_finalizes_background_task_and_releases_
     assert any(event.event_type == RUNTIME_MCP_SERVER_STOPPED for event in resumed.events)
 
 
+def test_runtime_provider_failure_resume_persists_failed_chunk_when_loop_raises(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "sample.txt").write_text("sample contents", encoding="utf-8")
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    (
+                        ProviderStreamEvent(
+                            kind="content",
+                            channel="tool",
+                            text=(
+                                '{"tool_name":"read_file",'
+                                '"arguments":{"filePath":"sample.txt"},'
+                                '"tool_call_id":"read-sample"}'
+                            ),
+                        ),
+                        ProviderStreamEvent(kind="done", done_reason="completed"),
+                    ),
+                    (
+                        ProviderStreamEvent(
+                            kind="error",
+                            channel="error",
+                            error="stream disconnect",
+                            error_kind="transient_failure",
+                        ),
+                        ProviderStreamEvent(kind="done", done_reason="error"),
+                    ),
+                ),
+            ),
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        model_provider_registry=registry,
+    )
+    task_id = "bg-provider-failure-raise"
+    child_session_id = "provider-retry-raise-child"
+
+    _ = list(
+        runtime._run_with_persistence(  # pyright: ignore[reportPrivateUsage]
+            RuntimeRequest(
+                prompt="read sample.txt",
+                session_id=child_session_id,
+                metadata={
+                    "provider_stream": True,
+                    "background_task_id": task_id,
+                    "background_run": True,
+                },
+            ),
+            allow_internal_metadata=True,
+        )
+    )
+    runtime._session_store.create_background_task(  # pyright: ignore[reportPrivateUsage]
+        workspace=tmp_path,
+        task=BackgroundTaskState(
+            task=BackgroundTaskRef(id=task_id),
+            request=BackgroundTaskRequestSnapshot(prompt="read sample.txt"),
+        ),
+    )
+    session_store = runtime._session_store  # pyright: ignore[reportPrivateUsage]
+    assert isinstance(session_store, SqliteSessionStore)
+    with session_store._write_connect(tmp_path) as connection:  # pyright: ignore[reportPrivateUsage]
+        _ = connection.execute(
+            """
+            UPDATE background_tasks
+            SET status = 'running', session_id = ?, result_available = 0,
+                error = NULL, finished_at = NULL
+            WHERE task_id = ?
+            """,
+            (child_session_id, task_id),
+        )
+        connection.commit()
+
+    def _raise_after_failed_chunk(**kwargs: object) -> Iterator[RuntimeStreamChunk]:
+        resumed_session = kwargs.get("session")
+        assert isinstance(resumed_session, SessionState)
+        sequence = kwargs.get("sequence")
+        assert isinstance(sequence, int)
+        failed_session = SessionState(
+            session=resumed_session.session,
+            status="failed",
+            turn=resumed_session.turn,
+            metadata=resumed_session.metadata,
+        )
+        yield RuntimeStreamChunk(
+            kind="event",
+            session=failed_session,
+            event=EventEnvelope(
+                session_id=failed_session.session.id,
+                sequence=sequence + 1,
+                event_type="runtime.failed",
+                source="runtime",
+                payload={"error": "resume loop crashed after failure"},
+            ),
+        )
+        raise RuntimeError("graph loop raised after failed chunk")
+
+    monkeypatch.setattr(  # pyright: ignore[reportPrivateUsage]
+        runtime,
+        "_execute_graph_loop",
+        _raise_after_failed_chunk,
+    )
+
+    resumed = runtime.resume(child_session_id)
+
+    assert resumed.session.status == "failed"
+    assert resumed.events[-1].payload == {"error": "resume loop crashed after failure"}
+    stored = session_store.load_session(workspace=tmp_path, session_id=child_session_id)
+    assert stored.session.status == "failed"
+    assert stored.events[-1].payload == {"error": "resume loop crashed after failure"}
+    terminal_task = runtime.load_background_task(task_id)
+    assert terminal_task.status == "failed"
+    assert terminal_task.error == "resume loop crashed after failure"
+
+
 def test_runtime_fallback_event_preserves_provider_error_details(tmp_path: Path) -> None:
     registry = ModelProviderRegistry(
         providers={

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -12178,6 +12178,78 @@ def test_runtime_provider_stream_json_error_payload_maps_to_context_limit_withou
     assert fallback_events == []
 
 
+def test_runtime_provider_transient_failure_after_tool_is_resumable(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "sample.txt").write_text("sample contents", encoding="utf-8")
+    created_providers: list[_ScriptedTurnProvider] = []
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    (
+                        ProviderStreamEvent(
+                            kind="content",
+                            channel="tool",
+                            text=(
+                                '{"tool_name":"read_file",'
+                                '"arguments":{"filePath":"sample.txt"},'
+                                '"tool_call_id":"read-sample"}'
+                            ),
+                        ),
+                        ProviderStreamEvent(kind="done", done_reason="completed"),
+                    ),
+                    (
+                        ProviderStreamEvent(
+                            kind="error",
+                            channel="error",
+                            error="stream disconnect",
+                            error_kind="transient_failure",
+                        ),
+                        ProviderStreamEvent(kind="done", done_reason="error"),
+                    ),
+                    ProviderTurnResult(output="resumed complete"),
+                ),
+                created_providers=created_providers,
+            ),
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(
+        RuntimeRequest(
+            prompt="read sample.txt",
+            session_id="provider-retry-session",
+            metadata={"provider_stream": True},
+        )
+    )
+
+    assert response.session.status == "failed"
+    assert response.events[-1].payload["provider_error_kind"] == "transient_failure"
+    snapshot = runtime.session_debug_snapshot(session_id="provider-retry-session")
+    assert snapshot.resumable is True
+    assert snapshot.resume_checkpoint_kind == "provider_failure_retryable"
+    assert snapshot.suggested_operator_action == "resume_provider_failure"
+    assert snapshot.last_tool is not None
+    assert snapshot.last_tool.tool_name == "read_file"
+
+    resumed = runtime.resume("provider-retry-session")
+
+    assert resumed.session.status == "completed"
+    assert resumed.output == "resumed complete"
+    assert created_providers[0].requests[-1].tool_results
+    assert created_providers[0].requests[-1].tool_results[0].tool_name == "read_file"
+    tool_completed_events = [
+        event for event in resumed.events if event.event_type == "runtime.tool_completed"
+    ]
+    assert len(tool_completed_events) == 1
+
+
 def test_runtime_fallback_event_preserves_provider_error_details(tmp_path: Path) -> None:
     registry = ModelProviderRegistry(
         providers={

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -12251,6 +12251,134 @@ def test_runtime_provider_transient_failure_after_tool_is_resumable(
     assert len(tool_completed_events) == 1
 
 
+def test_runtime_provider_failure_resume_reconciles_parent_background_tasks(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "sample.txt").write_text("sample contents", encoding="utf-8")
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    (
+                        ProviderStreamEvent(
+                            kind="content",
+                            channel="tool",
+                            text=(
+                                '{"tool_name":"read_file",'
+                                '"arguments":{"filePath":"sample.txt"},'
+                                '"tool_call_id":"read-sample"}'
+                            ),
+                        ),
+                        ProviderStreamEvent(kind="done", done_reason="completed"),
+                    ),
+                    (
+                        ProviderStreamEvent(
+                            kind="error",
+                            channel="error",
+                            error="stream disconnect",
+                            error_kind="transient_failure",
+                        ),
+                        ProviderStreamEvent(kind="done", done_reason="error"),
+                    ),
+                    ProviderTurnResult(output="parent resumed complete"),
+                ),
+            ),
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        model_provider_registry=registry,
+    )
+    parent_session_id = "provider-parent-retry-session"
+    task_id = "provider-parent-task-recover"
+    child_session_id = "provider-parent-child-complete"
+
+    failed = runtime.run(
+        RuntimeRequest(
+            prompt="read sample.txt",
+            session_id=parent_session_id,
+            metadata={"provider_stream": True},
+        )
+    )
+    assert failed.session.status == "failed"
+    assert runtime.session_debug_snapshot(session_id=parent_session_id).resumable is True
+
+    session_store = runtime._session_store  # pyright: ignore[reportPrivateUsage]
+    session_store.create_background_task(
+        workspace=tmp_path,
+        task=BackgroundTaskState(
+            task=BackgroundTaskRef(id=task_id),
+            status="running",
+            request=BackgroundTaskRequestSnapshot(
+                prompt="background child",
+                parent_session_id=parent_session_id,
+            ),
+            session_id=child_session_id,
+            created_at=1,
+            updated_at=1,
+            started_at=1,
+        ),
+    )
+    session_store.save_run(
+        workspace=tmp_path,
+        request=RuntimeRequest(
+            prompt="background child",
+            session_id=child_session_id,
+            parent_session_id=parent_session_id,
+            metadata={
+                "background_run": True,
+                "background_task_id": task_id,
+            },
+        ),
+        response=RuntimeResponse(
+            session=SessionState(
+                session=SessionRef(
+                    id=child_session_id,
+                    parent_id=parent_session_id,
+                ),
+                status="completed",
+                turn=1,
+                metadata={
+                    "background_run": True,
+                    "background_task_id": task_id,
+                },
+            ),
+            events=(
+                EventEnvelope(
+                    session_id=child_session_id,
+                    sequence=1,
+                    event_type="runtime.request_received",
+                    source="runtime",
+                    payload={"prompt": "background child"},
+                ),
+                EventEnvelope(
+                    session_id=child_session_id,
+                    sequence=2,
+                    event_type="graph.response_ready",
+                    source="graph",
+                    payload={},
+                ),
+            ),
+            output="background child",
+        ),
+    )
+
+    resumed = runtime.resume(parent_session_id)
+
+    assert resumed.session.status == "completed"
+    assert resumed.output == "parent resumed complete"
+    assert runtime.load_background_task(task_id).status == "completed"
+    recovered_events = [
+        event for event in resumed.events if event.event_type == RUNTIME_BACKGROUND_TASK_COMPLETED
+    ]
+    assert len(recovered_events) == 1
+    assert recovered_events[0].payload["task_id"] == task_id
+    assert recovered_events[0].payload["parent_session_id"] == parent_session_id
+    assert recovered_events[0].payload["child_session_id"] == child_session_id
+
+
 def test_runtime_provider_failure_resume_finalizes_background_task_and_releases_mcp(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- Persist retryable provider failure checkpoints after transient failures that occur after completed tools.
- Let session resume continue from checkpointed tool results instead of replaying completed tools.
- Add a CLI failure footer with debug/resume guidance for provider stream interruptions.

## Verification
- `uv run pytest tests/unit/runtime/test_runtime_service_extensions.py::test_runtime_provider_transient_failure_after_tool_is_resumable tests/unit/interface/test_cli_smoke.py::test_run_command_prints_provider_failure_footer tests/unit/runtime/test_session_storage.py`
- `uv run basedpyright --warnings src/voidcode/runtime/storage.py src/voidcode/runtime/service.py src/voidcode/runtime/resume.py src/voidcode/cli.py`
- `mise run lint`
- `mise run typecheck`
- `uv run pytest tests/unit/runtime/test_runtime_service_extensions.py`
- `uv run pytest tests/unit/runtime/test_session_storage.py`
- `uv run pytest tests/unit/interface/test_cli_smoke.py::test_run_command_prints_provider_failure_footer`
- `mise run frontend:check`

## Notes
- Full `mise run test` completed with 1723 passed and 3 timing/concurrency failures; each failed test passed when rerun individually.

Closes #337