### PR TITLE
feat: rework tool compaction and OpenCode-Go feedback

### DIFF
--- a/src/voidcode/graph/provider_graph.py
+++ b/src/voidcode/graph/provider_graph.py
@@ -142,6 +142,7 @@ class ProviderGraph:
             provider_name=self._provider_model.selection.provider,
             model_name=self._provider_model.selection.model,
             agent_preset=cast(dict[str, object] | None, request.metadata.get("agent_preset")),
+            model_metadata=self._provider_model.metadata,
             reasoning_effort=cast(str | None, request.metadata.get("reasoning_effort")),
             attempt=cast(int, request.metadata.get("provider_attempt", 0)),
             abort_signal=abort_signal,

--- a/src/voidcode/provider/litellm_backend.py
+++ b/src/voidcode/provider/litellm_backend.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import json
 import logging
 import re
-from collections.abc import Iterator
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, cast
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 if TYPE_CHECKING:
     import litellm as litellm_module
@@ -25,6 +25,7 @@ from ..tools.contracts import ToolCall, ToolDefinition
 from ..tools.output import sanitize_tool_arguments, sanitize_tool_result_data
 from .config import LiteLLMProviderConfig
 from .errors import provider_execution_error_from_api_payload
+from .model_catalog import ToolFeedbackMode
 from .protocol import (
     ProviderExecutionError,
     ProviderStreamEvent,
@@ -34,13 +35,11 @@ from .protocol import (
 )
 
 _DEFAULT_COMPLETION_TIMEOUT_SECONDS = 300.0
+type ReasoningEffortMode = Literal["auto", "direct", "glm_thinking", "disabled"]
 _DIRECT_REASONING_EFFORT_PROVIDERS = frozenset(
     {"openai", "anthropic", "google", "gemini", "vertex_ai", "litellm", "grok"}
 )
 _THINKING_DISABLED_EFFORTS = frozenset({"none", "off", "disable", "disabled"})
-_OPENCODE_GO_SYNTHETIC_TOOL_FEEDBACK_MODELS = frozenset(
-    {"minimax-m2.5", "minimax-m2.7", "qwen3.5-plus", "qwen3.6-plus"}
-)
 _SYNTHETIC_TOOL_FEEDBACK_PREFIX = "Completed tool calls for current request:"
 _CONTINUITY_SUMMARY_PREFIX = "Runtime continuity summary:"
 
@@ -100,6 +99,10 @@ def _message_size_chars(message: dict[str, object]) -> int:
     return len(json.dumps(message, ensure_ascii=False, sort_keys=True, default=str))
 
 
+def _empty_tool_feedback_model_overrides() -> dict[str, ToolFeedbackMode]:
+    return {}
+
+
 def _is_object_json_schema(schema: dict[str, object]) -> bool:
     schema_type = schema.get("type")
     if schema_type == "object":
@@ -149,6 +152,10 @@ class LiteLLMBackendSingleAgentProvider:
     config: LiteLLMProviderConfig | None
     completion_kwargs: dict[str, object] | None = None
     use_raw_model_name: bool = False
+    reasoning_effort_mode: ReasoningEffortMode = "auto"
+    tool_feedback_model_overrides: Mapping[str, ToolFeedbackMode] = field(
+        default_factory=_empty_tool_feedback_model_overrides
+    )
 
     @staticmethod
     def _to_tool_schema(tool: ToolDefinition) -> dict[str, object]:
@@ -220,18 +227,24 @@ class LiteLLMBackendSingleAgentProvider:
         if not effort:
             return kwargs
 
+        mode = self.reasoning_effort_mode
         provider_name = (request.provider_name or self.name).lower()
         model_name = (request.model_name or "").lower()
-        if provider_name == "opencode-go":
+        if mode == "disabled":
             return kwargs
-        if provider_name == "glm" or model_name.startswith(("glm-5", "glm-z1")):
+        if mode == "glm_thinking" or (
+            mode == "auto"
+            and (provider_name == "glm" or model_name.startswith(("glm-5", "glm-z1")))
+        ):
             thinking_type = (
                 "disabled" if effort.lower() in _THINKING_DISABLED_EFFORTS else "enabled"
             )
             _merge_extra_body(kwargs, {"thinking": {"type": thinking_type}})
             _allow_openai_param(kwargs, "extra_body")
             return kwargs
-        if provider_name in _DIRECT_REASONING_EFFORT_PROVIDERS:
+        if mode == "direct" or (
+            mode == "auto" and provider_name in _DIRECT_REASONING_EFFORT_PROVIDERS
+        ):
             kwargs["reasoning_effort"] = request.reasoning_effort
         return kwargs
 
@@ -240,13 +253,22 @@ class LiteLLMBackendSingleAgentProvider:
     ) -> dict[str, object]:
         return self._completion_kwargs_for_request(request)
 
+    def _tool_feedback_mode_for_request(self, request: ProviderTurnRequest) -> ToolFeedbackMode:
+        model_name = request.model_name
+        mode = (
+            self.tool_feedback_model_overrides.get(model_name) if model_name is not None else None
+        )
+        if mode is not None:
+            return mode
+        metadata_mode = (
+            None if request.model_metadata is None else request.model_metadata.tool_feedback_mode
+        )
+        return metadata_mode if metadata_mode is not None else "standard"
+
     def _build_messages(self, request: ProviderTurnRequest) -> list[dict[str, object]]:
         assembled_context = request.assembled_context
         messages: list[dict[str, object]] = []
-        if (
-            request.provider_name == "opencode-go"
-            and request.model_name in _OPENCODE_GO_SYNTHETIC_TOOL_FEEDBACK_MODELS
-        ):
+        if self._tool_feedback_mode_for_request(request) == "synthetic_user_message":
             tool_feedback_lines: list[str] = []
             for segment in assembled_context.segments:
                 if segment.role == "tool":

--- a/src/voidcode/provider/litellm_backend.py
+++ b/src/voidcode/provider/litellm_backend.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -37,6 +38,13 @@ _DIRECT_REASONING_EFFORT_PROVIDERS = frozenset(
     {"openai", "anthropic", "google", "gemini", "vertex_ai", "litellm", "grok"}
 )
 _THINKING_DISABLED_EFFORTS = frozenset({"none", "off", "disable", "disabled"})
+_OPENCODE_GO_SYNTHETIC_TOOL_FEEDBACK_MODELS = frozenset(
+    {"minimax-m2.5", "minimax-m2.7", "qwen3.5-plus", "qwen3.6-plus"}
+)
+_SYNTHETIC_TOOL_FEEDBACK_PREFIX = "Completed tool calls for current request:"
+_CONTINUITY_SUMMARY_PREFIX = "Runtime continuity summary:"
+
+logger = logging.getLogger(__name__)
 
 
 def _usage_int(raw: object) -> int:
@@ -86,6 +94,10 @@ def _allow_openai_param(kwargs: dict[str, object], param: str) -> None:
     if param not in params:
         params.append(param)
     kwargs["allowed_openai_params"] = params
+
+
+def _message_size_chars(message: dict[str, object]) -> int:
+    return len(json.dumps(message, ensure_ascii=False, sort_keys=True, default=str))
 
 
 def _is_object_json_schema(schema: dict[str, object]) -> bool:
@@ -231,7 +243,10 @@ class LiteLLMBackendSingleAgentProvider:
     def _build_messages(self, request: ProviderTurnRequest) -> list[dict[str, object]]:
         assembled_context = request.assembled_context
         messages: list[dict[str, object]] = []
-        if request.provider_name == "opencode-go":
+        if (
+            request.provider_name == "opencode-go"
+            and request.model_name in _OPENCODE_GO_SYNTHETIC_TOOL_FEEDBACK_MODELS
+        ):
             tool_feedback_lines: list[str] = []
             for segment in assembled_context.segments:
                 if segment.role == "tool":
@@ -353,6 +368,75 @@ class LiteLLMBackendSingleAgentProvider:
             messages.append({"role": segment.role, "content": segment.content})
         return messages
 
+    @staticmethod
+    def _provider_request_diagnostics(
+        *,
+        messages: list[dict[str, object]],
+        request: ProviderTurnRequest,
+    ) -> dict[str, object]:
+        message_sizes = [_message_size_chars(message) for message in messages]
+        largest_index = (
+            max(range(len(message_sizes)), key=message_sizes.__getitem__) if messages else None
+        )
+        largest_message: dict[str, object] | None = None
+        if largest_index is not None:
+            largest = messages[largest_index]
+            largest_message = {
+                "index": largest_index,
+                "role": largest.get("role"),
+                "size_chars": message_sizes[largest_index],
+            }
+            content = largest.get("content")
+            if isinstance(content, str):
+                if content.startswith(_SYNTHETIC_TOOL_FEEDBACK_PREFIX):
+                    largest_message["source"] = "synthetic_tool_feedback"
+                elif content.startswith(_CONTINUITY_SUMMARY_PREFIX):
+                    largest_message["source"] = "continuity_summary"
+
+        synthetic_tool_feedback_size = 0
+        continuity_summary_size = 0
+        for message in messages:
+            content = message.get("content")
+            if not isinstance(content, str):
+                continue
+            if content.startswith(_SYNTHETIC_TOOL_FEEDBACK_PREFIX):
+                synthetic_tool_feedback_size += len(content)
+            if content.startswith(_CONTINUITY_SUMMARY_PREFIX):
+                continuity_summary_size += len(content)
+
+        context_window = request.context_window
+        return {
+            "message_count": len(messages),
+            "estimated_chars": sum(message_sizes),
+            "largest_message": largest_message,
+            "retained_tool_result_count": context_window.retained_tool_result_count,
+            "synthetic_tool_feedback_size_chars": synthetic_tool_feedback_size,
+            "continuity_summary_size_chars": continuity_summary_size,
+            "compacted": context_window.compacted,
+        }
+
+    def _log_provider_request_diagnostics(
+        self,
+        *,
+        messages: list[dict[str, object]],
+        request: ProviderTurnRequest,
+    ) -> None:
+        diagnostics = self._provider_request_diagnostics(messages=messages, request=request)
+        logger.debug(
+            "provider request diagnostics: provider=%s model=%s messages=%d "
+            "estimated_chars=%d retained_tool_results=%d synthetic_tool_feedback_size=%d "
+            "continuity_summary_size=%d largest_message=%s compacted=%s",
+            request.provider_name or self.name,
+            request.model_name or "unknown",
+            diagnostics["message_count"],
+            diagnostics["estimated_chars"],
+            diagnostics["retained_tool_result_count"],
+            diagnostics["synthetic_tool_feedback_size_chars"],
+            diagnostics["continuity_summary_size_chars"],
+            diagnostics["largest_message"],
+            diagnostics["compacted"],
+        )
+
     def _auth_kwargs(self) -> dict[str, object]:
         if self.config is None:
             return {}
@@ -451,9 +535,11 @@ class LiteLLMBackendSingleAgentProvider:
             if self.config is None or self.config.timeout_seconds is None
             else self.config.timeout_seconds
         )
+        messages = self._build_messages(request)
+        self._log_provider_request_diagnostics(messages=messages, request=request)
         payload: dict[str, object] = {
             "model": model_identifier,
-            "messages": self._build_messages(request),
+            "messages": messages,
             "stream": False,
             "api_base": self._api_base(),
             "timeout": timeout_seconds,
@@ -503,9 +589,11 @@ class LiteLLMBackendSingleAgentProvider:
             if self.config is None or self.config.timeout_seconds is None
             else self.config.timeout_seconds
         )
+        messages = self._build_messages(request)
+        self._log_provider_request_diagnostics(messages=messages, request=request)
         payload: dict[str, object] = {
             "model": model_identifier,
-            "messages": self._build_messages(request),
+            "messages": messages,
             "stream": True,
             "api_base": self._api_base(),
             "timeout": timeout_seconds,

--- a/src/voidcode/provider/litellm_backend.py
+++ b/src/voidcode/provider/litellm_backend.py
@@ -188,10 +188,7 @@ class LiteLLMBackendSingleAgentProvider:
                     model_name="unknown",
                     message="litellm provider requires model name",
                 )
-            model_name = request.model_name
-            if self.config is not None and model_name in self.config.model_map:
-                return self.config.model_map[model_name]
-            return model_name
+            return self._mapped_model_name_for_request(request)
         if request.model_name is None:
             raise ProviderExecutionError(
                 kind="invalid_model",
@@ -199,15 +196,19 @@ class LiteLLMBackendSingleAgentProvider:
                 model_name="unknown",
                 message="provider requires model name",
             )
-        if self.config is not None and request.model_name in self.config.model_map:
-            model_name = self.config.model_map[request.model_name]
-        else:
-            model_name = request.model_name
+        model_name = self._mapped_model_name_for_request(request)
         if self.use_raw_model_name:
             return model_name
         if "/" in model_name:
             return model_name
         return f"{self.name}/{model_name}"
+
+    def _mapped_model_name_for_request(self, request: ProviderTurnRequest) -> str:
+        if request.model_name is None:
+            return ""
+        if self.config is not None and request.model_name in self.config.model_map:
+            return self.config.model_map[request.model_name]
+        return request.model_name
 
     def _api_base(self) -> str:
         base_url = None if self.config is None else self.config.base_url
@@ -254,10 +255,11 @@ class LiteLLMBackendSingleAgentProvider:
         return self._completion_kwargs_for_request(request)
 
     def _tool_feedback_mode_for_request(self, request: ProviderTurnRequest) -> ToolFeedbackMode:
-        model_name = request.model_name
-        mode = (
-            self.tool_feedback_model_overrides.get(model_name) if model_name is not None else None
-        )
+        request_model_name = request.model_name
+        mapped_model_name = self._mapped_model_name_for_request(request)
+        mode = self.tool_feedback_model_overrides.get(mapped_model_name)
+        if mode is None and request_model_name is not None:
+            mode = self.tool_feedback_model_overrides.get(request_model_name)
         if mode is not None:
             return mode
         metadata_mode = (
@@ -266,8 +268,8 @@ class LiteLLMBackendSingleAgentProvider:
         if metadata_mode is not None:
             return metadata_mode
         provider_name = request.provider_name or self.name
-        if model_name is not None:
-            inferred = infer_model_metadata(provider_name, model_name)
+        if mapped_model_name:
+            inferred = infer_model_metadata(provider_name, mapped_model_name)
             if inferred is not None and inferred.tool_feedback_mode is not None:
                 return inferred.tool_feedback_mode
         return "standard"

--- a/src/voidcode/provider/litellm_backend.py
+++ b/src/voidcode/provider/litellm_backend.py
@@ -25,7 +25,7 @@ from ..tools.contracts import ToolCall, ToolDefinition
 from ..tools.output import sanitize_tool_arguments, sanitize_tool_result_data
 from .config import LiteLLMProviderConfig
 from .errors import provider_execution_error_from_api_payload
-from .model_catalog import ToolFeedbackMode
+from .model_catalog import ToolFeedbackMode, infer_model_metadata
 from .protocol import (
     ProviderExecutionError,
     ProviderStreamEvent,
@@ -263,7 +263,14 @@ class LiteLLMBackendSingleAgentProvider:
         metadata_mode = (
             None if request.model_metadata is None else request.model_metadata.tool_feedback_mode
         )
-        return metadata_mode if metadata_mode is not None else "standard"
+        if metadata_mode is not None:
+            return metadata_mode
+        provider_name = request.provider_name or self.name
+        if model_name is not None:
+            inferred = infer_model_metadata(provider_name, model_name)
+            if inferred is not None and inferred.tool_feedback_mode is not None:
+                return inferred.tool_feedback_mode
+        return "standard"
 
     def _build_messages(self, request: ProviderTurnRequest) -> list[dict[str, object]]:
         assembled_context = request.assembled_context

--- a/src/voidcode/provider/model_catalog.py
+++ b/src/voidcode/provider/model_catalog.py
@@ -372,7 +372,7 @@ def _override_max_input_tokens(
     return override.max_input_tokens
 
 
-def _merge_model_metadata(
+def merge_model_metadata(
     *,
     inferred: ProviderModelMetadata | None,
     override: ProviderModelMetadata | None,
@@ -435,6 +435,9 @@ def _merge_model_metadata(
             inferred.tool_feedback_mode, override.tool_feedback_mode
         ),
     )
+
+
+_merge_model_metadata = merge_model_metadata
 
 
 def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMetadata | None:

--- a/src/voidcode/provider/model_catalog.py
+++ b/src/voidcode/provider/model_catalog.py
@@ -13,6 +13,8 @@ from pydantic import BaseModel, ConfigDict, ValidationError
 
 from .config import LiteLLMProviderConfig
 
+type ToolFeedbackMode = Literal["standard", "synthetic_user_message"]
+
 
 @dataclass(frozen=True, slots=True)
 class ProviderModelMetadata:
@@ -37,6 +39,7 @@ class ProviderModelMetadata:
     modalities_input: tuple[str, ...] | None = None
     modalities_output: tuple[str, ...] | None = None
     model_status: str | None = None
+    tool_feedback_mode: ToolFeedbackMode | None = None
     derived_max_input_tokens: bool = field(default=False, init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
@@ -97,6 +100,8 @@ class ProviderModelMetadata:
             payload["modalities_output"] = list(self.modalities_output)
         if self.model_status is not None:
             payload["model_status"] = self.model_status
+        if self.tool_feedback_mode is not None:
+            payload["tool_feedback_mode"] = self.tool_feedback_mode
         return payload
 
 
@@ -192,6 +197,7 @@ class _OpenAICompatibleModelItem(_DiscoveryPayloadModel):
     input_modalities: list[str] | None = None
     output_modalities: list[str] | None = None
     status: str | None = None
+    tool_feedback_mode: str | None = None
 
 
 class _OpenAICompatibleDiscoveryPayload(_DiscoveryPayloadModel):
@@ -323,6 +329,7 @@ def _metadata(
         modalities_input=_modalities_tuple(values.get("modalities_input")),
         modalities_output=_modalities_tuple(values.get("modalities_output")),
         model_status=_optional_str(values.get("model_status")),
+        tool_feedback_mode=_tool_feedback_mode(values.get("tool_feedback_mode")),
     )
 
 
@@ -332,6 +339,12 @@ def _modalities_tuple(value: object) -> tuple[str, ...] | None:
     raw_items = cast(Iterable[object], value)
     modalities = tuple(item for item in raw_items if isinstance(item, str) and item)
     return modalities or None
+
+
+def _tool_feedback_mode(value: object) -> ToolFeedbackMode | None:
+    if value in {"standard", "synthetic_user_message"}:
+        return cast(ToolFeedbackMode, value)
+    return None
 
 
 def _override_value[T](inferred: T | None, override: T | None) -> T | None:
@@ -418,6 +431,9 @@ def _merge_model_metadata(
         modalities_input=_override_value(inferred.modalities_input, override.modalities_input),
         modalities_output=_override_value(inferred.modalities_output, override.modalities_output),
         model_status=_override_value(inferred.model_status, override.model_status),
+        tool_feedback_mode=_override_value(
+            inferred.tool_feedback_mode, override.tool_feedback_mode
+        ),
     )
 
 
@@ -609,6 +625,9 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             else ("text",),
             "modalities_output": ("text",),
             "model_status": "preview" if "preview" in model else "active",
+            "tool_feedback_mode": "synthetic_user_message"
+            if provider == "opencode-go" and model.startswith(("qwen3.5-plus", "qwen3.6-plus"))
+            else "standard",
             **_cost(input_per_million=0.40, output_per_million=1.20),
         }
         if model.startswith(("qwen3.6-plus", "qwen3.6-flash", "qwen3.5-plus", "qwen3.5-flash")):
@@ -696,6 +715,9 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             else ("text",),
             "modalities_output": ("text",),
             "model_status": "active",
+            "tool_feedback_mode": "synthetic_user_message"
+            if provider == "opencode-go" and model.startswith("minimax-m2")
+            else "standard",
             **_cost(input_per_million=0.50, output_per_million=2.00),
         }
         if model.startswith("minimax-m2.5"):
@@ -704,6 +726,8 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             )
         if model.startswith("minimax-m2"):
             return _metadata(context_window=204_800, values=common_minimax)
+        if model.startswith("mimo-v2.5"):
+            return _metadata(context_window=256_000, values=common_minimax)
     if provider == "grok" or model.startswith("grok-"):
         common_grok = {
             "supports_tools": True,
@@ -885,6 +909,7 @@ def _metadata_from_discovery_item(
         modalities_input=input_modalities,
         modalities_output=output_modalities,
         model_status=_optional_str(raw.get("status")),
+        tool_feedback_mode=_tool_feedback_mode(raw.get("tool_feedback_mode")),
     )
     return metadata if metadata.payload() else None
 

--- a/src/voidcode/provider/opencode_go.py
+++ b/src/voidcode/provider/opencode_go.py
@@ -16,7 +16,7 @@ class OpenCodeGoSingleAgentProvider(LiteLLMBackendSingleAgentProvider):
 
     def _completion_kwargs_for_request(self, request: ProviderTurnRequest) -> dict[str, object]:
         kwargs = LiteLLMBackendSingleAgentProvider._completion_kwargs_for_request(self, request)
-        model_name = request.model_name or ""
+        model_name = self._mapped_model_name_for_request(request)
         if model_name in _ANTHROPIC_COMPATIBLE_MODELS:
             kwargs["custom_llm_provider"] = "anthropic"
             kwargs["api_base"] = "https://opencode.ai/zen/go"

--- a/src/voidcode/provider/opencode_go.py
+++ b/src/voidcode/provider/opencode_go.py
@@ -68,4 +68,5 @@ class OpenCodeGoModelProvider:
             name=self.name,
             config=adapted_config,
             use_raw_model_name=True,
+            reasoning_effort_mode="disabled",
         )

--- a/src/voidcode/provider/protocol.py
+++ b/src/voidcode/provider/protocol.py
@@ -8,6 +8,7 @@ from typing import Literal, Protocol, cast, runtime_checkable
 from ..command.resolver import resolve_tool_instruction
 from ..runtime.context_window import normalize_read_file_output
 from ..tools.contracts import ToolCall, ToolDefinition, ToolResult
+from .model_catalog import ProviderModelMetadata
 
 type ProviderMessageRole = Literal["system", "user", "assistant", "tool"]
 type ProviderStreamEventKind = Literal["delta", "content", "error", "done"]
@@ -52,6 +53,7 @@ class ProviderTurnRequest:
     provider_name: str | None = None
     model_name: str | None = None
     agent_preset: dict[str, object] | None = None
+    model_metadata: ProviderModelMetadata | None = None
     reasoning_effort: str | None = None
     attempt: int = 0
     abort_signal: ProviderAbortSignal | None = None

--- a/src/voidcode/provider/registry.py
+++ b/src/voidcode/provider/registry.py
@@ -24,6 +24,7 @@ from .model_catalog import (
     ProviderModelMetadata,
     discover_available_models,
     infer_model_metadata,
+    merge_model_metadata,
 )
 from .models import ProviderResolutionSource
 from .openai import OpenAIModelProvider
@@ -341,7 +342,10 @@ class ModelProviderRegistry:
             if catalog is not None:
                 metadata = catalog.model_metadata.get(model_name)
                 if metadata is not None:
-                    return metadata
+                    return merge_model_metadata(
+                        inferred=infer_model_metadata(provider_name, model_name),
+                        override=metadata,
+                    )
         return infer_model_metadata(provider_name, model_name)
 
     def provider_catalog(self, provider_name: str) -> ProviderModelCatalog | None:

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -256,7 +256,7 @@ def _empty_context_window_tool_limits() -> dict[str, int]:
 @dataclass(frozen=True, slots=True)
 class RuntimeContextWindowConfig:
     auto_compaction: bool = True
-    max_tool_results: int = 4
+    max_tool_results: int = 8
     max_tool_result_tokens: int | None = None
     max_context_ratio: float | None = None
     model_context_window_tokens: int | None = None
@@ -1093,7 +1093,7 @@ class _RuntimeContextWindowValidationModel(BaseModel):
 
     version: int = 1
     auto_compaction: bool = True
-    max_tool_results: int = 4
+    max_tool_results: int = 8
     max_tool_result_tokens: int | None = None
     max_context_ratio: float | None = None
     model_context_window_tokens: int | None = None

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -17,6 +17,45 @@ def _empty_tool_limits() -> dict[str, int]:
 
 
 @dataclass(frozen=True, slots=True)
+class DroppedToolResultDiagnostic:
+    tool_name: str
+    status: str
+    index: int
+    tool_call_id: str | None = None
+    path: str | None = None
+    command: str | None = None
+    pattern: str | None = None
+    error_kind: str | None = None
+    estimated_tokens: int | None = None
+    truncated: bool = False
+    partial: bool = False
+
+    def metadata_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "tool_name": self.tool_name,
+            "status": self.status,
+            "index": self.index,
+        }
+        if self.tool_call_id is not None:
+            payload["tool_call_id"] = self.tool_call_id
+        if self.path is not None:
+            payload["path"] = self.path
+        if self.command is not None:
+            payload["command"] = self.command
+        if self.pattern is not None:
+            payload["pattern"] = self.pattern
+        if self.error_kind is not None:
+            payload["error_kind"] = self.error_kind
+        if self.estimated_tokens is not None:
+            payload["estimated_tokens"] = self.estimated_tokens
+        if self.truncated:
+            payload["truncated"] = True
+        if self.partial:
+            payload["partial"] = True
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
 class RuntimeContinuityState:
     summary_text: str | None = None
     objective: str | None = None
@@ -37,6 +76,7 @@ class RuntimeContinuityState:
     dropped_tool_result_tokens: int | None = None
     token_budget: int | None = None
     token_estimate_source: str | None = None
+    dropped_tool_results: tuple[DroppedToolResultDiagnostic, ...] = ()
     # Lightweight versioning for continuity state to aid reinjection/refresh
     # semantics. This is incremented when the shape evolves and is included
     # in the serialized payload so consumers can decide how to handle newer
@@ -71,13 +111,17 @@ class RuntimeContinuityState:
             payload["token_budget"] = self.token_budget
         if self.token_estimate_source is not None:
             payload["token_estimate_source"] = self.token_estimate_source
+        if self.dropped_tool_results:
+            payload["dropped_tool_results"] = [
+                item.metadata_payload() for item in self.dropped_tool_results
+            ]
         return payload
 
 
 @dataclass(frozen=True, slots=True)
 class ContextWindowPolicy:
     auto_compaction: bool = True
-    max_tool_results: int = 4
+    max_tool_results: int = 8
     max_tool_result_tokens: int | None = None
     max_context_ratio: float | None = None
     model_context_window_tokens: int | None = None
@@ -267,6 +311,55 @@ def _metadata_string_tuple(payload: Mapping[str, object], key: str) -> tuple[str
     return tuple(values)
 
 
+def _optional_entry_string(entry: Mapping[str, object], key: str) -> str | None:
+    value = entry.get(key)
+    return value if isinstance(value, str) and value else None
+
+
+def _dropped_tool_diagnostics_from_metadata_payload(
+    payload: Mapping[str, object],
+) -> tuple[DroppedToolResultDiagnostic, ...]:
+    raw = payload.get("dropped_tool_results")
+    if not isinstance(raw, list | tuple):
+        return ()
+    diagnostics: list[DroppedToolResultDiagnostic] = []
+    for item in cast(list[object] | tuple[object, ...], raw):
+        if not isinstance(item, dict):
+            continue
+        entry = cast(dict[str, object], item)
+        tool_name = entry.get("tool_name")
+        status = entry.get("status")
+        index = entry.get("index")
+        if not isinstance(tool_name, str) or not tool_name:
+            continue
+        if not isinstance(status, str) or not status:
+            continue
+        if not isinstance(index, int) or isinstance(index, bool):
+            continue
+
+        estimated_tokens = entry.get("estimated_tokens")
+        diagnostics.append(
+            DroppedToolResultDiagnostic(
+                tool_name=tool_name,
+                status=status,
+                index=index,
+                tool_call_id=_optional_entry_string(entry, "tool_call_id"),
+                path=_optional_entry_string(entry, "path"),
+                command=_optional_entry_string(entry, "command"),
+                pattern=_optional_entry_string(entry, "pattern"),
+                error_kind=_optional_entry_string(entry, "error_kind"),
+                estimated_tokens=(
+                    estimated_tokens
+                    if isinstance(estimated_tokens, int) and not isinstance(estimated_tokens, bool)
+                    else None
+                ),
+                truncated=entry.get("truncated") is True,
+                partial=entry.get("partial") is True,
+            )
+        )
+    return tuple(diagnostics)
+
+
 def continuity_state_from_metadata_payload(
     payload: Mapping[str, object],
 ) -> RuntimeContinuityState | None:
@@ -332,6 +425,7 @@ def continuity_state_from_metadata_payload(
         dropped_tool_result_tokens=dropped_token_count,
         token_budget=resolved_token_budget,
         token_estimate_source=token_estimate_source,
+        dropped_tool_results=_dropped_tool_diagnostics_from_metadata_payload(payload),
         version=version if version is not None else 1,
     )
 
@@ -536,6 +630,37 @@ def _tool_result_token_estimate(
         ensure_ascii=False,
     )
     return _estimated_token_count(serialized, tokenizer_model=tokenizer_model)
+
+
+def _optional_tool_string(result: ToolResult, key: str) -> str | None:
+    value = result.data.get(key)
+    return value if isinstance(value, str) and value else None
+
+
+def _dropped_tool_diagnostics(
+    results: tuple[ToolResult, ...], *, tokenizer_model: str | None = None
+) -> tuple[DroppedToolResultDiagnostic, ...]:
+    diagnostics: list[DroppedToolResultDiagnostic] = []
+    for index, result in enumerate(results, start=1):
+        diagnostics.append(
+            DroppedToolResultDiagnostic(
+                tool_name=result.tool_name,
+                status=result.status,
+                index=index,
+                tool_call_id=_optional_tool_string(result, "tool_call_id"),
+                path=_optional_tool_string(result, "path"),
+                command=_optional_tool_string(result, "command"),
+                pattern=_optional_tool_string(result, "pattern"),
+                error_kind=result.error_kind,
+                estimated_tokens=_tool_result_token_estimate(
+                    result,
+                    tokenizer_model=tokenizer_model,
+                ).tokens,
+                truncated=result.truncated,
+                partial=result.partial,
+            )
+        )
+    return tuple(diagnostics)
 
 
 def _policy_token_budget(policy: ContextWindowPolicy) -> int | None:
@@ -822,6 +947,7 @@ def _build_continuity_state(
     dropped_tokens: int | None = None,
     token_budget: int | None = None,
     token_estimate_source: str | None = None,
+    tokenizer_model: str | None = None,
 ) -> RuntimeContinuityState:
     dropped_count = len(dropped_results)
     previous = _previous_continuity_state(session_metadata)
@@ -865,6 +991,7 @@ def _build_continuity_state(
             dropped_tool_result_tokens=dropped_tokens,
             token_budget=token_budget,
             token_estimate_source=token_estimate_source,
+            dropped_tool_results=previous.dropped_tool_results if previous is not None else (),
         )
 
     preview_count = min(preview_item_limit, dropped_count)
@@ -896,6 +1023,10 @@ def _build_continuity_state(
         dropped_tool_result_tokens=dropped_tokens,
         token_budget=token_budget,
         token_estimate_source=token_estimate_source,
+        dropped_tool_results=_dropped_tool_diagnostics(
+            dropped_results,
+            tokenizer_model=tokenizer_model,
+        ),
     )
     canonical_summary = _continuity_summary_text(state_without_summary)
     return RuntimeContinuityState(
@@ -918,6 +1049,7 @@ def _build_continuity_state(
         dropped_tool_result_tokens=state_without_summary.dropped_tool_result_tokens,
         token_budget=state_without_summary.token_budget,
         token_estimate_source=state_without_summary.token_estimate_source,
+        dropped_tool_results=state_without_summary.dropped_tool_results,
         version=2,
     )
 
@@ -1076,6 +1208,7 @@ def prepare_provider_context(
             dropped_tokens=dropped_tokens,
             token_budget=token_budget,
             token_estimate_source=token_estimate_source,
+            tokenizer_model=effective_policy.tokenizer_model,
         )
         if compacted
         else None

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -1171,7 +1171,7 @@ def prepare_provider_context(
 
     retained_count = len(retained_results)
     compacted = retained_count < original_count
-    dropped_results = tool_results[: original_count - retained_count]
+    dropped_results = prepared_results[: original_count - retained_count]
     original_tokens = None
     retained_tokens = None
     dropped_tokens = None

--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -557,6 +557,7 @@ class ProviderModelMetadata:
     modalities_input: tuple[str, ...] | None = None
     modalities_output: tuple[str, ...] | None = None
     model_status: str | None = None
+    tool_feedback_mode: Literal["standard", "synthetic_user_message"] | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/voidcode/runtime/http.py
+++ b/src/voidcode/runtime/http.py
@@ -2157,6 +2157,7 @@ class RuntimeTransportApp:
                 if metadata.modalities_output is not None
                 else None,
                 "model_status": metadata.model_status,
+                "tool_feedback_mode": metadata.tool_feedback_mode,
             }.items()
             if value is not None
         }

--- a/src/voidcode/runtime/provider_context.py
+++ b/src/voidcode/runtime/provider_context.py
@@ -5,6 +5,7 @@ import re
 from collections import defaultdict
 from typing import cast
 
+from ..provider.model_catalog import ToolFeedbackMode
 from ..tools.output import sanitize_tool_arguments, sanitize_tool_result_data
 from .context_window import RuntimeAssembledContext, RuntimeContextSegment
 from .contracts import (
@@ -43,6 +44,7 @@ def inspect_provider_context(
     model: str,
     execution_engine: str,
     available_tool_count: int,
+    tool_feedback_mode: ToolFeedbackMode = "standard",
 ) -> RuntimeProviderContextSnapshot:
     segments = tuple(
         _segment_snapshot(index, segment)
@@ -51,14 +53,14 @@ def inspect_provider_context(
     provider_messages = tuple(
         _provider_message_snapshots(
             segments=assembled_context.segments,
-            provider=provider,
+            tool_feedback_mode=tool_feedback_mode,
         )
     )
     diagnostics = tuple(
         _diagnostics(
             segments=assembled_context.segments,
             context_metadata=assembled_context.metadata,
-            provider=provider,
+            tool_feedback_mode=tool_feedback_mode,
             available_tool_count=available_tool_count,
         )
     )
@@ -146,10 +148,10 @@ def _segment_snapshot(
 def _provider_message_snapshots(
     *,
     segments: tuple[RuntimeContextSegment, ...],
-    provider: str,
+    tool_feedback_mode: ToolFeedbackMode,
 ) -> list[RuntimeProviderMessageSnapshot]:
-    if provider == "opencode-go":
-        return _opencode_go_message_snapshots(segments)
+    if tool_feedback_mode == "synthetic_user_message":
+        return _synthetic_tool_feedback_message_snapshots(segments)
     return _standard_tool_message_snapshots(segments)
 
 
@@ -210,7 +212,7 @@ def _standard_tool_message_snapshots(
     return messages
 
 
-def _opencode_go_message_snapshots(
+def _synthetic_tool_feedback_message_snapshots(
     segments: tuple[RuntimeContextSegment, ...],
 ) -> list[RuntimeProviderMessageSnapshot]:
     messages: list[RuntimeProviderMessageSnapshot] = []
@@ -244,7 +246,7 @@ def _opencode_go_message_snapshots(
             RuntimeProviderMessageSnapshot(
                 index=len(messages),
                 role="user",
-                source="opencode_go_synthetic_tool_feedback",
+                source="provider_synthetic_tool_feedback",
                 content=content,
                 content_truncated=content_truncated,
             )
@@ -302,7 +304,7 @@ def _diagnostics(
     *,
     segments: tuple[RuntimeContextSegment, ...],
     context_metadata: dict[str, object],
-    provider: str,
+    tool_feedback_mode: ToolFeedbackMode,
     available_tool_count: int,
 ) -> list[RuntimeProviderContextDiagnostic]:
     diagnostics: list[RuntimeProviderContextDiagnostic] = []
@@ -310,16 +312,18 @@ def _diagnostics(
     diagnostics.extend(_tool_pair_diagnostics(segments, available_tool_count=available_tool_count))
     diagnostics.extend(_context_window_diagnostics(context_metadata))
     diagnostics.extend(_todo_projection_diagnostics(segments))
-    if provider == "opencode-go" and any(segment.role == "tool" for segment in segments):
+    if tool_feedback_mode == "synthetic_user_message" and any(
+        segment.role == "tool" for segment in segments
+    ):
         diagnostics.append(
             RuntimeProviderContextDiagnostic(
                 severity="info",
                 code="provider_path_uses_synthetic_tool_feedback",
                 message=(
-                    "opencode-go receives completed tool results as one synthetic user "
+                    "Provider path receives completed tool results as one synthetic user "
                     "feedback block instead of provider-native tool-role messages."
                 ),
-                source="opencode_go_synthetic_tool_feedback",
+                source="provider_synthetic_tool_feedback",
                 suggested_fix=(
                     "Inspect provider_messages to verify each tool result appears exactly once."
                 ),

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -442,9 +442,10 @@ class RuntimeRunLoopCoordinator:
         provider_attempt = runtime._provider_attempt_from_metadata(graph_request.metadata)
         reasoning_capture_state = runtime._reasoning_capture_state()
         while True:
+            current_graph_request: GraphRunRequest = graph_request
             current_session = session
             base_context = runtime._prepare_provider_context_window(
-                prompt=graph_request.prompt,
+                prompt=current_graph_request.prompt,
                 tool_results=tuple(tool_results),
                 session_metadata=current_session.metadata,
             )
@@ -476,7 +477,7 @@ class RuntimeRunLoopCoordinator:
             session = runtime._session_with_context_window_metadata(current_session, context_window)
             skill_prompt_context = ""
             preserved_system_segments: list[str] = []
-            for segment in graph_request.assembled_context.segments:
+            for segment in current_graph_request.assembled_context.segments:
                 if segment.role != "system" or not isinstance(segment.content, str):
                     continue
                 if segment.content.startswith("Runtime-managed todo state is active"):
@@ -486,18 +487,18 @@ class RuntimeRunLoopCoordinator:
                     skill_prompt_context = segment.content
             graph_request = GraphRunRequest(
                 session=session,
-                prompt=graph_request.prompt,
-                available_tools=graph_request.available_tools,
+                prompt=current_graph_request.prompt,
+                available_tools=current_graph_request.available_tools,
                 context_window=context_window,
                 assembled_context=runtime._assemble_provider_context(
-                    prompt=graph_request.prompt,
+                    prompt=current_graph_request.prompt,
                     tool_results=context_window.tool_results,
                     session_metadata=session.metadata,
                     skill_prompt_context=skill_prompt_context,
                     preserved_system_segments=tuple(preserved_system_segments),
                 ),
-                metadata=graph_request.metadata,
-                abort_signal=graph_request.abort_signal,
+                metadata=current_graph_request.metadata,
+                abort_signal=current_graph_request.abort_signal,
             )
             effective_runtime_config = runtime._effective_runtime_config_from_metadata(
                 session.metadata
@@ -557,9 +558,8 @@ class RuntimeRunLoopCoordinator:
                         session.session.id,
                         hook_outcome.failed_error,
                     )
-            memory_payload = self._build_memory_refreshed_payload(context_window)
             if (
-                memory_payload is not None
+                context_window.compacted
                 and reinjected_continuity is None
                 and self._should_emit_memory_refreshed(
                     session=session,
@@ -568,24 +568,26 @@ class RuntimeRunLoopCoordinator:
                     retained_tool_result_count=context_window.retained_tool_result_count,
                 )
             ):
-                session = self._session_with_memory_refreshed_state(
-                    session=session,
-                    summary_anchor=context_window.summary_anchor,
-                    original_tool_result_count=context_window.original_tool_result_count,
-                    retained_tool_result_count=context_window.retained_tool_result_count,
-                )
-                sequence += 1
-                yield RuntimeStreamChunk(
-                    kind="event",
-                    session=session,
-                    event=EventEnvelope(
-                        session_id=session.session.id,
-                        sequence=sequence,
-                        event_type=RUNTIME_MEMORY_REFRESHED,
-                        source="runtime",
-                        payload=memory_payload,
-                    ),
-                )
+                memory_payload = self._build_memory_refreshed_payload(context_window)
+                if memory_payload is not None:
+                    session = self._session_with_memory_refreshed_state(
+                        session=session,
+                        summary_anchor=context_window.summary_anchor,
+                        original_tool_result_count=context_window.original_tool_result_count,
+                        retained_tool_result_count=context_window.retained_tool_result_count,
+                    )
+                    sequence += 1
+                    yield RuntimeStreamChunk(
+                        kind="event",
+                        session=session,
+                        event=EventEnvelope(
+                            session_id=session.session.id,
+                            sequence=sequence,
+                            event_type=RUNTIME_MEMORY_REFRESHED,
+                            source="runtime",
+                            payload=memory_payload,
+                        ),
+                    )
             tool_exception_recovery_enabled = (
                 effective_runtime_config.execution_engine == "provider"
             )

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -557,16 +557,23 @@ class RuntimeRunLoopCoordinator:
                         session.session.id,
                         hook_outcome.failed_error,
                     )
-            if context_window.compacted and reinjected_continuity is None:
-                token_metadata: dict[str, object] = {}
-                if context_window.token_budget is not None:
-                    token_metadata = {
-                        "original_tool_result_tokens": (context_window.original_tool_result_tokens),
-                        "retained_tool_result_tokens": (context_window.retained_tool_result_tokens),
-                        "dropped_tool_result_tokens": context_window.dropped_tool_result_tokens,
-                        "token_budget": context_window.token_budget,
-                        "token_estimate_source": context_window.token_estimate_source,
-                    }
+            memory_payload = self._build_memory_refreshed_payload(context_window)
+            if (
+                memory_payload is not None
+                and reinjected_continuity is None
+                and self._should_emit_memory_refreshed(
+                    session=session,
+                    summary_anchor=context_window.summary_anchor,
+                    original_tool_result_count=context_window.original_tool_result_count,
+                    retained_tool_result_count=context_window.retained_tool_result_count,
+                )
+            ):
+                session = self._session_with_memory_refreshed_state(
+                    session=session,
+                    summary_anchor=context_window.summary_anchor,
+                    original_tool_result_count=context_window.original_tool_result_count,
+                    retained_tool_result_count=context_window.retained_tool_result_count,
+                )
                 sequence += 1
                 yield RuntimeStreamChunk(
                     kind="event",
@@ -576,20 +583,7 @@ class RuntimeRunLoopCoordinator:
                         sequence=sequence,
                         event_type=RUNTIME_MEMORY_REFRESHED,
                         source="runtime",
-                        payload={
-                            "reason": context_window.compaction_reason,
-                            "original_tool_result_count": context_window.original_tool_result_count,
-                            "retained_tool_result_count": context_window.retained_tool_result_count,
-                            **token_metadata,
-                            "compacted": True,
-                            "summary_anchor": context_window.summary_anchor,
-                            "summary_source": context_window.summary_source,
-                            "continuity_state": (
-                                context_window.continuity_state.metadata_payload()
-                                if context_window.continuity_state is not None
-                                else None
-                            ),
-                        },
+                        payload=memory_payload,
                     ),
                 )
             tool_exception_recovery_enabled = (
@@ -1389,6 +1383,98 @@ class RuntimeRunLoopCoordinator:
         if context_window.continuity_state is not None:
             payload["continuity_state"] = context_window.continuity_state.metadata_payload()
         return payload
+
+    @staticmethod
+    def _build_memory_refreshed_payload(
+        context_window: RuntimeContextWindow,
+    ) -> dict[str, object] | None:
+        if not context_window.compacted:
+            return None
+        token_metadata: dict[str, object] = {}
+        if context_window.token_budget is not None:
+            token_metadata = {
+                "original_tool_result_tokens": context_window.original_tool_result_tokens,
+                "retained_tool_result_tokens": context_window.retained_tool_result_tokens,
+                "dropped_tool_result_tokens": context_window.dropped_tool_result_tokens,
+                "token_budget": context_window.token_budget,
+                "token_estimate_source": context_window.token_estimate_source,
+            }
+        return {
+            "reason": context_window.compaction_reason,
+            "original_tool_result_count": context_window.original_tool_result_count,
+            "retained_tool_result_count": context_window.retained_tool_result_count,
+            **token_metadata,
+            "compacted": True,
+            "summary_anchor": context_window.summary_anchor,
+            "summary_source": context_window.summary_source,
+            "continuity_state": (
+                context_window.continuity_state.metadata_payload()
+                if context_window.continuity_state is not None
+                else None
+            ),
+        }
+
+    @staticmethod
+    def _should_emit_memory_refreshed(
+        *,
+        session: SessionState,
+        summary_anchor: str | None,
+        original_tool_result_count: int,
+        retained_tool_result_count: int,
+    ) -> bool:
+        raw_runtime_state = session.metadata.get("runtime_state")
+        runtime_state = (
+            cast(dict[str, object], raw_runtime_state)
+            if isinstance(raw_runtime_state, dict)
+            else {}
+        )
+        current_run_id_raw = runtime_state.get("run_id")
+        current_run_id = current_run_id_raw if isinstance(current_run_id_raw, str) else None
+        raw_memory_state = runtime_state.get("memory_refreshed")
+        memory_state = (
+            cast(dict[str, object], raw_memory_state) if isinstance(raw_memory_state, dict) else {}
+        )
+        last_run_id_raw = memory_state.get("last_emitted_run_id")
+        last_run_id = last_run_id_raw if isinstance(last_run_id_raw, str) else None
+        if current_run_id is not None and last_run_id is not None and current_run_id != last_run_id:
+            return True
+        if summary_anchor is not None and memory_state.get("last_summary_anchor") == summary_anchor:
+            return False
+        return not (
+            memory_state.get("last_original_tool_result_count") == original_tool_result_count
+            and memory_state.get("last_retained_tool_result_count") == retained_tool_result_count
+        )
+
+    @staticmethod
+    def _session_with_memory_refreshed_state(
+        *,
+        session: SessionState,
+        summary_anchor: str | None,
+        original_tool_result_count: int,
+        retained_tool_result_count: int,
+    ) -> SessionState:
+        raw_runtime_state = session.metadata.get("runtime_state")
+        runtime_state = (
+            dict(cast(dict[str, object], raw_runtime_state))
+            if isinstance(raw_runtime_state, dict)
+            else {}
+        )
+        runtime_state["memory_refreshed"] = {
+            "last_summary_anchor": summary_anchor,
+            "last_original_tool_result_count": original_tool_result_count,
+            "last_retained_tool_result_count": retained_tool_result_count,
+            "last_emitted_run_id": (
+                runtime_state.get("run_id")
+                if isinstance(runtime_state.get("run_id"), str)
+                else None
+            ),
+        }
+        return SessionState(
+            session=session.session,
+            status=session.status,
+            turn=session.turn,
+            metadata={**session.metadata, "runtime_state": runtime_state},
+        )
 
     @staticmethod
     def _should_emit_context_pressure(

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -40,6 +40,7 @@ from ..provider.errors import format_invalid_provider_config_error, guidance_for
 from ..provider.model_catalog import (
     ProviderModelCatalog,
     infer_model_metadata,
+    merge_model_metadata,
 )
 from ..provider.model_catalog import (
     ProviderModelMetadata as CatalogProviderModelMetadata,
@@ -2965,7 +2966,11 @@ class VoidCodeRuntime:
             raw_payload = metadata_payloads.get(model_name)
             if isinstance(raw_payload, dict):
                 payload = cast(dict[str, object], raw_payload)
-                return VoidCodeRuntime._contract_metadata_from_payload(payload)
+                return VoidCodeRuntime._contract_metadata_for_model_payload(
+                    provider_name=provider_name,
+                    model_name=model_name,
+                    payload=payload,
+                )
         inferred = infer_model_metadata(provider_name, model_name)
         if inferred is None:
             return None
@@ -2993,6 +2998,50 @@ class VoidCodeRuntime:
             model_status=inferred.model_status,
             tool_feedback_mode=inferred.tool_feedback_mode,
         )
+
+    @staticmethod
+    def _contract_metadata_from_catalog(
+        catalog_metadata: CatalogProviderModelMetadata,
+    ) -> ProviderModelMetadata:
+        return ProviderModelMetadata(
+            context_window=catalog_metadata.context_window,
+            max_input_tokens=catalog_metadata.max_input_tokens,
+            max_output_tokens=catalog_metadata.max_output_tokens,
+            supports_tools=catalog_metadata.supports_tools,
+            supports_vision=catalog_metadata.supports_vision,
+            supports_streaming=catalog_metadata.supports_streaming,
+            supports_reasoning=catalog_metadata.supports_reasoning,
+            supports_json_mode=catalog_metadata.supports_json_mode,
+            cost_per_input_token=catalog_metadata.cost_per_input_token,
+            cost_per_output_token=catalog_metadata.cost_per_output_token,
+            cost_per_cache_read_token=catalog_metadata.cost_per_cache_read_token,
+            cost_per_cache_write_token=catalog_metadata.cost_per_cache_write_token,
+            supports_reasoning_effort=catalog_metadata.supports_reasoning_effort,
+            default_reasoning_effort=catalog_metadata.default_reasoning_effort,
+            supports_reasoning_summary=catalog_metadata.supports_reasoning_summary,
+            supports_thinking_budget=catalog_metadata.supports_thinking_budget,
+            supports_interleaved_reasoning=catalog_metadata.supports_interleaved_reasoning,
+            reasoning_visibility=catalog_metadata.reasoning_visibility,
+            modalities_input=catalog_metadata.modalities_input,
+            modalities_output=catalog_metadata.modalities_output,
+            model_status=catalog_metadata.model_status,
+            tool_feedback_mode=catalog_metadata.tool_feedback_mode,
+        )
+
+    @staticmethod
+    def _contract_metadata_for_model_payload(
+        *,
+        provider_name: str,
+        model_name: str,
+        payload: dict[str, object],
+    ) -> ProviderModelMetadata | None:
+        catalog_metadata = merge_model_metadata(
+            inferred=infer_model_metadata(provider_name, model_name),
+            override=VoidCodeRuntime._catalog_metadata_from_payload(payload),
+        )
+        if catalog_metadata is None:
+            return None
+        return VoidCodeRuntime._contract_metadata_from_catalog(catalog_metadata)
 
     def _context_window_policy_for_provider_attempt(
         self,
@@ -3049,12 +3098,20 @@ class VoidCodeRuntime:
             configured=configured,
             models=tuple(cast(list[str], catalog["models"])),
             model_metadata={
-                model: VoidCodeRuntime._contract_metadata_from_payload(payload)
+                model: metadata
                 for model, raw_payload in cast(
                     dict[str, object], catalog.get("model_metadata", {})
                 ).items()
                 if isinstance(raw_payload, dict)
                 for payload in (cast(dict[str, object], raw_payload),)
+                for metadata in (
+                    VoidCodeRuntime._contract_metadata_for_model_payload(
+                        provider_name=provider_name,
+                        model_name=model,
+                        payload=payload,
+                    ),
+                )
+                if metadata is not None
             },
             source=cast(str | None, catalog["source"]),
             last_refresh_status=cast(str | None, catalog["last_refresh_status"]),
@@ -3481,30 +3538,7 @@ class VoidCodeRuntime:
     @staticmethod
     def _contract_metadata_from_payload(payload: dict[str, object]) -> ProviderModelMetadata:
         catalog_metadata = VoidCodeRuntime._catalog_metadata_from_payload(payload)
-        return ProviderModelMetadata(
-            context_window=catalog_metadata.context_window,
-            max_input_tokens=catalog_metadata.max_input_tokens,
-            max_output_tokens=catalog_metadata.max_output_tokens,
-            supports_tools=catalog_metadata.supports_tools,
-            supports_vision=catalog_metadata.supports_vision,
-            supports_streaming=catalog_metadata.supports_streaming,
-            supports_reasoning=catalog_metadata.supports_reasoning,
-            supports_json_mode=catalog_metadata.supports_json_mode,
-            cost_per_input_token=catalog_metadata.cost_per_input_token,
-            cost_per_output_token=catalog_metadata.cost_per_output_token,
-            cost_per_cache_read_token=catalog_metadata.cost_per_cache_read_token,
-            cost_per_cache_write_token=catalog_metadata.cost_per_cache_write_token,
-            supports_reasoning_effort=catalog_metadata.supports_reasoning_effort,
-            default_reasoning_effort=catalog_metadata.default_reasoning_effort,
-            supports_reasoning_summary=catalog_metadata.supports_reasoning_summary,
-            supports_thinking_budget=catalog_metadata.supports_thinking_budget,
-            supports_interleaved_reasoning=catalog_metadata.supports_interleaved_reasoning,
-            reasoning_visibility=catalog_metadata.reasoning_visibility,
-            modalities_input=catalog_metadata.modalities_input,
-            modalities_output=catalog_metadata.modalities_output,
-            model_status=catalog_metadata.model_status,
-            tool_feedback_mode=catalog_metadata.tool_feedback_mode,
-        )
+        return VoidCodeRuntime._contract_metadata_from_catalog(catalog_metadata)
 
     def list_agent_summaries(self) -> tuple[AgentSummary, ...]:
         summaries: list[AgentSummary] = []
@@ -4065,6 +4099,15 @@ class VoidCodeRuntime:
         active_target = effective_config.resolved_provider.active_target
         provider = active_target.selection.provider or "unknown"
         model = active_target.selection.model or active_target.selection.raw_model or "unknown"
+        inferred_metadata = infer_model_metadata(provider, model) if provider != "unknown" else None
+        tool_feedback_mode = (
+            active_target.metadata.tool_feedback_mode
+            if active_target.metadata is not None
+            and active_target.metadata.tool_feedback_mode is not None
+            else inferred_metadata.tool_feedback_mode
+            if inferred_metadata is not None and inferred_metadata.tool_feedback_mode is not None
+            else "standard"
+        )
         tool_registry = self._tool_registry_for_effective_config(effective_config)
         return inspect_provider_context(
             assembled_context=assembled_context,
@@ -4072,12 +4115,7 @@ class VoidCodeRuntime:
             model=model,
             execution_engine=effective_config.execution_engine,
             available_tool_count=len(tool_registry.definitions()),
-            tool_feedback_mode=(
-                active_target.metadata.tool_feedback_mode
-                if active_target.metadata is not None
-                and active_target.metadata.tool_feedback_mode is not None
-                else "standard"
-            ),
+            tool_feedback_mode=tool_feedback_mode,
         )
 
     @staticmethod

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -2991,6 +2991,7 @@ class VoidCodeRuntime:
             modalities_input=inferred.modalities_input,
             modalities_output=inferred.modalities_output,
             model_status=inferred.model_status,
+            tool_feedback_mode=inferred.tool_feedback_mode,
         )
 
     def _context_window_policy_for_provider_attempt(
@@ -3411,6 +3412,14 @@ class VoidCodeRuntime:
         return items or None
 
     @staticmethod
+    def _tool_feedback_mode(
+        value: object,
+    ) -> Literal["standard", "synthetic_user_message"] | None:
+        if value in {"standard", "synthetic_user_message"}:
+            return cast(Literal["standard", "synthetic_user_message"], value)
+        return None
+
+    @staticmethod
     def _catalog_metadata_from_payload(
         payload: dict[str, object],
     ) -> CatalogProviderModelMetadata:
@@ -3464,6 +3473,9 @@ class VoidCodeRuntime:
                 payload.get("modalities_output")
             ),
             model_status=VoidCodeRuntime._optional_string(payload.get("model_status")),
+            tool_feedback_mode=VoidCodeRuntime._tool_feedback_mode(
+                payload.get("tool_feedback_mode")
+            ),
         )
 
     @staticmethod
@@ -3491,6 +3503,7 @@ class VoidCodeRuntime:
             modalities_input=catalog_metadata.modalities_input,
             modalities_output=catalog_metadata.modalities_output,
             model_status=catalog_metadata.model_status,
+            tool_feedback_mode=catalog_metadata.tool_feedback_mode,
         )
 
     def list_agent_summaries(self) -> tuple[AgentSummary, ...]:
@@ -4059,6 +4072,12 @@ class VoidCodeRuntime:
             model=model,
             execution_engine=effective_config.execution_engine,
             available_tool_count=len(tool_registry.definitions()),
+            tool_feedback_mode=(
+                active_target.metadata.tool_feedback_mode
+                if active_target.metadata is not None
+                and active_target.metadata.tool_feedback_mode is not None
+                else "standard"
+            ),
         )
 
     @staticmethod

--- a/tests/unit/provider/test_model_catalog.py
+++ b/tests/unit/provider/test_model_catalog.py
@@ -181,6 +181,25 @@ def test_discover_available_models_merges_partial_remote_metadata() -> None:
     assert metadata.model_status == "active"
 
 
+def test_infer_model_metadata_marks_tool_feedback_mode_by_model_route() -> None:
+    opencode_minimax = infer_model_metadata("opencode-go", "minimax-m2.7")
+    opencode_qwen = infer_model_metadata("opencode-go", "qwen3.6-plus")
+    opencode_mimo = infer_model_metadata("opencode-go", "mimo-v2.5-pro")
+    direct_minimax = infer_model_metadata("minimax", "minimax-m2.7")
+    direct_qwen = infer_model_metadata("qwen", "qwen3.6-plus")
+
+    assert opencode_minimax is not None
+    assert opencode_qwen is not None
+    assert opencode_mimo is not None
+    assert direct_minimax is not None
+    assert direct_qwen is not None
+    assert opencode_minimax.tool_feedback_mode == "synthetic_user_message"
+    assert opencode_qwen.tool_feedback_mode == "synthetic_user_message"
+    assert opencode_mimo.tool_feedback_mode == "standard"
+    assert direct_minimax.tool_feedback_mode == "standard"
+    assert direct_qwen.tool_feedback_mode == "standard"
+
+
 def test_discover_available_models_recomputes_input_limit_for_remote_context_override() -> None:
     result = discover_available_models(
         "openai",
@@ -351,6 +370,7 @@ def test_provider_model_metadata_payload_includes_limits_and_capabilities() -> N
         modalities_input=("text",),
         modalities_output=("text",),
         model_status="active",
+        tool_feedback_mode="synthetic_user_message",
     ).payload()
 
     assert payload == {
@@ -371,6 +391,7 @@ def test_provider_model_metadata_payload_includes_limits_and_capabilities() -> N
         "modalities_input": ["text"],
         "modalities_output": ["text"],
         "model_status": "active",
+        "tool_feedback_mode": "synthetic_user_message",
     }
 
 

--- a/tests/unit/provider/test_provider_adapters.py
+++ b/tests/unit/provider/test_provider_adapters.py
@@ -1472,6 +1472,57 @@ def test_provider_adapter_synthetic_tool_feedback_policy_is_provider_agnostic(
     assert "tool_calls" not in messages[1]
 
 
+def test_provider_adapter_infers_tool_feedback_when_metadata_omits_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = OpenCodeGoModelProvider().turn_provider()
+    request = _build_turn_request(model_name="opencode-go")
+    tool_results = (
+        ToolResult(
+            tool_name="list",
+            status="ok",
+            content="./\n  .voidcode.json",
+            data={"tool_call_id": "list_0", "arguments": {"path": "."}},
+        ),
+    )
+    request = ProviderTurnRequest(
+        assembled_context=_assembled_from_legacy(
+            prompt=request.prompt,
+            tool_results=tool_results,
+            context_window=_StubContextWindow(
+                prompt=request.context_window.prompt,
+                tool_results=tool_results,
+            ),
+            applied_skills=request.applied_skills,
+        ),
+        available_tools=request.available_tools,
+        raw_model="opencode-go/minimax-m2.7",
+        provider_name="opencode-go",
+        model_name="minimax-m2.7",
+        model_metadata=ProviderModelMetadata(context_window=204_800),
+        attempt=request.attempt,
+        abort_signal=request.abort_signal,
+    )
+    _patch_litellm_completion(
+        monkeypatch,
+        mode="completion",
+        completion_content="done",
+    )
+
+    _ = provider.propose_turn(request)
+
+    payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
+    assert isinstance(payload_obj, dict)
+    payload = cast(dict[str, object], payload_obj)
+    messages_obj = payload.get("messages")
+    assert isinstance(messages_obj, list)
+    messages = cast(list[dict[str, object]], messages_obj)
+    assert messages[1]["role"] == "user"
+    feedback = messages[1]["content"]
+    assert isinstance(feedback, str)
+    assert "Completed tool calls for current request:" in feedback
+
+
 def test_opencode_go_non_openai_families_declare_synthetic_tool_feedback_policy(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/provider/test_provider_adapters.py
+++ b/tests/unit/provider/test_provider_adapters.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -1236,7 +1237,7 @@ def test_provider_adapter_preserves_tool_call_id_and_arguments_in_tool_history(
     assert "tool_call_id" not in tool_content
 
 
-def test_opencode_go_provider_uses_user_tool_feedback_for_compatibility(
+def test_opencode_go_openai_compatible_provider_uses_tool_call_pairing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     provider = OpenCodeGoModelProvider().turn_provider()
@@ -1281,16 +1282,23 @@ def test_opencode_go_provider_uses_user_tool_feedback_for_compatibility(
     assert isinstance(messages_obj, list)
     messages = cast(list[dict[str, object]], messages_obj)
     assert messages[0] == {"role": "user", "content": "read sample.txt"}
-    assert messages[1]["role"] == "user"
-    feedback = messages[1]["content"]
-    assert isinstance(feedback, str)
-    assert "Completed tool calls for current request:" in feedback
-    assert '"tool_name": "list"' in feedback
-    assert '"arguments": {"path": "."}' in feedback
-    assert "tool_calls" not in messages[1]
+    assert messages[1] == {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "list_0",
+                "type": "function",
+                "function": {"name": "list", "arguments": '{"path": "."}'},
+            }
+        ],
+    }
+    assert messages[2]["role"] == "tool"
+    assert messages[2]["tool_call_id"] == "list_0"
+    assert "Completed tool calls for current request:" not in str(messages)
 
 
-def test_opencode_go_provider_sanitizes_user_tool_feedback(
+def test_opencode_go_openai_compatible_provider_sanitizes_tool_messages(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     provider = OpenCodeGoModelProvider().turn_provider()
@@ -1341,14 +1349,126 @@ def test_opencode_go_provider_sanitizes_user_tool_feedback(
     messages_obj = payload.get("messages")
     assert isinstance(messages_obj, list)
     messages = cast(list[dict[str, object]], messages_obj)
+    assert messages[1]["role"] == "assistant"
+    assert "tool_calls" in messages[1]
+    tool_content = messages[2]["content"]
+    assert isinstance(tool_content, str)
+    assert raw_content not in tool_content
+    assert raw_patch not in tool_content
+    assert raw_data_uri not in tool_content
+    assert '"omitted": true' in tool_content
+    assert '"data_uri": {"byte_count"' in tool_content
+
+
+def test_opencode_go_non_openai_families_keep_synthetic_tool_feedback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = OpenCodeGoModelProvider().turn_provider()
+    request = _build_turn_request(model_name="opencode-go")
+    tool_results = (
+        ToolResult(
+            tool_name="list",
+            status="ok",
+            content="./\n  .voidcode.json",
+            data={"tool_call_id": "list_0", "arguments": {"path": "."}},
+        ),
+    )
+    request = ProviderTurnRequest(
+        assembled_context=_assembled_from_legacy(
+            prompt=request.prompt,
+            tool_results=tool_results,
+            context_window=_StubContextWindow(
+                prompt=request.context_window.prompt,
+                tool_results=tool_results,
+            ),
+            applied_skills=request.applied_skills,
+        ),
+        available_tools=request.available_tools,
+        raw_model="opencode-go/minimax-m2.7",
+        provider_name="opencode-go",
+        model_name="minimax-m2.7",
+        attempt=request.attempt,
+        abort_signal=request.abort_signal,
+    )
+    _patch_litellm_completion(
+        monkeypatch,
+        mode="completion",
+        completion_content="done",
+    )
+
+    _ = provider.propose_turn(request)
+
+    payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
+    assert isinstance(payload_obj, dict)
+    payload = cast(dict[str, object], payload_obj)
+    messages_obj = payload.get("messages")
+    assert isinstance(messages_obj, list)
+    messages = cast(list[dict[str, object]], messages_obj)
     assert messages[1]["role"] == "user"
     feedback = messages[1]["content"]
     assert isinstance(feedback, str)
-    assert raw_content not in feedback
-    assert raw_patch not in feedback
-    assert raw_data_uri not in feedback
-    assert '"omitted": true' in feedback
-    assert '"data_uri": {"byte_count"' in feedback
+    assert "Completed tool calls for current request:" in feedback
+    assert '"tool_name": "list"' in feedback
+    assert "tool_calls" not in messages[1]
+
+
+def test_provider_adapter_logs_bounded_request_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="voidcode.provider.litellm_backend")
+    provider = OpenCodeGoModelProvider().turn_provider()
+    request = _build_turn_request(model_name="opencode-go")
+    tool_results = (
+        ToolResult(
+            tool_name="list",
+            status="ok",
+            content="./\n  .voidcode.json",
+            data={"tool_call_id": "list_0", "arguments": {"path": "."}},
+        ),
+    )
+    request = ProviderTurnRequest(
+        assembled_context=_assembled_from_legacy(
+            prompt=request.prompt,
+            tool_results=tool_results,
+            context_window=_StubContextWindow(
+                prompt=request.context_window.prompt,
+                tool_results=tool_results,
+                compacted=True,
+                retained_tool_result_count=1,
+                _continuity_state=_StubContinuityState(summary_text="Compacted old result"),
+            ),
+            applied_skills=request.applied_skills,
+        ),
+        available_tools=request.available_tools,
+        raw_model="opencode-go/minimax-m2.7",
+        provider_name="opencode-go",
+        model_name="minimax-m2.7",
+        attempt=request.attempt,
+        abort_signal=request.abort_signal,
+    )
+    _patch_litellm_completion(
+        monkeypatch,
+        mode="completion",
+        completion_content="done",
+    )
+
+    _ = provider.propose_turn(request)
+
+    diagnostic_records = [
+        record
+        for record in caplog.records
+        if record.message.startswith("provider request diagnostics:")
+    ]
+    assert diagnostic_records
+    message = diagnostic_records[-1].message
+    assert "provider=opencode-go" in message
+    assert "model=minimax-m2.7" in message
+    assert "messages=3" in message
+    assert "retained_tool_results=1" in message
+    assert "synthetic_tool_feedback_size=" in message
+    assert "continuity_summary_size=" in message
+    assert "largest_message=" in message
 
 
 def test_provider_adapter_uses_runtime_assembled_context_for_agent_system_message(

--- a/tests/unit/provider/test_provider_adapters.py
+++ b/tests/unit/provider/test_provider_adapters.py
@@ -22,6 +22,8 @@ from voidcode.provider.errors import (
 from voidcode.provider.glm import GLMModelProvider
 from voidcode.provider.google import GoogleModelProvider
 from voidcode.provider.litellm import LiteLLMModelProvider
+from voidcode.provider.litellm_backend import LiteLLMBackendSingleAgentProvider
+from voidcode.provider.model_catalog import ProviderModelMetadata, infer_model_metadata
 from voidcode.provider.openai import OpenAIModelProvider
 from voidcode.provider.opencode_go import OpenCodeGoModelProvider
 from voidcode.provider.protocol import (
@@ -1264,6 +1266,7 @@ def test_opencode_go_openai_compatible_provider_uses_tool_call_pairing(
         raw_model="opencode-go/kimi-k2.6",
         provider_name="opencode-go",
         model_name="kimi-k2.6",
+        model_metadata=infer_model_metadata("opencode-go", "kimi-k2.6"),
         attempt=request.attempt,
         abort_signal=request.abort_signal,
     )
@@ -1332,6 +1335,7 @@ def test_opencode_go_openai_compatible_provider_sanitizes_tool_messages(
         raw_model="opencode-go/glm-5.1",
         provider_name="opencode-go",
         model_name="glm-5.1",
+        model_metadata=infer_model_metadata("opencode-go", "glm-5.1"),
         attempt=request.attempt,
         abort_signal=request.abort_signal,
     )
@@ -1360,7 +1364,115 @@ def test_opencode_go_openai_compatible_provider_sanitizes_tool_messages(
     assert '"data_uri": {"byte_count"' in tool_content
 
 
-def test_opencode_go_non_openai_families_keep_synthetic_tool_feedback(
+def test_opencode_go_mimo_preserves_standard_tool_pairing_with_model_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = OpenCodeGoModelProvider().turn_provider()
+    request = _build_turn_request(model_name="opencode-go")
+    tool_results = (
+        ToolResult(
+            tool_name="list",
+            status="ok",
+            content="./\n  README.md",
+            data={"tool_call_id": "list_0", "arguments": {"path": "."}},
+        ),
+    )
+    request = ProviderTurnRequest(
+        assembled_context=_assembled_from_legacy(
+            prompt=request.prompt,
+            tool_results=tool_results,
+            context_window=_StubContextWindow(
+                prompt=request.context_window.prompt,
+                tool_results=tool_results,
+            ),
+            applied_skills=request.applied_skills,
+        ),
+        available_tools=request.available_tools,
+        raw_model="opencode-go/mimo-v2.5-pro",
+        provider_name="opencode-go",
+        model_name="mimo-v2.5-pro",
+        model_metadata=infer_model_metadata("opencode-go", "mimo-v2.5-pro"),
+        attempt=request.attempt,
+        abort_signal=request.abort_signal,
+    )
+    _patch_litellm_completion(
+        monkeypatch,
+        mode="completion",
+        completion_content="done",
+    )
+
+    _ = provider.propose_turn(request)
+
+    payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
+    assert isinstance(payload_obj, dict)
+    payload = cast(dict[str, object], payload_obj)
+    messages_obj = payload.get("messages")
+    assert isinstance(messages_obj, list)
+    messages = cast(list[dict[str, object]], messages_obj)
+    assert messages[1]["role"] == "assistant"
+    assert "tool_calls" in messages[1]
+    assert messages[2]["role"] == "tool"
+    assert messages[2]["tool_call_id"] == "list_0"
+    assert "Completed tool calls for current request:" not in str(messages)
+
+
+def test_provider_adapter_synthetic_tool_feedback_policy_is_provider_agnostic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = LiteLLMBackendSingleAgentProvider(
+        name="custom",
+        config=None,
+    )
+    request = _build_turn_request(model_name="custom")
+    tool_results = (
+        ToolResult(
+            tool_name="list",
+            status="ok",
+            content="./\n  .voidcode.json",
+            data={"tool_call_id": "list_0", "arguments": {"path": "."}},
+        ),
+    )
+    request = ProviderTurnRequest(
+        assembled_context=_assembled_from_legacy(
+            prompt=request.prompt,
+            tool_results=tool_results,
+            context_window=_StubContextWindow(
+                prompt=request.context_window.prompt,
+                tool_results=tool_results,
+            ),
+            applied_skills=request.applied_skills,
+        ),
+        available_tools=request.available_tools,
+        raw_model="custom/demo",
+        provider_name="custom",
+        model_name="demo",
+        model_metadata=ProviderModelMetadata(tool_feedback_mode="synthetic_user_message"),
+        attempt=request.attempt,
+        abort_signal=request.abort_signal,
+    )
+    _patch_litellm_completion(
+        monkeypatch,
+        mode="completion",
+        completion_content="done",
+    )
+
+    _ = provider.propose_turn(request)
+
+    payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
+    assert isinstance(payload_obj, dict)
+    payload = cast(dict[str, object], payload_obj)
+    messages_obj = payload.get("messages")
+    assert isinstance(messages_obj, list)
+    messages = cast(list[dict[str, object]], messages_obj)
+    assert messages[1]["role"] == "user"
+    feedback = messages[1]["content"]
+    assert isinstance(feedback, str)
+    assert "Completed tool calls for current request:" in feedback
+    assert '"tool_name": "list"' in feedback
+    assert "tool_calls" not in messages[1]
+
+
+def test_opencode_go_non_openai_families_declare_synthetic_tool_feedback_policy(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     provider = OpenCodeGoModelProvider().turn_provider()
@@ -1387,6 +1499,7 @@ def test_opencode_go_non_openai_families_keep_synthetic_tool_feedback(
         raw_model="opencode-go/minimax-m2.7",
         provider_name="opencode-go",
         model_name="minimax-m2.7",
+        model_metadata=infer_model_metadata("opencode-go", "minimax-m2.7"),
         attempt=request.attempt,
         abort_signal=request.abort_signal,
     )
@@ -1444,6 +1557,7 @@ def test_provider_adapter_logs_bounded_request_diagnostics(
         raw_model="opencode-go/minimax-m2.7",
         provider_name="opencode-go",
         model_name="minimax-m2.7",
+        model_metadata=infer_model_metadata("opencode-go", "minimax-m2.7"),
         attempt=request.attempt,
         abort_signal=request.abort_signal,
     )
@@ -1730,6 +1844,49 @@ def test_glm_provider_maps_disabled_reasoning_effort_to_disabled_thinking(
     assert isinstance(payload_obj, dict)
     payload = cast(dict[str, object], payload_obj)
     assert payload["extra_body"] == {"thinking": {"type": "disabled"}}
+
+
+def test_litellm_backend_reasoning_effort_can_be_disabled_by_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = LiteLLMBackendSingleAgentProvider(
+        name="custom",
+        config=LiteLLMProviderConfig(base_url="http://localhost:4000"),
+        reasoning_effort_mode="disabled",
+    )
+
+    _patch_litellm_completion(
+        monkeypatch,
+        mode="completion",
+        completion_content="ok",
+    )
+
+    _ = provider.propose_turn(
+        ProviderTurnRequest(
+            assembled_context=_assembled_from_legacy(
+                prompt="read sample.txt",
+                tool_results=(),
+                context_window=_StubContextWindow(prompt="read sample.txt", tool_results=()),
+                applied_skills=(),
+            ),
+            available_tools=(
+                ToolDefinition(name="read_file", description="read file", read_only=True),
+            ),
+            raw_model="custom/glm-5.1",
+            provider_name="custom",
+            model_name="glm-5.1",
+            reasoning_effort="high",
+            attempt=0,
+            abort_signal=None,
+        )
+    )
+
+    payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
+    assert isinstance(payload_obj, dict)
+    payload = cast(dict[str, object], payload_obj)
+    assert "reasoning_effort" not in payload
+    assert "extra_body" not in payload
+    assert "allowed_openai_params" not in payload
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/provider/test_provider_adapters.py
+++ b/tests/unit/provider/test_provider_adapters.py
@@ -1523,6 +1523,64 @@ def test_provider_adapter_infers_tool_feedback_when_metadata_omits_mode(
     assert "Completed tool calls for current request:" in feedback
 
 
+def test_provider_adapter_infers_tool_feedback_from_mapped_model_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = OpenCodeGoModelProvider(
+        config=SimplifiedProviderConfig(
+            api_key="opencode-go-key",
+            model_map={"my-minimax": "minimax-m2.7"},
+        )
+    ).turn_provider()
+    request = _build_turn_request(model_name="opencode-go")
+    tool_results = (
+        ToolResult(
+            tool_name="list",
+            status="ok",
+            content="./\n  .voidcode.json",
+            data={"tool_call_id": "list_0", "arguments": {"path": "."}},
+        ),
+    )
+    request = ProviderTurnRequest(
+        assembled_context=_assembled_from_legacy(
+            prompt=request.prompt,
+            tool_results=tool_results,
+            context_window=_StubContextWindow(
+                prompt=request.context_window.prompt,
+                tool_results=tool_results,
+            ),
+            applied_skills=request.applied_skills,
+        ),
+        available_tools=request.available_tools,
+        raw_model="opencode-go/my-minimax",
+        provider_name="opencode-go",
+        model_name="my-minimax",
+        model_metadata=ProviderModelMetadata(context_window=204_800),
+        attempt=request.attempt,
+        abort_signal=request.abort_signal,
+    )
+    _patch_litellm_completion(
+        monkeypatch,
+        mode="completion",
+        completion_content="done",
+    )
+
+    _ = provider.propose_turn(request)
+
+    payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
+    assert isinstance(payload_obj, dict)
+    payload = cast(dict[str, object], payload_obj)
+    assert payload["model"] == "minimax-m2.7"
+    assert payload["custom_llm_provider"] == "anthropic"
+    messages_obj = payload.get("messages")
+    assert isinstance(messages_obj, list)
+    messages = cast(list[dict[str, object]], messages_obj)
+    assert messages[1]["role"] == "user"
+    feedback = messages[1]["content"]
+    assert isinstance(feedback, str)
+    assert "Completed tool calls for current request:" in feedback
+
+
 def test_opencode_go_non_openai_families_declare_synthetic_tool_feedback_policy(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import sys
 from types import ModuleType
-from typing import Literal
+from typing import Literal, cast
 from unittest.mock import patch
 
 from voidcode.runtime.context_window import (
     ContextWindowPolicy,
+    DroppedToolResultDiagnostic,
     RuntimeAssembledContext,
     RuntimeContextSegment,
     RuntimeContinuityState,
@@ -62,6 +63,20 @@ def _sized_tool_result(index: int, *, content_size: int) -> ToolResult:
         status="ok",
         data={"index": index, "path": f"sample-{index}.txt"},
     )
+
+
+def test_context_window_policy_default_retains_more_tool_results_before_compaction() -> None:
+    policy = ContextWindowPolicy()
+    context = prepare_provider_context(
+        prompt="continue coding task",
+        tool_results=tuple(_tool_result(index) for index in range(1, 8)),
+        session_metadata={},
+        policy=policy,
+    )
+
+    assert policy.max_tool_results == 8
+    assert context.compacted is False
+    assert context.retained_tool_result_count == 7
 
 
 def test_prepare_provider_context_keeps_results_within_limit() -> None:
@@ -301,6 +316,13 @@ def test_prepare_provider_context_compacts_old_results_and_reports_metadata() ->
     assert context.continuity_state.dropped_tool_result_count == 2
     assert context.continuity_state.retained_tool_result_count == 2
     assert context.continuity_state.source == "tool_result_window"
+    assert len(context.continuity_state.dropped_tool_results) == 2
+    assert context.continuity_state.dropped_tool_results[0].metadata_payload() == {
+        "tool_name": "read_file",
+        "status": "ok",
+        "index": 1,
+        "estimated_tokens": context.continuity_state.dropped_tool_results[0].estimated_tokens,
+    }
     assert context.continuity_state.summary_text is not None
     assert "Compacted 2 earlier tool results:" in context.continuity_state.summary_text
     assert 'content_preview="content-1"' in context.continuity_state.summary_text
@@ -317,6 +339,9 @@ def test_prepare_provider_context_compacts_old_results_and_reports_metadata() ->
     assert continuity_payload["retained_tool_result_count"] == 2
     assert continuity_payload["source"] == "tool_result_window"
     assert continuity_payload["version"] == 2
+    assert continuity_payload["dropped_tool_results"] == [
+        item.metadata_payload() for item in context.continuity_state.dropped_tool_results
+    ]
     assert context.metadata_payload()["summary_anchor"] == context.summary_anchor
     assert context.metadata_payload()["summary_source"] == context.summary_source
 
@@ -710,6 +735,44 @@ def test_prepare_provider_context_continuity_metadata_includes_version() -> None
     assert payload.get("objective") == "read sample.txt"
 
 
+def test_prepare_provider_context_dropped_tool_diagnostics_omit_raw_content() -> None:
+    context = prepare_provider_context(
+        prompt="write secret.txt",
+        tool_results=(
+            ToolResult(
+                tool_name="write_file",
+                status="ok",
+                content="RAW SECRET CONTENT SHOULD NOT BE COPIED",
+                data={
+                    "tool_call_id": "write-1",
+                    "arguments": {"path": "secret.txt", "content": "hidden"},
+                    "path": "secret.txt",
+                },
+            ),
+            ToolResult(tool_name="list", status="ok", content="secret.txt", data={}),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(max_tool_results=1),
+    )
+
+    assert context.continuity_state is not None
+    payload = context.continuity_state.metadata_payload()
+    raw_dropped = payload["dropped_tool_results"]
+    assert isinstance(raw_dropped, list)
+    dropped = cast(list[object], raw_dropped)
+    assert dropped == [
+        {
+            "tool_name": "write_file",
+            "status": "ok",
+            "index": 1,
+            "tool_call_id": "write-1",
+            "path": "secret.txt",
+            "estimated_tokens": context.continuity_state.dropped_tool_results[0].estimated_tokens,
+        }
+    ]
+    assert "RAW SECRET CONTENT" not in str(dropped)
+
+
 def test_continuity_state_metadata_payload_round_trips_v2_fields() -> None:
     state = RuntimeContinuityState(
         summary_text="summary",
@@ -726,6 +789,16 @@ def test_continuity_state_metadata_payload_round_trips_v2_fields() -> None:
         dropped_tool_result_count=2,
         retained_tool_result_count=1,
         source="tool_result_window",
+        dropped_tool_results=(
+            DroppedToolResultDiagnostic(
+                tool_name="read_file",
+                status="ok",
+                index=1,
+                tool_call_id="read-1",
+                path="sample.txt",
+                estimated_tokens=12,
+            ),
+        ),
         version=2,
     )
 

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -144,7 +144,7 @@ def test_assemble_provider_context_injects_active_runtime_todos() -> None:
     ]
 
 
-def test_provider_context_inspector_reports_opencode_go_synthetic_feedback() -> None:
+def test_provider_context_inspector_reports_synthetic_feedback_mode() -> None:
     assembled = assemble_provider_context(
         prompt="continue",
         tool_results=(
@@ -169,10 +169,11 @@ def test_provider_context_inspector_reports_opencode_go_synthetic_feedback() -> 
         model="glm-5",
         execution_engine="provider",
         available_tool_count=3,
+        tool_feedback_mode="synthetic_user_message",
     )
 
     assert snapshot.provider == "opencode-go"
-    assert snapshot.provider_messages[-1].source == "opencode_go_synthetic_tool_feedback"
+    assert snapshot.provider_messages[-1].source == "provider_synthetic_tool_feedback"
     assert snapshot.provider_messages[-1].role == "user"
     synthetic_content = snapshot.provider_messages[-1].content or ""
     assert "Completed tool calls for current request" in synthetic_content

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -774,6 +774,28 @@ def test_prepare_provider_context_dropped_tool_diagnostics_omit_raw_content() ->
     assert "RAW SECRET CONTENT" not in str(dropped)
 
 
+def test_prepare_provider_context_dropped_diagnostics_use_prepared_results() -> None:
+    context = prepare_provider_context(
+        prompt="search",
+        tool_results=(
+            ToolResult(tool_name="grep", status="ok", content="x" * 200, data={"index": 1}),
+            ToolResult(tool_name="grep", status="ok", content="latest", data={"index": 2}),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=1,
+            recent_tool_result_count=1,
+            per_tool_result_tokens={"grep": 30},
+        ),
+    )
+
+    assert context.continuity_state is not None
+    (diagnostic,) = context.continuity_state.dropped_tool_results
+    assert diagnostic.truncated is True
+    assert diagnostic.partial is True
+    assert diagnostic.metadata_payload()["truncated"] is True
+
+
 def test_continuity_state_metadata_payload_round_trips_v2_fields() -> None:
     state = RuntimeContinuityState(
         summary_text="summary",

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -286,6 +286,7 @@ def test_runtime_config_defaults_to_provider_for_product_runs(
     assert config.execution_engine == "provider"
     assert config.model is None
     assert RuntimeConfig().execution_engine == "provider"
+    assert RuntimeContextWindowConfig().max_tool_results == 8
 
 
 def test_runtime_config_supports_provider_first_opt_in_with_stub_model(
@@ -351,6 +352,22 @@ def test_runtime_config_loads_context_window_policy_from_repo_file(tmp_path: Pat
         context_pressure_threshold=0.75,
         context_pressure_cooldown_steps=5,
     )
+
+
+def test_runtime_config_uses_current_context_window_defaults_for_partial_repo_file(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / RUNTIME_CONFIG_FILE_NAME
+    config_path.write_text(
+        json.dumps({"context_window": {"auto_compaction": True}}),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.context_window is not None
+    assert config.context_window == RuntimeContextWindowConfig(auto_compaction=True)
+    assert config.context_window.max_tool_results == 8
 
 
 def test_runtime_context_window_config_serializes_for_session_resume() -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -13289,7 +13289,6 @@ def test_runtime_hydrates_provider_tool_feedback_mode_from_catalog_cache(
                         "model_metadata": {
                             "minimax-m2.7": {
                                 "context_window": 204_800,
-                                "tool_feedback_mode": "synthetic_user_message",
                             }
                         },
                         "refreshed": True,

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1638,6 +1638,32 @@ def test_runtime_session_debug_snapshot_includes_provider_context(tmp_path: Path
     )
 
 
+def test_runtime_session_debug_snapshot_uses_model_tool_feedback_mode(
+    tmp_path: Path,
+) -> None:
+    _ = (tmp_path / "sample.txt").write_text("provider debug\n", encoding="utf-8")
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            model="opencode-go/minimax-m2.7",
+            execution_engine="deterministic",
+        ),
+    )
+
+    _ = runtime.run(RuntimeRequest(prompt="read sample.txt", session_id="synthetic-debug"))
+    snapshot = runtime.session_debug_snapshot(session_id="synthetic-debug")
+
+    provider_context = snapshot.provider_context
+    assert provider_context is not None
+    assert provider_context.provider == "opencode-go"
+    assert provider_context.provider_messages[-1].source == "provider_synthetic_tool_feedback"
+    assert provider_context.provider_messages[-1].role == "user"
+    assert any(
+        diagnostic.code == "provider_path_uses_synthetic_tool_feedback"
+        for diagnostic in provider_context.diagnostics
+    )
+
+
 def test_runtime_session_debug_snapshot_reconstructs_skill_prompt_context(
     tmp_path: Path,
 ) -> None:
@@ -13245,6 +13271,43 @@ def test_runtime_persists_provider_model_catalog_cache(tmp_path: Path) -> None:
     assert result.model_metadata["gpt-4o"].max_input_tokens == 111_616
     assert result.model_metadata["gpt-4o"].cost_per_input_token is not None
     assert result.model_metadata["gpt-4o"].modalities_input == ("text", "image")
+
+
+def test_runtime_hydrates_provider_tool_feedback_mode_from_catalog_cache(
+    tmp_path: Path,
+) -> None:
+    cache_dir = tmp_path / ".voidcode"
+    cache_dir.mkdir()
+    (cache_dir / "provider-model-catalog.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {
+                    "opencode-go": {
+                        "provider": "opencode-go",
+                        "models": ["minimax-m2.7"],
+                        "model_metadata": {
+                            "minimax-m2.7": {
+                                "context_window": 204_800,
+                                "tool_feedback_mode": "synthetic_user_message",
+                            }
+                        },
+                        "refreshed": True,
+                        "source": "fallback",
+                        "last_refresh_status": "skipped",
+                        "last_error": None,
+                        "discovery_mode": "unavailable",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+
+    result = runtime.provider_models_result("opencode-go")
+
+    assert result.model_metadata["minimax-m2.7"].tool_feedback_mode == ("synthetic_user_message")
 
 
 def test_runtime_provider_validation_refreshes_past_persisted_catalog_cache(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -8956,8 +8956,53 @@ def test_runtime_provider_compaction_emits_continuity_state_and_persists_metadat
         "anchor": summary_anchor,
         "source": summary_source,
     }
+    assert runtime_state["memory_refreshed"] == {
+        "last_summary_anchor": summary_anchor,
+        "last_original_tool_result_count": 2,
+        "last_retained_tool_result_count": 1,
+        "last_emitted_run_id": runtime_state["run_id"],
+    }
     replay_runtime_state = cast(dict[str, object], replay.session.metadata["runtime_state"])
     assert replay_runtime_state["continuity"] == expected_continuity
+
+
+def test_runtime_memory_refreshed_guard_suppresses_duplicate_anchor(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+    coordinator = runtime._run_loop_coordinator  # pyright: ignore[reportPrivateUsage]
+    session = SessionState(
+        session=SessionRef("memory-refresh-guard"),
+        status="running",
+        metadata={"runtime_state": {"run_id": "run-1"}},
+    )
+
+    first = coordinator._should_emit_memory_refreshed(  # pyright: ignore[reportPrivateUsage]
+        session=session,
+        summary_anchor="continuity:abc",
+        original_tool_result_count=9,
+        retained_tool_result_count=8,
+    )
+    updated = coordinator._session_with_memory_refreshed_state(  # pyright: ignore[reportPrivateUsage]
+        session=session,
+        summary_anchor="continuity:abc",
+        original_tool_result_count=9,
+        retained_tool_result_count=8,
+    )
+    duplicate = coordinator._should_emit_memory_refreshed(  # pyright: ignore[reportPrivateUsage]
+        session=updated,
+        summary_anchor="continuity:abc",
+        original_tool_result_count=9,
+        retained_tool_result_count=8,
+    )
+    changed = coordinator._should_emit_memory_refreshed(  # pyright: ignore[reportPrivateUsage]
+        session=updated,
+        summary_anchor="continuity:def",
+        original_tool_result_count=10,
+        retained_tool_result_count=8,
+    )
+
+    assert first is True
+    assert duplicate is False
+    assert changed is True
 
 
 def test_runtime_emits_context_pressure_with_cooldown_edge_control(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Raise default tool-result retention and add bounded dropped-tool diagnostics to continuity metadata.
- Deduplicate repeated `runtime.memory_refreshed` events by compaction anchor/count state.
- Use standard assistant/tool result pairing for OpenCode-Go OpenAI-compatible models while retaining synthetic feedback for MiniMax/Qwen, plus provider payload size diagnostics.

Closes #338

## Verification
- `uv run ruff check .`
- `uv run basedpyright --warnings src`
- `uv run pytest tests/unit/runtime/test_runtime_config.py tests/unit/runtime/test_context_window.py tests/unit/provider/test_provider_adapters.py tests/unit/runtime/test_runtime_service_extensions.py -k "context_window or opencode_go or logs_bounded_request_diagnostics or memory_refreshed or provider_compaction" -q`
- `uv run python -X utf8 -m pytest -n auto` (1730 passed)
- Frontend earlier in branch: `bun run lint && bun run typecheck`; `bun run vitest run --testTimeout=20000`; `uv build`; `bun run build`