### PR TITLE
test(runtime): add provider context parity coverage

### DIFF
--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -501,6 +501,38 @@ class _CapturingModelProvider:
 
 
 @dataclass(frozen=True, slots=True)
+class _ReadFileParityModelProvider:
+    name: str
+    requests: list[object]
+
+    def turn_provider(self) -> object:
+        requests = self.requests
+        name = self.name
+
+        class _Provider:
+            def __init__(self) -> None:
+                self.name = name
+
+            def propose_turn(self, request: object) -> object:
+                requests.append(request)
+                provider_protocol_module = importlib.import_module(
+                    "voidcode.runtime.provider_protocol"
+                )
+                tool_contracts_module = importlib.import_module("voidcode.tools.contracts")
+                if not _assembled_context(request).tool_results:
+                    return provider_protocol_module.ProviderTurnResult(
+                        tool_call=tool_contracts_module.ToolCall(
+                            tool_name="read_file",
+                            arguments={"filePath": "sample.txt"},
+                            tool_call_id="read-1",
+                        )
+                    )
+                return provider_protocol_module.ProviderTurnResult(output="done")
+
+        return _Provider()
+
+
+@dataclass(frozen=True, slots=True)
 class _DelegationE2EModelProvider:
     name: str
 
@@ -1279,6 +1311,207 @@ def test_provider_runtime_persists_and_injects_runtime_todo_state(tmp_path: Path
     raw_runtime_state = loaded.session.metadata["runtime_state"]
     assert isinstance(raw_runtime_state, dict)
     assert "todos" in raw_runtime_state
+
+
+def test_provider_context_live_persisted_replay_and_debug_parity_for_read_file(
+    tmp_path: Path,
+) -> None:
+    contracts_module = importlib.import_module("voidcode.runtime.contracts")
+    config_module = importlib.import_module("voidcode.runtime.config")
+    context_window_module = importlib.import_module("voidcode.runtime.context_window")
+    model_provider_module = importlib.import_module("voidcode.provider.registry")
+    permission_module = importlib.import_module("voidcode.runtime.permission")
+    service_module = importlib.import_module("voidcode.runtime.service")
+    runtime_request = cast(Callable[..., RuntimeRequestLike], contracts_module.RuntimeRequest)
+    requests: list[object] = []
+    _ = (tmp_path / "sample.txt").write_text("alpha\nbeta\n", encoding="utf-8")
+
+    runtime_config = config_module.RuntimeConfig(
+        approval_mode="allow",
+        execution_engine="provider",
+        model="opencode-go/minimax-m2.7",
+        context_window=config_module.RuntimeContextWindowConfig(
+            auto_compaction=False,
+            max_tool_result_tokens=100_000,
+        ),
+    )
+    runtime = service_module.VoidCodeRuntime(
+        workspace=tmp_path,
+        config=runtime_config,
+        permission_policy=permission_module.PermissionPolicy(mode="allow"),
+        model_provider_registry=model_provider_module.ModelProviderRegistry(
+            providers={
+                "opencode-go": _ReadFileParityModelProvider(
+                    name="opencode-go",
+                    requests=requests,
+                )
+            }
+        ),
+    )
+
+    response = runtime.run(
+        runtime_request(prompt="read sample.txt", session_id="provider-context-parity")
+    )
+    loaded = runtime.session_result(session_id="provider-context-parity")
+    replay_runtime = service_module.VoidCodeRuntime(
+        workspace=tmp_path,
+        config=runtime_config,
+        permission_policy=permission_module.PermissionPolicy(mode="allow"),
+        model_provider_registry=model_provider_module.ModelProviderRegistry(
+            providers={
+                "opencode-go": _ReadFileParityModelProvider(
+                    name="opencode-go",
+                    requests=[],
+                )
+            }
+        ),
+    )
+    replay = replay_runtime.resume("provider-context-parity")
+    snapshot = replay_runtime.session_debug_snapshot(session_id="provider-context-parity")
+
+    assert response.session.status == "completed"
+    assert len(requests) == 2
+    live_tool_result = _assembled_context(requests[1]).tool_results[0]
+    raw_content = live_tool_result.content
+    assert raw_content is not None
+    assert "<path>sample.txt</path>" in raw_content
+    assert "1: alpha" in raw_content
+    assert "2: beta" in raw_content
+    assert live_tool_result.data["tool_call_id"] == "read-1"
+    assert live_tool_result.data["arguments"] == {"filePath": "sample.txt"}
+    live_metadata = _assembled_context(requests[1]).metadata
+    assert (
+        live_metadata["original_tool_result_tokens"] == live_metadata["retained_tool_result_tokens"]
+    )
+    normalized = context_window_module.normalize_read_file_output(raw_content)
+    assert normalized == "alpha\nbeta"
+    normalized_tokens = context_window_module.count_text_tokens(normalized).tokens
+    assert cast(int, live_metadata["original_tool_result_tokens"]) > normalized_tokens
+
+    live_event = next(
+        event for event in response.events if event.event_type == "runtime.tool_completed"
+    )
+    loaded_event = next(
+        event for event in loaded.transcript if event.event_type == "runtime.tool_completed"
+    )
+    replay_event = next(
+        event for event in replay.events if event.event_type == "runtime.tool_completed"
+    )
+    assert live_event.payload["content"] == raw_content
+    assert loaded_event.payload["content"] == raw_content
+    assert replay_event.payload["content"] == raw_content
+    assert loaded_event.payload["tool_call_id"] == "read-1"
+    assert replay_event.payload["arguments"] == {"filePath": "sample.txt"}
+
+    provider_context = snapshot.provider_context
+    assert provider_context is not None
+    assert provider_context.provider == "opencode-go"
+    tool_segments = [segment for segment in provider_context.segments if segment.role == "tool"]
+    assert len(tool_segments) == 1
+    assert tool_segments[0].tool_name == "read_file"
+    assert tool_segments[0].content == raw_content
+    assert tool_segments[0].metadata["status"] == "ok"
+    assert provider_context.provider_messages[-1].source == "provider_synthetic_tool_feedback"
+    synthetic_feedback = provider_context.provider_messages[-1].content or ""
+    assert synthetic_feedback.count('"tool_name": "read_file"') == 1
+    assert "1: alpha" in synthetic_feedback
+    assert "tool_status" not in synthetic_feedback
+    assert "display" not in synthetic_feedback
+
+
+def test_provider_context_compacted_debug_snapshot_keeps_only_retained_live_shape(
+    tmp_path: Path,
+) -> None:
+    contracts_module = importlib.import_module("voidcode.runtime.contracts")
+    config_module = importlib.import_module("voidcode.runtime.config")
+    model_provider_module = importlib.import_module("voidcode.provider.registry")
+    permission_module = importlib.import_module("voidcode.runtime.permission")
+    provider_protocol_module = importlib.import_module("voidcode.runtime.provider_protocol")
+    service_module = importlib.import_module("voidcode.runtime.service")
+    tool_contracts_module = importlib.import_module("voidcode.tools.contracts")
+    runtime_request = cast(Callable[..., RuntimeRequestLike], contracts_module.RuntimeRequest)
+    requests: list[object] = []
+    _ = (tmp_path / "sample.txt").write_text("fresh\n", encoding="utf-8")
+
+    class _CompactionModelProvider:
+        def turn_provider(self) -> object:
+            class _Provider:
+                name = "opencode"
+
+                def propose_turn(self, request: object) -> object:
+                    requests.append(request)
+                    if len(requests) == 1:
+                        return provider_protocol_module.ProviderTurnResult(
+                            tool_call=tool_contracts_module.ToolCall(
+                                tool_name="shell_exec",
+                                arguments={
+                                    "command": "printf 'old shell output\\n'",
+                                    "description": "emit old shell output",
+                                },
+                                tool_call_id="shell-1",
+                            )
+                        )
+                    if len(requests) == 2:
+                        return provider_protocol_module.ProviderTurnResult(
+                            tool_call=tool_contracts_module.ToolCall(
+                                tool_name="read_file",
+                                arguments={"filePath": "sample.txt"},
+                                tool_call_id="read-1",
+                            )
+                        )
+                    return provider_protocol_module.ProviderTurnResult(output="done")
+
+            return _Provider()
+
+    runtime = service_module.VoidCodeRuntime(
+        workspace=tmp_path,
+        config=config_module.RuntimeConfig(
+            approval_mode="allow",
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            context_window=config_module.RuntimeContextWindowConfig(max_tool_results=1),
+        ),
+        permission_policy=permission_module.PermissionPolicy(mode="allow"),
+        model_provider_registry=model_provider_module.ModelProviderRegistry(
+            providers={"opencode": _CompactionModelProvider()}
+        ),
+    )
+
+    response = runtime.run(
+        runtime_request(prompt="compact old output", session_id="provider-context-compacted")
+    )
+    snapshot = runtime.session_debug_snapshot(session_id="provider-context-compacted")
+
+    assert response.session.status == "completed"
+    assert len(requests) == 3
+    third_context = _assembled_context(requests[2])
+    assert [result.tool_name for result in third_context.tool_results] == ["read_file"]
+
+    provider_context = snapshot.provider_context
+    assert provider_context is not None
+    assert provider_context.context_window["compacted"] is True
+    assert provider_context.context_window["original_tool_result_count"] == 2
+    assert provider_context.context_window["retained_tool_result_count"] == 1
+    continuity = provider_context.context_window["continuity_state"]
+    assert isinstance(continuity, dict)
+    assert continuity["dropped_tool_result_count"] == 1
+    assert "shell_exec" in cast(str, continuity["summary_text"])
+    retained_tool_segments = [
+        segment for segment in provider_context.segments if segment.role == "tool"
+    ]
+    assert [segment.tool_name for segment in retained_tool_segments] == ["read_file"]
+    assert retained_tool_segments[0].content == third_context.tool_results[0].content
+    provider_message_text = "\n".join(
+        message.content or "" for message in provider_context.provider_messages
+    )
+    assert '"tool_name": "read_file"' in provider_message_text
+    assert '"tool_name": "shell_exec"' not in provider_message_text
+    assert any(
+        segment.role == "system"
+        and segment.source == "continuity_summary"
+        and "shell_exec" in (segment.content or "")
+        for segment in provider_context.segments
+    )
 
 
 def test_runtime_delegated_mcp_and_background_hook_events_have_exact_metadata(

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 from types import ModuleType
 from typing import Literal, cast
@@ -297,6 +298,194 @@ def test_provider_context_inspector_reports_tool_pairing_problems() -> None:
     assert "missing_tool_result" in diagnostic_codes
     assert "orphan_tool_result" in diagnostic_codes
     assert "provider_requires_tools_schema" in diagnostic_codes
+
+
+def test_provider_context_parity_matrix_preserves_tool_shapes_across_debug_messages() -> None:
+    raw_read_content = "\n".join(
+        [
+            "<path>sample.txt</path>",
+            "<type>file</type>",
+            "<content>",
+            "1: alpha",
+            "2: beta",
+            "(End of file - total 2 lines)",
+            "</content>",
+        ]
+    )
+    tool_results = (
+        ToolResult(
+            tool_name="read_file",
+            status="ok",
+            content=raw_read_content,
+            data={
+                "tool_call_id": "read-1",
+                "arguments": {"path": "sample.txt"},
+                "path": "sample.txt",
+                "type": "file",
+            },
+        ),
+        ToolResult(
+            tool_name="shell_exec",
+            status="ok",
+            content="line-1\n[truncated: .voidcode/tool-output/shell_exec-abc.txt]",
+            data={
+                "tool_call_id": "shell-1",
+                "arguments": {"command": "python script.py"},
+                "command": "python script.py",
+                "exit_code": 0,
+                "output_path": ".voidcode/tool-output/shell_exec-abc.txt",
+            },
+            truncated=True,
+            partial=True,
+            reference=".voidcode/tool-output/shell_exec-abc.txt",
+        ),
+        ToolResult(
+            tool_name="grep",
+            status="ok",
+            content="Found 2 match(es) for 'alpha' in src\nsrc/a.py:1: alpha",
+            data={
+                "tool_call_id": "grep-1",
+                "arguments": {"pattern": "alpha", "path": "src"},
+                "pattern": "alpha",
+                "match_count": 2,
+                "matches": [{"file": "src/a.py", "line": 1, "text": "alpha"}],
+            },
+        ),
+        ToolResult(
+            tool_name="todo_write",
+            status="ok",
+            content="Updated 1 todos\n1. [in_progress/high] preserve context parity",
+            data={
+                "tool_call_id": "todo-1",
+                "arguments": {
+                    "todos": [
+                        {
+                            "content": "preserve context parity",
+                            "status": "in_progress",
+                            "priority": "high",
+                        }
+                    ]
+                },
+                "todos": [
+                    {
+                        "content": "preserve context parity",
+                        "status": "in_progress",
+                        "priority": "high",
+                    }
+                ],
+                "summary": {"total": 1, "in_progress": 1},
+            },
+        ),
+        ToolResult(
+            tool_name="task",
+            status="ok",
+            content="Background task launched.\n\nBackground Task ID: bg_123",
+            data={
+                "tool_call_id": "task-1",
+                "arguments": {"prompt": "inspect child"},
+                "task_id": "bg_123",
+                "child_session_id": "child-session",
+            },
+            reference="session:child-session",
+        ),
+        ToolResult(
+            tool_name="background_output",
+            status="ok",
+            content="Task Result\n\nTask ID: bg_123\nSummary: child done",
+            data={
+                "tool_call_id": "background-1",
+                "arguments": {"task_id": "bg_123"},
+                "task_id": "bg_123",
+                "child_session_id": "child-session",
+                "summary_output": "child done",
+            },
+            reference="session:child-session",
+        ),
+    )
+    assembled = assemble_provider_context(
+        prompt="continue",
+        tool_results=tool_results,
+        session_metadata={
+            "runtime_state": {
+                "todos": {
+                    "version": 1,
+                    "revision": 1,
+                    "todos": [
+                        {
+                            "content": "preserve context parity",
+                            "status": "in_progress",
+                            "priority": "high",
+                            "position": 1,
+                            "updated_at": 1,
+                        }
+                    ],
+                }
+            }
+        },
+        policy=ContextWindowPolicy(auto_compaction=False, max_tool_result_tokens=100_000),
+    )
+
+    standard_snapshot = inspect_provider_context(
+        assembled_context=assembled,
+        provider="openai",
+        model="gpt-4o",
+        execution_engine="provider",
+        available_tool_count=6,
+    )
+    synthetic_tool_results = (tool_results[0], tool_results[-1])
+    synthetic_assembled = assemble_provider_context(
+        prompt="continue",
+        tool_results=synthetic_tool_results,
+        session_metadata={},
+        policy=ContextWindowPolicy(auto_compaction=False, max_tool_result_tokens=100_000),
+    )
+    synthetic_snapshot = inspect_provider_context(
+        assembled_context=synthetic_assembled,
+        provider="opencode-go",
+        model="minimax-m2.7",
+        execution_engine="provider",
+        available_tool_count=6,
+        tool_feedback_mode="synthetic_user_message",
+    )
+
+    tool_segments = [segment for segment in standard_snapshot.segments if segment.role == "tool"]
+    tool_messages = [
+        message for message in standard_snapshot.provider_messages if message.role == "tool"
+    ]
+    assert [segment.tool_name for segment in tool_segments] == [
+        result.tool_name for result in tool_results
+    ]
+    assert len(tool_messages) == len(tool_results)
+    for result, segment, message in zip(tool_results, tool_segments, tool_messages, strict=True):
+        assert segment.content == result.content
+        assert segment.metadata["status"] == result.status
+        assert segment.metadata["reference"] == result.reference
+        assert message.content is not None
+        payload = json.loads(message.content)
+        assert payload["tool_name"] == result.tool_name
+        assert payload["status"] == result.status
+        assert payload["content"] == result.content
+        assert payload["reference"] == result.reference
+        assert "tool_call_id" not in payload["data"]
+        assert "arguments" not in payload["data"]
+
+    todo_system_segments = [
+        segment
+        for segment in standard_snapshot.segments
+        if segment.role == "system" and segment.source == "runtime_todo_state"
+    ]
+    assert len(todo_system_segments) == 1
+    assert "preserve context parity" in (todo_system_segments[0].content or "")
+    synthetic_feedback = synthetic_snapshot.provider_messages[-1].content or ""
+    assert synthetic_snapshot.provider_messages[-1].source == "provider_synthetic_tool_feedback"
+    for result in synthetic_tool_results:
+        assert synthetic_feedback.count(f'"tool_name": "{result.tool_name}"') == 1
+    assert "1: alpha" in synthetic_feedback
+    assert "child done" in synthetic_feedback
+    assert any(
+        diagnostic.code == "provider_path_uses_synthetic_tool_feedback"
+        for diagnostic in synthetic_snapshot.diagnostics
+    )
 
 
 def test_prepare_provider_context_compacts_old_results_and_reports_metadata() -> None:


### PR DESCRIPTION
## Summary
- Add a unit provider-context parity matrix covering retained tool result shapes for read_file, shell_exec spill references, grep, todo_write, task, and background_output.
- Add integration coverage comparing live provider context with persisted transcript, replay, debug snapshots, raw-shape token estimates, and OpenCode-Go synthetic feedback.
- Cover compacted sessions to ensure provider-visible debug context retains only live-visible tool results while preserving dropped state in continuity summaries.

Closes #355

## Verification
- uv run pytest tests/unit/runtime/test_context_window.py::test_provider_context_parity_matrix_preserves_tool_shapes_across_debug_messages tests/integration/test_read_only_slice.py::test_provider_context_live_persisted_replay_and_debug_parity_for_read_file tests/integration/test_read_only_slice.py::test_provider_context_compacted_debug_snapshot_keeps_only_retained_live_shape
- uv run pytest tests/unit/runtime/test_context_window.py tests/integration/test_read_only_slice.py
- MISE_TRUSTED_CONFIG_PATHS=/home/hunter/Workspace/voidcode-355/mise.toml mise run lint
- MISE_TRUSTED_CONFIG_PATHS=/home/hunter/Workspace/voidcode-355/mise.toml mise run typecheck
- MISE_TRUSTED_CONFIG_PATHS=/home/hunter/Workspace/voidcode-355/mise.toml mise run test
- MISE_TRUSTED_CONFIG_PATHS=/home/hunter/Workspace/voidcode-355/mise.toml mise run frontend:lint
- MISE_TRUSTED_CONFIG_PATHS=/home/hunter/Workspace/voidcode-355/mise.toml mise run frontend:typecheck
- MISE_TRUSTED_CONFIG_PATHS=/home/hunter/Workspace/voidcode-355/mise.toml mise run frontend:test
- MISE_TRUSTED_CONFIG_PATHS=/home/hunter/Workspace/voidcode-355/mise.toml mise run frontend:build