### PR TITLE
feat(runtime): simplify delegated category taxonomy

### DIFF
--- a/src/voidcode/runtime/config_schema.py
+++ b/src/voidcode/runtime/config_schema.py
@@ -271,10 +271,11 @@ def runtime_config_json_schema() -> dict[str, object]:
                 "additionalProperties": {"$ref": "#/$defs/categoryConfig"},
                 "propertyNames": {
                     "enum": [
+                        "brain",
                         "deep",
+                        "high",
+                        "low",
                         "quick",
-                        "ultrabrain",
-                        "unspecified-high",
                         "visual-engineering",
                         "writing",
                     ]

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -6571,7 +6571,7 @@ class VoidCodeRuntime:
         if not isinstance(raw_delegation, dict):
             return ()
         delegation = cast(dict[str, object], raw_delegation)
-        if delegation.get("category") != "ultrabrain":
+        if delegation.get("category") != "brain":
             return ()
         active_target = effective_config.resolved_provider.active_target.selection
         provider_name = active_target.provider
@@ -6586,11 +6586,11 @@ class VoidCodeRuntime:
                 "severity": "warning",
                 "category": "model_capability_mismatch",
                 "capability": "reasoning",
-                "requested_category": "ultrabrain",
+                "requested_category": "brain",
                 "provider": provider_name,
                 "model": model_name,
                 "message": (
-                    "task category 'ultrabrain' resolved to a model whose provider metadata "
+                    "task category 'brain' resolved to a model whose provider metadata "
                     "does not support reasoning"
                 ),
             },

--- a/src/voidcode/runtime/task.py
+++ b/src/voidcode/runtime/task.py
@@ -86,11 +86,12 @@ class ResolvedSubagentRoute:
 
 _CATEGORY_TO_SUBAGENT_PRESET: dict[str, SubagentExecutablePreset] = {
     "quick": "worker",
+    "low": "worker",
     "deep": "worker",
-    "ultrabrain": "advisor",
+    "brain": "advisor",
     "writing": "product",
     "visual-engineering": "product",
-    "unspecified-high": "worker",
+    "high": "worker",
 }
 SUPPORTED_SUBAGENT_CATEGORIES: tuple[str, ...] = tuple(sorted(_CATEGORY_TO_SUBAGENT_PRESET))
 

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -77,10 +77,11 @@ def _expected_category_models(
 ) -> dict[str, dict[str, object]]:
     configured_overrides = overrides or {}
     presets = {
+        "brain": "advisor",
         "deep": "worker",
+        "high": "worker",
+        "low": "worker",
         "quick": "worker",
-        "ultrabrain": "advisor",
-        "unspecified-high": "worker",
         "visual-engineering": "product",
         "writing": "product",
     }

--- a/tests/unit/runtime/test_background_task_storage.py
+++ b/tests/unit/runtime/test_background_task_storage.py
@@ -817,7 +817,7 @@ def test_background_task_storage_preserves_supervisor_completed_event_payload_fi
                 metadata={
                     "delegation": {
                         "mode": "background",
-                        "category": "ultrabrain",
+                        "category": "brain",
                     }
                 },
             ),
@@ -849,7 +849,7 @@ def test_background_task_storage_preserves_supervisor_completed_event_payload_fi
                 "delegated_task_id": "task-completed-event",
                 "approval_request_id": None,
                 "question_request_id": None,
-                "routing": {"mode": "background", "category": "ultrabrain"},
+                "routing": {"mode": "background", "category": "brain"},
                 "selected_preset": "advisor",
                 "selected_execution_engine": "provider",
                 "lifecycle_status": "completed",
@@ -867,7 +867,7 @@ def test_background_task_storage_preserves_supervisor_completed_event_payload_fi
     assert appended.payload["child_session_id"] == "child-session"
     assert appended.payload["status"] == "completed"
     assert appended.payload["result_available"] is True
-    assert appended.payload["routing_category"] == "ultrabrain"
+    assert appended.payload["routing_category"] == "brain"
     assert appended.payload["delegation"] == {
         "parent_session_id": "leader-session",
         "requested_child_session_id": "child-requested",
@@ -875,7 +875,7 @@ def test_background_task_storage_preserves_supervisor_completed_event_payload_fi
         "delegated_task_id": "task-completed-event",
         "approval_request_id": None,
         "question_request_id": None,
-        "routing": {"mode": "background", "category": "ultrabrain"},
+        "routing": {"mode": "background", "category": "brain"},
         "selected_preset": "advisor",
         "selected_execution_engine": "provider",
         "lifecycle_status": "completed",

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -1522,8 +1522,9 @@ def test_runtime_config_parses_category_model_overrides(tmp_path: Path) -> None:
         json.dumps(
             {
                 "categories": {
+                    "brain": {"model": "openai/o3"},
+                    "low": {"model": "openai/gpt-4o-mini"},
                     "quick": {"model": "openai/gpt-4o-mini"},
-                    "ultrabrain": {"model": "openai/o3"},
                 }
             }
         ),
@@ -1533,12 +1534,14 @@ def test_runtime_config_parses_category_model_overrides(tmp_path: Path) -> None:
     config = load_runtime_config(tmp_path, env={})
 
     assert config.categories == {
+        "brain": RuntimeCategoryConfig(model="openai/o3"),
+        "low": RuntimeCategoryConfig(model="openai/gpt-4o-mini"),
         "quick": RuntimeCategoryConfig(model="openai/gpt-4o-mini"),
-        "ultrabrain": RuntimeCategoryConfig(model="openai/o3"),
     }
     assert serialize_runtime_categories_config(config.categories) == {
+        "brain": {"model": "openai/o3"},
+        "low": {"model": "openai/gpt-4o-mini"},
         "quick": {"model": "openai/gpt-4o-mini"},
-        "ultrabrain": {"model": "openai/o3"},
     }
 
 

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -2996,7 +2996,7 @@ def test_runtime_allows_reasoning_effort_when_metadata_unknown(tmp_path: Path) -
     assert runtime_config_metadata["reasoning_effort"] == "medium"
 
 
-def test_runtime_ultrabrain_warns_when_resolved_model_lacks_reasoning_support(
+def test_runtime_brain_warns_when_resolved_model_lacks_reasoning_support(
     tmp_path: Path,
 ) -> None:
     registry = ModelProviderRegistry.with_defaults()
@@ -3013,7 +3013,7 @@ def test_runtime_ultrabrain_warns_when_resolved_model_lacks_reasoning_support(
         graph=_BackgroundTaskSuccessGraph(),
         config=RuntimeConfig(
             model="openai/gpt-4o",
-            categories={"ultrabrain": RuntimeCategoryConfig(model="openai/gpt-4o")},
+            categories={"brain": RuntimeCategoryConfig(model="openai/gpt-4o")},
         ),
         model_provider_registry=registry,
     )
@@ -3023,7 +3023,7 @@ def test_runtime_ultrabrain_warns_when_resolved_model_lacks_reasoning_support(
         RuntimeRequest(
             prompt="delegated child",
             parent_session_id="leader-session",
-            metadata={"delegation": {"mode": "sync", "category": "ultrabrain"}},
+            metadata={"delegation": {"mode": "sync", "category": "brain"}},
         )
     )
 
@@ -3036,11 +3036,11 @@ def test_runtime_ultrabrain_warns_when_resolved_model_lacks_reasoning_support(
         "severity": "warning",
         "category": "model_capability_mismatch",
         "capability": "reasoning",
-        "requested_category": "ultrabrain",
+        "requested_category": "brain",
         "provider": "openai",
         "model": "gpt-4o",
         "message": (
-            "task category 'ultrabrain' resolved to a model whose provider metadata "
+            "task category 'brain' resolved to a model whose provider metadata "
             "does not support reasoning"
         ),
     }

--- a/tests/unit/tools/test_task_tool.py
+++ b/tests/unit/tools/test_task_tool.py
@@ -219,9 +219,10 @@ def test_task_tool_rejects_unsupported_category_before_dispatch(tmp_path: Path) 
 def test_task_category_mapping_contract_is_exact() -> None:
     assert set(supported_subagent_categories()) == {
         "quick",
+        "low",
         "deep",
-        "unspecified-high",
-        "ultrabrain",
+        "high",
+        "brain",
         "writing",
         "visual-engineering",
     }
@@ -232,9 +233,10 @@ def test_task_category_mapping_contract_is_exact() -> None:
         for category in supported_subagent_categories()
     } == {
         "quick": "worker",
+        "low": "worker",
         "deep": "worker",
-        "unspecified-high": "worker",
-        "ultrabrain": "advisor",
+        "high": "worker",
+        "brain": "advisor",
         "writing": "product",
         "visual-engineering": "product",
     }


### PR DESCRIPTION
## Summary
- Rename the reasoning-heavy delegated category from `ultrabrain` to `brain`.
- Add `low` as the low-ambiguity/low-risk delegated category and replace `unspecified-high` with `high`.
- Update category schema, runtime diagnostics, CLI expectations, and runtime/tool tests.

## Category semantics
- `deep`: execution-oriented long-form worker path for thorough investigation/implementation.
- `brain`: reasoning/advisor path for hard architecture/debugging/decision work.

## Verification
- `uv run python -X utf8 -m pytest tests/unit/tools/test_task_tool.py tests/unit/runtime/test_config_schema.py tests/unit/runtime/test_runtime_config.py::test_runtime_config_parses_category_model_overrides tests/unit/runtime/test_runtime_service_extensions.py::test_runtime_brain_warns_when_resolved_model_lacks_reasoning_support tests/unit/runtime/test_background_task_storage.py -q` (`58 passed`)
- `mise run lint`
- `mise run typecheck`
- `mise run test:fast` (`1183 passed`)
- `mise run test` (`1820 passed`)