### PR TITLE
feat(runtime): add background task observability

### DIFF
--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -535,6 +535,20 @@ def _background_task_fields(task: BackgroundTaskState) -> list[tuple[str, object
         fields.append(("cancellation_cause", task.cancellation_cause))
     if task.error is not None:
         fields.append(("error", task.error))
+    observability = getattr(task, "observability", None)
+    if observability is not None:
+        fields.append(("waiting_reason", observability.waiting_reason))
+        if observability.queue_position is not None:
+            fields.append(("queue_position", observability.queue_position))
+        if observability.terminal_reason is not None:
+            fields.append(("terminal_reason", observability.terminal_reason))
+        if observability.concurrency is not None:
+            fields.append(("active_worker_slots", observability.concurrency.active_worker_slots))
+            fields.append(("concurrency_limit", observability.concurrency.limit))
+            fields.append(("queued_total", observability.concurrency.queued_total))
+        if observability.retry is not None:
+            fields.append(("retry_count", observability.retry.retry_count))
+            fields.append(("retry_backoff_seconds", observability.retry.backoff_seconds))
     routing = task.routing_identity
     if routing is not None:
         fields.append(("delegation_mode", routing.mode))
@@ -563,6 +577,13 @@ def _background_task_routing_payload(routing: object | None) -> dict[str, object
         }.items()
         if value is not None
     }
+
+
+def _background_task_observability_payload(task_or_result: object) -> dict[str, object] | None:
+    observability = getattr(task_or_result, "observability", None)
+    if observability is None:
+        return None
+    return cast(dict[str, object], observability.as_payload())
 
 
 def _background_task_error_type(error: str | None) -> str | None:
@@ -669,6 +690,7 @@ def _background_task_state_payload(
         "error": error,
         "error_type": error_type,
         "routing": _background_task_routing_payload(task.routing_identity),
+        "observability": _background_task_observability_payload(task),
         "next_steps": next_steps,
     }
     return payload
@@ -704,6 +726,7 @@ def _background_task_result_payload(
         "error_type": error_type,
         "cancellation_cause": cancellation_cause,
         "routing": _background_task_routing_payload(result.routing),
+        "observability": _background_task_observability_payload(result),
         "next_steps": next_steps,
     }
 
@@ -719,6 +742,7 @@ def _background_task_summary_payload(task: StoredBackgroundTaskSummary) -> dict[
         "prompt": task.prompt,
         "error": error,
         "error_type": _background_task_error_type(error),
+        "observability": _background_task_observability_payload(task),
     }
 
 
@@ -756,6 +780,22 @@ def _background_task_result_fields(result: BackgroundTaskResult) -> list[tuple[s
     cancellation_cause = getattr(result, "cancellation_cause", None)
     if cancellation_cause is not None:
         fields.append(("cancellation_cause", cancellation_cause))
+    observability = getattr(result, "observability", None)
+    if observability is not None:
+        fields.append(("waiting_reason", observability.waiting_reason))
+        if observability.queue_position is not None:
+            fields.append(("queue_position", observability.queue_position))
+        if observability.terminal_reason is not None:
+            fields.append(("terminal_reason", observability.terminal_reason))
+        if observability.concurrency is not None:
+            concurrency = observability.concurrency
+            fields.append(("active_worker_slots", concurrency.active_worker_slots))
+            fields.append(("concurrency_limit", concurrency.limit))
+            fields.append(("queued_total", concurrency.queued_total))
+        if observability.retry is not None:
+            retry = observability.retry
+            fields.append(("retry_count", retry.retry_count))
+            fields.append(("retry_backoff_seconds", retry.backoff_seconds))
     routing = result.routing
     if routing is not None:
         fields.append(("delegation_mode", routing.mode))
@@ -786,6 +826,14 @@ def _format_background_task_summary(task: StoredBackgroundTaskSummary) -> str:
     error = getattr(task, "error", None)
     if error is not None:
         fields.append(("error", error))
+    observability = getattr(task, "observability", None)
+    if observability is not None:
+        fields.append(("waiting_reason", observability.waiting_reason))
+        if observability.queue_position is not None:
+            fields.append(("queue_position", observability.queue_position))
+        if observability.concurrency is not None:
+            fields.append(("active_worker_slots", observability.concurrency.active_worker_slots))
+            fields.append(("queued_total", observability.concurrency.queued_total))
     return _format_named_record("TASK", fields)
 
 

--- a/src/voidcode/runtime/background_tasks.py
+++ b/src/voidcode/runtime/background_tasks.py
@@ -34,10 +34,14 @@ from .events import (
 from .session import SessionState
 from .storage import SessionEventAppender
 from .task import (
+    BackgroundTaskConcurrencyObservability,
+    BackgroundTaskObservability,
     BackgroundTaskRef,
     BackgroundTaskRequestSnapshot,
+    BackgroundTaskRetryObservability,
     BackgroundTaskState,
     BackgroundTaskStatus,
+    StoredBackgroundTaskSummary,
     is_background_task_terminal,
     validate_background_task_id,
 )
@@ -77,18 +81,38 @@ class _BackgroundTaskConcurrencySnapshot:
     queued_total: int
 
     def as_payload(self) -> dict[str, object]:
-        return {
-            "provider": self.provider,
-            "model": self.model,
-            "limit": self.limit,
-            "limit_source": self.limit_source,
-            "running_provider": self.running_provider,
-            "running_model": self.running_model,
-            "running_total": self.running_total,
-            "queued_provider": self.queued_provider,
-            "queued_model": self.queued_model,
-            "queued_total": self.queued_total,
-        }
+        return self.as_observability().as_payload()
+
+    def as_observability(self) -> BackgroundTaskConcurrencyObservability:
+        return BackgroundTaskConcurrencyObservability(
+            provider=self.provider,
+            model=self.model,
+            limit=self.limit,
+            limit_source=self.limit_source,
+            running_provider=self.running_provider,
+            running_model=self.running_model,
+            running_total=self.running_total,
+            active_worker_slots=self.running_total,
+            queued_provider=self.queued_provider,
+            queued_model=self.queued_model,
+            queued_total=self.queued_total,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _BackgroundTaskRetrySnapshot:
+    retry_count: int
+    max_retries: int
+    backoff_seconds: float
+    next_retry_at: int | None
+
+    def as_observability(self) -> BackgroundTaskRetryObservability:
+        return BackgroundTaskRetryObservability(
+            retry_count=self.retry_count,
+            max_retries=self.max_retries,
+            backoff_seconds=self.backoff_seconds,
+            next_retry_at=self.next_retry_at,
+        )
 
 
 class RuntimeBackgroundTaskSupervisor:
@@ -98,6 +122,98 @@ class RuntimeBackgroundTaskSupervisor:
         self._slot_available = threading.Condition(self._queue_lock)
         self._provider_running_counts: dict[str, int] = {}
         self._model_running_counts: dict[str, int] = {}
+        self._rate_limit_retries: dict[str, _BackgroundTaskRetrySnapshot] = {}
+
+    def task_observability(self, task: BackgroundTaskState) -> BackgroundTaskObservability:
+        try:
+            concurrency = self._concurrency_snapshot(task).as_observability()
+        except (RuntimeRequestError, ValueError):
+            concurrency = None
+        retry = self._retry_observability(task.task.id)
+        return BackgroundTaskObservability(
+            waiting_reason=self._waiting_reason(task=task, retry=retry),
+            terminal_reason=self._terminal_reason(task),
+            queue_position=self._queue_position(task),
+            concurrency=concurrency,
+            retry=retry,
+        )
+
+    def task_with_observability(self, task: BackgroundTaskState) -> BackgroundTaskState:
+        return replace(task, observability=self.task_observability(task))
+
+    def summary_with_observability(
+        self, summary: StoredBackgroundTaskSummary
+    ) -> StoredBackgroundTaskSummary:
+        task = self._runtime._session_store.load_background_task(
+            workspace=self._runtime._workspace,
+            task_id=summary.task.id,
+        )
+        return replace(summary, observability=self.task_observability(task))
+
+    def status_counts(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for summary in self._runtime._session_store.list_background_tasks(
+            workspace=self._runtime._workspace
+        ):
+            counts[summary.status] = counts.get(summary.status, 0) + 1
+        return counts
+
+    def active_worker_slots(self) -> int:
+        with self._queue_lock:
+            return sum(self._provider_running_counts.values())
+
+    def _retry_observability(self, task_id: str) -> BackgroundTaskRetryObservability | None:
+        with self._queue_lock:
+            retry = self._rate_limit_retries.get(task_id)
+        return None if retry is None else retry.as_observability()
+
+    def _queue_position(self, task: BackgroundTaskState) -> int | None:
+        if task.status != "queued":
+            return None
+        runtime = self._runtime
+        with self._queue_lock:
+            queued = [
+                summary.task.id
+                for summary in sorted(
+                    runtime._session_store.list_background_tasks(workspace=runtime._workspace),
+                    key=lambda summary: (summary.created_at, summary.task.id),
+                )
+                if summary.status == "queued"
+            ]
+        try:
+            return queued.index(task.task.id) + 1
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _terminal_reason(task: BackgroundTaskState) -> str | None:
+        if task.status == "completed":
+            return "completed"
+        if task.status == "failed":
+            return task.error or "failed"
+        if task.status == "cancelled":
+            return task.cancellation_cause or task.error or "cancelled"
+        if task.status == "interrupted":
+            return task.error or "interrupted"
+        return None
+
+    @staticmethod
+    def _waiting_reason(
+        *,
+        task: BackgroundTaskState,
+        retry: BackgroundTaskRetryObservability | None,
+    ) -> str:
+        if task.status == "queued":
+            return "queued"
+        if task.status == "running" and retry is not None:
+            return "rate_limited"
+        if task.status == "running" and task.cancel_requested_at is not None:
+            return "cancel_requested"
+        if task.status == "running" and task.approval_request_id is not None:
+            return "approval_blocked"
+        if task.status == "running" and task.question_request_id is not None:
+            return "question_blocked"
+        return task.status
 
     def start_background_task(self, request: RuntimeRequest) -> BackgroundTaskState:
         runtime = self._runtime
@@ -261,14 +377,27 @@ class RuntimeBackgroundTaskSupervisor:
         task_id: str,
         retry_count: int,
     ) -> bool:
-        deadline = time.monotonic() + self._rate_limit_backoff_seconds(retry_count)
-        while True:
-            if self._task_cancel_requested(task_id):
-                return True
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return False
-            time.sleep(min(remaining, 0.05))
+        backoff_seconds = self._rate_limit_backoff_seconds(retry_count)
+        deadline = time.monotonic() + backoff_seconds
+        next_retry_at = int((time.time() + backoff_seconds) * 1000)
+        with self._queue_lock:
+            self._rate_limit_retries[task_id] = _BackgroundTaskRetrySnapshot(
+                retry_count=retry_count,
+                max_retries=_BACKGROUND_TASK_RATE_LIMIT_RETRIES,
+                backoff_seconds=backoff_seconds,
+                next_retry_at=next_retry_at,
+            )
+        try:
+            while True:
+                if self._task_cancel_requested(task_id):
+                    return True
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                time.sleep(min(remaining, 0.05))
+        finally:
+            with self._queue_lock:
+                self._rate_limit_retries.pop(task_id, None)
 
     def _wait_for_slot_or_cancel(
         self,
@@ -524,7 +653,7 @@ class RuntimeBackgroundTaskSupervisor:
                 )
         if previous_task.status != "cancelled" and task.status == "cancelled":
             self.run_background_task_lifecycle_hook(task)
-        return task
+        return self.task_with_observability(task)
 
     def load_background_task_child_response(
         self,
@@ -568,7 +697,6 @@ class RuntimeBackgroundTaskSupervisor:
         child_result = self.load_background_task_child_result(task=task)
         approval_blocked = child_result is not None and child_result.status == "waiting"
         summary_output = self._leader_safe_child_summary(
-            task=task,
             child_result=child_result,
         )
         error = (
@@ -597,12 +725,12 @@ class RuntimeBackgroundTaskSupervisor:
             error=error or routing_error,
             result_available=result_available,
             cancellation_cause=task.cancellation_cause,
+            observability=self.task_observability(task),
         )
 
     @staticmethod
     def _leader_safe_child_summary(
         *,
-        task: BackgroundTaskState,
         child_result: RuntimeSessionResult | None,
     ) -> str | None:
         if child_result is None:

--- a/src/voidcode/runtime/background_tasks.py
+++ b/src/voidcode/runtime/background_tasks.py
@@ -156,7 +156,23 @@ class RuntimeBackgroundTaskSupervisor:
         )
 
     def task_with_observability(self, task: BackgroundTaskState) -> BackgroundTaskState:
-        return replace(task, observability=self.task_observability(task))
+        runtime = self._runtime
+        queued_summaries = runtime._session_store.list_queued_background_tasks(
+            workspace=runtime._workspace
+        )
+        tasks_by_id = {task.task.id: task}
+        for summary in queued_summaries:
+            if summary.task.id in tasks_by_id:
+                continue
+            tasks_by_id[summary.task.id] = runtime._session_store.load_background_task(
+                workspace=runtime._workspace,
+                task_id=summary.task.id,
+            )
+        context = self._observability_context(
+            queued_summaries=queued_summaries,
+            tasks_by_id=tasks_by_id,
+        )
+        return replace(task, observability=self.task_observability(task, context=context))
 
     def summary_with_observability(
         self, summary: StoredBackgroundTaskSummary
@@ -174,13 +190,11 @@ class RuntimeBackgroundTaskSupervisor:
         if not summaries:
             return ()
         runtime = self._runtime
-        global_summaries = runtime._session_store.list_background_tasks(
+        queued_summaries = runtime._session_store.list_queued_background_tasks(
             workspace=runtime._workspace
         )
         task_ids_to_load = {summary.task.id for summary in summaries}
-        task_ids_to_load.update(
-            summary.task.id for summary in global_summaries if summary.status == "queued"
-        )
+        task_ids_to_load.update(summary.task.id for summary in queued_summaries)
         tasks_by_id = {
             task_id: runtime._session_store.load_background_task(
                 workspace=runtime._workspace,
@@ -189,7 +203,7 @@ class RuntimeBackgroundTaskSupervisor:
             for task_id in task_ids_to_load
         }
         context = self._observability_context(
-            global_summaries=global_summaries,
+            queued_summaries=queued_summaries,
             tasks_by_id=tasks_by_id,
         )
         return tuple(
@@ -242,11 +256,9 @@ class RuntimeBackgroundTaskSupervisor:
         with self._queue_lock:
             queued = [
                 summary.task.id
-                for summary in sorted(
-                    runtime._session_store.list_background_tasks(workspace=runtime._workspace),
-                    key=lambda summary: (summary.created_at, summary.task.id),
+                for summary in runtime._session_store.list_queued_background_tasks(
+                    workspace=runtime._workspace
                 )
-                if summary.status == "queued"
             ]
         try:
             return queued.index(task.task.id) + 1
@@ -279,15 +291,9 @@ class RuntimeBackgroundTaskSupervisor:
     def _observability_context(
         self,
         *,
-        global_summaries: tuple[StoredBackgroundTaskSummary, ...],
+        queued_summaries: tuple[StoredBackgroundTaskSummary, ...],
         tasks_by_id: dict[str, BackgroundTaskState],
     ) -> _BackgroundTaskObservabilityContext:
-        queued_summaries = tuple(
-            sorted(
-                (summary for summary in global_summaries if summary.status == "queued"),
-                key=lambda summary: (summary.created_at, summary.task.id),
-            )
-        )
         queued_positions = {
             summary.task.id: index for index, summary in enumerate(queued_summaries, start=1)
         }
@@ -554,9 +560,9 @@ class RuntimeBackgroundTaskSupervisor:
         queued_provider = 0
         queued_model = 0
         queued_total = 0
-        for summary in runtime._session_store.list_background_tasks(workspace=runtime._workspace):
-            if summary.status != "queued":
-                continue
+        for summary in runtime._session_store.list_queued_background_tasks(
+            workspace=runtime._workspace
+        ):
             queued_total += 1
             task = runtime._session_store.load_background_task(
                 workspace=runtime._workspace,

--- a/src/voidcode/runtime/background_tasks.py
+++ b/src/voidcode/runtime/background_tasks.py
@@ -115,6 +115,18 @@ class _BackgroundTaskRetrySnapshot:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class _BackgroundTaskObservabilityContext:
+    queued_positions: dict[str, int]
+    queued_provider_counts: dict[str, int]
+    queued_model_counts: dict[str, int]
+    queued_total: int
+    running_provider_counts: dict[str, int]
+    running_model_counts: dict[str, int]
+    running_total: int
+    retries: dict[str, _BackgroundTaskRetrySnapshot]
+
+
 class RuntimeBackgroundTaskSupervisor:
     def __init__(self, runtime: VoidCodeRuntime) -> None:
         self._runtime = runtime
@@ -124,16 +136,21 @@ class RuntimeBackgroundTaskSupervisor:
         self._model_running_counts: dict[str, int] = {}
         self._rate_limit_retries: dict[str, _BackgroundTaskRetrySnapshot] = {}
 
-    def task_observability(self, task: BackgroundTaskState) -> BackgroundTaskObservability:
+    def task_observability(
+        self,
+        task: BackgroundTaskState,
+        *,
+        context: _BackgroundTaskObservabilityContext | None = None,
+    ) -> BackgroundTaskObservability:
         try:
-            concurrency = self._concurrency_snapshot(task).as_observability()
+            concurrency = self._concurrency_observability(task, context=context)
         except (RuntimeRequestError, ValueError):
             concurrency = None
-        retry = self._retry_observability(task.task.id)
+        retry = self._retry_observability(task.task.id, context=context)
         return BackgroundTaskObservability(
             waiting_reason=self._waiting_reason(task=task, retry=retry),
             terminal_reason=self._terminal_reason(task),
-            queue_position=self._queue_position(task),
+            queue_position=self._queue_position(task, context=context),
             concurrency=concurrency,
             retry=retry,
         )
@@ -150,6 +167,42 @@ class RuntimeBackgroundTaskSupervisor:
         )
         return replace(summary, observability=self.task_observability(task))
 
+    def summaries_with_observability(
+        self,
+        summaries: tuple[StoredBackgroundTaskSummary, ...],
+    ) -> tuple[StoredBackgroundTaskSummary, ...]:
+        if not summaries:
+            return ()
+        runtime = self._runtime
+        global_summaries = runtime._session_store.list_background_tasks(
+            workspace=runtime._workspace
+        )
+        task_ids_to_load = {summary.task.id for summary in summaries}
+        task_ids_to_load.update(
+            summary.task.id for summary in global_summaries if summary.status == "queued"
+        )
+        tasks_by_id = {
+            task_id: runtime._session_store.load_background_task(
+                workspace=runtime._workspace,
+                task_id=task_id,
+            )
+            for task_id in task_ids_to_load
+        }
+        context = self._observability_context(
+            global_summaries=global_summaries,
+            tasks_by_id=tasks_by_id,
+        )
+        return tuple(
+            replace(
+                summary,
+                observability=self.task_observability(
+                    tasks_by_id[summary.task.id],
+                    context=context,
+                ),
+            )
+            for summary in summaries
+        )
+
     def status_counts(self) -> dict[str, int]:
         counts: dict[str, int] = {}
         for summary in self._runtime._session_store.list_background_tasks(
@@ -162,14 +215,29 @@ class RuntimeBackgroundTaskSupervisor:
         with self._queue_lock:
             return sum(self._provider_running_counts.values())
 
-    def _retry_observability(self, task_id: str) -> BackgroundTaskRetryObservability | None:
-        with self._queue_lock:
-            retry = self._rate_limit_retries.get(task_id)
+    def _retry_observability(
+        self,
+        task_id: str,
+        *,
+        context: _BackgroundTaskObservabilityContext | None = None,
+    ) -> BackgroundTaskRetryObservability | None:
+        if context is not None:
+            retry = context.retries.get(task_id)
+        else:
+            with self._queue_lock:
+                retry = self._rate_limit_retries.get(task_id)
         return None if retry is None else retry.as_observability()
 
-    def _queue_position(self, task: BackgroundTaskState) -> int | None:
+    def _queue_position(
+        self,
+        task: BackgroundTaskState,
+        *,
+        context: _BackgroundTaskObservabilityContext | None = None,
+    ) -> int | None:
         if task.status != "queued":
             return None
+        if context is not None:
+            return context.queued_positions.get(task.task.id)
         runtime = self._runtime
         with self._queue_lock:
             queued = [
@@ -184,6 +252,72 @@ class RuntimeBackgroundTaskSupervisor:
             return queued.index(task.task.id) + 1
         except ValueError:
             return None
+
+    def _concurrency_observability(
+        self,
+        task: BackgroundTaskState,
+        *,
+        context: _BackgroundTaskObservabilityContext | None = None,
+    ) -> BackgroundTaskConcurrencyObservability:
+        if context is None:
+            return self._concurrency_snapshot(task).as_observability()
+        identity = self._concurrency_identity_for_task(task)
+        return BackgroundTaskConcurrencyObservability(
+            provider=identity.provider,
+            model=identity.model,
+            limit=identity.limit,
+            limit_source=identity.limit_source,
+            running_provider=context.running_provider_counts.get(identity.provider, 0),
+            running_model=context.running_model_counts.get(identity.model_key, 0),
+            running_total=context.running_total,
+            active_worker_slots=context.running_total,
+            queued_provider=context.queued_provider_counts.get(identity.provider, 0),
+            queued_model=context.queued_model_counts.get(identity.model_key, 0),
+            queued_total=context.queued_total,
+        )
+
+    def _observability_context(
+        self,
+        *,
+        global_summaries: tuple[StoredBackgroundTaskSummary, ...],
+        tasks_by_id: dict[str, BackgroundTaskState],
+    ) -> _BackgroundTaskObservabilityContext:
+        queued_summaries = tuple(
+            sorted(
+                (summary for summary in global_summaries if summary.status == "queued"),
+                key=lambda summary: (summary.created_at, summary.task.id),
+            )
+        )
+        queued_positions = {
+            summary.task.id: index for index, summary in enumerate(queued_summaries, start=1)
+        }
+        queued_provider_counts: dict[str, int] = {}
+        queued_model_counts: dict[str, int] = {}
+        for summary in queued_summaries:
+            task = tasks_by_id.get(summary.task.id)
+            if task is None:
+                continue
+            try:
+                identity = self._concurrency_identity_for_task(task)
+            except (RuntimeRequestError, ValueError):
+                continue
+            queued_provider_counts[identity.provider] = (
+                queued_provider_counts.get(identity.provider, 0) + 1
+            )
+            queued_model_counts[identity.model_key] = (
+                queued_model_counts.get(identity.model_key, 0) + 1
+            )
+        with self._queue_lock:
+            return _BackgroundTaskObservabilityContext(
+                queued_positions=queued_positions,
+                queued_provider_counts=queued_provider_counts,
+                queued_model_counts=queued_model_counts,
+                queued_total=len(queued_summaries),
+                running_provider_counts=dict(self._provider_running_counts),
+                running_model_counts=dict(self._model_running_counts),
+                running_total=sum(self._provider_running_counts.values()),
+                retries=dict(self._rate_limit_retries),
+            )
 
     @staticmethod
     def _terminal_reason(task: BackgroundTaskState) -> str | None:

--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -14,6 +14,7 @@ from .events import (
 from .question import QuestionResponse
 from .session import SessionRef, SessionState
 from .task import (
+    BackgroundTaskObservability,
     BackgroundTaskState,
     BackgroundTaskStatus,
     ResolvedSubagentRoute,
@@ -644,11 +645,24 @@ class CapabilityStatusSnapshot:
 
 
 @dataclass(frozen=True, slots=True)
+class RuntimeBackgroundTaskStatusSnapshot:
+    active_worker_slots: int
+    queued_count: int
+    running_count: int
+    terminal_count: int
+    default_concurrency: int
+    provider_concurrency: dict[str, int] = field(default_factory=dict)
+    model_concurrency: dict[str, int] = field(default_factory=dict)
+    status_counts: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
 class RuntimeStatusSnapshot:
     git: GitStatusSnapshot
     lsp: CapabilityStatusSnapshot
     mcp: CapabilityStatusSnapshot
     acp: CapabilityStatusSnapshot
+    background_tasks: RuntimeBackgroundTaskStatusSnapshot
 
 
 @dataclass(frozen=True, slots=True)
@@ -851,6 +865,7 @@ class BackgroundTaskResult:
     error: str | None = None
     result_available: bool = False
     cancellation_cause: str | None = None
+    observability: BackgroundTaskObservability | None = None
 
     @property
     def subagent_execution(self) -> SubagentExecutionContract:

--- a/src/voidcode/runtime/http.py
+++ b/src/voidcode/runtime/http.py
@@ -1865,6 +1865,9 @@ class RuntimeTransportApp:
             "finished_at": task.finished_at,
             "cancel_requested_at": task.cancel_requested_at,
             "routing": RuntimeTransportApp._serialize_subagent_routing(task.routing_identity),
+            "observability": (
+                None if task.observability is None else task.observability.as_payload()
+            ),
         }
 
     @staticmethod
@@ -1877,6 +1880,9 @@ class RuntimeTransportApp:
             "error": task.error,
             "created_at": task.created_at,
             "updated_at": task.updated_at,
+            "observability": (
+                None if task.observability is None else task.observability.as_payload()
+            ),
         }
 
     @staticmethod
@@ -2085,6 +2091,9 @@ class RuntimeTransportApp:
             "result_available": result.result_available,
             "cancellation_cause": result.cancellation_cause,
             "routing": RuntimeTransportApp._serialize_subagent_routing(result.routing),
+            "observability": (
+                None if result.observability is None else result.observability.as_payload()
+            ),
             "delegation": result.delegated_execution.as_payload(),
             "message": result.delegated_message.as_payload(),
         }
@@ -2278,6 +2287,16 @@ class RuntimeTransportApp:
             "lsp": RuntimeTransportApp._serialize_capability_status_snapshot(snapshot.lsp),
             "mcp": RuntimeTransportApp._serialize_capability_status_snapshot(snapshot.mcp),
             "acp": RuntimeTransportApp._serialize_capability_status_snapshot(snapshot.acp),
+            "background_tasks": {
+                "active_worker_slots": snapshot.background_tasks.active_worker_slots,
+                "queued_count": snapshot.background_tasks.queued_count,
+                "running_count": snapshot.background_tasks.running_count,
+                "terminal_count": snapshot.background_tasks.terminal_count,
+                "default_concurrency": snapshot.background_tasks.default_concurrency,
+                "provider_concurrency": snapshot.background_tasks.provider_concurrency,
+                "model_concurrency": snapshot.background_tasks.model_concurrency,
+                "status_counts": snapshot.background_tasks.status_counts,
+            },
         }
 
     @staticmethod

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -131,6 +131,7 @@ from .contracts import (
     ProviderSummary,
     ProviderValidationResult,
     ReviewFileDiff,
+    RuntimeBackgroundTaskStatusSnapshot,
     RuntimeNotification,
     RuntimeProviderContextSnapshot,
     RuntimeRequest,
@@ -2546,7 +2547,8 @@ class VoidCodeRuntime:
     def load_background_task(self, task_id: str) -> BackgroundTaskState:
         self._reconcile_background_tasks_if_needed()
         validate_background_task_id(task_id)
-        return self._session_store.load_background_task(workspace=self._workspace, task_id=task_id)
+        task = self._session_store.load_background_task(workspace=self._workspace, task_id=task_id)
+        return self._background_task_supervisor.task_with_observability(task)
 
     def load_background_task_result(
         self,
@@ -2561,7 +2563,10 @@ class VoidCodeRuntime:
 
     def list_background_tasks(self) -> tuple[StoredBackgroundTaskSummary, ...]:
         self._background_task_supervisor.reconcile_background_tasks_if_needed()
-        return self._session_store.list_background_tasks(workspace=self._workspace)
+        return tuple(
+            self._background_task_supervisor.summary_with_observability(summary)
+            for summary in self._session_store.list_background_tasks(workspace=self._workspace)
+        )
 
     def list_background_tasks_by_parent_session(
         self, *, parent_session_id: str
@@ -2571,9 +2576,12 @@ class VoidCodeRuntime:
             parent_session_id,
             field_name="parent_session_id",
         )
-        return self._session_store.list_background_tasks_by_parent_session(
-            workspace=self._workspace,
-            parent_session_id=validated_parent_session_id,
+        return tuple(
+            self._background_task_supervisor.summary_with_observability(summary)
+            for summary in self._session_store.list_background_tasks_by_parent_session(
+                workspace=self._workspace,
+                parent_session_id=validated_parent_session_id,
+            )
         )
 
     def cancel_background_task(self, task_id: str) -> BackgroundTaskState:
@@ -3825,6 +3833,7 @@ class VoidCodeRuntime:
         return tuple(summaries)
 
     def current_status(self) -> RuntimeStatusSnapshot:
+        self._background_task_supervisor.reconcile_background_tasks_if_needed()
         git = self._git_status_snapshot()
         lsp_state = self.current_lsp_state()
         mcp_state = self.current_mcp_state()
@@ -3891,6 +3900,7 @@ class VoidCodeRuntime:
                     ),
                 }
             )
+        background_status_counts = self._background_task_supervisor.status_counts()
         return RuntimeStatusSnapshot(
             git=git,
             lsp=CapabilityStatusSnapshot(state=lsp_status, error=lsp_error),
@@ -3914,6 +3924,19 @@ class VoidCodeRuntime:
                 },
             ),
             acp=self._acp_status_snapshot(acp_state),
+            background_tasks=RuntimeBackgroundTaskStatusSnapshot(
+                active_worker_slots=self._background_task_supervisor.active_worker_slots(),
+                queued_count=background_status_counts.get("queued", 0),
+                running_count=background_status_counts.get("running", 0),
+                terminal_count=sum(
+                    background_status_counts.get(status, 0)
+                    for status in ("completed", "failed", "cancelled", "interrupted")
+                ),
+                default_concurrency=self._config.background_task.default_concurrency,
+                provider_concurrency=dict(self._config.background_task.provider_concurrency),
+                model_concurrency=dict(self._config.background_task.model_concurrency),
+                status_counts=background_status_counts,
+            ),
         )
 
     @staticmethod

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -2563,9 +2563,8 @@ class VoidCodeRuntime:
 
     def list_background_tasks(self) -> tuple[StoredBackgroundTaskSummary, ...]:
         self._background_task_supervisor.reconcile_background_tasks_if_needed()
-        return tuple(
-            self._background_task_supervisor.summary_with_observability(summary)
-            for summary in self._session_store.list_background_tasks(workspace=self._workspace)
+        return self._background_task_supervisor.summaries_with_observability(
+            self._session_store.list_background_tasks(workspace=self._workspace)
         )
 
     def list_background_tasks_by_parent_session(
@@ -2576,9 +2575,8 @@ class VoidCodeRuntime:
             parent_session_id,
             field_name="parent_session_id",
         )
-        return tuple(
-            self._background_task_supervisor.summary_with_observability(summary)
-            for summary in self._session_store.list_background_tasks_by_parent_session(
+        return self._background_task_supervisor.summaries_with_observability(
+            self._session_store.list_background_tasks_by_parent_session(
                 workspace=self._workspace,
                 parent_session_id=validated_parent_session_id,
             )

--- a/src/voidcode/runtime/storage.py
+++ b/src/voidcode/runtime/storage.py
@@ -131,6 +131,10 @@ class SessionStore(Protocol):
         self, *, workspace: Path
     ) -> tuple[StoredBackgroundTaskSummary, ...]: ...
 
+    def list_queued_background_tasks(
+        self, *, workspace: Path
+    ) -> tuple[StoredBackgroundTaskSummary, ...]: ...
+
     def list_background_tasks_by_parent_session(
         self, *, workspace: Path, parent_session_id: str
     ) -> tuple[StoredBackgroundTaskSummary, ...]: ...
@@ -2148,6 +2152,24 @@ class SqliteSessionStore:
                     FROM background_tasks
                     WHERE workspace = ?
                     ORDER BY updated_at DESC, task_id ASC
+                    """,
+                    (str(workspace),),
+                ).fetchall(),
+            )
+        return tuple(self._background_task_summary_from_row(row) for row in rows)
+
+    def list_queued_background_tasks(
+        self, *, workspace: Path
+    ) -> tuple[StoredBackgroundTaskSummary, ...]:
+        with self._connect(workspace) as connection:
+            rows = cast(
+                list[sqlite3.Row],
+                connection.execute(
+                    """
+                    SELECT task_id, status, prompt, session_id, error, created_at, updated_at
+                    FROM background_tasks
+                    WHERE workspace = ? AND status = 'queued'
+                    ORDER BY created_at ASC, task_id ASC
                     """,
                     (str(workspace),),
                 ).fetchall(),

--- a/src/voidcode/runtime/task.py
+++ b/src/voidcode/runtime/task.py
@@ -307,6 +307,70 @@ class BackgroundTaskRequestSnapshot:
 
 
 @dataclass(frozen=True, slots=True)
+class BackgroundTaskConcurrencyObservability:
+    provider: str
+    model: str
+    limit: int
+    limit_source: str
+    running_provider: int
+    running_model: int
+    running_total: int
+    active_worker_slots: int
+    queued_provider: int
+    queued_model: int
+    queued_total: int
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "provider": self.provider,
+            "model": self.model,
+            "limit": self.limit,
+            "limit_source": self.limit_source,
+            "running_provider": self.running_provider,
+            "running_model": self.running_model,
+            "running_total": self.running_total,
+            "active_worker_slots": self.active_worker_slots,
+            "queued_provider": self.queued_provider,
+            "queued_model": self.queued_model,
+            "queued_total": self.queued_total,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BackgroundTaskRetryObservability:
+    retry_count: int
+    max_retries: int
+    backoff_seconds: float
+    next_retry_at: int | None = None
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "retry_count": self.retry_count,
+            "max_retries": self.max_retries,
+            "backoff_seconds": self.backoff_seconds,
+            "next_retry_at": self.next_retry_at,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BackgroundTaskObservability:
+    waiting_reason: str
+    terminal_reason: str | None = None
+    queue_position: int | None = None
+    concurrency: BackgroundTaskConcurrencyObservability | None = None
+    retry: BackgroundTaskRetryObservability | None = None
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "waiting_reason": self.waiting_reason,
+            "terminal_reason": self.terminal_reason,
+            "queue_position": self.queue_position,
+            "concurrency": (None if self.concurrency is None else self.concurrency.as_payload()),
+            "retry": None if self.retry is None else self.retry.as_payload(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class BackgroundTaskState:
     task: BackgroundTaskRef
     status: BackgroundTaskStatus = "queued"
@@ -324,6 +388,7 @@ class BackgroundTaskState:
     started_at: int | None = None
     finished_at: int | None = None
     cancel_requested_at: int | None = None
+    observability: BackgroundTaskObservability | None = None
 
     @property
     def parent_session_id(self) -> str | None:
@@ -359,6 +424,7 @@ class StoredBackgroundTaskSummary:
     error: str | None
     created_at: int
     updated_at: int
+    observability: BackgroundTaskObservability | None = None
 
 
 def validate_background_task_id(task_id: str) -> str:

--- a/tests/integration/test_http_delegated_parity.py
+++ b/tests/integration/test_http_delegated_parity.py
@@ -32,7 +32,7 @@ from typing import Any, Protocol, cast
 
 import pytest
 
-from voidcode.runtime.task import is_background_task_terminal
+from voidcode.runtime.task import BackgroundTaskStatus, is_background_task_terminal
 
 pytestmark = pytest.mark.usefixtures("_force_deterministic_engine_default")
 
@@ -275,7 +275,7 @@ def _wait_for_background_task_terminal(
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         task = runtime.load_background_task(task_id)
-        if is_background_task_terminal(task.status):
+        if is_background_task_terminal(cast(BackgroundTaskStatus, task.status)):
             return
         time.sleep(0.01)
     raise AssertionError(f"background task did not reach terminal state: {task_id}")
@@ -729,6 +729,7 @@ def test_http_background_task_list_endpoints_expose_global_and_parent_scoped_vie
             "error": None,
             "created_at": 2,
             "updated_at": 3,
+            "observability": None,
         }
     ]
 
@@ -809,7 +810,7 @@ def test_http_background_task_output_endpoint_exposes_typed_delegated_payload_fo
     deadline = time.monotonic() + 2.0
     while time.monotonic() < deadline:
         task = runtime.load_background_task(started.task.id)
-        if is_background_task_terminal(task.status):
+        if is_background_task_terminal(cast(BackgroundTaskStatus, task.status)):
             break
         time.sleep(0.01)
     else:
@@ -902,7 +903,7 @@ def test_http_background_task_output_endpoint_preserves_empty_child_output(tmp_p
             *,
             session: object,
         ) -> object:
-            _ = tool_results, session
+            _ = request, tool_results, session
             return type("_Step", (), {"output": "", "is_finished": True, "tool_call": None})()
 
     runtime = runtime_class(workspace=tmp_path, graph=_EmptyOutputGraph())

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -2933,6 +2933,9 @@ def test_transport_retries_mcp_and_returns_status_snapshot(tmp_path: Path) -> No
             runtime_contracts = importlib.import_module("voidcode.runtime.contracts")
             GitStatusSnapshot = runtime_contracts.GitStatusSnapshot
             CapabilityStatusSnapshot = runtime_contracts.CapabilityStatusSnapshot
+            RuntimeBackgroundTaskStatusSnapshot = (
+                runtime_contracts.RuntimeBackgroundTaskStatusSnapshot
+            )
             RuntimeStatusSnapshot = runtime_contracts.RuntimeStatusSnapshot
             return RuntimeStatusSnapshot(
                 git=GitStatusSnapshot(state="git_ready", root=str(tmp_path)),
@@ -2954,6 +2957,13 @@ def test_transport_retries_mcp_and_returns_status_snapshot(tmp_path: Path) -> No
                     },
                 ),
                 acp=CapabilityStatusSnapshot(state="unconfigured", error=None, details={}),
+                background_tasks=RuntimeBackgroundTaskStatusSnapshot(
+                    active_worker_slots=0,
+                    queued_count=0,
+                    running_count=0,
+                    terminal_count=0,
+                    default_concurrency=5,
+                ),
             )
 
         def review_snapshot(self) -> object:
@@ -3020,6 +3030,16 @@ def test_transport_retries_mcp_and_returns_status_snapshot(tmp_path: Path) -> No
             },
         },
         "acp": {"state": "unconfigured", "error": None, "details": {}},
+        "background_tasks": {
+            "active_worker_slots": 0,
+            "queued_count": 0,
+            "running_count": 0,
+            "terminal_count": 0,
+            "default_concurrency": 5,
+            "provider_concurrency": {},
+            "model_concurrency": {},
+            "status_counts": {},
+        },
     }
 
 

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -112,6 +112,7 @@ from voidcode.runtime.task import (
     BackgroundTaskRef,
     BackgroundTaskRequestSnapshot,
     BackgroundTaskState,
+    StoredBackgroundTaskSummary,
     is_background_task_terminal,
 )
 from voidcode.skills import SkillRegistry
@@ -1424,6 +1425,47 @@ def test_runtime_background_task_status_includes_queue_concurrency_observability
     queued_summary = next(summary for summary in summaries if summary.task.id == second.task.id)
     assert queued_summary.observability is not None
     assert queued_summary.observability.queue_position == 1
+
+    graph.release_first.set()
+    assert _wait_for_background_task(runtime, first.task.id).status == "completed"
+    assert _wait_for_background_task(runtime, second.task.id).status == "completed"
+
+
+def test_runtime_background_task_list_observability_batches_store_reads(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _BlockingBackgroundTaskGraph()
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=graph,
+        config=RuntimeConfig(background_task=RuntimeBackgroundTaskConfig(default_concurrency=1)),
+    )
+    first = runtime.start_background_task(RuntimeRequest(prompt="first background task"))
+    assert graph.first_started.wait(timeout=2.0)
+    second = runtime.start_background_task(RuntimeRequest(prompt="second background task"))
+    store = _private_attr(runtime, "_session_store")
+    original_list_background_tasks = store.list_background_tasks
+    original_load_background_task = store.load_background_task
+    calls = {"list": 0, "load": 0}
+
+    def counted_list_background_tasks(
+        *, workspace: Path
+    ) -> tuple[StoredBackgroundTaskSummary, ...]:
+        calls["list"] += 1
+        return original_list_background_tasks(workspace=workspace)
+
+    def counted_load_background_task(*, workspace: Path, task_id: str) -> BackgroundTaskState:
+        calls["load"] += 1
+        return original_load_background_task(workspace=workspace, task_id=task_id)
+
+    monkeypatch.setattr(store, "list_background_tasks", counted_list_background_tasks)
+    monkeypatch.setattr(store, "load_background_task", counted_load_background_task)
+
+    summaries = runtime.list_background_tasks()
+
+    assert {summary.task.id for summary in summaries} == {first.task.id, second.task.id}
+    assert calls == {"list": 2, "load": 2}
 
     graph.release_first.set()
     assert _wait_for_background_task(runtime, first.task.id).status == "completed"

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1379,6 +1379,57 @@ def test_runtime_background_task_concurrency_limit_queues_and_drains(tmp_path: P
     assert graph.prompts_seen == ["first background task", "second background task"]
 
 
+def test_runtime_background_task_status_includes_queue_concurrency_observability(
+    tmp_path: Path,
+) -> None:
+    graph = _BlockingBackgroundTaskGraph()
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=graph,
+        config=RuntimeConfig(background_task=RuntimeBackgroundTaskConfig(default_concurrency=1)),
+    )
+
+    first = runtime.start_background_task(RuntimeRequest(prompt="first background task"))
+    assert graph.first_started.wait(timeout=2.0)
+    second = runtime.start_background_task(RuntimeRequest(prompt="second background task"))
+
+    first_running = runtime.load_background_task(first.task.id)
+    second_queued = runtime.load_background_task(second.task.id)
+    runtime_status = runtime.current_status()
+
+    assert first_running.status == "running"
+    assert first_running.observability is not None
+    assert first_running.observability.waiting_reason == "running"
+    assert first_running.observability.queue_position is None
+    assert first_running.observability.concurrency is not None
+    assert first_running.observability.concurrency.active_worker_slots == 1
+    assert first_running.observability.concurrency.limit == 1
+    assert first_running.observability.concurrency.queued_total == 1
+
+    assert second_queued.status == "queued"
+    assert second_queued.observability is not None
+    assert second_queued.observability.waiting_reason == "queued"
+    assert second_queued.observability.queue_position == 1
+    assert second_queued.observability.concurrency is not None
+    assert second_queued.observability.concurrency.active_worker_slots == 1
+    assert second_queued.observability.concurrency.queued_total == 1
+
+    assert runtime_status.background_tasks.active_worker_slots == 1
+    assert runtime_status.background_tasks.queued_count == 1
+    assert runtime_status.background_tasks.running_count == 1
+    assert runtime_status.background_tasks.default_concurrency == 1
+    assert runtime_status.background_tasks.status_counts == {"queued": 1, "running": 1}
+
+    summaries = runtime.list_background_tasks()
+    queued_summary = next(summary for summary in summaries if summary.task.id == second.task.id)
+    assert queued_summary.observability is not None
+    assert queued_summary.observability.queue_position == 1
+
+    graph.release_first.set()
+    assert _wait_for_background_task(runtime, first.task.id).status == "completed"
+    assert _wait_for_background_task(runtime, second.task.id).status == "completed"
+
+
 def test_runtime_background_task_concurrency_identity_uses_model_provider_default_precedence(
     tmp_path: Path,
 ) -> None:
@@ -1462,6 +1513,7 @@ def test_runtime_background_task_configured_events_include_concurrency_metadata(
         "running_provider": 1,
         "running_model": 1,
         "running_total": 1,
+        "active_worker_slots": 1,
         "queued_provider": 0,
         "queued_model": 0,
         "queued_total": 0,
@@ -1490,6 +1542,55 @@ def test_runtime_background_task_rate_limit_retries_after_backoff(
 
     assert completed.status == "completed"
     assert graph.attempts == 2
+
+
+def test_runtime_background_task_observability_reports_rate_limit_backoff(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _RateLimitThenSuccessGraph()
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=graph)
+
+    def _observable_backoff(retry_count: int) -> float:
+        _ = retry_count
+        return 0.5
+
+    monkeypatch.setattr(
+        runtime._background_task_supervisor,  # pyright: ignore[reportPrivateUsage]
+        "_rate_limit_backoff_seconds",
+        _observable_backoff,
+    )
+
+    started = runtime.start_background_task(RuntimeRequest(prompt="retry observability"))
+    deadline = time.monotonic() + 2.0
+    observed = None
+    while time.monotonic() < deadline:
+        task = runtime.load_background_task(started.task.id)
+        if task.observability is not None and task.observability.retry is not None:
+            observed = task.observability
+            break
+        time.sleep(0.01)
+
+    assert observed is not None
+    assert observed.waiting_reason == "rate_limited"
+    assert observed.retry is not None
+    assert observed.retry.retry_count == 1
+    assert observed.retry.max_retries == 2
+    assert observed.retry.backoff_seconds == 0.5
+    assert observed.retry.next_retry_at is not None
+    assert observed.concurrency is not None
+    assert observed.concurrency.active_worker_slots == 0
+
+    completed = _wait_for_background_task(runtime, started.task.id)
+    result = runtime.load_background_task_result(started.task.id)
+
+    assert completed.status == "completed"
+    assert completed.observability is not None
+    assert completed.observability.waiting_reason == "completed"
+    assert completed.observability.terminal_reason == "completed"
+    assert completed.observability.retry is None
+    assert result.observability is not None
+    assert result.observability.terminal_reason == "completed"
 
 
 def test_runtime_background_rate_limit_retry_precedes_provider_fallback(
@@ -5474,6 +5575,9 @@ def test_runtime_background_task_persists_failure_state(tmp_path: Path) -> None:
     assert failed.status == "failed"
     assert failed.error is not None
     assert "background boom" in failed.error
+    assert failed.observability is not None
+    assert failed.observability.waiting_reason == "failed"
+    assert failed.observability.terminal_reason == failed.error
 
 
 def test_runtime_cancel_background_task_reconciles_orphaned_queued_task(tmp_path: Path) -> None:
@@ -5495,6 +5599,9 @@ def test_runtime_cancel_background_task_reconciles_orphaned_queued_task(tmp_path
     assert cancelled.status == "cancelled"
     assert cancelled.error == "cancelled before start"
     assert cancelled.cancel_requested_at is None
+    assert cancelled.observability is not None
+    assert cancelled.observability.waiting_reason == "cancelled"
+    assert cancelled.observability.terminal_reason == "cancelled before start"
 
 
 def test_runtime_reconciles_queued_background_tasks_on_init(tmp_path: Path) -> None:
@@ -5516,6 +5623,41 @@ def test_runtime_reconciles_queued_background_tasks_on_init(tmp_path: Path) -> N
 
     assert reconciled.status == "completed"
     assert reconciled.error is None
+
+
+def test_runtime_status_reconciles_stale_running_background_tasks(
+    tmp_path: Path,
+) -> None:
+    first_runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    store = _private_attr(first_runtime, "_session_store")
+    task_module = importlib.import_module("voidcode.runtime.task")
+    store.create_background_task(
+        workspace=tmp_path,
+        task=task_module.BackgroundTaskState(
+            task=task_module.BackgroundTaskRef(id="task-stale-running"),
+            request=task_module.BackgroundTaskRequestSnapshot(prompt="stale running"),
+            created_at=1,
+            updated_at=1,
+        ),
+    )
+    _ = store.mark_background_task_running(
+        workspace=tmp_path,
+        task_id="task-stale-running",
+        session_id="missing-child-session",
+    )
+
+    second_runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
+    status = second_runtime.current_status().background_tasks
+    task = second_runtime.load_background_task("task-stale-running")
+
+    assert status.active_worker_slots == 0
+    assert status.queued_count == 0
+    assert status.running_count == 0
+    assert status.terminal_count == 1
+    assert status.status_counts == {"interrupted": 1}
+    assert task.status == "interrupted"
+    assert task.observability is not None
+    assert task.observability.terminal_reason == "background task interrupted before completion"
 
 
 def test_runtime_drain_marks_invalid_queued_task_failed_and_continues(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1446,8 +1446,9 @@ def test_runtime_background_task_list_observability_batches_store_reads(
     second = runtime.start_background_task(RuntimeRequest(prompt="second background task"))
     store = _private_attr(runtime, "_session_store")
     original_list_background_tasks = store.list_background_tasks
+    original_list_queued_background_tasks = store.list_queued_background_tasks
     original_load_background_task = store.load_background_task
-    calls = {"list": 0, "load": 0}
+    calls = {"list": 0, "list_queued": 0, "load": 0}
 
     def counted_list_background_tasks(
         *, workspace: Path
@@ -1455,17 +1456,77 @@ def test_runtime_background_task_list_observability_batches_store_reads(
         calls["list"] += 1
         return original_list_background_tasks(workspace=workspace)
 
+    def counted_list_queued_background_tasks(
+        *, workspace: Path
+    ) -> tuple[StoredBackgroundTaskSummary, ...]:
+        calls["list_queued"] += 1
+        return original_list_queued_background_tasks(workspace=workspace)
+
     def counted_load_background_task(*, workspace: Path, task_id: str) -> BackgroundTaskState:
         calls["load"] += 1
         return original_load_background_task(workspace=workspace, task_id=task_id)
 
     monkeypatch.setattr(store, "list_background_tasks", counted_list_background_tasks)
+    monkeypatch.setattr(store, "list_queued_background_tasks", counted_list_queued_background_tasks)
     monkeypatch.setattr(store, "load_background_task", counted_load_background_task)
 
     summaries = runtime.list_background_tasks()
 
     assert {summary.task.id for summary in summaries} == {first.task.id, second.task.id}
-    assert calls == {"list": 2, "load": 2}
+    assert calls == {"list": 1, "list_queued": 1, "load": 2}
+
+    graph.release_first.set()
+    assert _wait_for_background_task(runtime, first.task.id).status == "completed"
+    assert _wait_for_background_task(runtime, second.task.id).status == "completed"
+
+
+def test_runtime_background_task_load_observability_uses_queued_scope(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _BlockingBackgroundTaskGraph()
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=graph,
+        config=RuntimeConfig(background_task=RuntimeBackgroundTaskConfig(default_concurrency=1)),
+    )
+    first = runtime.start_background_task(RuntimeRequest(prompt="first background task"))
+    assert graph.first_started.wait(timeout=2.0)
+    second = runtime.start_background_task(RuntimeRequest(prompt="second background task"))
+    store = _private_attr(runtime, "_session_store")
+    original_list_background_tasks = store.list_background_tasks
+    original_list_queued_background_tasks = store.list_queued_background_tasks
+    original_load_background_task = store.load_background_task
+    calls = {"list_queued": 0, "load": 0}
+
+    def fail_full_background_task_scan(
+        *, workspace: Path
+    ) -> tuple[StoredBackgroundTaskSummary, ...]:
+        _ = workspace
+        raise AssertionError("single task load observability must not scan full task history")
+
+    def counted_list_queued_background_tasks(
+        *, workspace: Path
+    ) -> tuple[StoredBackgroundTaskSummary, ...]:
+        calls["list_queued"] += 1
+        return original_list_queued_background_tasks(workspace=workspace)
+
+    def counted_load_background_task(*, workspace: Path, task_id: str) -> BackgroundTaskState:
+        calls["load"] += 1
+        return original_load_background_task(workspace=workspace, task_id=task_id)
+
+    monkeypatch.setattr(store, "list_background_tasks", fail_full_background_task_scan)
+    monkeypatch.setattr(store, "list_queued_background_tasks", counted_list_queued_background_tasks)
+    monkeypatch.setattr(store, "load_background_task", counted_load_background_task)
+
+    queued = runtime.load_background_task(second.task.id)
+
+    assert queued.status == "queued"
+    assert queued.observability is not None
+    assert queued.observability.queue_position == 1
+    assert calls == {"list_queued": 1, "load": 1}
+
+    monkeypatch.setattr(store, "list_background_tasks", original_list_background_tasks)
 
     graph.release_first.set()
     assert _wait_for_background_task(runtime, first.task.id).status == "completed"


### PR DESCRIPTION
## Summary
- Add runtime-owned background task observability snapshots for queue position, waiting/terminal reasons, live concurrency slots, configured limits, and retry/backoff state.
- Surface the observability payload through runtime task state/results, CLI task commands, HTTP task/status serializers, and parent lifecycle concurrency metadata.
- Add regression coverage for queued/running snapshots, rate-limit backoff visibility, stale running reconciliation in runtime status, and HTTP serialization parity.

## Verification
- `mise run check`
  - Ruff lint passed
  - basedpyright passed with 0 errors/warnings
  - Python tests: 1823 passed
  - Frontend lint/typecheck passed
  - Frontend tests: 162 passed

Closes #345