### PR TITLE
feat(runtime): add provider context diagnostic policy

### DIFF
--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -958,6 +958,21 @@ def _serialize_provider_context_snapshot(
             }
             for message in snapshot.provider_messages
         ],
+        "policy_decision": (
+            {
+                "mode": snapshot.policy_decision.mode,
+                "action": snapshot.policy_decision.action,
+                "blocked": snapshot.policy_decision.blocked,
+                "diagnostic_count": snapshot.policy_decision.diagnostic_count,
+                "diagnostic_codes": list(snapshot.policy_decision.diagnostic_codes),
+                "blocking_diagnostic_codes": list(
+                    snapshot.policy_decision.blocking_diagnostic_codes
+                ),
+                "message": snapshot.policy_decision.message,
+            }
+            if snapshot.policy_decision is not None
+            else None
+        ),
         "diagnostics": [
             {
                 "severity": diagnostic.severity,
@@ -967,6 +982,8 @@ def _serialize_provider_context_snapshot(
                 "segment_indices": list(diagnostic.segment_indices),
                 "suggested_fix": diagnostic.suggested_fix,
                 "details": diagnostic.details,
+                "policy_action": diagnostic.policy_action,
+                "policy_blocking": diagnostic.policy_blocking,
             }
             for diagnostic in snapshot.diagnostics
         ],

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -47,6 +47,7 @@ _VALID_APPROVAL_MODES = ("allow", "deny", "ask")
 _VALID_TUI_COMMANDS = ("command_palette", "session_new", "session_resume")
 type ExecutionEngineName = Literal["deterministic", "provider"]
 DEFAULT_EXECUTION_ENGINE: ExecutionEngineName = "provider"
+type RuntimeProviderContextDiagnosticMode = Literal["off", "warn", "block"]
 type RuntimeAgentPresetId = AgentManifestId
 type RuntimeAgentPromptSource = Literal["builtin"]
 
@@ -127,6 +128,8 @@ _CONTEXT_WINDOW_CONFIG_KEYS = frozenset(
         "continuity_preview_chars",
         "context_pressure_threshold",
         "context_pressure_cooldown_steps",
+        "provider_context_diagnostics",
+        "provider_context_oversized_feedback_chars",
     }
 )
 _FORMATTER_PRESET_CONFIG_KEYS = frozenset(
@@ -279,6 +282,8 @@ class RuntimeContextWindowConfig:
     continuity_preview_chars: int = 80
     context_pressure_threshold: float = 0.7
     context_pressure_cooldown_steps: int = 3
+    provider_context_diagnostics: RuntimeProviderContextDiagnosticMode = "warn"
+    provider_context_oversized_feedback_chars: int = 8_000
 
 
 @dataclass(frozen=True, slots=True)
@@ -1177,6 +1182,8 @@ class _RuntimeContextWindowValidationModel(BaseModel):
     continuity_preview_chars: int = 80
     context_pressure_threshold: float = 0.7
     context_pressure_cooldown_steps: int = 3
+    provider_context_diagnostics: RuntimeProviderContextDiagnosticMode = "warn"
+    provider_context_oversized_feedback_chars: int = 8_000
 
     @field_validator("auto_compaction", mode="before")
     @classmethod
@@ -1303,6 +1310,37 @@ class _RuntimeContextWindowValidationModel(BaseModel):
             )
         return value
 
+    @field_validator("provider_context_diagnostics", mode="before")
+    @classmethod
+    def _validate_provider_context_diagnostics(
+        cls, value: object
+    ) -> RuntimeProviderContextDiagnosticMode:
+        if value is None:
+            return "warn"
+        if value not in ("off", "warn", "block"):
+            raise ValueError(
+                "runtime config field 'context_window.provider_context_diagnostics' must be one "
+                "of: off, warn, block"
+            )
+        return value
+
+    @field_validator("provider_context_oversized_feedback_chars", mode="before")
+    @classmethod
+    def _validate_provider_context_oversized_feedback_chars(cls, value: object) -> int:
+        if value is None:
+            return 8_000
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise ValueError(
+                "runtime config field 'context_window.provider_context_oversized_feedback_chars' "
+                "must be an integer"
+            )
+        if value < 1:
+            raise ValueError(
+                "runtime config field 'context_window.provider_context_oversized_feedback_chars' "
+                "must be greater than or equal to 1"
+            )
+        return value
+
     @field_validator("per_tool_result_tokens", mode="before")
     @classmethod
     def _validate_per_tool_result_tokens(cls, value: object) -> dict[str, int]:
@@ -1356,6 +1394,8 @@ class _RuntimeContextWindowValidationModel(BaseModel):
             continuity_preview_chars=self.continuity_preview_chars,
             context_pressure_threshold=self.context_pressure_threshold,
             context_pressure_cooldown_steps=self.context_pressure_cooldown_steps,
+            provider_context_diagnostics=self.provider_context_diagnostics,
+            provider_context_oversized_feedback_chars=self.provider_context_oversized_feedback_chars,
         )
 
 
@@ -2208,6 +2248,10 @@ def serialize_runtime_context_window_config(
         "continuity_preview_chars": context_window.continuity_preview_chars,
         "context_pressure_threshold": context_window.context_pressure_threshold,
         "context_pressure_cooldown_steps": context_window.context_pressure_cooldown_steps,
+        "provider_context_diagnostics": context_window.provider_context_diagnostics,
+        "provider_context_oversized_feedback_chars": (
+            context_window.provider_context_oversized_feedback_chars
+        ),
     }
     if context_window.max_tool_result_tokens is not None:
         payload["max_tool_result_tokens"] = context_window.max_tool_result_tokens

--- a/src/voidcode/runtime/config_schema.py
+++ b/src/voidcode/runtime/config_schema.py
@@ -355,6 +355,23 @@ def runtime_config_json_schema() -> dict[str, object]:
                         "maximum": 1,
                     },
                     "context_pressure_cooldown_steps": {"type": "integer", "minimum": 1},
+                    "provider_context_diagnostics": {
+                        "type": "string",
+                        "enum": ["off", "warn", "block"],
+                        "description": (
+                            "Runtime policy for provider-context diagnostics before provider "
+                            "execution. 'warn' emits bounded metadata, 'block' fails selected "
+                            "high-severity diagnostics before the provider call, and 'off' keeps "
+                            "diagnostics debug-only."
+                        ),
+                    },
+                    "provider_context_oversized_feedback_chars": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": (
+                            "Character threshold for oversized retained tool feedback diagnostics."
+                        ),
+                    },
                 },
             },
             "lspServerConfig": {

--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -757,6 +757,10 @@ class RuntimeSessionDebugFailure:
     message: str
 
 
+type RuntimeProviderContextDiagnosticPolicyMode = Literal["off", "warn", "block"]
+type RuntimeProviderContextDiagnosticPolicyAction = Literal["none", "ignored", "warn", "block"]
+
+
 @dataclass(frozen=True, slots=True)
 class RuntimeProviderContextDiagnostic:
     severity: Literal["info", "warning", "error"]
@@ -766,6 +770,19 @@ class RuntimeProviderContextDiagnostic:
     segment_indices: tuple[int, ...] = ()
     suggested_fix: str | None = None
     details: dict[str, object] = field(default_factory=dict)
+    policy_action: RuntimeProviderContextDiagnosticPolicyAction = "none"
+    policy_blocking: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeProviderContextPolicyDecision:
+    mode: RuntimeProviderContextDiagnosticPolicyMode
+    action: RuntimeProviderContextDiagnosticPolicyAction
+    blocked: bool
+    diagnostic_count: int = 0
+    diagnostic_codes: tuple[str, ...] = ()
+    blocking_diagnostic_codes: tuple[str, ...] = ()
+    message: str = "Provider-context diagnostic policy did not find actionable diagnostics."
 
 
 @dataclass(frozen=True, slots=True)
@@ -803,6 +820,7 @@ class RuntimeProviderContextSnapshot:
     segments: tuple[RuntimeProviderContextSegmentSnapshot, ...] = ()
     provider_messages: tuple[RuntimeProviderMessageSnapshot, ...] = ()
     diagnostics: tuple[RuntimeProviderContextDiagnostic, ...] = ()
+    policy_decision: RuntimeProviderContextPolicyDecision | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/voidcode/runtime/http.py
+++ b/src/voidcode/runtime/http.py
@@ -2041,6 +2041,21 @@ class RuntimeTransportApp:
                 }
                 for message in snapshot.provider_messages
             ],
+            "policy_decision": (
+                {
+                    "mode": snapshot.policy_decision.mode,
+                    "action": snapshot.policy_decision.action,
+                    "blocked": snapshot.policy_decision.blocked,
+                    "diagnostic_count": snapshot.policy_decision.diagnostic_count,
+                    "diagnostic_codes": list(snapshot.policy_decision.diagnostic_codes),
+                    "blocking_diagnostic_codes": list(
+                        snapshot.policy_decision.blocking_diagnostic_codes
+                    ),
+                    "message": snapshot.policy_decision.message,
+                }
+                if snapshot.policy_decision is not None
+                else None
+            ),
             "diagnostics": [
                 {
                     "severity": diagnostic.severity,
@@ -2050,6 +2065,8 @@ class RuntimeTransportApp:
                     "segment_indices": list(diagnostic.segment_indices),
                     "suggested_fix": diagnostic.suggested_fix,
                     "details": diagnostic.details,
+                    "policy_action": diagnostic.policy_action,
+                    "policy_blocking": diagnostic.policy_blocking,
                 }
                 for diagnostic in snapshot.diagnostics
             ],

--- a/src/voidcode/runtime/provider_context.py
+++ b/src/voidcode/runtime/provider_context.py
@@ -10,6 +10,9 @@ from ..tools.output import sanitize_tool_arguments, sanitize_tool_result_data
 from .context_window import RuntimeAssembledContext, RuntimeContextSegment
 from .contracts import (
     RuntimeProviderContextDiagnostic,
+    RuntimeProviderContextDiagnosticPolicyAction,
+    RuntimeProviderContextDiagnosticPolicyMode,
+    RuntimeProviderContextPolicyDecision,
     RuntimeProviderContextSegmentSnapshot,
     RuntimeProviderContextSnapshot,
     RuntimeProviderMessageSnapshot,
@@ -17,6 +20,15 @@ from .contracts import (
 
 _MAX_DEBUG_CONTENT_CHARS = 2_000
 _OVERSIZED_TOOL_FEEDBACK_CHARS = 8_000
+_PROVIDER_CONTEXT_POLICY_BLOCKING_CODES = frozenset(
+    {
+        "missing_tool_result",
+        "orphan_tool_result",
+        "duplicate_tool_call_id",
+        "oversized_tool_feedback",
+        "provider_requires_tools_schema",
+    }
+)
 _SECRET_KEYS = frozenset(
     {
         "access_token",
@@ -45,6 +57,8 @@ def inspect_provider_context(
     execution_engine: str,
     available_tool_count: int,
     tool_feedback_mode: ToolFeedbackMode = "standard",
+    oversized_tool_feedback_chars: int = _OVERSIZED_TOOL_FEEDBACK_CHARS,
+    diagnostic_policy_mode: RuntimeProviderContextDiagnosticPolicyMode | None = None,
 ) -> RuntimeProviderContextSnapshot:
     segments = tuple(
         _segment_snapshot(index, segment)
@@ -62,8 +76,19 @@ def inspect_provider_context(
             context_metadata=assembled_context.metadata,
             tool_feedback_mode=tool_feedback_mode,
             available_tool_count=available_tool_count,
+            oversized_tool_feedback_chars=oversized_tool_feedback_chars,
         )
     )
+    policy_decision = (
+        evaluate_provider_context_policy(diagnostics, mode=diagnostic_policy_mode)
+        if diagnostic_policy_mode is not None
+        else None
+    )
+    if policy_decision is not None:
+        diagnostics = tuple(
+            _diagnostic_with_policy_metadata(diagnostic, policy_decision)
+            for diagnostic in diagnostics
+        )
     return RuntimeProviderContextSnapshot(
         provider=provider,
         model=model,
@@ -74,6 +99,92 @@ def inspect_provider_context(
         segments=segments,
         provider_messages=provider_messages,
         diagnostics=diagnostics,
+        policy_decision=policy_decision,
+    )
+
+
+def evaluate_provider_context_policy(
+    diagnostics: tuple[RuntimeProviderContextDiagnostic, ...],
+    *,
+    mode: RuntimeProviderContextDiagnosticPolicyMode,
+) -> RuntimeProviderContextPolicyDecision:
+    actionable = tuple(
+        diagnostic for diagnostic in diagnostics if diagnostic.severity in {"warning", "error"}
+    )
+    blocking = tuple(
+        diagnostic
+        for diagnostic in diagnostics
+        if diagnostic.severity == "error"
+        or diagnostic.code in _PROVIDER_CONTEXT_POLICY_BLOCKING_CODES
+    )
+    diagnostic_codes = tuple(diagnostic.code for diagnostic in actionable)
+    blocking_codes = tuple(diagnostic.code for diagnostic in blocking)
+    if mode == "off":
+        return RuntimeProviderContextPolicyDecision(
+            mode=mode,
+            action="ignored",
+            blocked=False,
+            diagnostic_count=len(actionable),
+            diagnostic_codes=diagnostic_codes,
+            blocking_diagnostic_codes=(),
+            message="Provider-context diagnostics policy is off; diagnostics are debug-only.",
+        )
+    if mode == "block" and blocking:
+        return RuntimeProviderContextPolicyDecision(
+            mode=mode,
+            action="block",
+            blocked=True,
+            diagnostic_count=len(actionable),
+            diagnostic_codes=diagnostic_codes,
+            blocking_diagnostic_codes=blocking_codes,
+            message="Provider execution blocked by provider-context diagnostics policy.",
+        )
+    if actionable:
+        return RuntimeProviderContextPolicyDecision(
+            mode=mode,
+            action="warn",
+            blocked=False,
+            diagnostic_count=len(actionable),
+            diagnostic_codes=diagnostic_codes,
+            blocking_diagnostic_codes=blocking_codes if mode == "block" else (),
+            message="Provider-context diagnostics policy recorded warnings without blocking.",
+        )
+    return RuntimeProviderContextPolicyDecision(
+        mode=mode,
+        action="none",
+        blocked=False,
+        diagnostic_count=0,
+        diagnostic_codes=(),
+        blocking_diagnostic_codes=(),
+    )
+
+
+def _diagnostic_with_policy_metadata(
+    diagnostic: RuntimeProviderContextDiagnostic,
+    decision: RuntimeProviderContextPolicyDecision,
+) -> RuntimeProviderContextDiagnostic:
+    if decision.action in {"none", "ignored"}:
+        action: RuntimeProviderContextDiagnosticPolicyAction = decision.action
+        blocking = False
+    elif decision.blocked and diagnostic.code in decision.blocking_diagnostic_codes:
+        action = "block"
+        blocking = True
+    elif diagnostic.severity in {"warning", "error"}:
+        action = "warn"
+        blocking = False
+    else:
+        action = "none"
+        blocking = False
+    return RuntimeProviderContextDiagnostic(
+        severity=diagnostic.severity,
+        code=diagnostic.code,
+        message=diagnostic.message,
+        source=diagnostic.source,
+        segment_indices=diagnostic.segment_indices,
+        suggested_fix=diagnostic.suggested_fix,
+        details={**diagnostic.details, "policy_mode": decision.mode},
+        policy_action=action,
+        policy_blocking=blocking,
     )
 
 
@@ -306,10 +417,17 @@ def _diagnostics(
     context_metadata: dict[str, object],
     tool_feedback_mode: ToolFeedbackMode,
     available_tool_count: int,
+    oversized_tool_feedback_chars: int,
 ) -> list[RuntimeProviderContextDiagnostic]:
     diagnostics: list[RuntimeProviderContextDiagnostic] = []
     diagnostics.extend(_duplicate_system_diagnostics(segments))
-    diagnostics.extend(_tool_pair_diagnostics(segments, available_tool_count=available_tool_count))
+    diagnostics.extend(
+        _tool_pair_diagnostics(
+            segments,
+            available_tool_count=available_tool_count,
+            oversized_tool_feedback_chars=oversized_tool_feedback_chars,
+        )
+    )
     diagnostics.extend(_context_window_diagnostics(context_metadata))
     diagnostics.extend(_todo_projection_diagnostics(segments))
     if tool_feedback_mode == "synthetic_user_message" and any(
@@ -356,7 +474,10 @@ def _duplicate_system_diagnostics(
 
 
 def _tool_pair_diagnostics(
-    segments: tuple[RuntimeContextSegment, ...], *, available_tool_count: int
+    segments: tuple[RuntimeContextSegment, ...],
+    *,
+    available_tool_count: int,
+    oversized_tool_feedback_chars: int,
 ) -> list[RuntimeProviderContextDiagnostic]:
     diagnostics: list[RuntimeProviderContextDiagnostic] = []
     assistant_ids: dict[str, list[int]] = defaultdict(list)
@@ -366,7 +487,7 @@ def _tool_pair_diagnostics(
             assistant_ids[segment.tool_call_id or ""].append(index)
         if segment.role == "tool":
             tool_ids[segment.tool_call_id or ""].append(index)
-            if len(segment.content or "") > _OVERSIZED_TOOL_FEEDBACK_CHARS:
+            if len(segment.content or "") > oversized_tool_feedback_chars:
                 diagnostics.append(
                     RuntimeProviderContextDiagnostic(
                         severity="warning",
@@ -379,7 +500,10 @@ def _tool_pair_diagnostics(
                         suggested_fix=(
                             "Prefer runtime-owned summaries or artifacts for large tool outputs."
                         ),
-                        details={"content_chars": len(segment.content or "")},
+                        details={
+                            "content_chars": len(segment.content or ""),
+                            "threshold_chars": oversized_tool_feedback_chars,
+                        },
                     )
                 )
     for tool_call_id, indices in assistant_ids.items():

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -28,7 +28,7 @@ from .context_window import (
     RuntimeContinuityState,
     continuity_summary_metadata,
 )
-from .contracts import RuntimeStreamChunk
+from .contracts import RuntimeProviderContextPolicyDecision, RuntimeStreamChunk
 from .events import (
     RUNTIME_CONTEXT_PRESSURE,
     RUNTIME_MEMORY_REFRESHED,
@@ -437,6 +437,7 @@ class RuntimeRunLoopCoordinator:
         provider_attempt = runtime._provider_attempt_from_metadata(graph_request.metadata)
         reasoning_capture_state = runtime._reasoning_capture_state()
         while True:
+            sequence = int(sequence)
             current_graph_request: GraphRunRequest = graph_request
             current_session = session
             base_context = runtime._prepare_provider_context_window(
@@ -498,6 +499,66 @@ class RuntimeRunLoopCoordinator:
             effective_runtime_config = runtime._effective_runtime_config_from_metadata(
                 session.metadata
             )
+            provider_context_policy_decision: RuntimeProviderContextPolicyDecision | None = (
+                runtime._provider_context_policy_decision_for_graph_request(
+                    graph_request=graph_request,
+                    effective_config=effective_runtime_config,
+                )
+            )
+            if provider_context_policy_decision is not None:
+                if provider_context_policy_decision.action == "warn":
+                    policy_event_sequence: int = sequence + 1
+                    yield RuntimeStreamChunk(
+                        kind="event",
+                        session=session,
+                        event=EventEnvelope(
+                            session_id=session.session.id,
+                            sequence=policy_event_sequence,
+                            event_type="runtime.provider_context_policy",
+                            source="runtime",
+                            payload={
+                                "mode": provider_context_policy_decision.mode,
+                                "action": provider_context_policy_decision.action,
+                                "blocked": provider_context_policy_decision.blocked,
+                                "diagnostic_count": (
+                                    provider_context_policy_decision.diagnostic_count
+                                ),
+                                "diagnostic_codes": list(
+                                    provider_context_policy_decision.diagnostic_codes
+                                ),
+                                "blocking_diagnostic_codes": list(
+                                    provider_context_policy_decision.blocking_diagnostic_codes
+                                ),
+                                "message": provider_context_policy_decision.message,
+                            },
+                        ),
+                    )
+                    sequence = policy_event_sequence
+                if provider_context_policy_decision.blocked:
+                    policy_failure_sequence: int = sequence + 1
+                    yield runtime._failed_chunk(
+                        session=session,
+                        sequence=policy_failure_sequence,
+                        error=provider_context_policy_decision.message,
+                        payload={
+                            "kind": "provider_context_policy_blocked",
+                            "provider_context_policy": {
+                                "mode": provider_context_policy_decision.mode,
+                                "action": provider_context_policy_decision.action,
+                                "blocked": provider_context_policy_decision.blocked,
+                                "diagnostic_count": (
+                                    provider_context_policy_decision.diagnostic_count
+                                ),
+                                "diagnostic_codes": list(
+                                    provider_context_policy_decision.diagnostic_codes
+                                ),
+                                "blocking_diagnostic_codes": list(
+                                    provider_context_policy_decision.blocking_diagnostic_codes
+                                ),
+                            },
+                        },
+                    )
+                    return
             context_window_config = effective_runtime_config.context_window
             pressure_threshold = (
                 context_window_config.context_pressure_threshold

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -40,6 +40,7 @@ from ..provider.auth import (
 from ..provider.errors import format_invalid_provider_config_error, guidance_for_provider_error_kind
 from ..provider.model_catalog import (
     ProviderModelCatalog,
+    ToolFeedbackMode,
     infer_model_metadata,
     merge_model_metadata,
 )
@@ -133,6 +134,7 @@ from .contracts import (
     ReviewFileDiff,
     RuntimeBackgroundTaskStatusSnapshot,
     RuntimeNotification,
+    RuntimeProviderContextPolicyDecision,
     RuntimeProviderContextSnapshot,
     RuntimeRequest,
     RuntimeRequestError,
@@ -4324,11 +4326,44 @@ class VoidCodeRuntime:
             skill_prompt_context=self._debug_skill_prompt_context(result.session.metadata),
         )
         effective_config = self._effective_runtime_config_from_metadata(result.session.metadata)
+        return self._provider_context_snapshot_for_assembled_context(
+            assembled_context=assembled_context,
+            effective_config=effective_config,
+        )
+
+    def _provider_context_snapshot_for_assembled_context(
+        self,
+        *,
+        assembled_context: RuntimeAssembledContext,
+        effective_config: EffectiveRuntimeConfig,
+    ) -> RuntimeProviderContextSnapshot:
+        active_target = effective_config.resolved_provider.active_target
+        provider = active_target.selection.provider or "unknown"
+        model = active_target.selection.model or active_target.selection.raw_model or "unknown"
+        tool_registry = self._tool_registry_for_effective_config(effective_config)
+        context_window_config = effective_config.context_window or RuntimeContextWindowConfig()
+        return inspect_provider_context(
+            assembled_context=assembled_context,
+            provider=provider,
+            model=model,
+            execution_engine=effective_config.execution_engine,
+            available_tool_count=len(tool_registry.definitions()),
+            tool_feedback_mode=self._tool_feedback_mode_for_effective_config(effective_config),
+            oversized_tool_feedback_chars=(
+                context_window_config.provider_context_oversized_feedback_chars
+            ),
+            diagnostic_policy_mode=context_window_config.provider_context_diagnostics,
+        )
+
+    @staticmethod
+    def _tool_feedback_mode_for_effective_config(
+        effective_config: EffectiveRuntimeConfig,
+    ) -> ToolFeedbackMode:
         active_target = effective_config.resolved_provider.active_target
         provider = active_target.selection.provider or "unknown"
         model = active_target.selection.model or active_target.selection.raw_model or "unknown"
         inferred_metadata = infer_model_metadata(provider, model) if provider != "unknown" else None
-        tool_feedback_mode = (
+        return (
             active_target.metadata.tool_feedback_mode
             if active_target.metadata is not None
             and active_target.metadata.tool_feedback_mode is not None
@@ -4336,15 +4371,23 @@ class VoidCodeRuntime:
             if inferred_metadata is not None and inferred_metadata.tool_feedback_mode is not None
             else "standard"
         )
-        tool_registry = self._tool_registry_for_effective_config(effective_config)
-        return inspect_provider_context(
-            assembled_context=assembled_context,
-            provider=provider,
-            model=model,
-            execution_engine=effective_config.execution_engine,
-            available_tool_count=len(tool_registry.definitions()),
-            tool_feedback_mode=tool_feedback_mode,
+
+    def _provider_context_policy_decision_for_graph_request(
+        self,
+        *,
+        graph_request: GraphRunRequest,
+        effective_config: EffectiveRuntimeConfig,
+    ) -> RuntimeProviderContextPolicyDecision | None:
+        if effective_config.execution_engine != "provider":
+            return None
+        context_window_config = effective_config.context_window or RuntimeContextWindowConfig()
+        if context_window_config.provider_context_diagnostics == "off":
+            return None
+        snapshot = self._provider_context_snapshot_for_assembled_context(
+            assembled_context=cast(RuntimeAssembledContext, graph_request.assembled_context),
+            effective_config=effective_config,
         )
+        return snapshot.policy_decision
 
     @staticmethod
     def _prompt_and_tool_results_from_debug_events(

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -1234,6 +1234,13 @@ def test_transport_reads_session_debug_snapshot(tmp_path: Path) -> None:
     assert cast(int, provider_context["segment_count"]) >= 3
     provider_segments = cast(list[dict[str, object]], provider_context["segments"])
     assert provider_segments[-1]["tool_name"] == "read_file"
+    policy_decision = cast(dict[str, object], provider_context["policy_decision"])
+    assert policy_decision["mode"] == "warn"
+    assert policy_decision["action"] in {"none", "warn"}
+    assert isinstance(policy_decision["diagnostic_codes"], list)
+    for diagnostic in cast(list[dict[str, object]], provider_context["diagnostics"]):
+        assert diagnostic["policy_action"] in {"none", "warn", "block", "ignored"}
+        assert isinstance(diagnostic["policy_blocking"], bool)
     assert payload["suggested_operator_action"] == "replay"
 
 

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -507,6 +507,14 @@ def test_sessions_debug_outputs_json_snapshot() -> None:
     assert payload["last_relevant_event"]["event_type"] == "graph.response_ready"
     assert payload["provider_context"]["segment_count"] >= 3
     assert payload["provider_context"]["segments"][-1]["tool_name"] == "read_file"
+    provider_context = payload["provider_context"]
+    policy_decision = provider_context["policy_decision"]
+    assert policy_decision["mode"] == "warn"
+    assert policy_decision["action"] in {"none", "warn"}
+    assert isinstance(policy_decision["diagnostic_codes"], list)
+    for diagnostic in provider_context["diagnostics"]:
+        assert diagnostic["policy_action"] in {"none", "warn", "block", "ignored"}
+        assert isinstance(diagnostic["policy_blocking"], bool)
     assert payload["suggested_operator_action"] == "replay"
     assert "Traceback" not in debug_result.stderr
 
@@ -1004,9 +1012,11 @@ def test_run_json_redacts_reasoning_by_default_and_shows_with_flag(capsys: Any) 
             _make_chunk(
                 session_id="demo-session",
                 status="completed",
-                event=_runtime_event(
-                    "runtime.reasoning_part",
-                    **reasoning_payload,
+                event=_StubEvent(
+                    sequence=0,
+                    event_type="runtime.reasoning_part",
+                    source="runtime",
+                    payload=dict(reasoning_payload),
                 ),
                 metadata={"show_thinking": show_thinking},
             ),

--- a/tests/unit/runtime/test_config_schema.py
+++ b/tests/unit/runtime/test_config_schema.py
@@ -125,6 +125,14 @@ def test_runtime_config_json_schema_exposes_core_fields() -> None:
         dict[str, object], context_window_properties["context_pressure_cooldown_steps"]
     )
     assert pressure_cooldown["minimum"] == 1
+    provider_context_diagnostics = cast(
+        dict[str, object], context_window_properties["provider_context_diagnostics"]
+    )
+    assert provider_context_diagnostics["enum"] == ["off", "warn", "block"]
+    provider_context_threshold = cast(
+        dict[str, object], context_window_properties["provider_context_oversized_feedback_chars"]
+    )
+    assert provider_context_threshold["minimum"] == 1
     tools_config = cast(dict[str, object], defs["toolsConfig"])
     assert tools_config["additionalProperties"] is False
     tools_properties = cast(dict[str, object], tools_config["properties"])

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -488,6 +488,92 @@ def test_provider_context_parity_matrix_preserves_tool_shapes_across_debug_messa
     )
 
 
+def test_provider_context_policy_marks_blocking_diagnostics() -> None:
+    assembled = RuntimeAssembledContext(
+        prompt="continue",
+        tool_results=(),
+        continuity_state=None,
+        metadata={},
+        segments=(
+            RuntimeContextSegment(role="user", content="continue"),
+            RuntimeContextSegment(
+                role="assistant",
+                content=None,
+                tool_call_id="missing-result",
+                tool_name="read_file",
+                tool_arguments={"path": "sample.txt"},
+            ),
+            RuntimeContextSegment(
+                role="tool",
+                content="x" * 12,
+                tool_call_id="orphan-result",
+                tool_name="grep",
+                metadata={"status": "ok", "data": {}},
+            ),
+        ),
+    )
+
+    snapshot = inspect_provider_context(
+        assembled_context=assembled,
+        provider="openai",
+        model="gpt-4o",
+        execution_engine="provider",
+        available_tool_count=0,
+        oversized_tool_feedback_chars=5,
+        diagnostic_policy_mode="block",
+    )
+
+    assert snapshot.policy_decision is not None
+    assert snapshot.policy_decision.blocked is True
+    assert snapshot.policy_decision.action == "block"
+    assert set(snapshot.policy_decision.blocking_diagnostic_codes) >= {
+        "missing_tool_result",
+        "orphan_tool_result",
+        "oversized_tool_feedback",
+    }
+    blocking_codes = {
+        diagnostic.code for diagnostic in snapshot.diagnostics if diagnostic.policy_blocking
+    }
+    assert {
+        "missing_tool_result",
+        "orphan_tool_result",
+        "oversized_tool_feedback",
+    } <= blocking_codes
+
+
+def test_provider_context_policy_off_keeps_diagnostics_debug_only() -> None:
+    assembled = RuntimeAssembledContext(
+        prompt="continue",
+        tool_results=(),
+        continuity_state=None,
+        metadata={},
+        segments=(
+            RuntimeContextSegment(role="user", content="continue"),
+            RuntimeContextSegment(
+                role="tool",
+                content="orphan",
+                tool_call_id="orphan-result",
+                tool_name="grep",
+                metadata={"status": "ok", "data": {}},
+            ),
+        ),
+    )
+
+    snapshot = inspect_provider_context(
+        assembled_context=assembled,
+        provider="openai",
+        model="gpt-4o",
+        execution_engine="provider",
+        available_tool_count=3,
+        diagnostic_policy_mode="off",
+    )
+
+    assert snapshot.policy_decision is not None
+    assert snapshot.policy_decision.action == "ignored"
+    assert snapshot.policy_decision.blocked is False
+    assert any(diagnostic.code == "orphan_tool_result" for diagnostic in snapshot.diagnostics)
+
+
 def test_prepare_provider_context_compacts_old_results_and_reports_metadata() -> None:
     context = prepare_provider_context(
         prompt="read sample.txt",

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -353,6 +353,8 @@ def test_runtime_config_loads_context_window_policy_from_repo_file(tmp_path: Pat
                     "continuity_preview_chars": 120,
                     "context_pressure_threshold": 0.75,
                     "context_pressure_cooldown_steps": 5,
+                    "provider_context_diagnostics": "block",
+                    "provider_context_oversized_feedback_chars": 16_000,
                 }
             }
         ),
@@ -378,6 +380,8 @@ def test_runtime_config_loads_context_window_policy_from_repo_file(tmp_path: Pat
         continuity_preview_chars=120,
         context_pressure_threshold=0.75,
         context_pressure_cooldown_steps=5,
+        provider_context_diagnostics="block",
+        provider_context_oversized_feedback_chars=16_000,
     )
 
 
@@ -404,6 +408,8 @@ def test_runtime_context_window_config_serializes_for_session_resume() -> None:
         per_tool_result_tokens={"shell_exec": 400},
         context_pressure_threshold=0.72,
         context_pressure_cooldown_steps=4,
+        provider_context_diagnostics="block",
+        provider_context_oversized_feedback_chars=12_000,
     )
 
     payload = serialize_runtime_context_window_config(config)
@@ -1919,6 +1925,17 @@ def test_runtime_config_rejects_invalid_repo_local_execution_engine(tmp_path: Pa
             "runtime config field 'context_window.context_pressure_cooldown_steps'"
             ".*greater than or equal to 1",
             id="context-window-pressure-cooldown-zero",
+        ),
+        pytest.param(
+            {"context_window": {"provider_context_diagnostics": "error"}},
+            "runtime config field 'context_window.provider_context_diagnostics'.*off, warn, block",
+            id="context-window-provider-context-diagnostics-invalid",
+        ),
+        pytest.param(
+            {"context_window": {"provider_context_oversized_feedback_chars": 0}},
+            "runtime config field 'context_window.provider_context_oversized_feedback_chars'"
+            ".*greater than or equal to 1",
+            id="context-window-provider-context-threshold-zero",
         ),
     ],
 )

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -9492,6 +9492,139 @@ def test_runtime_provider_compaction_emits_continuity_state_and_persists_metadat
     assert replay_runtime_state["continuity"] == expected_continuity
 
 
+def test_runtime_provider_context_policy_warn_does_not_block_provider_call(
+    tmp_path: Path,
+) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("oversized tool feedback", encoding="utf-8")
+    created_providers: list[_ScriptedTurnProvider] = []
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderTurnResult(tool_call=ToolCall("read_file", {"filePath": "sample.txt"})),
+                    ProviderTurnResult(output="done"),
+                ),
+                created_providers=created_providers,
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                provider_context_diagnostics="warn",
+                provider_context_oversized_feedback_chars=5,
+            ),
+        ),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="read sample.txt", session_id="policy-warn"))
+
+    policy_events = [
+        event for event in response.events if event.event_type == "runtime.provider_context_policy"
+    ]
+    assert response.session.status == "completed"
+    assert response.output == "done"
+    assert len(created_providers) == 1
+    assert len(created_providers[0].requests) == 2
+    assert len(policy_events) == 1
+    assert policy_events[0].payload["mode"] == "warn"
+    assert policy_events[0].payload["action"] == "warn"
+    assert policy_events[0].payload["blocked"] is False
+    assert "oversized_tool_feedback" in policy_events[0].payload["diagnostic_codes"]
+
+
+def test_runtime_provider_context_policy_block_fails_before_provider_call(
+    tmp_path: Path,
+) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("oversized tool feedback", encoding="utf-8")
+    created_providers: list[_ScriptedTurnProvider] = []
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderTurnResult(tool_call=ToolCall("read_file", {"filePath": "sample.txt"})),
+                    ProviderTurnResult(output="unused"),
+                ),
+                created_providers=created_providers,
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                provider_context_diagnostics="block",
+                provider_context_oversized_feedback_chars=5,
+            ),
+        ),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="read sample.txt", session_id="policy-block"))
+
+    assert response.session.status == "failed"
+    assert len(created_providers) == 1
+    assert len(created_providers[0].requests) == 1
+    failure = response.events[-1]
+    assert failure.event_type == "runtime.failed"
+    assert failure.payload["kind"] == "provider_context_policy_blocked"
+    policy = cast(dict[str, object], failure.payload["provider_context_policy"])
+    assert policy["mode"] == "block"
+    assert policy["action"] == "block"
+    assert policy["blocked"] is True
+    assert "oversized_tool_feedback" in policy["blocking_diagnostic_codes"]
+
+
+def test_runtime_provider_context_policy_off_preserves_provider_execution(
+    tmp_path: Path,
+) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("oversized tool feedback", encoding="utf-8")
+    created_providers: list[_ScriptedTurnProvider] = []
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderTurnResult(tool_call=ToolCall("read_file", {"filePath": "sample.txt"})),
+                    ProviderTurnResult(output="done"),
+                ),
+                created_providers=created_providers,
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                provider_context_diagnostics="off",
+                provider_context_oversized_feedback_chars=5,
+            ),
+        ),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="read sample.txt", session_id="policy-off"))
+
+    policy_events = [
+        event for event in response.events if event.event_type == "runtime.provider_context_policy"
+    ]
+    assert response.session.status == "completed"
+    assert response.output == "done"
+    assert len(created_providers) == 1
+    assert len(created_providers[0].requests) == 2
+    assert policy_events == []
+
+
 def test_runtime_memory_refreshed_guard_suppresses_duplicate_anchor(tmp_path: Path) -> None:
     runtime = VoidCodeRuntime(workspace=tmp_path)
     coordinator = runtime._run_loop_coordinator  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
## Summary
- Add configurable provider-context diagnostic handling (`off`, `warn`, `block`) with policy decisions and configurable oversized-feedback thresholds.
- Enforce blocking diagnostics before the next provider call while surfacing warn-mode decisions through runtime events and debug snapshots.
- Extend CLI/HTTP debug serialization and tests for policy decisions, diagnostic policy metadata, and warn/block/off behavior.

## Verification
- `mise run check`

Closes #353