### PR TITLE
feat(runtime): add reasoning parts and thinking controls

### DIFF
--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -74,7 +74,7 @@ from .runtime.contracts import (
     RuntimeStreamChunk,
     validate_runtime_request_metadata,
 )
-from .runtime.events import EventEnvelope
+from .runtime.events import EventEnvelope, redact_reasoning_payload
 from .runtime.permission import PermissionDecision, PermissionResolution
 from .runtime.service import VoidCodeRuntime
 from .runtime.session import SessionState, StoredSessionSummary
@@ -98,6 +98,7 @@ def _handle_run_command(args: argparse.Namespace) -> int:
     workspace = cast(Path, args.workspace)
     request_text = cast(str, args.request)
     json_output = cast(bool, getattr(args, "json", False))
+    show_thinking = cast(bool, getattr(args, "show_thinking", False))
     cli_reasoning_effort = cast(str | None, getattr(args, "reasoning_effort", None))
     config = load_runtime_config(
         workspace,
@@ -129,6 +130,7 @@ def _handle_run_command(args: argparse.Namespace) -> int:
                 request,
                 interactive=interactive,
                 emit_events=interactive and not json_output,
+                show_thinking=show_thinking,
             )
         except KeyboardInterrupt:
             print("Interrupted current run.", file=sys.stderr)
@@ -138,7 +140,13 @@ def _handle_run_command(args: argparse.Namespace) -> int:
 
         blocked_event = _pending_blocked_event(result.session, _last_event(result))
         if json_output:
-            print_json(_runtime_stream_payload(result, workspace=workspace))
+            print_json(
+                _runtime_stream_payload(
+                    result,
+                    workspace=workspace,
+                    show_thinking=show_thinking,
+                )
+            )
             if not interactive and blocked_event is not None:
                 return _blocked_exit_code(blocked_event)
         elif not interactive:
@@ -172,10 +180,12 @@ def _run_with_inline_approval(
     *,
     interactive: bool,
     emit_events: bool,
+    show_thinking: bool = False,
 ) -> RuntimeStreamResult:
     result = _consume_runtime_stream(
         runtime.run_stream(request),
         emit_events=emit_events,
+        show_thinking=show_thinking,
         on_interrupt=lambda session_id, run_id: runtime.cancel_session(
             session_id,
             run_id=run_id,
@@ -194,6 +204,7 @@ def _run_with_inline_approval(
                 approval_decision=_prompt_for_approval(approval_event),
             ),
             emit_events=emit_events,
+            show_thinking=show_thinking,
             on_interrupt=lambda session_id, run_id: runtime.cancel_session(
                 session_id,
                 run_id=run_id,
@@ -218,6 +229,7 @@ def _consume_runtime_stream(
     chunks: Iterator[RuntimeStreamChunk],
     *,
     emit_events: bool,
+    show_thinking: bool = False,
     on_interrupt: Callable[[str, str | None], object] | None = None,
 ) -> RuntimeStreamResult:
     output: str | None = None
@@ -234,6 +246,7 @@ def _consume_runtime_stream(
                             chunk.event.event_type,
                             chunk.event.source,
                             chunk.event.payload,
+                            show_thinking=show_thinking,
                         ),
                         flush=True,
                     )
@@ -327,11 +340,20 @@ def _print_runtime_response(
     *,
     event_offset: int = 0,
     include_result: bool = True,
+    show_thinking: bool = False,
 ) -> int:
     typed_result = cast("RuntimeResponseLike", result)
 
     for event in typed_result.events[event_offset:]:
-        print(format_event(event.event_type, event.source, event.payload), flush=True)
+        print(
+            format_event(
+                event.event_type,
+                event.source,
+                event.payload,
+                show_thinking=show_thinking,
+            ),
+            flush=True,
+        )
 
     if include_result:
         _print_runtime_output(typed_result.output)
@@ -403,13 +425,18 @@ def _print_runtime_failure_footer(
         )
 
 
-def _runtime_stream_payload(result: RuntimeStreamResult, *, workspace: Path) -> dict[str, object]:
+def _runtime_stream_payload(
+    result: RuntimeStreamResult,
+    *,
+    workspace: Path,
+    show_thinking: bool = False,
+) -> dict[str, object]:
     blocked_event = _pending_blocked_event(result.session, _last_event(result))
     payload: dict[str, object] = {
         "workspace": str(workspace),
         "session": serialize_session_state(result.session),
         "output": result.output,
-        "events": [serialize_event(event) for event in result.events],
+        "events": [serialize_event(event, show_thinking=show_thinking) for event in result.events],
     }
     if blocked_event is not None:
         payload["blocked"] = _blocked_payload(result, blocked_event)
@@ -761,7 +788,11 @@ def _format_background_task_summary(task: StoredBackgroundTaskSummary) -> str:
     return _format_named_record("TASK", fields)
 
 
-def _serialize_session_debug_snapshot(snapshot: RuntimeSessionDebugSnapshot) -> dict[str, object]:
+def _serialize_session_debug_snapshot(
+    snapshot: RuntimeSessionDebugSnapshot,
+    *,
+    show_thinking: bool = False,
+) -> dict[str, object]:
     session_payload: dict[str, object] = {"id": snapshot.session.session.id}
     if snapshot.session.session.parent_id is not None:
         session_payload["parent_id"] = snapshot.session.session.parent_id
@@ -807,25 +838,13 @@ def _serialize_session_debug_snapshot(snapshot: RuntimeSessionDebugSnapshot) -> 
         ),
         "revert_marker": _serialize_revert_marker(snapshot.revert_marker),
         "last_event_sequence": snapshot.last_event_sequence,
-        "last_relevant_event": (
-            {
-                "sequence": snapshot.last_relevant_event.sequence,
-                "event_type": snapshot.last_relevant_event.event_type,
-                "source": snapshot.last_relevant_event.source,
-                "payload": snapshot.last_relevant_event.payload,
-            }
-            if snapshot.last_relevant_event is not None
-            else None
+        "last_relevant_event": _serialize_session_debug_event(
+            snapshot.last_relevant_event,
+            show_thinking=show_thinking,
         ),
-        "last_failure_event": (
-            {
-                "sequence": snapshot.last_failure_event.sequence,
-                "event_type": snapshot.last_failure_event.event_type,
-                "source": snapshot.last_failure_event.source,
-                "payload": snapshot.last_failure_event.payload,
-            }
-            if snapshot.last_failure_event is not None
-            else None
+        "last_failure_event": _serialize_session_debug_event(
+            snapshot.last_failure_event,
+            show_thinking=show_thinking,
         ),
         "failure": (
             {
@@ -905,11 +924,32 @@ def _serialize_provider_context_snapshot(
     }
 
 
+def _serialize_session_debug_event(
+    event: object | None,
+    *,
+    show_thinking: bool = False,
+) -> dict[str, object] | None:
+    if event is None:
+        return None
+    typed_event = cast(EventEnvelope, event)
+    return {
+        "sequence": typed_event.sequence,
+        "event_type": typed_event.event_type,
+        "source": typed_event.source,
+        "payload": redact_reasoning_payload(
+            typed_event.event_type,
+            typed_event.payload,
+            show_thinking=show_thinking,
+        ),
+    }
+
+
 def _handle_sessions_resume_command(args: argparse.Namespace) -> int:
     workspace = cast(Path, args.workspace)
     session_id = cast(str, args.session_id)
     dry_run = cast(bool, getattr(args, "dry_run", False))
     approval_decision = cast(PermissionResolution | None, getattr(args, "approval_decision", None))
+    show_thinking = cast(bool, getattr(args, "show_thinking", False))
     runtime = VoidCodeRuntime(workspace=workspace)
     try:
         if dry_run:
@@ -937,7 +977,7 @@ def _handle_sessions_resume_command(args: argparse.Namespace) -> int:
     finally:
         _close_runtime(runtime)
 
-    _print_runtime_response(result)
+    _print_runtime_response(result, show_thinking=show_thinking)
     return 0
 
 
@@ -1012,6 +1052,7 @@ def _handle_sessions_import_command(args: argparse.Namespace) -> int:
 def _handle_sessions_debug_command(args: argparse.Namespace) -> int:
     workspace = cast(Path, args.workspace)
     session_id = cast(str, args.session_id)
+    show_thinking = cast(bool, getattr(args, "show_thinking", False))
     runtime = VoidCodeRuntime(workspace=workspace)
     try:
         try:
@@ -1021,7 +1062,11 @@ def _handle_sessions_debug_command(args: argparse.Namespace) -> int:
     finally:
         _close_runtime(runtime)
 
-    print(json.dumps(_serialize_session_debug_snapshot(snapshot), sort_keys=True))
+    debug_payload = _serialize_session_debug_snapshot(
+        snapshot,
+        show_thinking=show_thinking,
+    )
+    print(json.dumps(debug_payload, sort_keys=True))
     return 0
 
 
@@ -1544,7 +1589,10 @@ def _provider_model_metadata_payload(
             "cost_per_cache_write_token": metadata.cost_per_cache_write_token,
             "supports_reasoning_effort": metadata.supports_reasoning_effort,
             "default_reasoning_effort": metadata.default_reasoning_effort,
+            "supports_reasoning_summary": metadata.supports_reasoning_summary,
+            "supports_thinking_budget": metadata.supports_thinking_budget,
             "supports_interleaved_reasoning": metadata.supports_interleaved_reasoning,
+            "reasoning_visibility": metadata.reasoning_visibility,
             "modalities_input": list(metadata.modalities_input)
             if metadata.modalities_input is not None
             else None,
@@ -1571,6 +1619,7 @@ def _provider_readiness_payload(readiness: ProviderReadinessResult) -> dict[str,
         "context_window": readiness.context_window,
         "max_output_tokens": readiness.max_output_tokens,
         "fallback_chain": list(readiness.fallback_chain),
+        "reasoning_controls": getattr(readiness, "reasoning_controls", {}),
     }
 
 
@@ -1856,6 +1905,11 @@ def build_parser() -> argparse.ArgumentParser:
             "provider when supported (for example, 'low', 'medium', 'high'). Overrides "
             "any reasoning_effort configured in .voidcode.json or VOIDCODE_REASONING_EFFORT."
         ),
+    )
+    _ = run_parser.add_argument(
+        "--show-thinking",
+        action="store_true",
+        help="Show persisted reasoning/thinking text; hidden by default.",
     )
     _ = run_parser.add_argument(
         "--json",
@@ -2191,6 +2245,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Inspect the persisted session without resuming execution.",
     )
+    _ = resume_parser.add_argument(
+        "--show-thinking",
+        action="store_true",
+        help="Show persisted reasoning/thinking events during replay; hidden by default.",
+    )
     resume_parser.set_defaults(handler=_handle_sessions_resume_command)
 
     export_parser = sessions_subparsers.add_parser(
@@ -2286,6 +2345,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         default=True,
         help="Output JSON debug snapshot (default).",
+    )
+    _ = debug_parser.add_argument(
+        "--show-thinking",
+        action="store_true",
+        help="Include reasoning/thinking text in debug event payloads; hidden by default.",
     )
     debug_parser.set_defaults(handler=_handle_sessions_debug_command)
 

--- a/src/voidcode/cli_support.py
+++ b/src/voidcode/cli_support.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from .command.models import CommandDefinition
-from .runtime.events import EventEnvelope
+from .runtime.events import EventEnvelope, redact_reasoning_payload
 from .runtime.session import SessionState, StoredSessionSummary
 
 EXIT_SUCCESS = 0
@@ -31,18 +31,29 @@ def print_json(payload: object) -> None:
     print(json.dumps(payload, sort_keys=True))
 
 
-def format_event(event_type: str, source: str, data: dict[str, object]) -> str:
-    suffix = " ".join(f"{key}={value}" for key, value in sorted(data.items()))
+def format_event(
+    event_type: str,
+    source: str,
+    data: dict[str, object],
+    *,
+    show_thinking: bool = False,
+) -> str:
+    safe_data = redact_reasoning_payload(event_type, data, show_thinking=show_thinking)
+    suffix = " ".join(f"{key}={value}" for key, value in sorted(safe_data.items()))
     if suffix:
         return f"EVENT {event_type} source={source} {suffix}"
     return f"EVENT {event_type} source={source}"
 
 
-def serialize_event(event: EventEnvelope) -> dict[str, object]:
+def serialize_event(event: EventEnvelope, *, show_thinking: bool = False) -> dict[str, object]:
     return {
         "event_type": event.event_type,
         "source": event.source,
-        "payload": event.payload,
+        "payload": redact_reasoning_payload(
+            event.event_type,
+            event.payload,
+            show_thinking=show_thinking,
+        ),
     }
 
 

--- a/src/voidcode/graph/provider_graph.py
+++ b/src/voidcode/graph/provider_graph.py
@@ -421,6 +421,8 @@ class ProviderGraph:
         }
         if stream_event.text is not None:
             payload["text"] = stream_event.text
+        if stream_event.metadata is not None:
+            payload["metadata"] = stream_event.metadata
         if stream_event.error is not None:
             payload["error"] = stream_event.error
         if stream_event.error_kind is not None:

--- a/src/voidcode/provider/litellm_backend.py
+++ b/src/voidcode/provider/litellm_backend.py
@@ -549,7 +549,10 @@ class LiteLLMBackendSingleAgentProvider:
                     reasoning_obj = delta.get("reasoning_content") or delta.get("reasoning")
                     if isinstance(reasoning_obj, str) and reasoning_obj:
                         yield ProviderStreamEvent(
-                            kind="delta", channel="reasoning", text=reasoning_obj
+                            kind="delta",
+                            channel="reasoning",
+                            text=reasoning_obj,
+                            metadata={"source": "delta.reasoning"},
                         )
                     raw_thinking_blocks = delta.get("thinking_blocks")
                     if isinstance(raw_thinking_blocks, list):
@@ -563,7 +566,10 @@ class LiteLLMBackendSingleAgentProvider:
                             thinking_text = block.get("thinking")
                             if isinstance(thinking_text, str) and thinking_text:
                                 yield ProviderStreamEvent(
-                                    kind="delta", channel="reasoning", text=thinking_text
+                                    kind="delta",
+                                    channel="reasoning",
+                                    text=thinking_text,
+                                    metadata={"source": "delta.thinking_blocks"},
                                 )
                     text_obj = delta.get("content")
                     if isinstance(text_obj, str) and text_obj:

--- a/src/voidcode/provider/model_catalog.py
+++ b/src/voidcode/provider/model_catalog.py
@@ -30,7 +30,10 @@ class ProviderModelMetadata:
     cost_per_cache_write_token: float | None = None
     supports_reasoning_effort: bool | None = None
     default_reasoning_effort: str | None = None
+    supports_reasoning_summary: bool | None = None
+    supports_thinking_budget: bool | None = None
     supports_interleaved_reasoning: bool | None = None
+    reasoning_visibility: str | None = None
     modalities_input: tuple[str, ...] | None = None
     modalities_output: tuple[str, ...] | None = None
     model_status: str | None = None
@@ -80,8 +83,14 @@ class ProviderModelMetadata:
             payload["supports_reasoning_effort"] = self.supports_reasoning_effort
         if self.default_reasoning_effort is not None:
             payload["default_reasoning_effort"] = self.default_reasoning_effort
+        if self.supports_reasoning_summary is not None:
+            payload["supports_reasoning_summary"] = self.supports_reasoning_summary
+        if self.supports_thinking_budget is not None:
+            payload["supports_thinking_budget"] = self.supports_thinking_budget
         if self.supports_interleaved_reasoning is not None:
             payload["supports_interleaved_reasoning"] = self.supports_interleaved_reasoning
+        if self.reasoning_visibility is not None:
+            payload["reasoning_visibility"] = self.reasoning_visibility
         if self.modalities_input is not None:
             payload["modalities_input"] = list(self.modalities_input)
         if self.modalities_output is not None:
@@ -175,7 +184,10 @@ class _OpenAICompatibleModelItem(_DiscoveryPayloadModel):
     supports_json_mode: bool | None = None
     supports_reasoning_effort: bool | None = None
     default_reasoning_effort: str | None = None
+    supports_reasoning_summary: bool | None = None
+    supports_thinking_budget: bool | None = None
     supports_interleaved_reasoning: bool | None = None
+    reasoning_visibility: str | None = None
     modalities: list[str] | None = None
     input_modalities: list[str] | None = None
     output_modalities: list[str] | None = None
@@ -304,7 +316,10 @@ def _metadata(
         cost_per_cache_write_token=_non_negative_float(values.get("cost_per_cache_write_token")),
         supports_reasoning_effort=_optional_bool(values.get("supports_reasoning_effort")),
         default_reasoning_effort=_optional_str(values.get("default_reasoning_effort")),
+        supports_reasoning_summary=_optional_bool(values.get("supports_reasoning_summary")),
+        supports_thinking_budget=_optional_bool(values.get("supports_thinking_budget")),
         supports_interleaved_reasoning=_optional_bool(values.get("supports_interleaved_reasoning")),
+        reasoning_visibility=_optional_str(values.get("reasoning_visibility")),
         modalities_input=_modalities_tuple(values.get("modalities_input")),
         modalities_output=_modalities_tuple(values.get("modalities_output")),
         model_status=_optional_str(values.get("model_status")),
@@ -386,9 +401,19 @@ def _merge_model_metadata(
         default_reasoning_effort=_override_value(
             inferred.default_reasoning_effort, override.default_reasoning_effort
         ),
+        supports_reasoning_summary=_override_value(
+            inferred.supports_reasoning_summary, override.supports_reasoning_summary
+        ),
+        supports_thinking_budget=_override_value(
+            inferred.supports_thinking_budget, override.supports_thinking_budget
+        ),
         supports_interleaved_reasoning=_override_value(
             inferred.supports_interleaved_reasoning,
             override.supports_interleaved_reasoning,
+        ),
+        reasoning_visibility=_override_value(
+            inferred.reasoning_visibility,
+            override.reasoning_visibility,
         ),
         modalities_input=_override_value(inferred.modalities_input, override.modalities_input),
         modalities_output=_override_value(inferred.modalities_output, override.modalities_output),
@@ -412,7 +437,12 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             "default_reasoning_effort": "medium"
             if model.startswith(("gpt-5", "o1", "o3", "o4"))
             else None,
+            "supports_reasoning_summary": model.startswith(("gpt-5", "o1", "o3", "o4")),
+            "supports_thinking_budget": False,
             "supports_interleaved_reasoning": model.startswith(("gpt-5", "o3", "o4")),
+            "reasoning_visibility": "summary"
+            if model.startswith(("gpt-5", "o1", "o3", "o4"))
+            else "hidden",
             "modalities_input": ("text", "image")
             if not model.startswith(("o1", "o3-mini"))
             else ("text",),
@@ -468,9 +498,14 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             "default_reasoning_effort": "medium"
             if model.startswith(("claude-opus-4", "claude-sonnet-4"))
             else None,
+            "supports_reasoning_summary": False,
+            "supports_thinking_budget": model.startswith(("claude-opus-4", "claude-sonnet-4")),
             "supports_interleaved_reasoning": model.startswith(
                 ("claude-opus-4", "claude-sonnet-4")
             ),
+            "reasoning_visibility": "full"
+            if model.startswith(("claude-opus-4", "claude-sonnet-4"))
+            else "hidden",
             "modalities_input": ("text", "image") if "haiku" not in model else ("text",),
             "modalities_output": ("text",),
             "model_status": "active",
@@ -501,7 +536,12 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             "default_reasoning_effort": "medium"
             if model.startswith(("gemini-2.5", "gemini-3"))
             else None,
+            "supports_reasoning_summary": False,
+            "supports_thinking_budget": model.startswith(("gemini-2.5", "gemini-3")),
             "supports_interleaved_reasoning": False,
+            "reasoning_visibility": "summary"
+            if model.startswith(("gemini-2.5", "gemini-3"))
+            else "hidden",
             "modalities_input": ("text", "image", "audio", "video"),
             "modalities_output": ("text",),
             "model_status": "preview" if "preview" in model else "active",
@@ -532,7 +572,10 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             "supports_json_mode": True,
             "supports_reasoning_effort": False,
             "default_reasoning_effort": None,
+            "supports_reasoning_summary": False,
+            "supports_thinking_budget": False,
             "supports_interleaved_reasoning": False,
+            "reasoning_visibility": "full" if "reasoner" in model else "hidden",
             "modalities_input": ("text",),
             "modalities_output": ("text",),
             "model_status": "active",
@@ -555,7 +598,12 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             "supports_json_mode": True,
             "supports_reasoning_effort": False,
             "default_reasoning_effort": None,
+            "supports_reasoning_summary": False,
+            "supports_thinking_budget": False,
             "supports_interleaved_reasoning": False,
+            "reasoning_visibility": "full"
+            if model.startswith(("qwq", "qvq", "qwen3"))
+            else "hidden",
             "modalities_input": ("text", "image")
             if model.startswith(("qvq",)) or "vl" in model
             else ("text",),
@@ -583,7 +631,10 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             "default_reasoning_effort": "medium"
             if provider != "opencode-go" and model.startswith(("glm-5", "glm-z1"))
             else None,
+            "supports_reasoning_summary": False,
+            "supports_thinking_budget": False,
             "supports_interleaved_reasoning": False,
+            "reasoning_visibility": "full" if model.startswith(("glm-5", "glm-z1")) else "hidden",
             "modalities_input": ("text", "image")
             if model.startswith("glm-4v") or "vision" in model
             else ("text",),
@@ -604,7 +655,10 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             "supports_json_mode": True,
             "supports_reasoning_effort": False,
             "default_reasoning_effort": None,
+            "supports_reasoning_summary": False,
+            "supports_thinking_budget": False,
             "supports_interleaved_reasoning": False,
+            "reasoning_visibility": "full" if "thinking" in model else "hidden",
             "modalities_input": ("text",),
             "modalities_output": ("text",),
             "model_status": "active",
@@ -631,7 +685,12 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             "supports_json_mode": True,
             "supports_reasoning_effort": False,
             "default_reasoning_effort": None,
+            "supports_reasoning_summary": False,
+            "supports_thinking_budget": False,
             "supports_interleaved_reasoning": False,
+            "reasoning_visibility": "full"
+            if model.startswith(("minimax-m2", "mimo-v2.5"))
+            else "hidden",
             "modalities_input": ("text", "image")
             if model.startswith("mimo-v2-omni")
             else ("text",),
@@ -656,7 +715,12 @@ def infer_model_metadata(provider_name: str, model_name: str) -> ProviderModelMe
             "default_reasoning_effort": "medium"
             if "reasoning" in model or model.startswith("grok-4")
             else None,
+            "supports_reasoning_summary": False,
+            "supports_thinking_budget": False,
             "supports_interleaved_reasoning": False,
+            "reasoning_visibility": "full"
+            if "reasoning" in model or model.startswith("grok-4")
+            else "hidden",
             "modalities_input": ("text", "image"),
             "modalities_output": ("text",),
             "model_status": "active",

--- a/src/voidcode/provider/protocol.py
+++ b/src/voidcode/provider/protocol.py
@@ -215,6 +215,7 @@ class ProviderStreamEvent:
     kind: ProviderStreamEventKind
     channel: ProviderStreamChannel = "text"
     text: str | None = None
+    metadata: dict[str, object] | None = None
     error: str | None = None
     error_kind: ProviderErrorKind | None = None
     done_reason: ProviderDoneReason | None = None

--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -52,6 +52,7 @@ class RuntimeRequestMetadata(TypedDict, total=False):
     max_steps: int
     provider_stream: bool
     reasoning_effort: str
+    show_thinking: bool
     skills: list[str]
     force_load_skills: list[str]
 
@@ -88,6 +89,7 @@ _STABLE_RUNTIME_REQUEST_METADATA_KEYS = frozenset(
         "max_steps",
         "provider_stream",
         "reasoning_effort",
+        "show_thinking",
         "skills",
         "force_load_skills",
     }
@@ -394,6 +396,12 @@ def validate_runtime_request_metadata(
             field_name="reasoning_effort",
         )
 
+    if "show_thinking" in metadata:
+        show_thinking = metadata["show_thinking"]
+        if not isinstance(show_thinking, bool):
+            raise RuntimeRequestError("request metadata 'show_thinking' must be a boolean")
+        normalized["show_thinking"] = show_thinking
+
     if "skills" in metadata:
         raw_skills = metadata["skills"]
         if not isinstance(raw_skills, list):
@@ -542,7 +550,10 @@ class ProviderModelMetadata:
     cost_per_cache_write_token: float | None = None
     supports_reasoning_effort: bool | None = None
     default_reasoning_effort: str | None = None
+    supports_reasoning_summary: bool | None = None
+    supports_thinking_budget: bool | None = None
     supports_interleaved_reasoning: bool | None = None
+    reasoning_visibility: str | None = None
     modalities_input: tuple[str, ...] | None = None
     modalities_output: tuple[str, ...] | None = None
     model_status: str | None = None
@@ -574,6 +585,7 @@ class ProviderReadinessResult:
     context_window: int | None = None
     max_output_tokens: int | None = None
     fallback_chain: tuple[str, ...] = ()
+    reasoning_controls: dict[str, object] = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/voidcode/runtime/events.py
+++ b/src/voidcode/runtime/events.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from typing import Final, Literal, cast
 
 type EventSource = Literal["runtime", "graph", "tool"]
@@ -63,6 +64,8 @@ type PrototypeAdditiveEventType = Literal[
     "runtime.delegated_result_available",
     "runtime.skill_loaded",
     "runtime.todo_updated",
+    "runtime.reasoning_part",
+    "runtime.reasoning_diagnostic",
 ]
 type DelegatedBackgroundTaskEventType = Literal[
     "runtime.background_task_waiting_approval",
@@ -159,6 +162,14 @@ RUNTIME_DELEGATED_RESULT_AVAILABLE: Final[PrototypeAdditiveEventType] = (
 )
 RUNTIME_SKILL_LOADED: Final[PrototypeAdditiveEventType] = "runtime.skill_loaded"
 RUNTIME_TODO_UPDATED: Final[PrototypeAdditiveEventType] = "runtime.todo_updated"
+RUNTIME_REASONING_PART: Final[PrototypeAdditiveEventType] = "runtime.reasoning_part"
+RUNTIME_REASONING_DIAGNOSTIC: Final[PrototypeAdditiveEventType] = "runtime.reasoning_diagnostic"
+
+REASONING_TEXT_LIMIT_CHARS: Final[int] = 4000
+REASONING_PREVIEW_LIMIT_CHARS: Final[int] = 240
+REASONING_SESSION_TEXT_LIMIT_CHARS: Final[int] = 16_000
+REASONING_SESSION_PART_LIMIT: Final[int] = 32
+_SAFE_PROVIDER_REASONING_METADATA_KEYS: Final[frozenset[str]] = frozenset({"source"})
 
 EMITTED_EVENT_TYPES: Final[tuple[ExistingEventType, ...]] = (
     RUNTIME_REQUEST_RECEIVED,
@@ -217,7 +228,99 @@ PROTOTYPE_ADDITIVE_EVENT_TYPES: Final[tuple[PrototypeAdditiveEventType, ...]] = 
     RUNTIME_DELEGATED_RESULT_AVAILABLE,
     RUNTIME_SKILL_LOADED,
     RUNTIME_TODO_UPDATED,
+    RUNTIME_REASONING_PART,
+    RUNTIME_REASONING_DIAGNOSTIC,
 )
+
+
+def runtime_reasoning_part_payload(
+    *,
+    text: str,
+    source: str = "provider_stream",
+    provider_metadata: Mapping[str, object] | None = None,
+    started_at: str | None = None,
+    ended_at: str | None = None,
+) -> dict[str, object]:
+    """Build a bounded, runtime-owned reasoning part payload."""
+
+    captured_at = datetime.now(UTC).isoformat()
+    text_char_count = len(text)
+    truncated = text_char_count > REASONING_TEXT_LIMIT_CHARS
+    bounded_text = text[:REASONING_TEXT_LIMIT_CHARS]
+    preview = bounded_text[:REASONING_PREVIEW_LIMIT_CHARS]
+    payload: dict[str, object] = {
+        "type": "reasoning",
+        "text": bounded_text,
+        "text_char_count": text_char_count,
+        "truncated": truncated,
+        "source": source,
+        "visibility": "showable",
+        "time": {
+            "start": started_at or captured_at,
+            "end": ended_at or captured_at,
+        },
+        "preview": preview,
+    }
+    if provider_metadata:
+        payload["provider_metadata"] = dict(provider_metadata)
+    return payload
+
+
+def runtime_reasoning_part_from_provider_stream(
+    payload: Mapping[str, object],
+) -> dict[str, object] | None:
+    if payload.get("channel") != "reasoning":
+        return None
+    kind = payload.get("kind")
+    if kind not in {"delta", "content"}:
+        return None
+    text = payload.get("text")
+    if not isinstance(text, str) or not text:
+        return None
+    provider_metadata: dict[str, object] = {
+        "stream_kind": kind,
+        "stream_channel": "reasoning",
+    }
+    raw_metadata = payload.get("metadata")
+    if isinstance(raw_metadata, Mapping):
+        for key, value in cast(Mapping[str, object], raw_metadata).items():
+            if key not in _SAFE_PROVIDER_REASONING_METADATA_KEYS:
+                continue
+            if isinstance(value, str) and value:
+                provider_metadata[key] = value[:REASONING_PREVIEW_LIMIT_CHARS]
+    return runtime_reasoning_part_payload(
+        text=text,
+        source="provider_stream",
+        provider_metadata=provider_metadata,
+    )
+
+
+def is_reasoning_payload(event_type: str, payload: Mapping[str, object]) -> bool:
+    if event_type == RUNTIME_REASONING_PART:
+        return True
+    return event_type == "graph.provider_stream" and payload.get("channel") == "reasoning"
+
+
+def redact_reasoning_payload(
+    event_type: str,
+    payload: Mapping[str, object],
+    *,
+    show_thinking: bool = False,
+) -> dict[str, object]:
+    redacted = dict(payload)
+    if show_thinking or not is_reasoning_payload(event_type, payload):
+        return redacted
+    if "text" in redacted:
+        redacted.pop("text", None)
+        redacted["text_omitted"] = True
+    if "preview" in redacted:
+        redacted.pop("preview", None)
+        redacted["preview_omitted"] = True
+    if event_type == RUNTIME_REASONING_PART:
+        redacted["visibility"] = "hidden"
+    return redacted
+
+
 KNOWN_EVENT_TYPES: Final[tuple[KnownEventType, ...]] = (
     *EMITTED_EVENT_TYPES,
     *PROTOTYPE_ADDITIVE_EVENT_TYPES,

--- a/src/voidcode/runtime/http.py
+++ b/src/voidcode/runtime/http.py
@@ -9,6 +9,7 @@ from collections.abc import AsyncIterator, Callable, Iterator
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from typing import Protocol, cast, final
+from urllib.parse import parse_qs
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
@@ -22,6 +23,7 @@ from .contracts import (
     ProviderInspectResult,
     ProviderModelMetadata,
     ProviderModelsResult,
+    ProviderReadinessResult,
     ProviderSummary,
     ProviderValidationResult,
     ReviewChangedFile,
@@ -44,7 +46,7 @@ from .contracts import (
     validate_session_id,
     validate_session_reference_id,
 )
-from .events import DelegatedLifecycleEventPayload, EventEnvelope
+from .events import DelegatedLifecycleEventPayload, EventEnvelope, redact_reasoning_payload
 from .permission import PermissionResolution
 from .question import QuestionResponse
 from .service import ActiveRunInterruptResult, VoidCodeRuntime
@@ -383,6 +385,20 @@ class RuntimeTransportApp:
         if callable(exit_method):
             exit_method(None, None, None)
 
+    @staticmethod
+    def _show_thinking_from_scope(scope: dict[str, object]) -> bool:
+        raw_query = scope.get("query_string", b"")
+        if isinstance(raw_query, bytes):
+            query = raw_query.decode("utf-8", errors="ignore")
+        elif isinstance(raw_query, str):
+            query = raw_query
+        else:
+            return False
+        values = parse_qs(query, keep_blank_values=True).get("show_thinking", ())
+        if not values:
+            values = parse_qs(query, keep_blank_values=True).get("showThinking", ())
+        return any(value.strip().lower() in {"1", "true", "yes", "on"} for value in values)
+
     @contextmanager
     def _active_request_scope(self) -> Iterator[None]:
         request_scope = (
@@ -408,6 +424,7 @@ class RuntimeTransportApp:
 
         method = cast(str, scope.get("method", "GET"))
         path = cast(str, scope.get("path", "/"))
+        show_thinking = self._show_thinking_from_scope(scope)
 
         if path == "/api/runtime/run/stream":
             if method != "POST":
@@ -417,7 +434,7 @@ class RuntimeTransportApp:
                     payload={"error": "method not allowed"},
                 )
                 return
-            await self._handle_run_stream(receive, send)
+            await self._handle_run_stream(receive, send, show_thinking=show_thinking)
             return
 
         if path == "/api/sessions":
@@ -609,7 +626,11 @@ class RuntimeTransportApp:
                         payload={"error": "method not allowed"},
                     )
                     return
-                await self._handle_background_task_output(task_id=task_id, send=send)
+                await self._handle_background_task_output(
+                    task_id=task_id,
+                    send=send,
+                    show_thinking=show_thinking,
+                )
                 return
             if method != "GET":
                 await self._json_response(
@@ -723,6 +744,7 @@ class RuntimeTransportApp:
                     session_id=session_id,
                     receive=receive,
                     send=send,
+                    show_thinking=show_thinking,
                 )
                 return
             if is_question_route:
@@ -737,6 +759,7 @@ class RuntimeTransportApp:
                     session_id=session_id,
                     receive=receive,
                     send=send,
+                    show_thinking=show_thinking,
                 )
                 return
             if is_result_route:
@@ -747,7 +770,11 @@ class RuntimeTransportApp:
                         payload={"error": "method not allowed"},
                     )
                     return
-                await self._handle_session_result(session_id=session_id, send=send)
+                await self._handle_session_result(
+                    session_id=session_id,
+                    send=send,
+                    show_thinking=show_thinking,
+                )
                 return
             if is_debug_route:
                 if method != "GET":
@@ -757,7 +784,11 @@ class RuntimeTransportApp:
                         payload={"error": "method not allowed"},
                     )
                     return
-                await self._handle_session_debug(session_id=session_id, send=send)
+                await self._handle_session_debug(
+                    session_id=session_id,
+                    send=send,
+                    show_thinking=show_thinking,
+                )
                 return
             if is_undo_route:
                 if method != "POST":
@@ -800,7 +831,11 @@ class RuntimeTransportApp:
                     payload={"error": "method not allowed"},
                 )
                 return
-            await self._handle_resume(session_id=session_id, send=send)
+            await self._handle_resume(
+                session_id=session_id,
+                send=send,
+                show_thinking=show_thinking,
+            )
             return
 
         provider_prefix = "/api/providers/"
@@ -950,7 +985,13 @@ class RuntimeTransportApp:
                 return
             raise RuntimeError(f"unsupported lifespan message type: {message_type!r}")
 
-    async def _handle_run_stream(self, receive: Receive, send: Send) -> None:
+    async def _handle_run_stream(
+        self,
+        receive: Receive,
+        send: Send,
+        *,
+        show_thinking: bool = False,
+    ) -> None:
         runtime: RuntimeTransport | None = None
         try:
             body = await self._read_body(receive)
@@ -983,10 +1024,18 @@ class RuntimeTransportApp:
 
                 await self._send_stream_start(send)
 
-                emitted_failed_chunk = await self._send_runtime_stream_chunk(send, first_chunk)
+                emitted_failed_chunk = await self._send_runtime_stream_chunk(
+                    send,
+                    first_chunk,
+                    show_thinking=show_thinking,
+                )
                 try:
                     async for chunk in stream:
-                        chunk_failed = await self._send_runtime_stream_chunk(send, chunk)
+                        chunk_failed = await self._send_runtime_stream_chunk(
+                            send,
+                            chunk,
+                            show_thinking=show_thinking,
+                        )
                         emitted_failed_chunk = emitted_failed_chunk or chunk_failed
                 except Exception:
                     if not emitted_failed_chunk:
@@ -1015,8 +1064,10 @@ class RuntimeTransportApp:
         self,
         send: Send,
         chunk: RuntimeStreamChunk,
+        *,
+        show_thinking: bool = False,
     ) -> bool:
-        payload = self._serialize_runtime_stream_chunk(chunk)
+        payload = self._serialize_runtime_stream_chunk(chunk, show_thinking=show_thinking)
         data = json.dumps(payload, sort_keys=True).encode("utf-8")
         await send(
             {
@@ -1108,7 +1159,13 @@ class RuntimeTransportApp:
             payload=self._serialize_background_task_state(task),
         )
 
-    async def _handle_background_task_output(self, *, task_id: str, send: Send) -> None:
+    async def _handle_background_task_output(
+        self,
+        *,
+        task_id: str,
+        send: Send,
+        show_thinking: bool = False,
+    ) -> None:
         with self._active_request_scope():
             runtime = self._runtime_factory()
             try:
@@ -1138,7 +1195,10 @@ class RuntimeTransportApp:
             status=200,
             payload={
                 "task": self._serialize_background_task_result(task_result),
-                "session_result": self._serialize_session_result(child_session_result)
+                "session_result": self._serialize_session_result(
+                    child_session_result,
+                    show_thinking=show_thinking,
+                )
                 if child_session_result is not None
                 else None,
                 "output": resolved_output,
@@ -1371,7 +1431,13 @@ class RuntimeTransportApp:
                 self._close_runtime(runtime, workspace_coordinator=self._workspace_coordinator)
         await self._json_response(send, status=200, payload=result)
 
-    async def _handle_resume(self, *, session_id: str, send: Send) -> None:
+    async def _handle_resume(
+        self,
+        *,
+        session_id: str,
+        send: Send,
+        show_thinking: bool = False,
+    ) -> None:
         with self._active_request_scope():
             runtime = self._runtime_factory()
             try:
@@ -1384,10 +1450,16 @@ class RuntimeTransportApp:
         await self._json_response(
             send,
             status=200,
-            payload=self._serialize_runtime_response(response),
+            payload=self._serialize_runtime_response(response, show_thinking=show_thinking),
         )
 
-    async def _handle_session_result(self, *, session_id: str, send: Send) -> None:
+    async def _handle_session_result(
+        self,
+        *,
+        session_id: str,
+        send: Send,
+        show_thinking: bool = False,
+    ) -> None:
         with self._active_request_scope():
             runtime = self._runtime_factory()
             try:
@@ -1400,10 +1472,16 @@ class RuntimeTransportApp:
         await self._json_response(
             send,
             status=200,
-            payload=self._serialize_session_result(result),
+            payload=self._serialize_session_result(result, show_thinking=show_thinking),
         )
 
-    async def _handle_session_debug(self, *, session_id: str, send: Send) -> None:
+    async def _handle_session_debug(
+        self,
+        *,
+        session_id: str,
+        send: Send,
+        show_thinking: bool = False,
+    ) -> None:
         runtime = self._runtime_factory()
         try:
             snapshot = runtime.session_debug_snapshot(session_id=session_id)
@@ -1415,7 +1493,10 @@ class RuntimeTransportApp:
         await self._json_response(
             send,
             status=200,
-            payload=self._serialize_session_debug_snapshot(snapshot),
+            payload=self._serialize_session_debug_snapshot(
+                snapshot,
+                show_thinking=show_thinking,
+            ),
         )
 
     async def _handle_session_undo(self, *, session_id: str, send: Send) -> None:
@@ -1488,6 +1569,7 @@ class RuntimeTransportApp:
         session_id: str,
         receive: Receive,
         send: Send,
+        show_thinking: bool = False,
     ) -> None:
         try:
             body = await self._read_body(receive)
@@ -1512,7 +1594,7 @@ class RuntimeTransportApp:
         await self._json_response(
             send,
             status=200,
-            payload=self._serialize_runtime_response(response),
+            payload=self._serialize_runtime_response(response, show_thinking=show_thinking),
         )
 
     async def _handle_question_answer(
@@ -1521,6 +1603,7 @@ class RuntimeTransportApp:
         session_id: str,
         receive: Receive,
         send: Send,
+        show_thinking: bool = False,
     ) -> None:
         try:
             body = await self._read_body(receive)
@@ -1545,7 +1628,7 @@ class RuntimeTransportApp:
         await self._json_response(
             send,
             status=200,
-            payload=self._serialize_runtime_response(response),
+            payload=self._serialize_runtime_response(response, show_thinking=show_thinking),
         )
 
     async def _handle_acknowledge_notification(
@@ -1691,19 +1774,33 @@ class RuntimeTransportApp:
         return cast(str, payload.request_id), parsed
 
     @staticmethod
-    def _serialize_runtime_stream_chunk(chunk: RuntimeStreamChunk) -> dict[str, object]:
+    def _serialize_runtime_stream_chunk(
+        chunk: RuntimeStreamChunk,
+        *,
+        show_thinking: bool = False,
+    ) -> dict[str, object]:
         return {
             "kind": chunk.kind,
             "session": RuntimeTransportApp._serialize_session_state(chunk.session),
-            "event": RuntimeTransportApp._serialize_event(chunk.event),
+            "event": RuntimeTransportApp._serialize_event(
+                chunk.event,
+                show_thinking=show_thinking,
+            ),
             "output": chunk.output,
         }
 
     @staticmethod
-    def _serialize_runtime_response(response: RuntimeResponse) -> dict[str, object]:
+    def _serialize_runtime_response(
+        response: RuntimeResponse,
+        *,
+        show_thinking: bool = False,
+    ) -> dict[str, object]:
         return {
             "session": RuntimeTransportApp._serialize_session_state(response.session),
-            "events": [RuntimeTransportApp._serialize_event(event) for event in response.events],
+            "events": [
+                RuntimeTransportApp._serialize_event(event, show_thinking=show_thinking)
+                for event in response.events
+            ],
             "output": response.output,
         }
 
@@ -1783,7 +1880,11 @@ class RuntimeTransportApp:
         }
 
     @staticmethod
-    def _serialize_session_result(result: RuntimeSessionResult) -> dict[str, object]:
+    def _serialize_session_result(
+        result: RuntimeSessionResult,
+        *,
+        show_thinking: bool = False,
+    ) -> dict[str, object]:
         return {
             "session": RuntimeTransportApp._serialize_session_state(result.session),
             "prompt": result.prompt,
@@ -1795,7 +1896,13 @@ class RuntimeTransportApp:
             "revert_marker": RuntimeTransportApp._serialize_revert_marker(result.revert_marker),
             "transcript": [
                 {
-                    **cast(dict[str, object], RuntimeTransportApp._serialize_event(event)),
+                    **cast(
+                        dict[str, object],
+                        RuntimeTransportApp._serialize_event(
+                            event,
+                            show_thinking=show_thinking,
+                        ),
+                    ),
                     "reverted": result.revert_marker is not None
                     and result.revert_marker.active
                     and event.sequence >= result.revert_marker.sequence,
@@ -1815,6 +1922,8 @@ class RuntimeTransportApp:
     @staticmethod
     def _serialize_session_debug_snapshot(
         snapshot: RuntimeSessionDebugSnapshot,
+        *,
+        show_thinking: bool = False,
     ) -> dict[str, object]:
         return {
             "session": RuntimeTransportApp._serialize_session_state(snapshot.session),
@@ -1854,10 +1963,12 @@ class RuntimeTransportApp:
             "revert_marker": RuntimeTransportApp._serialize_revert_marker(snapshot.revert_marker),
             "last_event_sequence": snapshot.last_event_sequence,
             "last_relevant_event": RuntimeTransportApp._serialize_session_debug_event(
-                snapshot.last_relevant_event
+                snapshot.last_relevant_event,
+                show_thinking=show_thinking,
             ),
             "last_failure_event": RuntimeTransportApp._serialize_session_debug_event(
-                snapshot.last_failure_event
+                snapshot.last_failure_event,
+                show_thinking=show_thinking,
             ),
             "failure": (
                 {
@@ -1939,7 +2050,11 @@ class RuntimeTransportApp:
         }
 
     @staticmethod
-    def _serialize_session_debug_event(event: object | None) -> dict[str, object] | None:
+    def _serialize_session_debug_event(
+        event: object | None,
+        *,
+        show_thinking: bool = False,
+    ) -> dict[str, object] | None:
         if event is None:
             return None
         typed_event = cast("RuntimeSessionDebugEventLike", event)
@@ -1947,7 +2062,11 @@ class RuntimeTransportApp:
             "sequence": typed_event.sequence,
             "event_type": typed_event.event_type,
             "source": typed_event.source,
-            "payload": typed_event.payload,
+            "payload": redact_reasoning_payload(
+                typed_event.event_type,
+                typed_event.payload,
+                show_thinking=show_thinking,
+            ),
         }
 
     @staticmethod
@@ -2027,7 +2146,10 @@ class RuntimeTransportApp:
                 "cost_per_cache_write_token": metadata.cost_per_cache_write_token,
                 "supports_reasoning_effort": metadata.supports_reasoning_effort,
                 "default_reasoning_effort": metadata.default_reasoning_effort,
+                "supports_reasoning_summary": metadata.supports_reasoning_summary,
+                "supports_thinking_budget": metadata.supports_thinking_budget,
                 "supports_interleaved_reasoning": metadata.supports_interleaved_reasoning,
+                "reasoning_visibility": metadata.reasoning_visibility,
                 "modalities_input": list(metadata.modalities_input)
                 if metadata.modalities_input is not None
                 else None,
@@ -2071,6 +2193,29 @@ class RuntimeTransportApp:
                     result.current_model_metadata
                 )
             ),
+            "readiness": (
+                None
+                if result.readiness is None
+                else RuntimeTransportApp._serialize_provider_readiness_result(result.readiness)
+            ),
+        }
+
+    @staticmethod
+    def _serialize_provider_readiness_result(result: ProviderReadinessResult) -> dict[str, object]:
+        return {
+            "provider": result.provider,
+            "model": result.model,
+            "configured": result.configured,
+            "ok": result.ok,
+            "status": result.status,
+            "guidance": result.guidance,
+            "auth_present": result.auth_present,
+            "streaming_configured": result.streaming_configured,
+            "streaming_supported": result.streaming_supported,
+            "context_window": result.context_window,
+            "max_output_tokens": result.max_output_tokens,
+            "fallback_chain": list(result.fallback_chain),
+            "reasoning_controls": result.reasoning_controls,
         }
 
     @staticmethod
@@ -2210,7 +2355,11 @@ class RuntimeTransportApp:
         }
 
     @staticmethod
-    def _serialize_event(event: EventEnvelope | None) -> dict[str, object] | None:
+    def _serialize_event(
+        event: EventEnvelope | None,
+        *,
+        show_thinking: bool = False,
+    ) -> dict[str, object] | None:
         if event is None:
             return None
         delegated = event.delegated_lifecycle
@@ -2219,7 +2368,11 @@ class RuntimeTransportApp:
             "sequence": event.sequence,
             "event_type": event.event_type,
             "source": event.source,
-            "payload": event.payload,
+            "payload": redact_reasoning_payload(
+                event.event_type,
+                event.payload,
+                show_thinking=show_thinking,
+            ),
         }
         if delegated is not None:
             payload["delegated_lifecycle"] = (

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -440,6 +440,7 @@ class RuntimeRunLoopCoordinator:
         active_permission_policy = permission_policy or runtime._permission_policy
         continuity_to_reinject: RuntimeContinuityState | None = preserved_continuity_state
         provider_attempt = runtime._provider_attempt_from_metadata(graph_request.metadata)
+        reasoning_capture_state = runtime._reasoning_capture_state()
         while True:
             current_session = session
             base_context = runtime._prepare_provider_context_window(
@@ -817,11 +818,29 @@ class RuntimeRunLoopCoordinator:
                 getattr(graph_step, "events", ()),
                 session_id=session.session.id,
                 start_sequence=sequence + 1,
+                reasoning_capture_state=reasoning_capture_state,
             ):
                 sequence = event.sequence
                 yield RuntimeStreamChunk(kind="event", session=current_chunk_session, event=event)
 
             if is_final_step:
+                reasoning_diagnostic = runtime._reasoning_output_diagnostic(
+                    session=current_chunk_session,
+                    capture_state=reasoning_capture_state,
+                )
+                if reasoning_diagnostic is not None:
+                    sequence += 1
+                    yield RuntimeStreamChunk(
+                        kind="event",
+                        session=current_chunk_session,
+                        event=EventEnvelope(
+                            session_id=session.session.id,
+                            sequence=sequence,
+                            event_type="runtime.reasoning_diagnostic",
+                            source="runtime",
+                            payload=reasoning_diagnostic,
+                        ),
+                    )
                 if getattr(graph_step, "output", None) is not None:
                     yield RuntimeStreamChunk(
                         kind="output",

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -152,6 +152,8 @@ from .contracts import (
     validate_session_reference_id,
 )
 from .events import (
+    REASONING_SESSION_PART_LIMIT,
+    REASONING_SESSION_TEXT_LIMIT_CHARS,
     RUNTIME_ACP_CONNECTED,
     RUNTIME_ACP_DELEGATED_LIFECYCLE,
     RUNTIME_ACP_DISCONNECTED,
@@ -172,9 +174,12 @@ from .events import (
     RUNTIME_MCP_SERVER_STOPPED,
     RUNTIME_QUESTION_ANSWERED,
     RUNTIME_QUESTION_REQUESTED,
+    RUNTIME_REASONING_DIAGNOSTIC,
+    RUNTIME_REASONING_PART,
     RUNTIME_SKILLS_APPLIED,
     RUNTIME_SKILLS_LOADED,
     EventEnvelope,
+    runtime_reasoning_part_from_provider_stream,
 )
 from .execution_seams import (
     cache_key_for_effective_config,
@@ -350,6 +355,16 @@ class _ActiveRunHandle:
     run_id: str
     abort_signal: _ActiveRunAbortSignal
     metadata: dict[str, object]
+
+
+@dataclass(slots=True)
+class _ReasoningCaptureState:
+    part_count: int = 0
+    text_char_count: int = 0
+    limit_diagnostic_emitted: bool = False
+    stream_observed: bool = False
+    reasoning_observed: bool = False
+    output_diagnostic_emitted: bool = False
 
 
 def _provider_target_label(target: ResolvedProviderModel) -> str:
@@ -1065,6 +1080,8 @@ class VoidCodeRuntime:
         model_name = active_target.model
         if provider_name is None or model_name is None:
             return
+        if provider_name.strip().lower() == "opencode-go":
+            return
         metadata = self._metadata_for_provider_model(provider_name, model_name)
         if metadata is None:
             return
@@ -1713,6 +1730,7 @@ class VoidCodeRuntime:
         request_metadata = self._fresh_request_metadata(request.metadata)
         session_request_metadata = dict(request_metadata)
         session_request_metadata.pop("background_rate_limit_retry", None)
+        session_request_metadata.pop("show_thinking", None)
         session = SessionState(
             session=SessionRef(id=resolved_session_id, parent_id=request.parent_session_id),
             status="running",
@@ -1759,6 +1777,21 @@ class VoidCodeRuntime:
                     event_type=RUNTIME_CATEGORY_MODEL_DIAGNOSTIC,
                     source="runtime",
                     payload=diagnostic,
+                ),
+            )
+
+        reasoning_diagnostic = self._reasoning_controls_diagnostic_for_config(effective_config)
+        if reasoning_diagnostic is not None:
+            sequence += 1
+            yield RuntimeStreamChunk(
+                kind="event",
+                session=session,
+                event=EventEnvelope(
+                    session_id=session.session.id,
+                    sequence=sequence,
+                    event_type=RUNTIME_REASONING_DIAGNOSTIC,
+                    source="runtime",
+                    payload=reasoning_diagnostic,
                 ),
             )
 
@@ -2951,7 +2984,10 @@ class VoidCodeRuntime:
             cost_per_cache_write_token=inferred.cost_per_cache_write_token,
             supports_reasoning_effort=inferred.supports_reasoning_effort,
             default_reasoning_effort=inferred.default_reasoning_effort,
+            supports_reasoning_summary=inferred.supports_reasoning_summary,
+            supports_thinking_budget=inferred.supports_thinking_budget,
             supports_interleaved_reasoning=inferred.supports_interleaved_reasoning,
+            reasoning_visibility=inferred.reasoning_visibility,
             modalities_input=inferred.modalities_input,
             modalities_output=inferred.modalities_output,
             model_status=inferred.model_status,
@@ -3092,7 +3128,105 @@ class VoidCodeRuntime:
             context_window=context_window,
             max_output_tokens=max_output_tokens,
             fallback_chain=fallback_chain,
+            reasoning_controls=self._reasoning_controls_diagnostic(
+                effective_config=effective_config,
+                provider_name=provider_name,
+                model_name=model_name,
+            ),
         )
+
+    def _reasoning_controls_diagnostic(
+        self,
+        *,
+        effective_config: EffectiveRuntimeConfig,
+        provider_name: str | None,
+        model_name: str | None,
+    ) -> dict[str, object]:
+        effort = effective_config.reasoning_effort
+        payload: dict[str, object] = {
+            "reasoning_effort_requested": effort is not None,
+            "reasoning_effort": effort,
+            "status": "not_requested" if effort is None else "unknown",
+            "forwarded": False,
+            "translated": False,
+            "ignored": False,
+        }
+        if provider_name is None or model_name is None:
+            payload["status"] = "unavailable"
+            payload["reason"] = "provider_model_unresolved"
+            return payload
+        metadata = self._metadata_for_provider_model(provider_name, model_name)
+        if metadata is not None:
+            payload["supports_reasoning"] = metadata.supports_reasoning
+            payload["supports_reasoning_effort"] = metadata.supports_reasoning_effort
+            payload["supports_reasoning_summary"] = metadata.supports_reasoning_summary
+            payload["supports_thinking_budget"] = metadata.supports_thinking_budget
+            payload["supports_interleaved_reasoning"] = metadata.supports_interleaved_reasoning
+            payload["reasoning_visibility"] = metadata.reasoning_visibility
+        if effort is None:
+            return payload
+        normalized_provider = provider_name.strip().lower()
+        normalized_model = model_name.strip().lower()
+        if normalized_provider == "opencode-go":
+            payload["status"] = "ignored"
+            payload["ignored"] = True
+            payload["reason"] = "opencode_go_adapter_does_not_forward_reasoning_effort"
+            return payload
+        if metadata is not None and metadata.supports_reasoning_effort is False:
+            payload["status"] = "unsupported"
+            payload["reason"] = "model_metadata_disallows_reasoning_effort"
+            return payload
+        if normalized_provider == "glm" or normalized_model.startswith(("glm-5", "glm-z1")):
+            payload["status"] = "translated"
+            payload["translated"] = True
+            payload["provider_parameter"] = "extra_body.thinking.type"
+            disabled_efforts = {"none", "off", "disable", "disabled"}
+            payload["provider_value"] = (
+                "disabled" if effort.lower() in disabled_efforts else "enabled"
+            )
+            return payload
+        direct_reasoning_effort_providers = {
+            "openai",
+            "anthropic",
+            "google",
+            "gemini",
+            "vertex_ai",
+            "litellm",
+            "grok",
+        }
+        if normalized_provider in direct_reasoning_effort_providers:
+            payload["status"] = "forwarded"
+            payload["forwarded"] = True
+            payload["provider_parameter"] = "reasoning_effort"
+            return payload
+        payload["status"] = "best_effort"
+        payload["forwarded"] = metadata is None or metadata.supports_reasoning_effort is not False
+        payload["reason"] = "provider_metadata_unknown"
+        return payload
+
+    def _reasoning_controls_diagnostic_for_config(
+        self,
+        effective_config: EffectiveRuntimeConfig,
+    ) -> dict[str, object] | None:
+        if effective_config.execution_engine != "provider":
+            return None
+        active_target = effective_config.resolved_provider.active_target.selection
+        provider_name = active_target.provider
+        model_name = active_target.model
+        diagnostic = self._reasoning_controls_diagnostic(
+            effective_config=effective_config,
+            provider_name=provider_name,
+            model_name=model_name,
+        )
+        if diagnostic.get("reasoning_effort_requested") is not True:
+            return None
+        return {
+            "severity": "info",
+            "category": "reasoning_controls",
+            "provider": provider_name,
+            "model": model_name,
+            **diagnostic,
+        }
 
     def inspect_provider(self, provider_name: str) -> ProviderInspectResult:
         if not provider_name or "/" in provider_name:
@@ -3311,8 +3445,17 @@ class VoidCodeRuntime:
             default_reasoning_effort=VoidCodeRuntime._optional_string(
                 payload.get("default_reasoning_effort")
             ),
+            supports_reasoning_summary=VoidCodeRuntime._optional_bool(
+                payload.get("supports_reasoning_summary")
+            ),
+            supports_thinking_budget=VoidCodeRuntime._optional_bool(
+                payload.get("supports_thinking_budget")
+            ),
             supports_interleaved_reasoning=VoidCodeRuntime._optional_bool(
                 payload.get("supports_interleaved_reasoning")
+            ),
+            reasoning_visibility=VoidCodeRuntime._optional_string(
+                payload.get("reasoning_visibility")
             ),
             modalities_input=VoidCodeRuntime._optional_string_tuple(
                 payload.get("modalities_input")
@@ -3341,7 +3484,10 @@ class VoidCodeRuntime:
             cost_per_cache_write_token=catalog_metadata.cost_per_cache_write_token,
             supports_reasoning_effort=catalog_metadata.supports_reasoning_effort,
             default_reasoning_effort=catalog_metadata.default_reasoning_effort,
+            supports_reasoning_summary=catalog_metadata.supports_reasoning_summary,
+            supports_thinking_budget=catalog_metadata.supports_thinking_budget,
             supports_interleaved_reasoning=catalog_metadata.supports_interleaved_reasoning,
+            reasoning_visibility=catalog_metadata.reasoning_visibility,
             modalities_input=catalog_metadata.modalities_input,
             modalities_output=catalog_metadata.modalities_output,
             model_status=catalog_metadata.model_status,
@@ -5367,20 +5513,115 @@ class VoidCodeRuntime:
         )
 
     @staticmethod
+    def _reasoning_capture_state() -> _ReasoningCaptureState:
+        # Referenced via extracted run-loop collaborator.
+        return _ReasoningCaptureState()
+
+    def _reasoning_output_diagnostic(
+        self,
+        *,
+        session: SessionState,
+        capture_state: _ReasoningCaptureState,
+    ) -> dict[str, object] | None:
+        # Referenced via extracted run-loop collaborator.
+        if capture_state.output_diagnostic_emitted or not capture_state.stream_observed:
+            return None
+        capture_state.output_diagnostic_emitted = True
+        effective_config = self._effective_runtime_config_from_metadata(session.metadata)
+        if effective_config.execution_engine != "provider":
+            return None
+        active_target = effective_config.resolved_provider.active_target.selection
+        provider_name = active_target.provider
+        model_name = active_target.model
+        metadata = (
+            self._metadata_for_provider_model(provider_name, model_name)
+            if provider_name is not None and model_name is not None
+            else None
+        )
+        supports_reasoning = metadata.supports_reasoning if metadata is not None else None
+        if capture_state.reasoning_observed:
+            severity = "info"
+            reason = "reasoning_output_observed"
+        elif supports_reasoning is True:
+            severity = "warning"
+            reason = "reasoning_capable_model_returned_no_reasoning_output"
+        else:
+            severity = "info"
+            reason = "no_reasoning_output_observed"
+        return {
+            "severity": severity,
+            "category": "reasoning_output",
+            "reason": reason,
+            "provider": provider_name,
+            "model": model_name,
+            "reasoning_output_observed": capture_state.reasoning_observed,
+            "supports_reasoning": supports_reasoning,
+            "captured_part_count": capture_state.part_count,
+            "captured_text_char_count": capture_state.text_char_count,
+        }
+
+    @staticmethod
     def _renumber_events(
-        events: tuple[GraphEvent, ...], *, session_id: str, start_sequence: int
+        events: tuple[GraphEvent, ...],
+        *,
+        session_id: str,
+        start_sequence: int,
+        reasoning_capture_state: _ReasoningCaptureState | None = None,
     ) -> tuple[EventEnvelope, ...]:
         # Referenced via extracted run-loop collaborator.
-        return tuple(
-            EventEnvelope(
-                session_id=session_id,
-                sequence=start_sequence + index,
-                event_type=event.event_type,
-                source=event.source,
-                payload=event.payload,
+        envelopes: list[EventEnvelope] = []
+        capture_state = reasoning_capture_state or _ReasoningCaptureState()
+        for event in events:
+            event_type = event.event_type
+            source = event.source
+            payload = event.payload
+            reasoning_payload = None
+            if event.event_type == "graph.provider_stream":
+                capture_state.stream_observed = True
+                reasoning_payload = runtime_reasoning_part_from_provider_stream(event.payload)
+            if reasoning_payload is not None:
+                capture_state.reasoning_observed = True
+                text_char_count = reasoning_payload.get("text_char_count")
+                bounded_text = reasoning_payload.get("text")
+                next_text_count = capture_state.text_char_count + (
+                    len(bounded_text) if isinstance(bounded_text, str) else 0
+                )
+                if (
+                    capture_state.part_count >= REASONING_SESSION_PART_LIMIT
+                    or next_text_count > REASONING_SESSION_TEXT_LIMIT_CHARS
+                ):
+                    event_type = RUNTIME_REASONING_DIAGNOSTIC
+                    source = "runtime"
+                    diagnostic_payload: dict[str, object] = {
+                        "severity": "warning",
+                        "category": "reasoning_capture_limit",
+                        "reason": "session_reasoning_capture_limit_exceeded",
+                        "captured_part_count": capture_state.part_count,
+                        "captured_text_char_count": capture_state.text_char_count,
+                        "omitted_text_char_count": text_char_count
+                        if isinstance(text_char_count, int)
+                        else None,
+                    }
+                    payload = diagnostic_payload
+                    if capture_state.limit_diagnostic_emitted:
+                        continue
+                    capture_state.limit_diagnostic_emitted = True
+                else:
+                    event_type = RUNTIME_REASONING_PART
+                    source = "runtime"
+                    payload = reasoning_payload
+                    capture_state.part_count += 1
+                    capture_state.text_char_count = next_text_count
+            envelopes.append(
+                EventEnvelope(
+                    session_id=session_id,
+                    sequence=start_sequence + len(envelopes),
+                    event_type=event_type,
+                    source=source,
+                    payload=payload,
+                )
             )
-            for index, event in enumerate(events)
-        )
+        return tuple(envelopes)
 
     @staticmethod
     def _loaded_skill_names(skill_registry: SkillRegistry) -> list[str]:

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -260,6 +260,7 @@ def _run_app(
     method: str,
     path: str,
     body: bytes = b"",
+    query_string: bytes = b"",
 ) -> _TransportResponse:
     messages: list[dict[str, object]] = [{"type": "http.request", "body": body, "more_body": False}]
     sent: list[dict[str, object]] = []
@@ -276,6 +277,7 @@ def _run_app(
         "type": "http",
         "method": method,
         "path": path,
+        "query_string": query_string,
     }
     asyncio.run(app(scope, _receive, _send))
 
@@ -925,6 +927,276 @@ def test_transport_reads_session_result_with_transcript(tmp_path: Path) -> None:
     assert [
         event["event_type"] for event in cast(list[dict[str, object]], payload["transcript"])
     ] == [event.event_type for event in stored.events]
+
+
+def test_transport_session_result_redacts_reasoning_until_query_opt_in() -> None:
+    runtime_http = importlib.import_module("voidcode.runtime.http")
+    runtime_contracts = importlib.import_module("voidcode.runtime.contracts")
+    runtime_events = importlib.import_module("voidcode.runtime.events")
+    runtime_session = importlib.import_module("voidcode.runtime.session")
+
+    session = runtime_session.SessionState(
+        session=runtime_session.SessionRef(id="reasoning-session"),
+        status="completed",
+        metadata={"show_thinking": True},
+    )
+    reasoning_event = runtime_events.EventEnvelope(
+        session_id="reasoning-session",
+        sequence=1,
+        event_type="runtime.reasoning_part",
+        source="runtime",
+        payload=runtime_events.runtime_reasoning_part_payload(text="private chain"),
+    )
+    result = runtime_contracts.RuntimeSessionResult(
+        session=session,
+        prompt="think",
+        status="completed",
+        summary="Completed",
+        output="answer",
+        transcript=(reasoning_event,),
+        last_event_sequence=1,
+    )
+
+    class ReasoningResultRuntime:
+        def session_result(self, *, session_id: str) -> object:
+            assert session_id == "reasoning-session"
+            return result
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    app = runtime_http.RuntimeTransportApp(runtime_factory=ReasoningResultRuntime)
+
+    redacted_response = _run_app(
+        app,
+        method="GET",
+        path="/api/sessions/reasoning-session/result",
+    )
+    redacted_payload = cast(dict[str, object], redacted_response.json())
+    redacted_event = cast(list[dict[str, object]], redacted_payload["transcript"])[0]
+    redacted_reasoning = cast(dict[str, object], redacted_event["payload"])
+    assert redacted_reasoning["text_omitted"] is True
+    assert redacted_reasoning["preview_omitted"] is True
+    assert "private chain" not in json.dumps(redacted_payload)
+
+    shown_response = _run_app(
+        app,
+        method="GET",
+        path="/api/sessions/reasoning-session/result",
+        query_string=b"show_thinking=true",
+    )
+    shown_payload = cast(dict[str, object], shown_response.json())
+    shown_event = cast(list[dict[str, object]], shown_payload["transcript"])[0]
+    shown_reasoning = cast(dict[str, object], shown_event["payload"])
+    assert shown_reasoning["text"] == "private chain"
+    assert shown_reasoning["preview"] == "private chain"
+
+
+def test_transport_resume_response_redacts_reasoning_until_query_opt_in() -> None:
+    runtime_http = importlib.import_module("voidcode.runtime.http")
+    runtime_contracts = importlib.import_module("voidcode.runtime.contracts")
+    runtime_events = importlib.import_module("voidcode.runtime.events")
+    runtime_session = importlib.import_module("voidcode.runtime.session")
+
+    session = runtime_session.SessionState(
+        session=runtime_session.SessionRef(id="reasoning-session"),
+        status="completed",
+        metadata={"show_thinking": True},
+    )
+    reasoning_event = runtime_events.EventEnvelope(
+        session_id="reasoning-session",
+        sequence=1,
+        event_type="runtime.reasoning_part",
+        source="runtime",
+        payload=runtime_events.runtime_reasoning_part_payload(text="private chain"),
+    )
+    response = runtime_contracts.RuntimeResponse(
+        session=session,
+        events=(reasoning_event,),
+        output="answer",
+    )
+
+    class ReasoningResumeRuntime:
+        def resume(self, session_id: str) -> object:
+            assert session_id == "reasoning-session"
+            return response
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    app = runtime_http.RuntimeTransportApp(runtime_factory=ReasoningResumeRuntime)
+
+    redacted_response = _run_app(
+        app,
+        method="GET",
+        path="/api/sessions/reasoning-session",
+    )
+    redacted_payload = cast(dict[str, object], redacted_response.json())
+    redacted_event = cast(list[dict[str, object]], redacted_payload["events"])[0]
+    redacted_reasoning = cast(dict[str, object], redacted_event["payload"])
+    assert redacted_reasoning["text_omitted"] is True
+    assert redacted_reasoning["preview_omitted"] is True
+    assert "private chain" not in json.dumps(redacted_payload)
+
+    shown_response = _run_app(
+        app,
+        method="GET",
+        path="/api/sessions/reasoning-session",
+        query_string=b"show_thinking=true",
+    )
+    shown_payload = cast(dict[str, object], shown_response.json())
+    shown_event = cast(list[dict[str, object]], shown_payload["events"])[0]
+    shown_reasoning = cast(dict[str, object], shown_event["payload"])
+    assert shown_reasoning["text"] == "private chain"
+    assert shown_reasoning["preview"] == "private chain"
+
+
+def test_transport_run_stream_ignores_show_thinking_request_metadata() -> None:
+    runtime_http = importlib.import_module("voidcode.runtime.http")
+    runtime_contracts = importlib.import_module("voidcode.runtime.contracts")
+    runtime_events = importlib.import_module("voidcode.runtime.events")
+    runtime_session = importlib.import_module("voidcode.runtime.session")
+
+    session = runtime_session.SessionState(
+        session=runtime_session.SessionRef(id="reasoning-session"),
+        status="completed",
+    )
+    reasoning_event = runtime_events.EventEnvelope(
+        session_id="reasoning-session",
+        sequence=1,
+        event_type="runtime.reasoning_part",
+        source="runtime",
+        payload=runtime_events.runtime_reasoning_part_payload(text="private chain"),
+    )
+
+    class ReasoningRunRuntime:
+        def run_stream(self, request: object) -> Iterator[object]:
+            typed_request = cast(RuntimeRequestLike, request)
+            assert typed_request.metadata["show_thinking"] is True
+            yield runtime_contracts.RuntimeStreamChunk(
+                kind="event",
+                session=session,
+                event=reasoning_event,
+            )
+            yield runtime_contracts.RuntimeStreamChunk(
+                kind="output",
+                session=session,
+                output="answer",
+            )
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    app = runtime_http.RuntimeTransportApp(runtime_factory=ReasoningRunRuntime)
+    body = json.dumps(
+        {
+            "prompt": "think",
+            "metadata": {"show_thinking": True},
+        }
+    ).encode("utf-8")
+
+    redacted_response = _run_app(
+        app,
+        method="POST",
+        path="/api/runtime/run/stream",
+        body=body,
+    )
+    redacted_payloads = _parse_sse_payloads(redacted_response)
+    redacted_event = cast(dict[str, object], redacted_payloads[0]["event"])
+    redacted_reasoning = cast(dict[str, object], redacted_event["payload"])
+    assert redacted_reasoning["text_omitted"] is True
+    assert redacted_reasoning["preview_omitted"] is True
+    assert "private chain" not in redacted_response.body.decode("utf-8")
+
+    shown_response = _run_app(
+        app,
+        method="POST",
+        path="/api/runtime/run/stream",
+        body=body,
+        query_string=b"show_thinking=true",
+    )
+    shown_payloads = _parse_sse_payloads(shown_response)
+    shown_event = cast(dict[str, object], shown_payloads[0]["event"])
+    shown_reasoning = cast(dict[str, object], shown_event["payload"])
+    assert shown_reasoning["text"] == "private chain"
+    assert shown_reasoning["preview"] == "private chain"
+
+
+def test_transport_background_task_output_redacts_reasoning_until_query_opt_in() -> None:
+    runtime_http = importlib.import_module("voidcode.runtime.http")
+    runtime_contracts = importlib.import_module("voidcode.runtime.contracts")
+    runtime_events = importlib.import_module("voidcode.runtime.events")
+    runtime_session = importlib.import_module("voidcode.runtime.session")
+
+    task_result = runtime_contracts.BackgroundTaskResult(
+        task_id="task-reasoning",
+        parent_session_id="parent-session",
+        child_session_id="child-session",
+        status="completed",
+        summary_output="answer",
+        result_available=True,
+    )
+    session = runtime_session.SessionState(
+        session=runtime_session.SessionRef(id="child-session"),
+        status="completed",
+        metadata={"show_thinking": True},
+    )
+    reasoning_event = runtime_events.EventEnvelope(
+        session_id="child-session",
+        sequence=1,
+        event_type="runtime.reasoning_part",
+        source="runtime",
+        payload=runtime_events.runtime_reasoning_part_payload(text="private chain"),
+    )
+    session_result = runtime_contracts.RuntimeSessionResult(
+        session=session,
+        prompt="think",
+        status="completed",
+        summary="Completed",
+        output="answer",
+        transcript=(reasoning_event,),
+        last_event_sequence=1,
+    )
+
+    class ReasoningTaskRuntime:
+        def load_background_task_result(self, task_id: str) -> object:
+            assert task_id == "task-reasoning"
+            return task_result
+
+        def session_result(self, *, session_id: str) -> object:
+            assert session_id == "child-session"
+            return session_result
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    app = runtime_http.RuntimeTransportApp(runtime_factory=ReasoningTaskRuntime)
+
+    redacted_response = _run_app(
+        app,
+        method="GET",
+        path="/api/tasks/task-reasoning/output",
+    )
+    redacted_payload = cast(dict[str, object], redacted_response.json())
+    redacted_session = cast(dict[str, object], redacted_payload["session_result"])
+    redacted_event = cast(list[dict[str, object]], redacted_session["transcript"])[0]
+    redacted_reasoning = cast(dict[str, object], redacted_event["payload"])
+    assert redacted_reasoning["text_omitted"] is True
+    assert redacted_reasoning["preview_omitted"] is True
+    assert "private chain" not in json.dumps(redacted_payload)
+
+    shown_response = _run_app(
+        app,
+        method="GET",
+        path="/api/tasks/task-reasoning/output",
+        query_string=b"show_thinking=true",
+    )
+    shown_payload = cast(dict[str, object], shown_response.json())
+    shown_session = cast(dict[str, object], shown_payload["session_result"])
+    shown_event = cast(list[dict[str, object]], shown_session["transcript"])[0]
+    shown_reasoning = cast(dict[str, object], shown_event["payload"])
+    assert shown_reasoning["text"] == "private chain"
+    assert shown_reasoning["preview"] == "private chain"
 
 
 def test_transport_reads_session_debug_snapshot(tmp_path: Path) -> None:

--- a/tests/unit/graph/test_single_agent_slice.py
+++ b/tests/unit/graph/test_single_agent_slice.py
@@ -168,6 +168,29 @@ class _StreamOutputTurnProvider:
         )
 
 
+class _StreamReasoningMetadataTurnProvider:
+    name = "opencode"
+
+    def propose_turn(self, request: ProviderTurnRequest) -> ProviderTurnResult:
+        _ = request
+        return ProviderTurnResult(output="should-not-be-used")
+
+    def stream_turn(self, request: ProviderTurnRequest):
+        _ = request
+        return iter(
+            (
+                ProviderStreamEvent(
+                    kind="delta",
+                    channel="reasoning",
+                    text="private chain",
+                    metadata={"source": "fixture"},
+                ),
+                ProviderStreamEvent(kind="delta", channel="text", text="answer"),
+                ProviderStreamEvent(kind="done", done_reason="completed"),
+            )
+        )
+
+
 class _StreamErrorTurnProvider:
     name = "opencode"
 
@@ -1033,6 +1056,38 @@ def test_provider_provider_graph_streams_ordered_events_and_deterministic_output
     model_turn_events = [event for event in step.events if event.event_type == "graph.model_turn"]
     assert model_turn_events
     assert model_turn_events[0].payload["streaming"] is True
+
+
+def test_provider_graph_preserves_reasoning_stream_metadata() -> None:
+    provider_model = resolve_provider_model(
+        "opencode/gpt-5.4",
+        registry=ModelProviderRegistry.with_defaults(),
+    )
+    graph = ProviderGraph(
+        provider=_StreamReasoningMetadataTurnProvider(),
+        provider_model=provider_model,
+    )
+
+    step = graph.step(
+        request=GraphRunRequest(
+            session=_session(),
+            prompt="think",
+            available_tools=_tool_definitions(),
+            context_window=RuntimeContextWindow(prompt="think"),
+            assembled_context=_assembled_from_context_window(RuntimeContextWindow(prompt="think")),
+            metadata={"provider_stream": True},
+        ),
+        tool_results=(),
+        session=_session(),
+    )
+
+    stream_events = [event for event in step.events if event.event_type == "graph.provider_stream"]
+    reasoning_event = next(
+        event for event in stream_events if event.payload.get("channel") == "reasoning"
+    )
+    assert reasoning_event.payload["text"] == "private chain"
+    assert reasoning_event.payload["metadata"] == {"source": "fixture"}
+    assert step.output == "answer"
 
 
 def test_provider_provider_graph_stream_done_without_text_does_not_fallback_propose_turn() -> None:

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -15,6 +15,8 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+from voidcode.runtime.events import runtime_reasoning_part_payload
+
 from .._paths import with_src_pythonpath
 
 
@@ -959,6 +961,87 @@ def test_run_command_forwards_reasoning_effort_flag_to_metadata_and_config() -> 
     assert request.metadata["reasoning_effort"] == "high"
 
 
+def test_run_command_show_thinking_flag_does_not_persist_request_metadata() -> None:
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/demo-workspace")
+    config = SimpleNamespace(approval_mode="allow")
+    chunks = (
+        _make_chunk(
+            session_id="demo-session",
+            status="completed",
+            event=_runtime_event("runtime.request_received", prompt="read README.md"),
+        ),
+        _make_chunk(session_id="demo-session", status="completed", output="done\n"),
+    )
+
+    with patch.object(cli, "load_runtime_config", autospec=True, return_value=config):
+        with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
+            runtime_class.return_value.run_stream.return_value = iter(chunks)
+            result = cli.main(
+                [
+                    "run",
+                    "read README.md",
+                    "--workspace",
+                    str(workspace),
+                    "--show-thinking",
+                ]
+            )
+
+    assert result == 0
+    request = runtime_class.return_value.run_stream.call_args.args[0]
+    assert "show_thinking" not in request.metadata
+
+
+def test_run_json_redacts_reasoning_by_default_and_shows_with_flag(capsys: Any) -> None:
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/demo-workspace")
+    config = SimpleNamespace(approval_mode="allow")
+
+    def _chunks(*, show_thinking: bool = False) -> tuple[_StubChunk, ...]:
+        reasoning_payload = runtime_reasoning_part_payload(text="private chain")
+        return (
+            _make_chunk(
+                session_id="demo-session",
+                status="completed",
+                event=_runtime_event(
+                    "runtime.reasoning_part",
+                    **reasoning_payload,
+                ),
+                metadata={"show_thinking": show_thinking},
+            ),
+            _make_chunk(session_id="demo-session", status="completed", output="answer\n"),
+        )
+
+    with patch.object(cli, "load_runtime_config", autospec=True, return_value=config):
+        with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
+            runtime_class.return_value.run_stream.return_value = iter(_chunks())
+            assert cli.main(["run", "think", "--workspace", str(workspace), "--json"]) == 0
+    redacted = json.loads(capsys.readouterr().out)
+    assert redacted["events"][0]["payload"]["text_omitted"] is True
+    assert redacted["events"][0]["payload"]["preview_omitted"] is True
+    assert "private chain" not in json.dumps(redacted)
+
+    with patch.object(cli, "load_runtime_config", autospec=True, return_value=config):
+        with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
+            runtime_class.return_value.run_stream.return_value = iter(_chunks(show_thinking=True))
+            assert (
+                cli.main(
+                    [
+                        "run",
+                        "think",
+                        "--workspace",
+                        str(workspace),
+                        "--json",
+                        "--show-thinking",
+                    ]
+                )
+                == 0
+            )
+    shown = json.loads(capsys.readouterr().out)
+    assert shown["events"][0]["payload"]["text"] == "private chain"
+    assert shown["events"][0]["payload"]["preview"] == "private chain"
+
+
 def test_run_command_omits_reasoning_effort_metadata_when_flag_absent() -> None:
     cli = importlib.import_module("voidcode.cli")
     workspace = Path("/tmp/demo-workspace")
@@ -1779,6 +1862,15 @@ def test_config_show_outputs_workspace_effective_config() -> None:
             "context_window": None,
             "max_output_tokens": None,
             "fallback_chain": ["repo/model"],
+            "reasoning_controls": {
+                "reasoning_effort_requested": True,
+                "reasoning_effort": "medium",
+                "status": "best_effort",
+                "forwarded": True,
+                "translated": False,
+                "ignored": False,
+                "reason": "provider_metadata_unknown",
+            },
         },
         "context_budget": {"context_window": None, "max_output_tokens": None},
         "mcp": _expected_unconfigured_mcp_status(),
@@ -2010,6 +2102,15 @@ def test_config_show_outputs_resumed_session_effective_config() -> None:
             "context_window": None,
             "max_output_tokens": None,
             "fallback_chain": ["repo/model", "repo/session-fallback"],
+            "reasoning_controls": {
+                "reasoning_effort_requested": True,
+                "reasoning_effort": "high",
+                "status": "best_effort",
+                "forwarded": True,
+                "translated": False,
+                "ignored": False,
+                "reason": "provider_metadata_unknown",
+            },
         },
         "context_budget": {"context_window": None, "max_output_tokens": None},
         "mcp": _expected_unconfigured_mcp_status(),
@@ -2126,6 +2227,7 @@ def test_config_show_delegates_to_runtime_effective_config(capsys: Any) -> None:
             "context_window": None,
             "max_output_tokens": None,
             "fallback_chain": ["runtime/model"],
+            "reasoning_controls": {},
         },
         "context_budget": {"context_window": None, "max_output_tokens": None},
         "mcp": _expected_unconfigured_mcp_status(),

--- a/tests/unit/provider/test_model_catalog.py
+++ b/tests/unit/provider/test_model_catalog.py
@@ -84,6 +84,24 @@ def test_discover_available_models_includes_known_model_budget_metadata() -> Non
     assert "unknown-model" not in result.model_metadata
 
 
+def test_infer_model_metadata_exposes_reasoning_visibility_controls() -> None:
+    openai_metadata = infer_model_metadata("openai", "gpt-5")
+    assert openai_metadata is not None
+    assert openai_metadata.supports_reasoning_summary is True
+    assert openai_metadata.supports_thinking_budget is False
+    assert openai_metadata.reasoning_visibility == "summary"
+
+    anthropic_metadata = infer_model_metadata("anthropic", "claude-sonnet-4-6")
+    assert anthropic_metadata is not None
+    assert anthropic_metadata.supports_thinking_budget is True
+    assert anthropic_metadata.reasoning_visibility == "full"
+
+    glm_metadata = infer_model_metadata("glm", "glm-5")
+    assert glm_metadata is not None
+    assert glm_metadata.supports_reasoning_effort is True
+    assert glm_metadata.reasoning_visibility == "full"
+
+
 def test_discover_available_models_merges_remote_metadata_over_inferred_defaults() -> None:
     result = discover_available_models(
         "openai",
@@ -305,7 +323,10 @@ def test_infer_model_metadata_exposes_model_capability_flags() -> None:
         cost_per_output_token=0.000015,
         supports_reasoning_effort=True,
         default_reasoning_effort="medium",
+        supports_reasoning_summary=False,
+        supports_thinking_budget=True,
         supports_interleaved_reasoning=True,
+        reasoning_visibility="full",
         modalities_input=("text", "image"),
         modalities_output=("text",),
         model_status="active",
@@ -323,7 +344,10 @@ def test_provider_model_metadata_payload_includes_limits_and_capabilities() -> N
         cost_per_output_token=0.000002,
         supports_reasoning_effort=True,
         default_reasoning_effort="low",
+        supports_reasoning_summary=True,
+        supports_thinking_budget=False,
         supports_interleaved_reasoning=False,
+        reasoning_visibility="summary",
         modalities_input=("text",),
         modalities_output=("text",),
         model_status="active",
@@ -340,7 +364,10 @@ def test_provider_model_metadata_payload_includes_limits_and_capabilities() -> N
         "cost_per_output_token": 0.000002,
         "supports_reasoning_effort": True,
         "default_reasoning_effort": "low",
+        "supports_reasoning_summary": True,
+        "supports_thinking_budget": False,
         "supports_interleaved_reasoning": False,
+        "reasoning_visibility": "summary",
         "modalities_input": ["text"],
         "modalities_output": ["text"],
         "model_status": "active",

--- a/tests/unit/provider/test_provider_adapters.py
+++ b/tests/unit/provider/test_provider_adapters.py
@@ -2013,7 +2013,12 @@ def test_provider_adapter_stream_turn_emits_reasoning_events_from_reasoning_cont
     events = list(provider.stream_turn(_build_turn_request(model_name="openai")))
 
     assert events == [
-        ProviderStreamEvent(kind="delta", channel="reasoning", text="Thinking step."),
+        ProviderStreamEvent(
+            kind="delta",
+            channel="reasoning",
+            text="Thinking step.",
+            metadata={"source": "delta.reasoning"},
+        ),
         ProviderStreamEvent(kind="delta", channel="text", text="Done."),
         ProviderStreamEvent(kind="done", done_reason="completed"),
     ]
@@ -2055,7 +2060,12 @@ def test_provider_adapter_stream_turn_emits_reasoning_events_from_reasoning(
     events = list(provider.stream_turn(_build_turn_request(model_name="openai")))
 
     assert events == [
-        ProviderStreamEvent(kind="delta", channel="reasoning", text="Reasoning step."),
+        ProviderStreamEvent(
+            kind="delta",
+            channel="reasoning",
+            text="Reasoning step.",
+            metadata={"source": "delta.reasoning"},
+        ),
         ProviderStreamEvent(kind="delta", channel="text", text="Done."),
         ProviderStreamEvent(kind="done", done_reason="completed"),
     ]
@@ -2097,7 +2107,12 @@ def test_provider_adapter_stream_turn_emits_reasoning_events_from_thinking_block
     events = list(provider.stream_turn(_build_turn_request(model_name="anthropic")))
 
     assert events == [
-        ProviderStreamEvent(kind="delta", channel="reasoning", text="Private chain."),
+        ProviderStreamEvent(
+            kind="delta",
+            channel="reasoning",
+            text="Private chain.",
+            metadata={"source": "delta.thinking_blocks"},
+        ),
         ProviderStreamEvent(kind="delta", channel="text", text="Visible answer"),
         ProviderStreamEvent(kind="done", done_reason="completed"),
     ]

--- a/tests/unit/runtime/test_provider_readiness.py
+++ b/tests/unit/runtime/test_provider_readiness.py
@@ -84,6 +84,54 @@ def test_provider_readiness_includes_fallback_and_context_metadata(tmp_path: Pat
     assert readiness.max_output_tokens == 16_384
     assert readiness.streaming_supported is True
     assert readiness.fallback_chain == ("openai/gpt-4o", "openai/gpt-4o-mini")
+    assert readiness.reasoning_controls["status"] == "not_requested"
+
+
+def test_provider_readiness_reports_translated_reasoning_effort_controls(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            model="glm/glm-5",
+            execution_engine="provider",
+            reasoning_effort="high",
+        ),
+    )
+    try:
+        readiness = runtime.provider_readiness()
+    finally:
+        runtime.__exit__(None, None, None)
+
+    controls = readiness.reasoning_controls
+    assert controls["reasoning_effort_requested"] is True
+    assert controls["status"] == "translated"
+    assert controls["translated"] is True
+    assert controls["provider_parameter"] == "extra_body.thinking.type"
+    assert controls["provider_value"] == "enabled"
+
+
+def test_provider_readiness_reports_ignored_opencode_go_reasoning_effort(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            model="opencode-go/glm-5",
+            execution_engine="provider",
+            reasoning_effort="high",
+        ),
+    )
+    try:
+        readiness = runtime.provider_readiness()
+    finally:
+        runtime.__exit__(None, None, None)
+
+    assert readiness.reasoning_controls["status"] == "ignored"
+    assert readiness.reasoning_controls["ignored"] is True
+    assert readiness.reasoning_controls["reason"] == (
+        "opencode_go_adapter_does_not_forward_reasoning_effort"
+    )
 
 
 def test_provider_readiness_marks_streaming_unsupported_as_not_ready(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_runtime_events.py
+++ b/tests/unit/runtime/test_runtime_events.py
@@ -27,6 +27,8 @@ from voidcode.runtime.events import (
     RUNTIME_LSP_SERVER_STOPPED,
     RUNTIME_MCP_SERVER_FAILED,
     RUNTIME_MEMORY_REFRESHED,
+    RUNTIME_REASONING_DIAGNOSTIC,
+    RUNTIME_REASONING_PART,
     RUNTIME_SESSION_ENDED,
     RUNTIME_SESSION_IDLE,
     RUNTIME_SESSION_STARTED,
@@ -40,6 +42,8 @@ from voidcode.runtime.events import (
     DelegatedLifecycleMessage,
     DelegatedRoutingPayload,
     EventEnvelope,
+    redact_reasoning_payload,
+    runtime_reasoning_part_payload,
 )
 from voidcode.runtime.task import SubagentRoutingIdentity
 from voidcode.runtime.tool_display import build_tool_display
@@ -80,7 +84,34 @@ def test_future_additive_event_types_cover_async_lifecycle_surfaces() -> None:
         RUNTIME_DELEGATED_RESULT_AVAILABLE,
         RUNTIME_SKILL_LOADED,
         RUNTIME_TODO_UPDATED,
+        RUNTIME_REASONING_PART,
+        RUNTIME_REASONING_DIAGNOSTIC,
     )
+
+
+def test_reasoning_redaction_omits_text_and_preview_by_default() -> None:
+    payload = runtime_reasoning_part_payload(text="private chain")
+
+    redacted = redact_reasoning_payload(RUNTIME_REASONING_PART, payload)
+
+    assert redacted["text_omitted"] is True
+    assert redacted["preview_omitted"] is True
+    assert "text" not in redacted
+    assert "preview" not in redacted
+    assert "private chain" not in repr(redacted)
+
+
+def test_reasoning_redaction_can_show_thinking_explicitly() -> None:
+    payload = runtime_reasoning_part_payload(text="private chain")
+
+    shown = redact_reasoning_payload(
+        RUNTIME_REASONING_PART,
+        payload,
+        show_thinking=True,
+    )
+
+    assert shown["text"] == "private chain"
+    assert shown["preview"] == "private chain"
 
 
 def test_delegated_lifecycle_payload_preserves_typed_transport_shape() -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -7464,6 +7464,27 @@ def test_runtime_rejects_non_boolean_provider_stream_request_metadata(tmp_path: 
         )
 
 
+def test_runtime_accepts_show_thinking_request_metadata(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_SkillCapturingStubGraph())
+
+    _ = runtime.run(RuntimeRequest(prompt="hello", metadata={"show_thinking": True}))
+
+    assert _SkillCapturingStubGraph.last_request is not None
+    assert _SkillCapturingStubGraph.last_request.metadata["show_thinking"] is True
+
+
+def test_runtime_rejects_non_boolean_show_thinking_request_metadata(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_SkillCapturingStubGraph())
+
+    with pytest.raises(ValueError, match="request metadata 'show_thinking' must be a boolean"):
+        _ = runtime.run(
+            RuntimeRequest(
+                prompt="hello",
+                metadata=cast(RuntimeRequestMetadataPayload, {"show_thinking": "yes"}),
+            )
+        )
+
+
 def test_runtime_accepts_reasoning_effort_request_metadata(tmp_path: Path) -> None:
     runtime = VoidCodeRuntime(workspace=tmp_path, graph=_SkillCapturingStubGraph())
 
@@ -12032,6 +12053,271 @@ def test_runtime_provider_streaming_emits_ordered_provider_stream_events(
     assert [event.payload["kind"] for event in stream_events] == ["delta", "delta", "done"]
     output_chunks = [chunk.output for chunk in chunks if chunk.kind == "output"]
     assert output_chunks == ["hello world"]
+
+
+def test_runtime_provider_streaming_persists_reasoning_as_runtime_part(
+    tmp_path: Path,
+) -> None:
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    (
+                        ProviderStreamEvent(
+                            kind="delta",
+                            channel="reasoning",
+                            text="private chain",
+                            metadata={
+                                "source": "fixture.reasoning",
+                                "raw_secret": "must not persist",
+                            },
+                        ),
+                        ProviderStreamEvent(kind="delta", channel="text", text="answer"),
+                        ProviderStreamEvent(kind="done", done_reason="completed"),
+                    ),
+                ),
+            ),
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        model_provider_registry=registry,
+    )
+
+    chunks = list(
+        runtime.run_stream(RuntimeRequest(prompt="think", metadata={"provider_stream": True}))
+    )
+
+    events = [chunk.event for chunk in chunks if chunk.event is not None]
+    reasoning_events = [event for event in events if event.event_type == "runtime.reasoning_part"]
+    assert len(reasoning_events) == 1
+    reasoning_payload = reasoning_events[0].payload
+    assert reasoning_payload["type"] == "reasoning"
+    assert reasoning_payload["text"] == "private chain"
+    assert reasoning_payload["visibility"] == "showable"
+    assert isinstance(reasoning_payload["time"], dict)
+    assert reasoning_payload["source"] == "provider_stream"
+    assert reasoning_payload["provider_metadata"] == {
+        "stream_kind": "delta",
+        "stream_channel": "reasoning",
+        "source": "fixture.reasoning",
+    }
+    assert [chunk.output for chunk in chunks if chunk.kind == "output"] == ["answer"]
+
+    result = runtime.session_result(session_id=chunks[-1].session.session.id)
+    persisted_reasoning = [
+        event for event in result.transcript if event.event_type == "runtime.reasoning_part"
+    ]
+    assert persisted_reasoning[0].payload["text"] == "private chain"
+
+
+def test_runtime_does_not_persist_show_thinking_request_metadata(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_SkillCapturingStubGraph())
+
+    response = runtime.run(RuntimeRequest(prompt="hello", metadata={"show_thinking": True}))
+
+    assert "show_thinking" not in response.session.metadata
+
+
+def test_runtime_reasoning_capture_has_aggregate_limit(tmp_path: Path) -> None:
+    reasoning_events = tuple(
+        ProviderStreamEvent(kind="delta", channel="reasoning", text="x" * 4000) for _ in range(40)
+    )
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    (
+                        *reasoning_events,
+                        ProviderStreamEvent(kind="delta", channel="text", text="answer"),
+                        ProviderStreamEvent(kind="done", done_reason="completed"),
+                    ),
+                ),
+            ),
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        model_provider_registry=registry,
+    )
+
+    chunks = list(
+        runtime.run_stream(RuntimeRequest(prompt="think", metadata={"provider_stream": True}))
+    )
+
+    events = [chunk.event for chunk in chunks if chunk.event is not None]
+    reasoning_parts = [event for event in events if event.event_type == "runtime.reasoning_part"]
+    limit_events = [
+        event
+        for event in events
+        if event.event_type == "runtime.reasoning_diagnostic"
+        and event.payload.get("category") == "reasoning_capture_limit"
+    ]
+    assert len(reasoning_parts) == 4
+    assert len(limit_events) == 1
+    assert limit_events[0].payload["captured_text_char_count"] == 16_000
+
+
+def test_runtime_reasoning_capture_limit_spans_provider_turns(tmp_path: Path) -> None:
+    (tmp_path / "sample.txt").write_text("sample contents", encoding="utf-8")
+    first_turn_reasoning = tuple(
+        ProviderStreamEvent(kind="delta", channel="reasoning", text="x" * 4000) for _ in range(3)
+    )
+    second_turn_reasoning = tuple(
+        ProviderStreamEvent(kind="delta", channel="reasoning", text="y" * 4000) for _ in range(3)
+    )
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    (
+                        *first_turn_reasoning,
+                        ProviderStreamEvent(
+                            kind="content",
+                            channel="tool",
+                            text=(
+                                '{"tool_name":"read_file","arguments":{"filePath":"sample.txt"}}'
+                            ),
+                        ),
+                        ProviderStreamEvent(kind="done", done_reason="tool_calls"),
+                    ),
+                    (
+                        *second_turn_reasoning,
+                        ProviderStreamEvent(kind="delta", channel="text", text="answer"),
+                        ProviderStreamEvent(kind="done", done_reason="completed"),
+                    ),
+                ),
+            ),
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        model_provider_registry=registry,
+    )
+
+    chunks = list(
+        runtime.run_stream(
+            RuntimeRequest(prompt="read sample.txt", metadata={"provider_stream": True})
+        )
+    )
+
+    events = [chunk.event for chunk in chunks if chunk.event is not None]
+    reasoning_parts = [event for event in events if event.event_type == "runtime.reasoning_part"]
+    limit_events = [
+        event
+        for event in events
+        if event.event_type == "runtime.reasoning_diagnostic"
+        and event.payload.get("category") == "reasoning_capture_limit"
+    ]
+    assert len(reasoning_parts) == 4
+    assert len(limit_events) == 1
+    assert limit_events[0].payload["captured_part_count"] == 4
+    assert limit_events[0].payload["captured_text_char_count"] == 16_000
+
+
+def test_runtime_reports_reasoning_output_diagnostic_for_reasoning_capable_model(
+    tmp_path: Path,
+) -> None:
+    registry = ModelProviderRegistry(
+        providers={
+            "openai": _ScriptedModelProvider(
+                name="openai",
+                outcomes=(
+                    (
+                        ProviderStreamEvent(kind="delta", channel="text", text="answer"),
+                        ProviderStreamEvent(kind="done", done_reason="completed"),
+                    ),
+                ),
+            ),
+        }
+    )
+    registry.model_catalog = {
+        "openai": ProviderModelCatalog(
+            provider="openai",
+            models=("gpt-5",),
+            refreshed=True,
+            model_metadata={"gpt-5": ProviderModelMetadata(supports_reasoning=True)},
+        )
+    }
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(execution_engine="provider", model="openai/gpt-5"),
+        model_provider_registry=registry,
+    )
+
+    chunks = list(
+        runtime.run_stream(RuntimeRequest(prompt="think", metadata={"provider_stream": True}))
+    )
+
+    diagnostics = [
+        chunk.event
+        for chunk in chunks
+        if chunk.event is not None
+        and chunk.event.event_type == "runtime.reasoning_diagnostic"
+        and chunk.event.payload.get("category") == "reasoning_output"
+    ]
+    assert len(diagnostics) == 1
+    assert diagnostics[0].payload["severity"] == "warning"
+    assert diagnostics[0].payload["reason"] == (
+        "reasoning_capable_model_returned_no_reasoning_output"
+    )
+    assert diagnostics[0].payload["reasoning_output_observed"] is False
+
+
+def test_runtime_reports_reasoning_output_observed_diagnostic(tmp_path: Path) -> None:
+    registry = ModelProviderRegistry(
+        providers={
+            "openai": _ScriptedModelProvider(
+                name="openai",
+                outcomes=(
+                    (
+                        ProviderStreamEvent(
+                            kind="delta",
+                            channel="reasoning",
+                            text="private chain",
+                        ),
+                        ProviderStreamEvent(kind="delta", channel="text", text="answer"),
+                        ProviderStreamEvent(kind="done", done_reason="completed"),
+                    ),
+                ),
+            ),
+        }
+    )
+    registry.model_catalog = {
+        "openai": ProviderModelCatalog(
+            provider="openai",
+            models=("gpt-5",),
+            refreshed=True,
+            model_metadata={"gpt-5": ProviderModelMetadata(supports_reasoning=True)},
+        )
+    }
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(execution_engine="provider", model="openai/gpt-5"),
+        model_provider_registry=registry,
+    )
+
+    chunks = list(
+        runtime.run_stream(RuntimeRequest(prompt="think", metadata={"provider_stream": True}))
+    )
+
+    diagnostics = [
+        chunk.event
+        for chunk in chunks
+        if chunk.event is not None
+        and chunk.event.event_type == "runtime.reasoning_diagnostic"
+        and chunk.event.payload.get("category") == "reasoning_output"
+    ]
+    assert len(diagnostics) == 1
+    assert diagnostics[0].payload["severity"] == "info"
+    assert diagnostics[0].payload["reason"] == "reasoning_output_observed"
+    assert diagnostics[0].payload["reasoning_output_observed"] is True
 
 
 def test_runtime_run_stream_preserves_streamed_tool_requests(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Adds runtime-owned reasoning part events from provider reasoning streams with bounded text, timing metadata, visibility state, and safe provider metadata.
- Adds CLI and HTTP show-thinking controls that redact reasoning by default and reveal text only through explicit current-request/query opt-in.
- Expands provider reasoning capability/readiness diagnostics and emits runtime diagnostics for observed or missing reasoning output.

## Verification
- `uv run ruff check .`
- `uv run basedpyright --warnings src`
- `uv run pytest -n auto` (`1761 passed`)
- `cd frontend && bun run lint && bun run typecheck && bun run test:run` (`162 passed`)

Closes #335