### PR TITLE
feat(runtime): add tmp-first tool output artifacts

### DIFF
--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -909,6 +909,7 @@ def _serialize_session_debug_snapshot(
                 "status": snapshot.last_tool.status,
                 "summary": snapshot.last_tool.summary,
                 "arguments": snapshot.last_tool.arguments,
+                "artifact": getattr(snapshot.last_tool, "artifact", {}),
                 "sequence": snapshot.last_tool.sequence,
             }
             if snapshot.last_tool is not None

--- a/src/voidcode/runtime/bundle.py
+++ b/src/voidcode/runtime/bundle.py
@@ -565,6 +565,8 @@ class _SessionBundleBuilder:
         if not isinstance(artifact_id, str) or artifact_id == "":
             return None
         read_result = read_tool_output_artifact(artifact, offset=0, limit=1_000_000)
+        if read_result.get("status") == "invalid":
+            return None
         missing = bool(read_result.get("artifact_missing"))
         raw_content = read_result.get("content")
         content = raw_content if isinstance(raw_content, str) and not missing else None

--- a/src/voidcode/runtime/bundle.py
+++ b/src/voidcode/runtime/bundle.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Final, Literal, cast, final
 
 from .. import __version__ as VOIDCODE_VERSION
+from ..tools.output import read_tool_output_artifact
 from .contracts import (
     RuntimeRequest,
     RuntimeResponse,
@@ -171,6 +172,17 @@ class SessionBundleDiagnostics:
 
 
 @dataclass(frozen=True, slots=True)
+class SessionBundleArtifactPayload:
+    artifact_id: str
+    session_id: str | None
+    tool_call_id: str | None
+    tool_name: str | None
+    metadata: dict[str, object]
+    content: str | None
+    missing: bool
+
+
+@dataclass(frozen=True, slots=True)
 class SessionBundleManifest:
     schema_version: int
     voidcode_version: str
@@ -182,6 +194,7 @@ class SessionBundleManifest:
     session_count: int
     event_count: int
     background_task_count: int
+    artifact_count: int = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -190,6 +203,7 @@ class SessionBundle:
     sessions: tuple[SessionBundleSessionPayload, ...]
     background_tasks: tuple[SessionBundleBackgroundTaskPayload, ...]
     diagnostics: SessionBundleDiagnostics
+    artifacts: tuple[SessionBundleArtifactPayload, ...] = ()
 
     def to_payload(self) -> dict[str, object]:
         """Return the canonical JSON-serializable bundle payload."""
@@ -200,6 +214,7 @@ class SessionBundle:
             "sessions": [_session_payload(session) for session in self.sessions],
             "background_tasks": [_task_payload(task) for task in self.background_tasks],
             "diagnostics": _diagnostics_payload(self.diagnostics),
+            "artifacts": [_artifact_payload(artifact) for artifact in self.artifacts],
         }
 
 
@@ -251,6 +266,7 @@ def _manifest_payload(manifest: SessionBundleManifest) -> dict[str, object]:
         "session_count": manifest.session_count,
         "event_count": manifest.event_count,
         "background_task_count": manifest.background_task_count,
+        "artifact_count": manifest.artifact_count,
     }
 
 
@@ -278,6 +294,18 @@ def _task_payload(task: SessionBundleBackgroundTaskPayload) -> dict[str, object]
         "error": task.error,
         "created_at": task.created_at,
         "updated_at": task.updated_at,
+    }
+
+
+def _artifact_payload(artifact: SessionBundleArtifactPayload) -> dict[str, object]:
+    return {
+        "artifact_id": artifact.artifact_id,
+        "session_id": artifact.session_id,
+        "tool_call_id": artifact.tool_call_id,
+        "tool_name": artifact.tool_name,
+        "metadata": artifact.metadata,
+        "content": artifact.content,
+        "missing": artifact.missing,
     }
 
 
@@ -443,6 +471,8 @@ def _redaction_summary(options: SessionBundleOptions) -> dict[str, object]:
         notes.append(
             f"Tool output text is truncated to {options.tool_output_preview_chars} characters."
         )
+    else:
+        notes.append("Available temp tool output artifacts are embedded in the bundle.")
     return {
         "redacted": options.redact,
         "include_tool_output": options.include_tool_output,
@@ -478,6 +508,7 @@ class _SessionBundleBuilder:
         validate_session_id(session_id)
         sessions, event_count = self._collect_sessions(session_id=session_id)
         background_tasks = self._collect_background_tasks(session_id=session_id)
+        artifacts = self._collect_artifacts(sessions=sessions)
         manifest = SessionBundleManifest(
             schema_version=SESSION_BUNDLE_SCHEMA_VERSION,
             voidcode_version=VOIDCODE_VERSION,
@@ -489,6 +520,7 @@ class _SessionBundleBuilder:
             session_count=len(sessions),
             event_count=event_count,
             background_task_count=len(background_tasks),
+            artifact_count=len(artifacts),
         )
         diagnostics = SessionBundleDiagnostics(
             storage=self._sanitize_diagnostics_block(self._storage_diagnostics),
@@ -500,6 +532,55 @@ class _SessionBundleBuilder:
             sessions=sessions,
             background_tasks=background_tasks,
             diagnostics=diagnostics,
+            artifacts=artifacts,
+        )
+
+    def _collect_artifacts(
+        self, *, sessions: tuple[SessionBundleSessionPayload, ...]
+    ) -> tuple[SessionBundleArtifactPayload, ...]:
+        if not self._options.include_tool_output:
+            return ()
+        artifacts: list[SessionBundleArtifactPayload] = []
+        seen: set[str] = set()
+        for session in sessions:
+            for event in session.events:
+                payload = event.get("payload")
+                if not isinstance(payload, dict):
+                    continue
+                payload_dict = cast(dict[str, object], payload)
+                artifact = payload_dict.get("artifact")
+                if not isinstance(artifact, dict):
+                    continue
+                artifact_payload = self._build_artifact_payload(cast(dict[str, object], artifact))
+                if artifact_payload is None or artifact_payload.artifact_id in seen:
+                    continue
+                seen.add(artifact_payload.artifact_id)
+                artifacts.append(artifact_payload)
+        return tuple(artifacts)
+
+    def _build_artifact_payload(
+        self, artifact: dict[str, object]
+    ) -> SessionBundleArtifactPayload | None:
+        artifact_id = artifact.get("artifact_id")
+        if not isinstance(artifact_id, str) or artifact_id == "":
+            return None
+        read_result = read_tool_output_artifact(artifact, offset=0, limit=1_000_000)
+        missing = bool(read_result.get("artifact_missing"))
+        raw_content = read_result.get("content")
+        content = raw_content if isinstance(raw_content, str) and not missing else None
+        sanitized_content = _sanitize_export_text(content, options=self._options)
+        metadata = _apply_payload_options(dict(artifact), options=self._options)
+        session_id = artifact.get("session_id")
+        tool_call_id = artifact.get("tool_call_id")
+        tool_name = artifact.get("tool_name")
+        return SessionBundleArtifactPayload(
+            artifact_id=artifact_id,
+            session_id=session_id if isinstance(session_id, str) else None,
+            tool_call_id=tool_call_id if isinstance(tool_call_id, str) else None,
+            tool_name=tool_name if isinstance(tool_name, str) else None,
+            metadata={**metadata, "status": "missing" if missing else "available"},
+            content=sanitized_content,
+            missing=missing,
         )
 
     def _sanitize_diagnostics_block(
@@ -728,6 +809,9 @@ def parse_session_bundle(payload: object) -> SessionBundle:
             manifest_payload.get("background_task_count", 0),
             where="manifest.background_task_count",
         ),
+        artifact_count=_ensure_int(
+            manifest_payload.get("artifact_count", 0), where="manifest.artifact_count"
+        ),
     )
     sessions_raw = _ensure_list(root.get("sessions", []), where="sessions")
     sessions: list[SessionBundleSessionPayload] = []
@@ -745,11 +829,17 @@ def parse_session_bundle(payload: object) -> SessionBundle:
         config_summary=_optional_dict(diagnostics_payload.get("config_summary")),
         provider_summary=_optional_dict(diagnostics_payload.get("provider_summary")),
     )
+    artifacts_raw = _ensure_list(root.get("artifacts", []), where="artifacts")
+    artifacts: list[SessionBundleArtifactPayload] = []
+    for index, raw in enumerate(artifacts_raw):
+        artifact_dict = _ensure_dict(raw, where=f"artifacts[{index}]")
+        artifacts.append(_parse_artifact_payload(artifact_dict, index=index))
     return SessionBundle(
         manifest=manifest,
         sessions=tuple(sessions),
         background_tasks=tuple(tasks),
         diagnostics=diagnostics,
+        artifacts=tuple(artifacts),
     )
 
 
@@ -877,6 +967,43 @@ def _parse_task_payload(
         error=error,
         created_at=created_at,
         updated_at=updated_at,
+    )
+
+
+def _parse_artifact_payload(
+    payload: dict[str, object], *, index: int
+) -> SessionBundleArtifactPayload:
+    artifact_id = _ensure_str(payload.get("artifact_id"), where=f"artifacts[{index}].artifact_id")
+    raw_session_id = payload.get("session_id")
+    raw_tool_call_id = payload.get("tool_call_id")
+    raw_tool_name = payload.get("tool_name")
+    raw_content = payload.get("content")
+    return SessionBundleArtifactPayload(
+        artifact_id=artifact_id,
+        session_id=(
+            _ensure_str(raw_session_id, where=f"artifacts[{index}].session_id")
+            if isinstance(raw_session_id, str)
+            else None
+        ),
+        tool_call_id=(
+            _ensure_str(raw_tool_call_id, where=f"artifacts[{index}].tool_call_id")
+            if isinstance(raw_tool_call_id, str)
+            else None
+        ),
+        tool_name=(
+            _ensure_str(raw_tool_name, where=f"artifacts[{index}].tool_name")
+            if isinstance(raw_tool_name, str)
+            else None
+        ),
+        metadata=dict(
+            _ensure_dict(payload.get("metadata", {}), where=f"artifacts[{index}].metadata")
+        ),
+        content=(
+            _ensure_str(raw_content, where=f"artifacts[{index}].content")
+            if isinstance(raw_content, str)
+            else None
+        ),
+        missing=bool(payload.get("missing", False)),
     )
 
 
@@ -1191,6 +1318,7 @@ __all__ = [
     "SESSION_BUNDLE_SCHEMA_NAME",
     "SESSION_BUNDLE_SCHEMA_VERSION",
     "SessionBundle",
+    "SessionBundleArtifactPayload",
     "SessionBundleBackgroundTaskPayload",
     "SessionBundleDiagnostics",
     "SessionBundleError",

--- a/src/voidcode/runtime/bundle.py
+++ b/src/voidcode/runtime/bundle.py
@@ -109,6 +109,7 @@ _TOOL_OUTPUT_KEYS: Final[frozenset[str]] = frozenset(
 
 
 _DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS: Final[int] = 2_000
+_BUNDLE_ARTIFACT_READ_LIMIT_LINES: Final[int] = 1_000_000
 
 
 class SessionBundleError(ValueError):
@@ -180,6 +181,8 @@ class SessionBundleArtifactPayload:
     metadata: dict[str, object]
     content: str | None
     missing: bool
+    content_truncated: bool = False
+    content_next_offset: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -306,6 +309,8 @@ def _artifact_payload(artifact: SessionBundleArtifactPayload) -> dict[str, objec
         "metadata": artifact.metadata,
         "content": artifact.content,
         "missing": artifact.missing,
+        "content_truncated": artifact.content_truncated,
+        "content_next_offset": artifact.content_next_offset,
     }
 
 
@@ -564,13 +569,18 @@ class _SessionBundleBuilder:
         artifact_id = artifact.get("artifact_id")
         if not isinstance(artifact_id, str) or artifact_id == "":
             return None
-        read_result = read_tool_output_artifact(artifact, offset=0, limit=1_000_000)
+        read_result = read_tool_output_artifact(
+            artifact, offset=0, limit=_BUNDLE_ARTIFACT_READ_LIMIT_LINES
+        )
         if read_result.get("status") == "invalid":
             return None
         missing = bool(read_result.get("artifact_missing"))
         raw_content = read_result.get("content")
         content = raw_content if isinstance(raw_content, str) and not missing else None
         sanitized_content = _sanitize_export_text(content, options=self._options)
+        raw_next_offset = read_result.get("next_offset")
+        content_next_offset = raw_next_offset if isinstance(raw_next_offset, int) else None
+        content_truncated = content_next_offset is not None
         metadata = _apply_payload_options(dict(artifact), options=self._options)
         session_id = artifact.get("session_id")
         tool_call_id = artifact.get("tool_call_id")
@@ -580,9 +590,17 @@ class _SessionBundleBuilder:
             session_id=session_id if isinstance(session_id, str) else None,
             tool_call_id=tool_call_id if isinstance(tool_call_id, str) else None,
             tool_name=tool_name if isinstance(tool_name, str) else None,
-            metadata={**metadata, "status": "missing" if missing else "available"},
+            metadata={
+                **metadata,
+                "status": "missing" if missing else "available",
+                "content_truncated": content_truncated,
+                "content_next_offset": content_next_offset,
+                "bundle_read_limit_lines": _BUNDLE_ARTIFACT_READ_LIMIT_LINES,
+            },
             content=sanitized_content,
             missing=missing,
+            content_truncated=content_truncated,
+            content_next_offset=content_next_offset,
         )
 
     def _sanitize_diagnostics_block(
@@ -980,6 +998,7 @@ def _parse_artifact_payload(
     raw_tool_call_id = payload.get("tool_call_id")
     raw_tool_name = payload.get("tool_name")
     raw_content = payload.get("content")
+    raw_content_next_offset = payload.get("content_next_offset")
     return SessionBundleArtifactPayload(
         artifact_id=artifact_id,
         session_id=(
@@ -1006,6 +1025,12 @@ def _parse_artifact_payload(
             else None
         ),
         missing=bool(payload.get("missing", False)),
+        content_truncated=bool(payload.get("content_truncated", False)),
+        content_next_offset=(
+            _ensure_int(raw_content_next_offset, where=f"artifacts[{index}].content_next_offset")
+            if raw_content_next_offset is not None
+            else None
+        ),
     )
 
 

--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -748,6 +748,7 @@ class RuntimeSessionDebugToolSummary:
     status: str
     summary: str
     arguments: dict[str, object] = field(default_factory=dict)
+    artifact: dict[str, object] = field(default_factory=dict)
     sequence: int | None = None
 
 

--- a/src/voidcode/runtime/http.py
+++ b/src/voidcode/runtime/http.py
@@ -1990,6 +1990,7 @@ class RuntimeTransportApp:
                     "status": snapshot.last_tool.status,
                     "summary": snapshot.last_tool.summary,
                     "arguments": snapshot.last_tool.arguments,
+                    "artifact": getattr(snapshot.last_tool, "artifact", {}),
                     "sequence": snapshot.last_tool.sequence,
                 }
                 if snapshot.last_tool is not None

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -340,7 +340,12 @@ class RuntimeRunLoopCoordinator:
             )
 
         sanitized_arguments = sanitize_tool_arguments(dict(tool_call.arguments))
-        tool_result = cap_tool_result_output(tool_result, workspace=runtime._workspace)
+        tool_result = cap_tool_result_output(
+            tool_result,
+            workspace=runtime._workspace,
+            session_id=session.session.id,
+            tool_call_id=tool_call_id,
+        )
         tool_result = replace(
             tool_result,
             data=sanitize_tool_result_data(tool_result.data),
@@ -1166,7 +1171,12 @@ class RuntimeRunLoopCoordinator:
                 return
 
             sanitized_arguments = sanitize_tool_arguments(dict(plan_tool_call.arguments))
-            tool_result = cap_tool_result_output(tool_result, workspace=runtime._workspace)
+            tool_result = cap_tool_result_output(
+                tool_result,
+                workspace=runtime._workspace,
+                session_id=session.session.id,
+                tool_call_id=tool_call_id,
+            )
             tool_result = replace(
                 tool_result,
                 data=sanitize_tool_result_data(tool_result.data),

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -68,7 +68,14 @@ from ..tools.contracts import (
     ToolResult,
 )
 from ..tools.guidance import definition_with_guidance
-from ..tools.output import sanitize_tool_result_data
+from ..tools.output import (
+    read_tool_output_artifact,
+    sanitize_tool_result_data,
+    search_tool_output_artifact,
+)
+from ..tools.output import (
+    resolve_tool_output_artifact as resolve_tool_output_artifact_metadata,
+)
 from ..tools.question import QuestionTool
 from ..tools.runtime_context import current_runtime_tool_context
 from ..tools.skill import SkillTool
@@ -2647,6 +2654,83 @@ class VoidCodeRuntime:
         self._validate_session_workspace(result.session, session_id=session_id)
         return result
 
+    def resolve_tool_output_artifact(
+        self,
+        *,
+        session_id: str,
+        artifact_id: str | None = None,
+        tool_call_id: str | None = None,
+    ) -> dict[str, object]:
+        """Resolve spilled tool output artifact metadata for a session."""
+
+        result = self._load_session_result(session_id=session_id)
+        artifact = resolve_tool_output_artifact_metadata(
+            result.transcript,
+            artifact_id=artifact_id,
+            tool_call_id=tool_call_id,
+        )
+        if artifact is None:
+            return {
+                "status": "artifact_not_found",
+                "artifact_missing": True,
+                "artifact_id": artifact_id,
+                "tool_call_id": tool_call_id,
+                "session_id": session_id,
+            }
+        read_result = read_tool_output_artifact(artifact, offset=0, limit=0)
+        status = read_result.get("status")
+        return {
+            **artifact,
+            "status": status if isinstance(status, str) else artifact.get("status", "unknown"),
+            "artifact_missing": bool(read_result.get("artifact_missing")),
+        }
+
+    def read_tool_output_artifact(
+        self,
+        *,
+        session_id: str,
+        artifact_id: str | None = None,
+        tool_call_id: str | None = None,
+        offset: int = 0,
+        limit: int = 2000,
+    ) -> dict[str, object]:
+        """Read a bounded slice from a spilled tool output artifact."""
+
+        artifact = self.resolve_tool_output_artifact(
+            session_id=session_id,
+            artifact_id=artifact_id,
+            tool_call_id=tool_call_id,
+        )
+        if artifact.get("status") == "artifact_not_found":
+            return artifact
+        return read_tool_output_artifact(artifact, offset=offset, limit=limit)
+
+    def search_tool_output_artifact(
+        self,
+        *,
+        session_id: str,
+        pattern: str,
+        artifact_id: str | None = None,
+        tool_call_id: str | None = None,
+        case_sensitive: bool = False,
+        limit: int = 100,
+    ) -> dict[str, object]:
+        """Search a spilled tool output artifact by artifact id or tool call id."""
+
+        artifact = self.resolve_tool_output_artifact(
+            session_id=session_id,
+            artifact_id=artifact_id,
+            tool_call_id=tool_call_id,
+        )
+        if artifact.get("status") == "artifact_not_found":
+            return artifact
+        return search_tool_output_artifact(
+            artifact,
+            pattern=pattern,
+            case_sensitive=case_sensitive,
+            limit=limit,
+        )
+
     def session_debug_snapshot(self, *, session_id: str) -> RuntimeSessionDebugSnapshot:
         validate_session_id(session_id)
         active = self._is_active_session_id(session_id)
@@ -4299,6 +4383,7 @@ class VoidCodeRuntime:
             if len(summary) > 160:
                 summary = summary[:157] + "..."
             arguments = payload.get("arguments")
+            artifact = VoidCodeRuntime._artifact_debug_metadata(payload)
             return RuntimeSessionDebugToolSummary(
                 tool_name=tool_name,
                 status=status,
@@ -4306,9 +4391,40 @@ class VoidCodeRuntime:
                 arguments=(
                     dict(cast(dict[str, object], arguments)) if isinstance(arguments, dict) else {}
                 ),
+                artifact=artifact,
                 sequence=event.sequence,
             )
         return None
+
+    @staticmethod
+    def _artifact_debug_metadata(payload: dict[str, object]) -> dict[str, object]:
+        artifact = payload.get("artifact")
+        if not isinstance(artifact, dict):
+            return {}
+        artifact_metadata = dict(cast(dict[str, object], artifact))
+        read_result = read_tool_output_artifact(artifact_metadata, offset=0, limit=0)
+        status = read_result.get("status")
+        if isinstance(status, str):
+            artifact_metadata["status"] = status
+        artifact_metadata["artifact_missing"] = bool(read_result.get("artifact_missing"))
+        if "content" in artifact_metadata:
+            artifact_metadata.pop("content")
+        return artifact_metadata
+
+    @classmethod
+    def _payload_with_artifact_status(cls, payload: dict[str, object]) -> dict[str, object]:
+        artifact = payload.get("artifact")
+        if not isinstance(artifact, dict):
+            return dict(payload)
+        artifact_metadata = cls._artifact_debug_metadata(payload)
+        return {
+            **payload,
+            "artifact": artifact_metadata,
+            "artifact_status": artifact_metadata.get("status", payload.get("artifact_status")),
+            "artifact_missing": artifact_metadata.get(
+                "artifact_missing", payload.get("artifact_missing")
+            ),
+        }
 
     def _provider_context_debug_snapshot(
         self,
@@ -4386,6 +4502,7 @@ class VoidCodeRuntime:
             "tool",
             "tool_status",
         }
+        payload = VoidCodeRuntime._payload_with_artifact_status(payload)
         return sanitize_tool_result_data(
             {key: value for key, value in payload.items() if key not in runtime_envelope_keys}
         )

--- a/src/voidcode/tools/__init__.py
+++ b/src/voidcode/tools/__init__.py
@@ -16,9 +16,11 @@ from .output import (
     MAX_TOOL_OUTPUT_BYTES,
     MAX_TOOL_OUTPUT_LINES,
     cap_tool_result_output,
+    read_tool_output_artifact,
     sanitize_tool_arguments,
     sanitize_tool_data,
     sanitize_tool_result_data,
+    search_tool_output_artifact,
 )
 from .question import QuestionTool
 from .read_file import ReadFileTool
@@ -63,7 +65,9 @@ __all__ = [
     "MAX_TOOL_OUTPUT_BYTES",
     "MAX_TOOL_OUTPUT_LINES",
     "cap_tool_result_output",
+    "read_tool_output_artifact",
     "sanitize_tool_arguments",
     "sanitize_tool_data",
     "sanitize_tool_result_data",
+    "search_tool_output_artifact",
 ]

--- a/src/voidcode/tools/__init__.py
+++ b/src/voidcode/tools/__init__.py
@@ -17,10 +17,12 @@ from .output import (
     MAX_TOOL_OUTPUT_LINES,
     cap_tool_result_output,
     read_tool_output_artifact,
+    resolve_tool_output_artifact,
     sanitize_tool_arguments,
     sanitize_tool_data,
     sanitize_tool_result_data,
     search_tool_output_artifact,
+    tool_output_artifact_temp_root,
 )
 from .question import QuestionTool
 from .read_file import ReadFileTool
@@ -66,8 +68,10 @@ __all__ = [
     "MAX_TOOL_OUTPUT_LINES",
     "cap_tool_result_output",
     "read_tool_output_artifact",
+    "resolve_tool_output_artifact",
     "sanitize_tool_arguments",
     "sanitize_tool_data",
     "sanitize_tool_result_data",
     "search_tool_output_artifact",
+    "tool_output_artifact_temp_root",
 ]

--- a/src/voidcode/tools/output.py
+++ b/src/voidcode/tools/output.py
@@ -351,7 +351,7 @@ def resolve_tool_output_artifact(
             continue
         artifact_dict = dict(artifact_mapping)
         if _artifact_path_from_metadata(artifact_dict) is None:
-            return None
+            continue
         return artifact_dict
     return None
 

--- a/src/voidcode/tools/output.py
+++ b/src/voidcode/tools/output.py
@@ -28,6 +28,7 @@ _SENSITIVE_TEXT_ARGUMENT_KEYS = frozenset(
 _INLINE_BLOB_KEYS = frozenset({"data_uri", "dataUri", "base64", "blob"})
 _ARTIFACT_REFERENCE_PREFIX = "artifact:"
 _ARTIFACT_PRODUCER = "voidcode.tool_output.v1"
+_ARTIFACT_ID_PATTERN = re.compile(r"^artifact_[0-9a-f]{24}$")
 _ARTIFACT_TEMP_ROOT_NAME = "voidcode-tool-output"
 _EMPTY_REDACTED_ARGUMENT_KEYS: frozenset[str] = frozenset()
 _PROVIDER_REDACTED_ARGUMENT_KEYS_BY_TOOL = {
@@ -291,7 +292,7 @@ def _artifact_path_from_metadata(artifact: Mapping[str, object]) -> Path | None:
     if producer != _ARTIFACT_PRODUCER:
         return None
     artifact_id = artifact.get("artifact_id")
-    if not isinstance(artifact_id, str) or not artifact_id.startswith("artifact_"):
+    if not isinstance(artifact_id, str) or _ARTIFACT_ID_PATTERN.fullmatch(artifact_id) is None:
         return None
     raw_path = artifact.get("path")
     if not isinstance(raw_path, str) or raw_path == "":
@@ -300,7 +301,7 @@ def _artifact_path_from_metadata(artifact: Mapping[str, object]) -> Path | None:
     root = tool_output_artifact_temp_root().resolve()
     if path == root or root not in path.parents:
         return None
-    if artifact_id not in path.name:
+    if not path.name.endswith(f"-{artifact_id}.txt"):
         return None
     return path
 

--- a/src/voidcode/tools/output.py
+++ b/src/voidcode/tools/output.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import os
 import re
-import tempfile
+import sys
 import time
 from collections.abc import Mapping
 from dataclasses import replace
@@ -29,7 +29,7 @@ _INLINE_BLOB_KEYS = frozenset({"data_uri", "dataUri", "base64", "blob"})
 _ARTIFACT_REFERENCE_PREFIX = "artifact:"
 _ARTIFACT_PRODUCER = "voidcode.tool_output.v1"
 _ARTIFACT_ID_PATTERN = re.compile(r"^artifact_[0-9a-f]{24}$")
-_ARTIFACT_TEMP_ROOT_NAME = "voidcode-tool-output"
+_ARTIFACT_CACHE_DIR_NAME = "tool-output"
 _EMPTY_REDACTED_ARGUMENT_KEYS: frozenset[str] = frozenset()
 _PROVIDER_REDACTED_ARGUMENT_KEYS_BY_TOOL = {
     "apply_patch": frozenset({"patch"}),
@@ -174,10 +174,24 @@ def _safe_artifact_segment(value: str | None, *, fallback: str) -> str:
     return safe[:96] or fallback
 
 
-def tool_output_artifact_temp_root() -> Path:
-    """Return the private runtime temp root for tool output artifacts."""
+def _user_cache_root() -> Path:
+    if sys.platform == "win32":
+        cache_home = os.environ.get("LOCALAPPDATA") or os.environ.get("APPDATA")
+        if cache_home:
+            return Path(cache_home) / "voidcode"
+        return Path.home() / "AppData" / "Local" / "voidcode"
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Caches" / "voidcode"
+    cache_home = os.environ.get("XDG_CACHE_HOME")
+    if cache_home:
+        return Path(cache_home) / "voidcode"
+    return Path.home() / ".cache" / "voidcode"
 
-    root = Path(tempfile.gettempdir()) / _ARTIFACT_TEMP_ROOT_NAME
+
+def tool_output_artifact_temp_root() -> Path:
+    """Return the private per-user root for tool output artifacts."""
+
+    root = _user_cache_root() / _ARTIFACT_CACHE_DIR_NAME
     root.mkdir(mode=0o700, parents=True, exist_ok=True)
     try:
         root.chmod(0o700)

--- a/src/voidcode/tools/output.py
+++ b/src/voidcode/tools/output.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import re
 import tempfile
 import time
@@ -26,6 +27,8 @@ _SENSITIVE_TEXT_ARGUMENT_KEYS = frozenset(
 )
 _INLINE_BLOB_KEYS = frozenset({"data_uri", "dataUri", "base64", "blob"})
 _ARTIFACT_REFERENCE_PREFIX = "artifact:"
+_ARTIFACT_PRODUCER = "voidcode.tool_output.v1"
+_ARTIFACT_TEMP_ROOT_NAME = "voidcode-tool-output"
 
 
 def _string_summary(value: str, *, include_preview: bool) -> dict[str, object]:
@@ -106,6 +109,18 @@ def _safe_artifact_segment(value: str | None, *, fallback: str) -> str:
     return safe[:96] or fallback
 
 
+def tool_output_artifact_temp_root() -> Path:
+    """Return the private runtime temp root for tool output artifacts."""
+
+    root = Path(tempfile.gettempdir()) / _ARTIFACT_TEMP_ROOT_NAME
+    root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    try:
+        root.chmod(0o700)
+    except OSError:
+        pass
+    return root
+
+
 def _artifact_id(
     *,
     session_id: str | None,
@@ -126,7 +141,7 @@ def _tool_output_artifact_path(
     tool_name: str,
     artifact_id: str,
 ) -> Path:
-    temp_root = Path(tempfile.gettempdir()) / "voidcode-tool-output"
+    temp_root = tool_output_artifact_temp_root()
     session_segment = _safe_artifact_segment(session_id, fallback="unknown-session")
     call_segment = _safe_artifact_segment(tool_call_id, fallback="unknown-tool-call")
     tool_segment = _safe_artifact_segment(tool_name, fallback="tool")
@@ -155,15 +170,31 @@ def _artifact_metadata(
         tool_name=tool_name,
         artifact_id=artifact_id,
     )
-    artifact_path.parent.mkdir(parents=True, exist_ok=True)
-    artifact_path.write_text(content, encoding="utf-8", newline="\n")
+    artifact_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    try:
+        artifact_path.parent.chmod(0o700)
+    except OSError:
+        pass
+    encoded_with_newlines = content.encode("utf-8")
+    file_descriptor = os.open(
+        artifact_path,
+        os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+        0o600,
+    )
+    with os.fdopen(file_descriptor, "w", encoding="utf-8", newline="\n") as artifact_file:
+        _ = artifact_file.write(content)
+    try:
+        artifact_path.chmod(0o600)
+    except OSError:
+        pass
     return {
         "artifact_id": artifact_id,
+        "producer": _ARTIFACT_PRODUCER,
         "session_id": session_id,
         "tool_call_id": tool_call_id,
         "tool_name": tool_name,
         "kind": kind,
-        "byte_count": len(encoded),
+        "byte_count": len(encoded_with_newlines),
         "line_count": len(content.splitlines()),
         "sha256": content_hash,
         "content_type": "text/plain; charset=utf-8",
@@ -183,11 +214,81 @@ def _artifact_missing_payload(artifact: Mapping[str, object]) -> dict[str, objec
     }
 
 
+def _artifact_invalid_payload(artifact: Mapping[str, object]) -> dict[str, object]:
+    return {
+        "artifact_id": artifact.get("artifact_id"),
+        "status": "invalid",
+        "artifact_missing": True,
+    }
+
+
 def _artifact_path_from_metadata(artifact: Mapping[str, object]) -> Path | None:
+    producer = artifact.get("producer")
+    if producer != _ARTIFACT_PRODUCER:
+        return None
+    artifact_id = artifact.get("artifact_id")
+    if not isinstance(artifact_id, str) or not artifact_id.startswith("artifact_"):
+        return None
     raw_path = artifact.get("path")
     if not isinstance(raw_path, str) or raw_path == "":
         return None
-    return Path(raw_path)
+    path = Path(raw_path).resolve()
+    root = tool_output_artifact_temp_root().resolve()
+    if path == root or root not in path.parents:
+        return None
+    if artifact_id not in path.name:
+        return None
+    return path
+
+
+def _line_count(path: Path) -> int:
+    count = 0
+    with path.open(encoding="utf-8") as artifact_file:
+        for _line in artifact_file:
+            count += 1
+    return count
+
+
+def _event_payload(event: object) -> Mapping[str, object] | None:
+    if isinstance(event, Mapping):
+        event_mapping = cast(Mapping[str, object], event)
+        payload = event_mapping.get("payload")
+    else:
+        payload = getattr(event, "payload", None)
+    if not isinstance(payload, Mapping):
+        return None
+    return cast(Mapping[str, object], payload)
+
+
+def resolve_tool_output_artifact(
+    events: object,
+    *,
+    artifact_id: str | None = None,
+    tool_call_id: str | None = None,
+) -> dict[str, object] | None:
+    """Resolve runtime-generated artifact metadata from event payloads by id or tool call."""
+
+    if artifact_id is None and tool_call_id is None:
+        raise ValueError("artifact_id or tool_call_id is required")
+    if not isinstance(events, list | tuple):
+        return None
+    for event in cast(list[object] | tuple[object, ...], events):
+        payload = _event_payload(event)
+        if payload is None:
+            continue
+        artifact = payload.get("artifact")
+        if not isinstance(artifact, Mapping):
+            continue
+        artifact_mapping = cast(Mapping[str, object], artifact)
+        if artifact_id is not None and artifact_mapping.get("artifact_id") != artifact_id:
+            continue
+        if tool_call_id is not None and artifact_mapping.get("tool_call_id") != tool_call_id:
+            continue
+        artifact_dict = dict(artifact_mapping)
+        if _artifact_path_from_metadata(artifact_dict) is None:
+            return None
+        return artifact_dict
+    return None
 
 
 def read_tool_output_artifact(
@@ -199,21 +300,31 @@ def read_tool_output_artifact(
     """Read a bounded line slice from a temp-backed tool output artifact."""
 
     path = _artifact_path_from_metadata(artifact)
-    if path is None or not path.is_file():
+    if path is None:
+        return _artifact_invalid_payload(artifact)
+    if not path.is_file():
         return _artifact_missing_payload(artifact)
 
-    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
     start = max(0, offset)
     bounded_limit = max(0, limit)
-    selected = lines[start : start + bounded_limit]
+    selected: list[str] = []
+    next_offset: int | None = None
+    with path.open(encoding="utf-8") as artifact_file:
+        for line_index, line in enumerate(artifact_file):
+            if line_index < start:
+                continue
+            if len(selected) >= bounded_limit:
+                next_offset = line_index
+                break
+            selected.append(line)
     return {
         "artifact_id": artifact.get("artifact_id"),
         "status": "available",
         "artifact_missing": False,
         "offset": start,
         "limit": bounded_limit,
-        "line_count": len(lines),
-        "next_offset": start + len(selected) if start + len(selected) < len(lines) else None,
+        "line_count": _line_count(path),
+        "next_offset": next_offset,
         "content": "".join(selected),
     }
 
@@ -228,17 +339,21 @@ def search_tool_output_artifact(
     """Search a temp-backed tool output artifact and return bounded matching lines."""
 
     path = _artifact_path_from_metadata(artifact)
-    if path is None or not path.is_file():
+    if path is None:
+        return _artifact_invalid_payload(artifact)
+    if not path.is_file():
         return _artifact_missing_payload(artifact)
 
     flags = 0 if case_sensitive else re.IGNORECASE
     regex = re.compile(pattern, flags)
     matches: list[dict[str, object]] = []
-    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-        if regex.search(line):
-            matches.append({"line_number": line_number, "line": line})
-            if len(matches) >= max(0, limit):
-                break
+    with path.open(encoding="utf-8") as artifact_file:
+        for line_number, line in enumerate(artifact_file, start=1):
+            line_text = line.rstrip("\n")
+            if regex.search(line_text):
+                matches.append({"line_number": line_number, "line": line_text})
+                if len(matches) >= max(0, limit):
+                    break
     return {
         "artifact_id": artifact.get("artifact_id"),
         "status": "available",
@@ -357,8 +472,10 @@ __all__ = [
     "MAX_TOOL_OUTPUT_LINES",
     "cap_tool_result_output",
     "read_tool_output_artifact",
+    "resolve_tool_output_artifact",
     "sanitize_tool_arguments",
     "sanitize_tool_data",
     "sanitize_tool_result_data",
     "search_tool_output_artifact",
+    "tool_output_artifact_temp_root",
 ]

--- a/src/voidcode/tools/output.py
+++ b/src/voidcode/tools/output.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 import hashlib
+import re
+import tempfile
+import time
+from collections.abc import Mapping
 from dataclasses import replace
 from pathlib import Path
 from typing import cast
@@ -21,6 +25,7 @@ _SENSITIVE_TEXT_ARGUMENT_KEYS = frozenset(
     }
 )
 _INLINE_BLOB_KEYS = frozenset({"data_uri", "dataUri", "base64", "blob"})
+_ARTIFACT_REFERENCE_PREFIX = "artifact:"
 
 
 def _string_summary(value: str, *, include_preview: bool) -> dict[str, object]:
@@ -95,20 +100,167 @@ def _preview_text(content: str, *, max_lines: int, max_bytes: int) -> str:
     return _utf8_prefix(line_limited, max_bytes=max_bytes)
 
 
-def _tool_output_reference_path(workspace: Path, tool_name: str, content: str) -> Path:
-    digest = hashlib.sha256(f"{tool_name}\0{content}".encode()).hexdigest()[:24]
-    safe_tool_name = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in tool_name)
-    return workspace / ".voidcode" / "tool-output" / f"{safe_tool_name}-{digest}.txt"
+def _safe_artifact_segment(value: str | None, *, fallback: str) -> str:
+    raw = value if value else fallback
+    safe = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in raw)
+    return safe[:96] or fallback
+
+
+def _artifact_id(
+    *,
+    session_id: str | None,
+    tool_call_id: str | None,
+    tool_name: str,
+    content_hash: str,
+) -> str:
+    digest = hashlib.sha256(
+        f"{session_id or ''}\0{tool_call_id or ''}\0{tool_name}\0{content_hash}".encode()
+    ).hexdigest()[:24]
+    return f"artifact_{digest}"
+
+
+def _tool_output_artifact_path(
+    *,
+    session_id: str | None,
+    tool_call_id: str | None,
+    tool_name: str,
+    artifact_id: str,
+) -> Path:
+    temp_root = Path(tempfile.gettempdir()) / "voidcode-tool-output"
+    session_segment = _safe_artifact_segment(session_id, fallback="unknown-session")
+    call_segment = _safe_artifact_segment(tool_call_id, fallback="unknown-tool-call")
+    tool_segment = _safe_artifact_segment(tool_name, fallback="tool")
+    return temp_root / session_segment / f"{call_segment}-{tool_segment}-{artifact_id}.txt"
+
+
+def _artifact_metadata(
+    *,
+    session_id: str | None,
+    tool_call_id: str | None,
+    tool_name: str,
+    content: str,
+    kind: str,
+) -> dict[str, object]:
+    encoded = content.encode("utf-8")
+    content_hash = hashlib.sha256(encoded).hexdigest()
+    artifact_id = _artifact_id(
+        session_id=session_id,
+        tool_call_id=tool_call_id,
+        tool_name=tool_name,
+        content_hash=content_hash,
+    )
+    artifact_path = _tool_output_artifact_path(
+        session_id=session_id,
+        tool_call_id=tool_call_id,
+        tool_name=tool_name,
+        artifact_id=artifact_id,
+    )
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    artifact_path.write_text(content, encoding="utf-8", newline="\n")
+    return {
+        "artifact_id": artifact_id,
+        "session_id": session_id,
+        "tool_call_id": tool_call_id,
+        "tool_name": tool_name,
+        "kind": kind,
+        "byte_count": len(encoded),
+        "line_count": len(content.splitlines()),
+        "sha256": content_hash,
+        "content_type": "text/plain; charset=utf-8",
+        "created_at": int(time.time() * 1000),
+        "path": str(artifact_path),
+        "uri": artifact_path.resolve().as_uri(),
+        "status": "available",
+    }
+
+
+def _artifact_missing_payload(artifact: Mapping[str, object]) -> dict[str, object]:
+    return {
+        "artifact_id": artifact.get("artifact_id"),
+        "status": "missing",
+        "artifact_missing": True,
+        "path": artifact.get("path"),
+    }
+
+
+def _artifact_path_from_metadata(artifact: Mapping[str, object]) -> Path | None:
+    raw_path = artifact.get("path")
+    if not isinstance(raw_path, str) or raw_path == "":
+        return None
+    return Path(raw_path)
+
+
+def read_tool_output_artifact(
+    artifact: Mapping[str, object],
+    *,
+    offset: int = 0,
+    limit: int = 2000,
+) -> dict[str, object]:
+    """Read a bounded line slice from a temp-backed tool output artifact."""
+
+    path = _artifact_path_from_metadata(artifact)
+    if path is None or not path.is_file():
+        return _artifact_missing_payload(artifact)
+
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    start = max(0, offset)
+    bounded_limit = max(0, limit)
+    selected = lines[start : start + bounded_limit]
+    return {
+        "artifact_id": artifact.get("artifact_id"),
+        "status": "available",
+        "artifact_missing": False,
+        "offset": start,
+        "limit": bounded_limit,
+        "line_count": len(lines),
+        "next_offset": start + len(selected) if start + len(selected) < len(lines) else None,
+        "content": "".join(selected),
+    }
+
+
+def search_tool_output_artifact(
+    artifact: Mapping[str, object],
+    *,
+    pattern: str,
+    case_sensitive: bool = False,
+    limit: int = 100,
+) -> dict[str, object]:
+    """Search a temp-backed tool output artifact and return bounded matching lines."""
+
+    path = _artifact_path_from_metadata(artifact)
+    if path is None or not path.is_file():
+        return _artifact_missing_payload(artifact)
+
+    flags = 0 if case_sensitive else re.IGNORECASE
+    regex = re.compile(pattern, flags)
+    matches: list[dict[str, object]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if regex.search(line):
+            matches.append({"line_number": line_number, "line": line})
+            if len(matches) >= max(0, limit):
+                break
+    return {
+        "artifact_id": artifact.get("artifact_id"),
+        "status": "available",
+        "artifact_missing": False,
+        "pattern": pattern,
+        "match_count": len(matches),
+        "matches": matches,
+    }
 
 
 def cap_tool_result_output(
     result: ToolResult,
     *,
     workspace: Path,
+    session_id: str | None = None,
+    tool_call_id: str | None = None,
     max_lines: int = MAX_TOOL_OUTPUT_LINES,
     max_bytes: int = MAX_TOOL_OUTPUT_BYTES,
 ) -> ToolResult:
-    """Cap model-visible tool output/error text and save the full text by reference."""
+    """Cap model-visible tool output/error text and save the full text as a temp artifact."""
+
+    _ = workspace  # kept for compatibility with existing tool-output capping call sites
 
     if result.content is None or result.content == "":
         if result.error is None or result.error == "":
@@ -117,21 +269,31 @@ def cap_tool_result_output(
         error_lines = len(result.error.splitlines())
         if error_size <= max_bytes and error_lines <= max_lines:
             return result
-        output_path = _tool_output_reference_path(
-            workspace.resolve(), result.tool_name, result.error
+        artifact = _artifact_metadata(
+            session_id=session_id,
+            tool_call_id=tool_call_id,
+            tool_name=result.tool_name,
+            content=result.error,
+            kind="error",
         )
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_text(result.error, encoding="utf-8", newline="\n")
         preview = _preview_text(result.error, max_lines=max_lines, max_bytes=max_bytes)
-        reference = output_path.relative_to(workspace.resolve()).as_posix()
-        hint = f"\n\n[Tool error truncated: Full error saved to: {reference}]"
+        reference = f"{_ARTIFACT_REFERENCE_PREFIX}{artifact['artifact_id']}"
+        hint = (
+            "\n\n[Tool error truncated: "
+            f"artifact_id={artifact['artifact_id']}. "
+            "Use artifact retrieval by artifact_id or tool_call_id to read/search the full error.]"
+        )
         return replace(
             result,
             error=f"{preview}{hint}",
             data={
                 **result.data,
                 "truncated": True,
-                "output_path": reference,
+                "artifact": artifact,
+                "artifact_id": artifact["artifact_id"],
+                "artifact_status": "available",
+                "artifact_missing": False,
+                "output_path": artifact["path"],
                 "original_error_byte_count": error_size,
                 "original_error_line_count": error_lines,
                 "tool_output_max_bytes": max_bytes,
@@ -148,18 +310,23 @@ def cap_tool_result_output(
     if encoded_size <= max_bytes and line_count <= max_lines:
         return result
 
-    output_path = _tool_output_reference_path(workspace.resolve(), result.tool_name, content)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(content, encoding="utf-8", newline="\n")
+    artifact = _artifact_metadata(
+        session_id=session_id,
+        tool_call_id=tool_call_id,
+        tool_name=result.tool_name,
+        content=content,
+        kind="content",
+    )
 
     preview = _preview_text(content, max_lines=max_lines, max_bytes=max_bytes)
     omitted_bytes = max(0, encoded_size - len(preview.encode("utf-8")))
     omitted_lines = max(0, line_count - len(preview.splitlines()))
-    reference = output_path.relative_to(workspace.resolve()).as_posix()
+    reference = f"{_ARTIFACT_REFERENCE_PREFIX}{artifact['artifact_id']}"
     hint = (
         "\n\n[Tool output truncated: "
         f"omitted {omitted_bytes} bytes and {omitted_lines} lines. "
-        f"Full output saved to: {reference}]"
+        f"artifact_id={artifact['artifact_id']}. "
+        "Use artifact retrieval by artifact_id or tool_call_id to read/search the full output.]"
     )
 
     return replace(
@@ -168,7 +335,11 @@ def cap_tool_result_output(
         data={
             **result.data,
             "truncated": True,
-            "output_path": reference,
+            "artifact": artifact,
+            "artifact_id": artifact["artifact_id"],
+            "artifact_status": "available",
+            "artifact_missing": False,
+            "output_path": artifact["path"],
             "original_byte_count": encoded_size,
             "original_line_count": line_count,
             "tool_output_max_bytes": max_bytes,
@@ -185,7 +356,9 @@ __all__ = [
     "MAX_TOOL_OUTPUT_BYTES",
     "MAX_TOOL_OUTPUT_LINES",
     "cap_tool_result_output",
+    "read_tool_output_artifact",
     "sanitize_tool_arguments",
     "sanitize_tool_data",
     "sanitize_tool_result_data",
+    "search_tool_output_artifact",
 ]

--- a/tests/unit/runtime/test_session_bundle.py
+++ b/tests/unit/runtime/test_session_bundle.py
@@ -26,6 +26,7 @@ from voidcode.runtime.task import (
     BackgroundTaskRequestSnapshot,
     BackgroundTaskState,
 )
+from voidcode.tools import ToolResult, cap_tool_result_output
 
 
 def _save_sample_session(tmp_path: Path, *, session_id: str = "bundle-session") -> None:
@@ -107,6 +108,51 @@ def _save_background_task_with_secrets(tmp_path: Path) -> None:
             error="failed with Bearer taskerrorsecret",
         ),
     )
+
+
+def _save_session_with_tool_artifact(tmp_path: Path) -> dict[str, object]:
+    store = SqliteSessionStore()
+    content = "".join(f"artifact-line-{index}\n" for index in range(8))
+    capped = cap_tool_result_output(
+        ToolResult(tool_name="shell_exec", status="ok", content=content),
+        workspace=tmp_path,
+        session_id="artifact-session",
+        tool_call_id="artifact-call",
+        max_lines=2,
+        max_bytes=10_000,
+    )
+    payload = {
+        **capped.data,
+        "tool": "shell_exec",
+        "tool_call_id": "artifact-call",
+        "status": capped.status,
+        "content": capped.content,
+        "error": capped.error,
+    }
+    response = RuntimeResponse(
+        session=SessionState(
+            session=SessionRef(id="artifact-session"),
+            status="completed",
+            turn=1,
+            metadata={},
+        ),
+        events=(
+            EventEnvelope(
+                session_id="artifact-session",
+                sequence=1,
+                event_type="runtime.tool_completed",
+                source="tool",
+                payload=payload,
+            ),
+        ),
+        output="done",
+    )
+    store.save_run(
+        workspace=tmp_path,
+        request=RuntimeRequest(prompt="artifact", session_id="artifact-session"),
+        response=response,
+    )
+    return payload
 
 
 def _minimal_bundle_payload(sessions: list[dict[str, object]]) -> dict[str, object]:
@@ -222,6 +268,68 @@ def test_session_bundle_json_and_zip_roundtrip(tmp_path: Path) -> None:
 
     assert json_bundle.to_payload() == bundle.to_payload()
     assert zip_bundle.to_payload() == bundle.to_payload()
+
+
+def test_session_bundle_includes_available_artifacts_only_when_tool_output_requested(
+    tmp_path: Path,
+) -> None:
+    tool_payload = _save_session_with_tool_artifact(tmp_path)
+    store = SqliteSessionStore()
+
+    default_bundle = build_session_bundle(
+        session_store=store,
+        workspace=tmp_path,
+        session_id="artifact-session",
+    )
+    full_bundle = build_session_bundle(
+        session_store=store,
+        workspace=tmp_path,
+        session_id="artifact-session",
+        options=SessionBundleOptions(include_tool_output=True),
+    )
+
+    assert default_bundle.manifest.artifact_count == 0
+    assert default_bundle.artifacts == ()
+    assert full_bundle.manifest.artifact_count == 1
+    artifact = full_bundle.artifacts[0]
+    assert artifact.artifact_id == tool_payload["artifact_id"]
+    assert artifact.tool_call_id == "artifact-call"
+    assert artifact.missing is False
+    assert artifact.content is not None
+    assert artifact.content.endswith("artifact-line-7\n")
+    assert full_bundle.to_payload()["artifacts"] == [
+        {
+            "artifact_id": artifact.artifact_id,
+            "session_id": "artifact-session",
+            "tool_call_id": "artifact-call",
+            "tool_name": "shell_exec",
+            "metadata": artifact.metadata,
+            "content": artifact.content,
+            "missing": False,
+        }
+    ]
+
+
+def test_session_bundle_reports_missing_artifact_without_content(tmp_path: Path) -> None:
+    tool_payload = _save_session_with_tool_artifact(tmp_path)
+    artifact = tool_payload["artifact"]
+    assert isinstance(artifact, dict)
+    Path(cast(str, artifact["path"])).unlink()
+    store = SqliteSessionStore()
+
+    bundle = build_session_bundle(
+        session_store=store,
+        workspace=tmp_path,
+        session_id="artifact-session",
+        options=SessionBundleOptions(include_tool_output=True),
+    )
+
+    assert bundle.manifest.artifact_count == 1
+    bundled_artifact = bundle.artifacts[0]
+    assert bundled_artifact.artifact_id == tool_payload["artifact_id"]
+    assert bundled_artifact.missing is True
+    assert bundled_artifact.content is None
+    assert bundled_artifact.metadata["status"] == "missing"
 
 
 def test_session_bundle_import_roundtrip_never_overwrites_existing_session(

--- a/tests/unit/runtime/test_session_bundle.py
+++ b/tests/unit/runtime/test_session_bundle.py
@@ -332,6 +332,59 @@ def test_session_bundle_reports_missing_artifact_without_content(tmp_path: Path)
     assert bundled_artifact.metadata["status"] == "missing"
 
 
+def test_session_bundle_skips_forged_artifact_paths(tmp_path: Path) -> None:
+    secret_path = tmp_path / "secret.txt"
+    secret_path.write_text("must not be bundled", encoding="utf-8")
+    response = RuntimeResponse(
+        session=SessionState(
+            session=SessionRef(id="forged-artifact-session"),
+            status="completed",
+            turn=1,
+            metadata={},
+        ),
+        events=(
+            EventEnvelope(
+                session_id="forged-artifact-session",
+                sequence=1,
+                event_type="runtime.tool_completed",
+                source="tool",
+                payload={
+                    "tool": "shell_exec",
+                    "tool_call_id": "forged-call",
+                    "status": "ok",
+                    "content": "forged",
+                    "artifact": {
+                        "producer": "voidcode.tool_output.v1",
+                        "artifact_id": "artifact_forged",
+                        "tool_call_id": "forged-call",
+                        "path": str(secret_path),
+                        "status": "available",
+                    },
+                },
+            ),
+        ),
+        output="done",
+    )
+    store = SqliteSessionStore()
+    store.save_run(
+        workspace=tmp_path,
+        request=RuntimeRequest(prompt="forged", session_id="forged-artifact-session"),
+        response=response,
+    )
+
+    bundle = build_session_bundle(
+        session_store=store,
+        workspace=tmp_path,
+        session_id="forged-artifact-session",
+        options=SessionBundleOptions(include_tool_output=True),
+    )
+    encoded = json.dumps(bundle.to_payload(), sort_keys=True)
+
+    assert bundle.manifest.artifact_count == 0
+    assert bundle.artifacts == ()
+    assert "must not be bundled" not in encoded
+
+
 def test_session_bundle_import_roundtrip_never_overwrites_existing_session(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_session_bundle.py
+++ b/tests/unit/runtime/test_session_bundle.py
@@ -385,6 +385,59 @@ def test_session_bundle_skips_forged_artifact_paths(tmp_path: Path) -> None:
     assert "must not be bundled" not in encoded
 
 
+def test_session_bundle_skips_short_id_forged_temp_artifact_path(tmp_path: Path) -> None:
+    real_payload = _save_session_with_tool_artifact(tmp_path)
+    real_artifact = real_payload["artifact"]
+    assert isinstance(real_artifact, dict)
+    forged_artifact = {
+        **cast(dict[str, object], real_artifact),
+        "artifact_id": "artifact_",
+        "tool_call_id": "forged-call",
+    }
+    response = RuntimeResponse(
+        session=SessionState(
+            session=SessionRef(id="forged-temp-artifact-session"),
+            status="completed",
+            turn=1,
+            metadata={},
+        ),
+        events=(
+            EventEnvelope(
+                session_id="forged-temp-artifact-session",
+                sequence=1,
+                event_type="runtime.tool_completed",
+                source="tool",
+                payload={
+                    "tool": "shell_exec",
+                    "tool_call_id": "forged-call",
+                    "status": "ok",
+                    "content": "forged",
+                    "artifact": forged_artifact,
+                },
+            ),
+        ),
+        output="done",
+    )
+    store = SqliteSessionStore()
+    store.save_run(
+        workspace=tmp_path,
+        request=RuntimeRequest(prompt="forged", session_id="forged-temp-artifact-session"),
+        response=response,
+    )
+
+    bundle = build_session_bundle(
+        session_store=store,
+        workspace=tmp_path,
+        session_id="forged-temp-artifact-session",
+        options=SessionBundleOptions(include_tool_output=True),
+    )
+    encoded = json.dumps(bundle.to_payload(), sort_keys=True)
+
+    assert bundle.manifest.artifact_count == 0
+    assert bundle.artifacts == ()
+    assert "artifact-line-7" not in encoded
+
+
 def test_session_bundle_import_roundtrip_never_overwrites_existing_session(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_session_bundle.py
+++ b/tests/unit/runtime/test_session_bundle.py
@@ -6,6 +6,7 @@ from typing import cast
 
 import pytest
 
+import voidcode.runtime.bundle as bundle_module
 from voidcode.runtime.bundle import (
     SESSION_BUNDLE_REDACTED_PLACEHOLDER,
     SESSION_BUNDLE_SCHEMA_NAME,
@@ -306,8 +307,37 @@ def test_session_bundle_includes_available_artifacts_only_when_tool_output_reque
             "metadata": artifact.metadata,
             "content": artifact.content,
             "missing": False,
+            "content_truncated": False,
+            "content_next_offset": None,
         }
     ]
+
+
+def test_session_bundle_marks_artifact_content_truncated_when_read_limit_hit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool_payload = _save_session_with_tool_artifact(tmp_path)
+    store = SqliteSessionStore()
+    monkeypatch.setattr(bundle_module, "_BUNDLE_ARTIFACT_READ_LIMIT_LINES", 2)
+
+    bundle = build_session_bundle(
+        session_store=store,
+        workspace=tmp_path,
+        session_id="artifact-session",
+        options=SessionBundleOptions(include_tool_output=True),
+    )
+
+    assert bundle.manifest.artifact_count == 1
+    artifact = bundle.artifacts[0]
+    assert artifact.artifact_id == tool_payload["artifact_id"]
+    assert artifact.missing is False
+    assert artifact.content == "artifact-line-0\nartifact-line-1\n"
+    assert artifact.content_truncated is True
+    assert artifact.content_next_offset == 2
+    assert artifact.metadata["content_truncated"] is True
+    assert artifact.metadata["content_next_offset"] == 2
+    assert artifact.metadata["bundle_read_limit_lines"] == 2
 
 
 def test_session_bundle_reports_missing_artifact_without_content(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_tool_execution_timeout.py
+++ b/tests/unit/runtime/test_tool_execution_timeout.py
@@ -16,7 +16,7 @@ from voidcode.runtime.events import EventEnvelope
 from voidcode.runtime.service import ToolRegistry, VoidCodeRuntime
 from voidcode.runtime.session import SessionRef, SessionState
 from voidcode.runtime.storage import SqliteSessionStore
-from voidcode.tools import ShellExecTool
+from voidcode.tools import ShellExecTool, tool_output_artifact_temp_root
 from voidcode.tools.contracts import ToolCall, ToolDefinition, ToolResult
 from voidcode.tools.runtime_context import RuntimeToolInvocationContext, bind_runtime_tool_context
 
@@ -373,7 +373,9 @@ def test_runtime_caps_large_tool_output_before_feedback(tmp_path: Path) -> None:
     payload = completed_events[0].payload
     assert payload["truncated"] is True
     assert isinstance(payload["output_path"], str)
-    assert str(payload["output_path"]).startswith("/tmp/")
+    output_path = Path(payload["output_path"]).resolve()
+    artifact_root = tool_output_artifact_temp_root().resolve()
+    assert artifact_root in output_path.parents
     assert payload["artifact_missing"] is False
     assert isinstance(payload["artifact_id"], str)
     artifact = payload["artifact"]
@@ -384,7 +386,7 @@ def test_runtime_caps_large_tool_output_before_feedback(tmp_path: Path) -> None:
     assert "Tool output truncated" in payload["content"]
     assert f"artifact_id={payload['artifact_id']}" in payload["content"]
     assert "line-2099" not in payload["content"]
-    assert Path(payload["output_path"]).read_text(encoding="utf-8").endswith("line-2099\n")
+    assert output_path.read_text(encoding="utf-8").endswith("line-2099\n")
     assert not (tmp_path / ".voidcode" / "tool-output").exists()
 
 

--- a/tests/unit/runtime/test_tool_execution_timeout.py
+++ b/tests/unit/runtime/test_tool_execution_timeout.py
@@ -366,10 +366,19 @@ def test_runtime_caps_large_tool_output_before_feedback(tmp_path: Path) -> None:
     payload = completed_events[0].payload
     assert payload["truncated"] is True
     assert isinstance(payload["output_path"], str)
+    assert str(payload["output_path"]).startswith("/tmp/")
+    assert payload["artifact_missing"] is False
+    assert isinstance(payload["artifact_id"], str)
+    artifact = payload["artifact"]
+    assert isinstance(artifact, dict)
+    assert artifact["session_id"] == completed_events[0].session_id
+    assert artifact["tool_call_id"] == payload["tool_call_id"]
     assert isinstance(payload["content"], str)
     assert "Tool output truncated" in payload["content"]
+    assert f"artifact_id={payload['artifact_id']}" in payload["content"]
     assert "line-2099" not in payload["content"]
-    assert (tmp_path / payload["output_path"]).read_text(encoding="utf-8").endswith("line-2099\n")
+    assert Path(payload["output_path"]).read_text(encoding="utf-8").endswith("line-2099\n")
+    assert not (tmp_path / ".voidcode" / "tool-output").exists()
 
 
 def test_runtime_sanitizes_tool_arguments_and_data_before_events_and_feedback(

--- a/tests/unit/runtime/test_tool_execution_timeout.py
+++ b/tests/unit/runtime/test_tool_execution_timeout.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from voidcode.runtime.config import RuntimeConfig
-from voidcode.runtime.contracts import RuntimeRequest
+from voidcode.runtime.contracts import RuntimeProviderContextSegmentSnapshot, RuntimeRequest
 from voidcode.runtime.service import ToolRegistry, VoidCodeRuntime
 from voidcode.tools import ShellExecTool
 from voidcode.tools.contracts import ToolCall, ToolDefinition, ToolResult
@@ -379,6 +379,78 @@ def test_runtime_caps_large_tool_output_before_feedback(tmp_path: Path) -> None:
     assert "line-2099" not in payload["content"]
     assert Path(payload["output_path"]).read_text(encoding="utf-8").endswith("line-2099\n")
     assert not (tmp_path / ".voidcode" / "tool-output").exists()
+
+
+def test_runtime_resolves_tool_output_artifacts_and_reports_missing_debug_state(
+    tmp_path: Path,
+) -> None:
+    session_id = "artifact-resolver-session"
+    runtime = _make_runtime(tmp_path, _LargeOutputTool(), tool_timeout_seconds=None)
+
+    _ = list(runtime.run_stream(RuntimeRequest(prompt="go", session_id=session_id)))
+    replay = runtime.resume(session_id)
+    completed_event = next(
+        event for event in replay.events if event.event_type == "runtime.tool_completed"
+    )
+    artifact_id = completed_event.payload["artifact_id"]
+    tool_call_id = completed_event.payload["tool_call_id"]
+    assert isinstance(artifact_id, str)
+    assert isinstance(tool_call_id, str)
+
+    metadata = runtime.resolve_tool_output_artifact(
+        session_id=session_id,
+        artifact_id=artifact_id,
+    )
+    assert metadata["status"] == "available"
+    assert metadata["artifact_missing"] is False
+
+    read_result = runtime.read_tool_output_artifact(
+        session_id=session_id,
+        tool_call_id=tool_call_id,
+        offset=2099,
+        limit=1,
+    )
+    assert read_result["content"] == "line-2099\n"
+    search_result = runtime.search_tool_output_artifact(
+        session_id=session_id,
+        artifact_id=artifact_id,
+        pattern="line-2099",
+    )
+    assert search_result["match_count"] == 1
+
+    artifact = completed_event.payload["artifact"]
+    assert isinstance(artifact, dict)
+    Path(cast(str, artifact["path"])).unlink()
+
+    missing = runtime.resolve_tool_output_artifact(
+        session_id=session_id,
+        artifact_id=artifact_id,
+    )
+    assert missing["status"] == "missing"
+    assert missing["artifact_missing"] is True
+    missing_read = runtime.read_tool_output_artifact(
+        session_id=session_id,
+        artifact_id=artifact_id,
+    )
+    assert missing_read["status"] == "missing"
+    snapshot = runtime.session_debug_snapshot(session_id=session_id)
+    assert snapshot.last_tool is not None
+    assert snapshot.last_tool.artifact["artifact_id"] == artifact_id
+    assert snapshot.last_tool.artifact["status"] == "missing"
+    assert snapshot.last_tool.artifact["artifact_missing"] is True
+    assert snapshot.provider_context is not None
+    artifact_segments: list[RuntimeProviderContextSegmentSnapshot] = []
+    for segment in snapshot.provider_context.segments:
+        segment_data = segment.metadata.get("data")
+        if not isinstance(segment_data, dict):
+            continue
+        typed_segment_data = cast(dict[str, object], segment_data)
+        if typed_segment_data.get("artifact_id") == artifact_id:
+            artifact_segments.append(segment)
+    assert artifact_segments
+    segment_data = artifact_segments[-1].metadata["data"]
+    assert isinstance(segment_data, dict)
+    assert segment_data["artifact_missing"] is True
 
 
 def test_runtime_sanitizes_tool_arguments_and_data_before_events_and_feedback(

--- a/tests/unit/runtime/test_tool_execution_timeout.py
+++ b/tests/unit/runtime/test_tool_execution_timeout.py
@@ -7,8 +7,15 @@ from pathlib import Path
 from typing import Any, cast
 
 from voidcode.runtime.config import RuntimeConfig
-from voidcode.runtime.contracts import RuntimeProviderContextSegmentSnapshot, RuntimeRequest
+from voidcode.runtime.contracts import (
+    RuntimeProviderContextSegmentSnapshot,
+    RuntimeRequest,
+    RuntimeResponse,
+)
+from voidcode.runtime.events import EventEnvelope
 from voidcode.runtime.service import ToolRegistry, VoidCodeRuntime
+from voidcode.runtime.session import SessionRef, SessionState
+from voidcode.runtime.storage import SqliteSessionStore
 from voidcode.tools import ShellExecTool
 from voidcode.tools.contracts import ToolCall, ToolDefinition, ToolResult
 from voidcode.tools.runtime_context import RuntimeToolInvocationContext, bind_runtime_tool_context
@@ -451,6 +458,85 @@ def test_runtime_resolves_tool_output_artifacts_and_reports_missing_debug_state(
     segment_data = artifact_segments[-1].metadata["data"]
     assert isinstance(segment_data, dict)
     assert segment_data["artifact_missing"] is True
+
+
+def test_runtime_artifact_resolver_skips_invalid_candidate_for_same_tool_call(
+    tmp_path: Path,
+) -> None:
+    source_runtime = _make_runtime(tmp_path, _LargeOutputTool(), tool_timeout_seconds=None)
+    _ = list(source_runtime.run_stream(RuntimeRequest(prompt="go", session_id="source-session")))
+    source_replay = source_runtime.resume("source-session")
+    completed_event = next(
+        event for event in source_replay.events if event.event_type == "runtime.tool_completed"
+    )
+    valid_artifact = completed_event.payload["artifact"]
+    assert isinstance(valid_artifact, dict)
+    tool_call_id = completed_event.payload["tool_call_id"]
+    assert isinstance(tool_call_id, str)
+    forged_artifact = {
+        **cast(dict[str, object], valid_artifact),
+        "artifact_id": "artifact_",
+    }
+    session_id = "resolver-invalid-first-session"
+    store = SqliteSessionStore()
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(execution_engine="deterministic"),
+        session_store=store,
+    )
+    store.save_run(
+        workspace=tmp_path,
+        request=RuntimeRequest(prompt="go", session_id=session_id),
+        response=RuntimeResponse(
+            session=SessionState(
+                session=SessionRef(id=session_id),
+                status="completed",
+                turn=1,
+                metadata={},
+            ),
+            events=(
+                EventEnvelope(
+                    session_id=session_id,
+                    sequence=1,
+                    event_type="runtime.tool_completed",
+                    source="tool",
+                    payload={
+                        "tool": "large_output_tool",
+                        "tool_call_id": tool_call_id,
+                        "status": "ok",
+                        "content": "forged",
+                        "artifact": forged_artifact,
+                    },
+                ),
+                EventEnvelope(
+                    session_id=session_id,
+                    sequence=2,
+                    event_type="runtime.tool_completed",
+                    source="tool",
+                    payload={
+                        **completed_event.payload,
+                        "tool_call_id": tool_call_id,
+                    },
+                ),
+            ),
+            output="done",
+        ),
+    )
+
+    metadata = runtime.resolve_tool_output_artifact(
+        session_id=session_id,
+        tool_call_id=tool_call_id,
+    )
+    read_result = runtime.read_tool_output_artifact(
+        session_id=session_id,
+        tool_call_id=tool_call_id,
+        offset=2099,
+        limit=1,
+    )
+
+    assert metadata["artifact_id"] == completed_event.payload["artifact_id"]
+    assert metadata["status"] == "available"
+    assert read_result["content"] == "line-2099\n"
 
 
 def test_runtime_sanitizes_tool_arguments_and_data_before_events_and_feedback(

--- a/tests/unit/tools/test_shell_exec_tool.py
+++ b/tests/unit/tools/test_shell_exec_tool.py
@@ -213,11 +213,16 @@ def test_shell_exec_large_output_spills_full_payload_via_central_cap(tmp_path: P
     assert capped.reference is not None
     assert isinstance(capped.content, str)
     assert "[Tool output truncated:" in capped.content
-    assert "Full output saved to:" in capped.content
+    assert "artifact_id=" in capped.content
+    assert "read/search the full output" in capped.content
+    assert capped.reference.startswith("artifact:")
 
-    reference_path = tmp_path / capped.reference
+    artifact = capped.data["artifact"]
+    assert isinstance(artifact, dict)
+    reference_path = Path(str(artifact["path"]))
     assert reference_path.exists()
     assert len(reference_path.read_text(encoding="utf-8")) == payload_size
+    assert not (tmp_path / ".voidcode" / "tool-output").exists()
 
 
 # ── Target contract: ShellExecArgs.description ──────────────────────────

--- a/tests/unit/tools/test_tool_output_truncation.py
+++ b/tests/unit/tools/test_tool_output_truncation.py
@@ -7,9 +7,11 @@ from voidcode.tools import (
     ToolResult,
     cap_tool_result_output,
     read_tool_output_artifact,
+    resolve_tool_output_artifact,
     sanitize_tool_arguments,
     sanitize_tool_result_data,
     search_tool_output_artifact,
+    tool_output_artifact_temp_root,
 )
 
 
@@ -41,8 +43,12 @@ def test_cap_tool_result_output_caps_by_line_count_and_saves_full_output(tmp_pat
     assert isinstance(raw_artifact, dict)
     artifact = cast(dict[str, object], raw_artifact)
     assert artifact["status"] == "available"
+    assert artifact["producer"] == "voidcode.tool_output.v1"
     assert capped.data["artifact_id"] == artifact["artifact_id"]
-    assert Path(cast(str, artifact["path"])).read_text(encoding="utf-8") == content
+    artifact_path = Path(cast(str, artifact["path"]))
+    assert artifact_path.read_text(encoding="utf-8") == content
+    assert artifact_path.stat().st_mode & 0o777 == 0o600
+    assert tool_output_artifact_temp_root().stat().st_mode & 0o777 == 0o700
     assert capped.data["original_line_count"] == 6
 
 
@@ -73,6 +79,50 @@ def test_tool_output_artifact_retrieval_supports_offsets_and_search(tmp_path: Pa
     matches = search_result["matches"]
     assert isinstance(matches, list)
     assert matches[0] == {"line_number": 2, "line": "beta"}
+
+
+def test_tool_output_artifact_resolves_from_events_by_id_or_tool_call(tmp_path: Path) -> None:
+    result = ToolResult(tool_name="sample", status="ok", content="one\ntwo\nthree\n")
+    capped = cap_tool_result_output(
+        result,
+        workspace=tmp_path,
+        session_id="session-1",
+        tool_call_id="call-1",
+        max_lines=1,
+        max_bytes=10_000,
+    )
+    artifact_id = capped.data["artifact_id"]
+    assert isinstance(artifact_id, str)
+    events = [{"payload": {"artifact": capped.data["artifact"]}}]
+
+    by_artifact_id = resolve_tool_output_artifact(events, artifact_id=artifact_id)
+    by_tool_call_id = resolve_tool_output_artifact(events, tool_call_id="call-1")
+
+    assert by_artifact_id is not None
+    assert by_artifact_id["artifact_id"] == artifact_id
+    assert by_tool_call_id is not None
+    assert by_tool_call_id["tool_call_id"] == "call-1"
+
+
+def test_tool_output_artifact_rejects_untrusted_paths(tmp_path: Path) -> None:
+    outside_file = tmp_path / "secret.txt"
+    outside_file.write_text("must not read", encoding="utf-8")
+    forged_artifact: dict[str, object] = {
+        "producer": "voidcode.tool_output.v1",
+        "artifact_id": "artifact_forged",
+        "path": str(outside_file),
+    }
+
+    read_result = read_tool_output_artifact(forged_artifact)
+    search_result = search_tool_output_artifact(forged_artifact, pattern="must")
+    resolved = resolve_tool_output_artifact(
+        [{"payload": {"artifact": forged_artifact}}], artifact_id="artifact_forged"
+    )
+
+    assert read_result["status"] == "invalid"
+    assert "content" not in read_result
+    assert search_result["status"] == "invalid"
+    assert resolved is None
 
 
 def test_tool_output_artifact_retrieval_reports_missing(tmp_path: Path) -> None:

--- a/tests/unit/tools/test_tool_output_truncation.py
+++ b/tests/unit/tools/test_tool_output_truncation.py
@@ -126,6 +126,55 @@ def test_tool_output_artifact_rejects_untrusted_paths(tmp_path: Path) -> None:
     assert resolved is None
 
 
+def test_tool_output_artifact_rejects_short_id_for_another_artifact_path(
+    tmp_path: Path,
+) -> None:
+    result = ToolResult(tool_name="sample", status="ok", content="one\ntwo\nthree\n")
+    capped = cap_tool_result_output(result, workspace=tmp_path, max_lines=1, max_bytes=10_000)
+    real_artifact = capped.data["artifact"]
+    assert isinstance(real_artifact, dict)
+    forged_artifact = {
+        **cast(dict[str, object], real_artifact),
+        "artifact_id": "artifact_",
+    }
+
+    read_result = read_tool_output_artifact(forged_artifact)
+    search_result = search_tool_output_artifact(forged_artifact, pattern="three")
+    resolved = resolve_tool_output_artifact(
+        [{"payload": {"artifact": forged_artifact}}], artifact_id="artifact_"
+    )
+
+    assert read_result["status"] == "invalid"
+    assert "content" not in read_result
+    assert search_result["status"] == "invalid"
+    assert resolved is None
+
+
+def test_tool_output_artifact_rejects_valid_shaped_id_for_another_artifact_path(
+    tmp_path: Path,
+) -> None:
+    result = ToolResult(tool_name="sample", status="ok", content="one\ntwo\nthree\n")
+    capped = cap_tool_result_output(result, workspace=tmp_path, max_lines=1, max_bytes=10_000)
+    real_artifact = capped.data["artifact"]
+    assert isinstance(real_artifact, dict)
+    forged_id = "artifact_000000000000000000000000"
+    forged_artifact = {
+        **cast(dict[str, object], real_artifact),
+        "artifact_id": forged_id,
+    }
+
+    read_result = read_tool_output_artifact(forged_artifact)
+    search_result = search_tool_output_artifact(forged_artifact, pattern="three")
+    resolved = resolve_tool_output_artifact(
+        [{"payload": {"artifact": forged_artifact}}], artifact_id=forged_id
+    )
+
+    assert read_result["status"] == "invalid"
+    assert "content" not in read_result
+    assert search_result["status"] == "invalid"
+    assert resolved is None
+
+
 def test_tool_output_artifact_retrieval_reports_missing(tmp_path: Path) -> None:
     result = ToolResult(tool_name="sample", status="ok", content="one\ntwo\nthree\n")
     capped = cap_tool_result_output(result, workspace=tmp_path, max_lines=1, max_bytes=10_000)

--- a/tests/unit/tools/test_tool_output_truncation.py
+++ b/tests/unit/tools/test_tool_output_truncation.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
+import voidcode.tools.output as output_module
 from voidcode.tools import (
     ToolResult,
     cap_tool_result_output,
@@ -51,6 +52,33 @@ def test_cap_tool_result_output_caps_by_line_count_and_saves_full_output(tmp_pat
     assert artifact_path.stat().st_mode & 0o777 == 0o600
     assert tool_output_artifact_temp_root().stat().st_mode & 0o777 == 0o700
     assert capped.data["original_line_count"] == 6
+
+
+def test_tool_output_artifact_temp_root_uses_xdg_cache_home(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr(output_module.sys, "platform", "linux")
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
+
+    root = tool_output_artifact_temp_root()
+
+    assert root == tmp_path / "xdg-cache" / "voidcode" / "tool-output"
+    assert root.stat().st_mode & 0o777 == 0o700
+
+
+def test_tool_output_artifact_temp_root_uses_windows_local_app_data(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr(output_module.sys, "platform", "win32")
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "LocalAppData"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "RoamingAppData"))
+
+    root = tool_output_artifact_temp_root()
+
+    assert root == tmp_path / "LocalAppData" / "voidcode" / "tool-output"
+    assert root.stat().st_mode & 0o777 == 0o700
 
 
 def test_tool_output_artifact_retrieval_supports_offsets_and_search(tmp_path: Path) -> None:

--- a/tests/unit/tools/test_tool_output_truncation.py
+++ b/tests/unit/tools/test_tool_output_truncation.py
@@ -105,6 +105,69 @@ def test_tool_output_artifact_resolves_from_events_by_id_or_tool_call(tmp_path: 
     assert by_tool_call_id["tool_call_id"] == "call-1"
 
 
+def test_tool_output_artifact_resolver_skips_invalid_candidate_for_same_tool_call(
+    tmp_path: Path,
+) -> None:
+    result = ToolResult(tool_name="sample", status="ok", content="one\ntwo\nthree\n")
+    capped = cap_tool_result_output(
+        result,
+        workspace=tmp_path,
+        session_id="session-1",
+        tool_call_id="call-1",
+        max_lines=1,
+        max_bytes=10_000,
+    )
+    valid_artifact = capped.data["artifact"]
+    assert isinstance(valid_artifact, dict)
+    forged_artifact = {
+        **cast(dict[str, object], valid_artifact),
+        "artifact_id": "artifact_",
+    }
+    events: list[object] = [
+        {"payload": {"artifact": forged_artifact}},
+        {"payload": {"artifact": valid_artifact}},
+    ]
+
+    resolved = resolve_tool_output_artifact(events, tool_call_id="call-1")
+
+    assert resolved is not None
+    assert resolved["artifact_id"] == capped.data["artifact_id"]
+
+
+def test_tool_output_artifact_resolver_skips_invalid_candidate_for_same_artifact_id(
+    tmp_path: Path,
+) -> None:
+    result = ToolResult(tool_name="sample", status="ok", content="one\ntwo\nthree\n")
+    capped = cap_tool_result_output(
+        result,
+        workspace=tmp_path,
+        session_id="session-1",
+        tool_call_id="call-1",
+        max_lines=1,
+        max_bytes=10_000,
+    )
+    valid_artifact = capped.data["artifact"]
+    assert isinstance(valid_artifact, dict)
+    artifact = cast(dict[str, object], valid_artifact)
+    raw_artifact_id = artifact["artifact_id"]
+    assert isinstance(raw_artifact_id, str)
+    artifact_id = raw_artifact_id
+    artifact_path = Path(cast(str, artifact["path"]))
+    forged_artifact = {
+        **artifact,
+        "path": str(artifact_path.with_name("tool-call-artifact_000000000000000000000000.txt")),
+    }
+    events: list[object] = [
+        {"payload": {"artifact": forged_artifact}},
+        {"payload": {"artifact": valid_artifact}},
+    ]
+
+    resolved = resolve_tool_output_artifact(events, artifact_id=artifact_id)
+
+    assert resolved is not None
+    assert resolved["artifact_id"] == artifact_id
+
+
 def test_tool_output_artifact_rejects_untrusted_paths(tmp_path: Path) -> None:
     outside_file = tmp_path / "secret.txt"
     outside_file.write_text("must not read", encoding="utf-8")

--- a/tests/unit/tools/test_tool_output_truncation.py
+++ b/tests/unit/tools/test_tool_output_truncation.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
 from voidcode.tools import (
     ToolResult,
     cap_tool_result_output,
+    read_tool_output_artifact,
     sanitize_tool_arguments,
     sanitize_tool_result_data,
+    search_tool_output_artifact,
 )
 
 
@@ -32,9 +35,58 @@ def test_cap_tool_result_output_caps_by_line_count_and_saves_full_output(tmp_pat
     assert capped.truncated is True
     assert capped.partial is True
     assert isinstance(capped.reference, str)
-    assert (tmp_path / capped.reference).read_text(encoding="utf-8") == content
-    assert capped.data["output_path"] == capped.reference
+    assert capped.reference.startswith("artifact:")
+    assert not (tmp_path / ".voidcode" / "tool-output").exists()
+    raw_artifact = capped.data["artifact"]
+    assert isinstance(raw_artifact, dict)
+    artifact = cast(dict[str, object], raw_artifact)
+    assert artifact["status"] == "available"
+    assert capped.data["artifact_id"] == artifact["artifact_id"]
+    assert Path(cast(str, artifact["path"])).read_text(encoding="utf-8") == content
     assert capped.data["original_line_count"] == 6
+
+
+def test_tool_output_artifact_retrieval_supports_offsets_and_search(tmp_path: Path) -> None:
+    content = "alpha\nbeta\ngamma\nbeta-two\n"
+    result = ToolResult(tool_name="sample", status="ok", content=content)
+
+    capped = cap_tool_result_output(
+        result,
+        workspace=tmp_path,
+        session_id="session-1",
+        tool_call_id="call-1",
+        max_lines=2,
+        max_bytes=10_000,
+    )
+
+    raw_artifact = capped.data["artifact"]
+    assert isinstance(raw_artifact, dict)
+    artifact = cast(dict[str, object], raw_artifact)
+    read_result = read_tool_output_artifact(artifact, offset=1, limit=2)
+    assert read_result["artifact_missing"] is False
+    assert read_result["content"] == "beta\ngamma\n"
+    assert read_result["next_offset"] == 3
+
+    search_result = search_tool_output_artifact(artifact, pattern="beta")
+    assert search_result["artifact_missing"] is False
+    assert search_result["match_count"] == 2
+    matches = search_result["matches"]
+    assert isinstance(matches, list)
+    assert matches[0] == {"line_number": 2, "line": "beta"}
+
+
+def test_tool_output_artifact_retrieval_reports_missing(tmp_path: Path) -> None:
+    result = ToolResult(tool_name="sample", status="ok", content="one\ntwo\nthree\n")
+    capped = cap_tool_result_output(result, workspace=tmp_path, max_lines=1, max_bytes=10_000)
+    raw_artifact = capped.data["artifact"]
+    assert isinstance(raw_artifact, dict)
+    artifact = cast(dict[str, object], raw_artifact)
+    Path(cast(str, artifact["path"])).unlink()
+
+    missing = read_tool_output_artifact(artifact)
+
+    assert missing["status"] == "missing"
+    assert missing["artifact_missing"] is True
 
 
 def test_cap_tool_result_output_caps_by_utf8_byte_count_safely(tmp_path: Path) -> None:
@@ -47,7 +99,10 @@ def test_cap_tool_result_output_caps_by_utf8_byte_count_safely(tmp_path: Path) -
     assert "�" not in capped.content
     assert "Tool output truncated" in capped.content
     assert isinstance(capped.reference, str)
-    assert (tmp_path / capped.reference).read_text(encoding="utf-8") == content
+    raw_artifact = capped.data["artifact"]
+    assert isinstance(raw_artifact, dict)
+    artifact = cast(dict[str, object], raw_artifact)
+    assert Path(cast(str, artifact["path"])).read_text(encoding="utf-8") == content
 
 
 def test_cap_tool_result_output_skips_errors_and_empty_content(tmp_path: Path) -> None:
@@ -68,7 +123,10 @@ def test_cap_tool_result_output_caps_large_errors(tmp_path: Path) -> None:
     assert "Tool error truncated" in capped.error
     assert capped.truncated is True
     assert isinstance(capped.reference, str)
-    assert (tmp_path / capped.reference).read_text(encoding="utf-8") == error_text
+    raw_artifact = capped.data["artifact"]
+    assert isinstance(raw_artifact, dict)
+    artifact = cast(dict[str, object], raw_artifact)
+    assert Path(cast(str, artifact["path"])).read_text(encoding="utf-8") == error_text
 
 
 def test_sanitize_tool_arguments_omits_sensitive_text_fields() -> None:


### PR DESCRIPTION
## Summary
- Store oversized tool outputs as runtime temp artifacts instead of workspace `.voidcode/tool-output` files.
- Emit stable artifact metadata on tool completion events and provide bounded read/search plus event-based artifact resolution helpers.
- Include available artifacts in session bundles only when tool output is explicitly requested, while skipping forged artifact paths.

## Verification
- `uv run ruff check .`
- `uv run basedpyright --warnings src`
- `uv build`
- `uv run pytest -n auto` (1832 passed)
- `uv run pytest tests/unit/tools/test_shell_exec_tool.py::test_shell_exec_large_output_spills_full_payload_via_central_cap tests/unit/tools/test_tool_output_truncation.py tests/unit/runtime/test_tool_execution_timeout.py tests/unit/runtime/test_session_bundle.py` (45 passed after final rebase)

Closes #356