### PR TITLE
fix: preserve tool output fidelity

### DIFF
--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -618,7 +618,7 @@ def _tool_result_token_estimate(
     payload = {
         "tool_name": result.tool_name,
         "status": result.status,
-        "content": normalize_tool_result_content(result.content),
+        "content": result.content,
         "error": result.error,
         "data": result.data,
     }

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -27,7 +27,6 @@ from .context_window import (
     RuntimeContextWindow,
     RuntimeContinuityState,
     continuity_summary_metadata,
-    normalize_tool_result_content,
 )
 from .contracts import RuntimeStreamChunk
 from .events import (
@@ -358,11 +357,7 @@ class RuntimeRunLoopCoordinator:
             "tool_call_id": tool_call_id,
             "arguments": sanitized_arguments,
             "status": tool_result.status,
-            "content": (
-                normalize_tool_result_content(tool_result.content)
-                if tool_result.tool_name == "read_file"
-                else tool_result.content
-            ),
+            "content": tool_result.content,
             "error": tool_result.error,
         }
         completed_payload.setdefault("tool", tool_result.tool_name)
@@ -1241,11 +1236,7 @@ class RuntimeRunLoopCoordinator:
                 "tool_call_id": tool_call_id,
                 "arguments": sanitized_arguments,
                 "status": tool_result.status,
-                "content": (
-                    normalize_tool_result_content(tool_result.content)
-                    if tool_result.tool_name == "read_file"
-                    else tool_result.content
-                ),
+                "content": tool_result.content,
                 "error": tool_result.error,
             }
             completed_payload.setdefault("tool", tool_result.tool_name)

--- a/src/voidcode/tools/edit.py
+++ b/src/voidcode/tools/edit.py
@@ -425,7 +425,9 @@ class EditTool:
         name="edit",
         description=(
             "Edit a file by replacing text. Supports multiple replacement strategies "
-            "for flexible matching."
+            "for flexible matching. When constructing oldString from read_file output, "
+            "omit any leading line-number prefix such as '42: ' and pass only the "
+            "file's actual text."
         ),
         input_schema={
             "path": {

--- a/src/voidcode/tools/shell_exec.py
+++ b/src/voidcode/tools/shell_exec.py
@@ -17,16 +17,6 @@ from ._pydantic_args import ShellExecArgs
 from .contracts import RuntimeToolTimeoutError, ToolCall, ToolDefinition, ToolResult
 from .runtime_context import current_runtime_tool_context
 
-MAX_OUTPUT_CHARS = 200_000
-
-
-def _truncate(text: str | None) -> tuple[str, bool]:
-    if text is None:
-        return "", False
-    if len(text) <= MAX_OUTPUT_CHARS:
-        return text, False
-    return text[:MAX_OUTPUT_CHARS], True
-
 
 def _decode_process_output(payload: bytes | None) -> str:
     if payload is None:
@@ -178,10 +168,6 @@ class ShellExecTool:
         if stderr:
             output = f"{output}{stderr}" if output else stderr
 
-        content, content_truncated = _truncate(output)
-        stdout, stdout_truncated = _truncate(stdout)
-        stderr, stderr_truncated = _truncate(stderr)
-
         if aborted:
             reason = getattr(abort_signal, "reason", None)
             content = "User aborted the command."
@@ -196,20 +182,20 @@ class ShellExecTool:
                     "stdout": stdout,
                     "stderr": stderr,
                     "timeout": timeout_seconds,
-                    "truncated": stdout_truncated or stderr_truncated,
+                    "truncated": False,
                     "interrupted": True,
                     "cancelled": True,
                     "reason": reason if isinstance(reason, str) else None,
                 },
-                truncated=stdout_truncated or stderr_truncated,
-                partial=stdout_truncated or stderr_truncated,
+                truncated=False,
+                partial=False,
                 timeout_seconds=timeout_seconds,
             )
 
         return ToolResult(
             tool_name=self.definition.name,
             status="ok",
-            content=content,
+            content=output,
             data={
                 "command": command_text,
                 "cwd": str(policy.workspace_root),
@@ -217,12 +203,12 @@ class ShellExecTool:
                 "stdout": stdout,
                 "stderr": stderr,
                 "timeout": timeout_seconds,
-                "stdout_truncated": stdout_truncated,
-                "stderr_truncated": stderr_truncated,
-                "truncated": content_truncated or stdout_truncated or stderr_truncated,
-                "output_char_count": len(content),
+                "stdout_truncated": False,
+                "stderr_truncated": False,
+                "truncated": False,
+                "output_char_count": len(output),
             },
-            truncated=content_truncated or stdout_truncated or stderr_truncated,
-            partial=content_truncated or stdout_truncated or stderr_truncated,
+            truncated=False,
+            partial=False,
             timeout_seconds=timeout_seconds,
         )

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -865,3 +865,39 @@ def test_normalize_read_file_output_preserves_output_capped_footer() -> None:
     assert normalized == (
         "alpha\n(Output capped at 50 KB. Showing lines 1-1. Use offset=2 to continue.)"
     )
+
+
+def test_context_window_token_estimate_counts_raw_read_file_content() -> None:
+    raw_content = "\n".join(
+        [
+            "<path>sample.txt</path>",
+            "<type>file</type>",
+            "<content>",
+            "1: alpha",
+            "2: beta",
+            "(End of file - total 2 lines)",
+            "</content>",
+        ]
+    )
+    stripped_content = normalize_read_file_output(raw_content)
+    policy = ContextWindowPolicy(
+        auto_compaction=False,
+        max_tool_result_tokens=100_000,
+    )
+
+    raw_context = prepare_provider_context(
+        prompt="read sample.txt",
+        tool_results=(ToolResult(tool_name="read_file", status="ok", content=raw_content),),
+        session_metadata={},
+        policy=policy,
+    )
+    stripped_context = prepare_provider_context(
+        prompt="read sample.txt",
+        tool_results=(ToolResult(tool_name="read_file", status="ok", content=stripped_content),),
+        session_metadata={},
+        policy=policy,
+    )
+
+    assert raw_context.original_tool_result_tokens is not None
+    assert stripped_context.original_tool_result_tokens is not None
+    assert raw_context.original_tool_result_tokens > stripped_context.original_tool_result_tokens

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1668,6 +1668,9 @@ def test_runtime_session_debug_snapshot_includes_provider_context(tmp_path: Path
     assert [segment.role for segment in provider_context.segments][-2:] == ["assistant", "tool"]
     assert provider_context.segments[-1].source == "retained_tool_result"
     assert provider_context.segments[-1].tool_name == "read_file"
+    assert provider_context.segments[-1].content is not None
+    assert "<path>sample.txt</path>" in provider_context.segments[-1].content
+    assert "1: provider debug" in provider_context.segments[-1].content
     assert provider_context.segments[-1].metadata["status"] == "ok"
     reconstructed_data = provider_context.segments[-1].metadata["data"]
     assert isinstance(reconstructed_data, dict)

--- a/tests/unit/runtime/test_session_storage.py
+++ b/tests/unit/runtime/test_session_storage.py
@@ -62,6 +62,35 @@ def test_session_storage_persists_parent_lineage_across_read_surfaces(tmp_path: 
     assert notifications[0].session.parent_id == "leader-session"
 
 
+def test_tool_results_from_events_preserves_raw_read_file_content() -> None:
+    raw_content = "\n".join(
+        [
+            "<path>sample.txt</path>",
+            "<type>file</type>",
+            "<content>",
+            "1: alpha",
+            "(End of file - total 1 lines)",
+            "</content>",
+        ]
+    )
+    event = EventEnvelope(
+        session_id="session-1",
+        sequence=1,
+        event_type="runtime.tool_completed",
+        source="tool",
+        payload={
+            "tool": "read_file",
+            "status": "ok",
+            "content": raw_content,
+        },
+    )
+    tool_results_from_events = _private_attr(SqliteSessionStore, "_tool_results_from_events")
+
+    tool_results = tool_results_from_events((event,))
+
+    assert tool_results[0]["content"] == raw_content
+
+
 def test_session_storage_revert_marker_filters_active_view_only(tmp_path: Path) -> None:
     store = SqliteSessionStore()
     request = RuntimeRequest(prompt="mistaken request", session_id="undo-session")

--- a/tests/unit/tools/test_shell_exec_tool.py
+++ b/tests/unit/tools/test_shell_exec_tool.py
@@ -9,6 +9,7 @@ import pytest
 
 from voidcode.runtime.service import ToolRegistry
 from voidcode.tools import ShellExecTool, ToolCall
+from voidcode.tools.output import MAX_TOOL_OUTPUT_BYTES, cap_tool_result_output
 from voidcode.tools.shell_exec import kill_timed_out_process
 
 
@@ -178,7 +179,7 @@ def test_shell_exec_windows_timeout_cleanup_falls_back_after_taskkill_nonzero(
     assert killed is True
 
 
-def test_shell_exec_tool_truncates_large_output(tmp_path: Path) -> None:
+def test_shell_exec_tool_returns_full_output_for_large_subprocess(tmp_path: Path) -> None:
     tool = ShellExecTool()
     command = f'"{sys.executable}" -c "import sys; sys.stdout.write(chr(120)*250000)"'
 
@@ -189,10 +190,34 @@ def test_shell_exec_tool_truncates_large_output(tmp_path: Path) -> None:
 
     assert result.status == "ok"
     assert isinstance(result.content, str)
-    assert len(result.content) == 200000
-    assert result.data.get("truncated") is True
-    assert result.data.get("stdout_truncated") is True
-    assert result.data.get("output_char_count") == 200000
+    assert len(result.content) == 250000
+    assert result.data.get("truncated") is False
+    assert result.data.get("stdout_truncated") is False
+    assert result.data.get("stderr_truncated") is False
+    assert result.data.get("output_char_count") == 250000
+
+
+def test_shell_exec_large_output_spills_full_payload_via_central_cap(tmp_path: Path) -> None:
+    payload_size = MAX_TOOL_OUTPUT_BYTES + 10_000
+    tool = ShellExecTool()
+    command = f'"{sys.executable}" -c "import sys; sys.stdout.write(chr(120)*{payload_size})"'
+
+    result = tool.invoke(
+        ToolCall(tool_name="shell_exec", arguments={"command": command}),
+        workspace=tmp_path,
+    )
+    capped = cap_tool_result_output(result, workspace=tmp_path)
+
+    assert capped.truncated is True
+    assert capped.partial is True
+    assert capped.reference is not None
+    assert isinstance(capped.content, str)
+    assert "[Tool output truncated:" in capped.content
+    assert "Full output saved to:" in capped.content
+
+    reference_path = tmp_path / capped.reference
+    assert reference_path.exists()
+    assert len(reference_path.read_text(encoding="utf-8")) == payload_size
 
 
 # ── Target contract: ShellExecArgs.description ──────────────────────────


### PR DESCRIPTION
## Summary
- Preserve full `shell_exec` output until the central tool-output cap spills it to `.voidcode/tool-output`, avoiding unrecoverable 200k-char clipping.
- Keep `read_file` content raw across runtime events, storage/resume reconstruction, token estimates, and provider-context debug views.
- Add regression coverage for shell spill references, raw read-file token accounting, storage reconstruction, and provider-context preservation.

## Verification
- `mise run check`
  - Python lint/typecheck passed
  - Python tests: 1816 passed
  - Frontend lint/typecheck passed
  - Frontend tests: 162 passed
- Manual smoke: verified 250k shell output reference preserves the full payload and `read_file` raw `<path>/<content>` + numbered lines remain in context.