### PR TITLE
Use provider usage for context pressure

### DIFF
--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -218,6 +218,7 @@ class RuntimeContextWindow:
     dropped_tool_result_tokens: int | None = None
     token_budget: int | None = None
     token_estimate_source: str | None = None
+    model_context_window_tokens: int | None = None
     reserved_output_tokens: int | None = None
     truncated_tool_result_count: int = 0
     continuity_state: RuntimeContinuityState | None = None
@@ -1125,6 +1126,7 @@ def prepare_provider_context(
             token_estimate_source=(
                 _token_estimate_source(effective_policy) if token_budget is not None else None
             ),
+            model_context_window_tokens=effective_policy.model_context_window_tokens,
             reserved_output_tokens=effective_policy.reserved_output_tokens,
         )
 
@@ -1231,6 +1233,7 @@ def prepare_provider_context(
         dropped_tool_result_tokens=dropped_tokens,
         token_budget=token_budget,
         token_estimate_source=token_estimate_source,
+        model_context_window_tokens=effective_policy.model_context_window_tokens,
         reserved_output_tokens=effective_policy.reserved_output_tokens,
         truncated_tool_result_count=truncated_count,
         continuity_state=continuity_state,

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -575,6 +575,7 @@ class RuntimeRunLoopCoordinator:
                 session=session,
                 context_window=context_window,
                 threshold=pressure_threshold,
+                include_provider_usage=False,
             )
             if pressure_payload is not None and self._should_emit_context_pressure(
                 session=session,
@@ -855,11 +856,14 @@ class RuntimeRunLoopCoordinator:
                 session,
                 getattr(graph_step, "provider_usage", None),
             )
-            pressure_payload = self._build_context_pressure_payload(
-                session=session,
-                context_window=context_window,
-                threshold=pressure_threshold,
-            )
+            pressure_payload = None
+            if getattr(graph_step, "provider_usage", None) is not None:
+                pressure_payload = self._build_context_pressure_payload(
+                    session=session,
+                    context_window=context_window,
+                    threshold=pressure_threshold,
+                    include_provider_usage=True,
+                )
             if pressure_payload is not None and self._should_emit_context_pressure(
                 session=session,
                 pressure_ratio=cast(float, pressure_payload["pressure_ratio"]),
@@ -1456,14 +1460,18 @@ class RuntimeRunLoopCoordinator:
         session: SessionState,
         context_window: RuntimeContextWindow,
         threshold: float,
+        include_provider_usage: bool = False,
     ) -> dict[str, object] | None:
-        provider_payload = RuntimeRunLoopCoordinator._build_provider_usage_context_pressure_payload(
-            session=session,
-            context_window=context_window,
-            threshold=threshold,
-        )
-        if provider_payload is not None:
-            return provider_payload
+        if include_provider_usage:
+            provider_payload = (
+                RuntimeRunLoopCoordinator._build_provider_usage_context_pressure_payload(
+                    session=session,
+                    context_window=context_window,
+                    threshold=threshold,
+                )
+            )
+            if provider_payload is not None:
+                return provider_payload
 
         budget = context_window.token_budget
         estimated_tokens = context_window.original_tool_result_tokens

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -1455,7 +1455,9 @@ class RuntimeRunLoopCoordinator:
         threshold: float,
     ) -> dict[str, object] | None:
         budget = RuntimeRunLoopCoordinator._provider_usage_budget(context_window)
-        provider_total_tokens = RuntimeRunLoopCoordinator._latest_provider_total_tokens(session)
+        provider_total_tokens = RuntimeRunLoopCoordinator._latest_current_provider_total_tokens(
+            session
+        )
         if budget is None or provider_total_tokens is None:
             return None
         if budget <= 0 or provider_total_tokens <= 0:
@@ -1494,11 +1496,15 @@ class RuntimeRunLoopCoordinator:
         return max(1, model_window - reserved_output_tokens)
 
     @staticmethod
-    def _latest_provider_total_tokens(session: SessionState) -> int | None:
+    def _latest_current_provider_total_tokens(session: SessionState) -> int | None:
         raw_provider_usage = session.metadata.get("provider_usage")
         if not isinstance(raw_provider_usage, dict):
             return None
         provider_usage = cast(dict[str, object], raw_provider_usage)
+        current_run_id = RuntimeRunLoopCoordinator._current_run_id(session)
+        latest_run_id = provider_usage.get("latest_run_id")
+        if not isinstance(current_run_id, str) or latest_run_id != current_run_id:
+            return None
         raw_latest = provider_usage.get("latest")
         if not isinstance(raw_latest, dict):
             return None
@@ -1515,6 +1521,15 @@ class RuntimeRunLoopCoordinator:
                 return None
             total_tokens += raw_value
         return total_tokens
+
+    @staticmethod
+    def _current_run_id(session: SessionState) -> str | None:
+        raw_runtime_state = session.metadata.get("runtime_state")
+        if not isinstance(raw_runtime_state, dict):
+            return None
+        runtime_state = cast(dict[str, object], raw_runtime_state)
+        run_id = runtime_state.get("run_id")
+        return run_id if isinstance(run_id, str) and run_id else None
 
     @staticmethod
     def _build_memory_refreshed_payload(

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -461,6 +461,7 @@ class RuntimeRunLoopCoordinator:
                     dropped_tool_result_tokens=base_context.dropped_tool_result_tokens,
                     token_budget=base_context.token_budget,
                     token_estimate_source=base_context.token_estimate_source,
+                    model_context_window_tokens=base_context.model_context_window_tokens,
                     reserved_output_tokens=base_context.reserved_output_tokens,
                     truncated_tool_result_count=base_context.truncated_tool_result_count,
                     continuity_state=reinjected_continuity,
@@ -1412,6 +1413,14 @@ class RuntimeRunLoopCoordinator:
         context_window: RuntimeContextWindow,
         threshold: float,
     ) -> dict[str, object] | None:
+        provider_payload = RuntimeRunLoopCoordinator._build_provider_usage_context_pressure_payload(
+            session=session,
+            context_window=context_window,
+            threshold=threshold,
+        )
+        if provider_payload is not None:
+            return provider_payload
+
         budget = context_window.token_budget
         estimated_tokens = context_window.original_tool_result_tokens
         if budget is None or estimated_tokens is None or budget <= 0 or estimated_tokens <= 0:
@@ -1437,6 +1446,75 @@ class RuntimeRunLoopCoordinator:
         if context_window.continuity_state is not None:
             payload["continuity_state"] = context_window.continuity_state.metadata_payload()
         return payload
+
+    @staticmethod
+    def _build_provider_usage_context_pressure_payload(
+        *,
+        session: SessionState,
+        context_window: RuntimeContextWindow,
+        threshold: float,
+    ) -> dict[str, object] | None:
+        budget = RuntimeRunLoopCoordinator._provider_usage_budget(context_window)
+        provider_total_tokens = RuntimeRunLoopCoordinator._latest_provider_total_tokens(session)
+        if budget is None or provider_total_tokens is None:
+            return None
+        if budget <= 0 or provider_total_tokens <= 0:
+            return None
+        pressure_ratio = provider_total_tokens / budget
+        if pressure_ratio < threshold:
+            return None
+        payload: dict[str, object] = {
+            "kind": "pressure_signal",
+            "session_id": session.session.id,
+            "estimated_tokens": provider_total_tokens,
+            "provider_total_tokens": provider_total_tokens,
+            "budget_max_tokens": budget,
+            "pressure_ratio": pressure_ratio,
+            "threshold": threshold,
+            "reason": "provider_usage_ratio_exceeded",
+            "compacted": context_window.compacted,
+            "token_estimate_source": "provider_usage",
+            "original_tool_result_count": context_window.original_tool_result_count,
+            "retained_tool_result_count": context_window.retained_tool_result_count,
+        }
+        if context_window.summary_anchor is not None:
+            payload["summary_anchor"] = context_window.summary_anchor
+        if context_window.summary_source is not None:
+            payload["summary_source"] = context_window.summary_source
+        if context_window.continuity_state is not None:
+            payload["continuity_state"] = context_window.continuity_state.metadata_payload()
+        return payload
+
+    @staticmethod
+    def _provider_usage_budget(context_window: RuntimeContextWindow) -> int | None:
+        model_window = context_window.model_context_window_tokens
+        if model_window is None:
+            return None
+        reserved_output_tokens = context_window.reserved_output_tokens or 0
+        return max(1, model_window - reserved_output_tokens)
+
+    @staticmethod
+    def _latest_provider_total_tokens(session: SessionState) -> int | None:
+        raw_provider_usage = session.metadata.get("provider_usage")
+        if not isinstance(raw_provider_usage, dict):
+            return None
+        provider_usage = cast(dict[str, object], raw_provider_usage)
+        raw_latest = provider_usage.get("latest")
+        if not isinstance(raw_latest, dict):
+            return None
+        latest = cast(dict[str, object], raw_latest)
+        total_tokens = 0
+        for key in (
+            "input_tokens",
+            "output_tokens",
+            "cache_creation_tokens",
+            "cache_read_tokens",
+        ):
+            raw_value = latest.get(key, 0)
+            if not isinstance(raw_value, int) or isinstance(raw_value, bool):
+                return None
+            total_tokens += raw_value
+        return total_tokens
 
     @staticmethod
     def _build_memory_refreshed_payload(

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -855,6 +855,50 @@ class RuntimeRunLoopCoordinator:
                 session,
                 getattr(graph_step, "provider_usage", None),
             )
+            pressure_payload = self._build_context_pressure_payload(
+                session=session,
+                context_window=context_window,
+                threshold=pressure_threshold,
+            )
+            if pressure_payload is not None and self._should_emit_context_pressure(
+                session=session,
+                pressure_ratio=cast(float, pressure_payload["pressure_ratio"]),
+                threshold=pressure_threshold,
+                cooldown_steps=pressure_cooldown_steps,
+                tool_result_count=context_window.original_tool_result_count,
+            ):
+                session = self._session_with_context_pressure_state(
+                    session=session,
+                    pressure_ratio=cast(float, pressure_payload["pressure_ratio"]),
+                    threshold=pressure_threshold,
+                    tool_result_count=context_window.original_tool_result_count,
+                )
+                sequence += 1
+                yield RuntimeStreamChunk(
+                    kind="event",
+                    session=session,
+                    event=EventEnvelope(
+                        session_id=session.session.id,
+                        sequence=sequence,
+                        event_type=RUNTIME_CONTEXT_PRESSURE,
+                        source="runtime",
+                        payload=pressure_payload,
+                    ),
+                )
+                hook_outcome = runtime._run_lifecycle_hooks(
+                    session=session,
+                    sequence=sequence,
+                    surface="context_pressure",
+                    payload=pressure_payload,
+                )
+                yield from hook_outcome.chunks
+                sequence = hook_outcome.last_sequence
+                if hook_outcome.failed_error is not None:
+                    logger.warning(
+                        "context_pressure hook failed for %s: %s",
+                        session.session.id,
+                        hook_outcome.failed_error,
+                    )
             current_chunk_session = session
             if is_final_step:
                 current_chunk_session = runtime._session_with_plan_state(
@@ -1505,6 +1549,10 @@ class RuntimeRunLoopCoordinator:
         latest_run_id = provider_usage.get("latest_run_id")
         if not isinstance(current_run_id, str) or latest_run_id != current_run_id:
             return None
+        current_provider_attempt = RuntimeRunLoopCoordinator._current_provider_attempt(session)
+        latest_provider_attempt = provider_usage.get("latest_provider_attempt")
+        if latest_provider_attempt != current_provider_attempt:
+            return None
         raw_latest = provider_usage.get("latest")
         if not isinstance(raw_latest, dict):
             return None
@@ -1530,6 +1578,13 @@ class RuntimeRunLoopCoordinator:
         runtime_state = cast(dict[str, object], raw_runtime_state)
         run_id = runtime_state.get("run_id")
         return run_id if isinstance(run_id, str) and run_id else None
+
+    @staticmethod
+    def _current_provider_attempt(session: SessionState) -> int:
+        raw_provider_attempt = session.metadata.get("provider_attempt", 0)
+        if isinstance(raw_provider_attempt, int) and not isinstance(raw_provider_attempt, bool):
+            return raw_provider_attempt
+        return 0
 
     @staticmethod
     def _build_memory_refreshed_payload(

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -5845,6 +5845,7 @@ class VoidCodeRuntime:
         turn_count = 0
         if isinstance(raw_turn_count, int) and not isinstance(raw_turn_count, bool):
             turn_count = raw_turn_count
+        current_run_id = VoidCodeRuntime._run_id_from_session_metadata(session.metadata)
         return SessionState(
             session=session.session,
             status=session.status,
@@ -5853,6 +5854,7 @@ class VoidCodeRuntime:
                 **session.metadata,
                 "provider_usage": {
                     "latest": usage_payload,
+                    "latest_run_id": current_run_id,
                     "cumulative": cumulative_payload,
                     "turn_count": turn_count + 1,
                 },

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -5846,6 +5846,7 @@ class VoidCodeRuntime:
         if isinstance(raw_turn_count, int) and not isinstance(raw_turn_count, bool):
             turn_count = raw_turn_count
         current_run_id = VoidCodeRuntime._run_id_from_session_metadata(session.metadata)
+        current_provider_attempt = VoidCodeRuntime._provider_attempt_from_metadata(session.metadata)
         return SessionState(
             session=session.session,
             status=session.status,
@@ -5855,6 +5856,7 @@ class VoidCodeRuntime:
                 "provider_usage": {
                     "latest": usage_payload,
                     "latest_run_id": current_run_id,
+                    "latest_provider_attempt": current_provider_attempt,
                     "cumulative": cumulative_payload,
                     "turn_count": turn_count + 1,
                 },

--- a/src/voidcode/tools/apply_patch.py
+++ b/src/voidcode/tools/apply_patch.py
@@ -300,6 +300,8 @@ def _apply_marker_patch(patch_text: str, *, workspace: Path) -> ToolResult:
     planned_add_paths: set[str] = set()
     staged_contents: dict[str, str] = {}
     for hunk in hunks:
+        if hunk.move_path is not None and hunk.move_path == hunk.path:
+            raise ValueError(f"Move destination must differ from source: {hunk.move_path}")
         _assert_within_workspace(workspace, Path(hunk.path))
         if hunk.move_path is not None:
             _assert_within_workspace(workspace, Path(hunk.move_path))

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -990,6 +990,7 @@ def test_context_window_policy_metadata_round_trips() -> None:
         auto_compaction=False,
         max_tool_results=6,
         max_tool_result_tokens=200,
+        model_context_window_tokens=1_000,
         reserved_output_tokens=20,
         recent_tool_result_count=2,
         default_tool_result_tokens=30,

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -10121,6 +10121,52 @@ def test_runtime_context_pressure_uses_provider_usage_when_available(tmp_path: P
     assert cast(float, payload["pressure_ratio"]) == 0.8
 
 
+def test_runtime_context_pressure_does_not_reuse_provider_usage_pre_step(
+    tmp_path: Path,
+) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("tiny\n", encoding="utf-8")
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderTurnResult(
+                        tool_call=ToolCall("read_file", {"filePath": "sample.txt"}),
+                        usage=ProviderTokenUsage(input_tokens=75, output_tokens=5),
+                    ),
+                    ProviderTurnResult(output="done"),
+                ),
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                model_context_window_tokens=100,
+                context_pressure_threshold=0.7,
+                context_pressure_cooldown_steps=1,
+            ),
+        ),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="read sample.txt"))
+
+    provider_pressure_events = [
+        event
+        for event in response.events
+        if event.event_type == RUNTIME_CONTEXT_PRESSURE
+        and event.payload.get("token_estimate_source") == "provider_usage"
+    ]
+    assert response.session.status == "completed"
+    assert len(provider_pressure_events) == 1
+    assert provider_pressure_events[0].payload["original_tool_result_count"] == 0
+
+
 def test_runtime_context_pressure_keeps_local_fallback_when_provider_usage_is_low(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -180,13 +180,15 @@ def test_runtime_extracts_shell_external_path_candidates(
     command: str,
     expected: tuple[str, ...],
 ) -> None:
-    assert VoidCodeRuntime._extract_shell_path_candidates(command) == expected
+    runtime_type = cast(Any, VoidCodeRuntime)
+    assert runtime_type._extract_shell_path_candidates(command) == expected
 
 
 def test_runtime_ignores_shell_executable_path_candidate() -> None:
     command = f'"{sys.executable}" -c "print(1)"'
 
-    assert VoidCodeRuntime._extract_shell_path_candidates(command) == ()
+    runtime_type = cast(Any, VoidCodeRuntime)
+    assert runtime_type._extract_shell_path_candidates(command) == ()
 
 
 def test_runtime_canonicalize_candidate_path_handles_unknown_user_tilde(
@@ -194,7 +196,8 @@ def test_runtime_canonicalize_candidate_path_handles_unknown_user_tilde(
 ) -> None:
     runtime = VoidCodeRuntime(workspace=tmp_path)
 
-    canonical = runtime._canonicalize_candidate_path("~unknownuser/file.txt")
+    runtime_private = cast(Any, runtime)
+    canonical = runtime_private._canonicalize_candidate_path("~unknownuser/file.txt")
 
     assert canonical == (tmp_path / "~unknownuser/file.txt").resolve(strict=False)
 
@@ -9535,7 +9538,8 @@ def test_runtime_provider_context_policy_warn_does_not_block_provider_call(
     assert policy_events[0].payload["mode"] == "warn"
     assert policy_events[0].payload["action"] == "warn"
     assert policy_events[0].payload["blocked"] is False
-    assert "oversized_tool_feedback" in policy_events[0].payload["diagnostic_codes"]
+    diagnostic_codes = cast(tuple[str, ...], policy_events[0].payload["diagnostic_codes"])
+    assert "oversized_tool_feedback" in diagnostic_codes
 
 
 def test_runtime_provider_context_policy_block_fails_before_provider_call(
@@ -9580,7 +9584,8 @@ def test_runtime_provider_context_policy_block_fails_before_provider_call(
     assert policy["mode"] == "block"
     assert policy["action"] == "block"
     assert policy["blocked"] is True
-    assert "oversized_tool_feedback" in policy["blocking_diagnostic_codes"]
+    blocking_diagnostic_codes = cast(tuple[str, ...], policy["blocking_diagnostic_codes"])
+    assert "oversized_tool_feedback" in blocking_diagnostic_codes
 
 
 def test_runtime_provider_context_policy_off_preserves_provider_execution(
@@ -9931,6 +9936,98 @@ def test_runtime_provider_turn_usage_is_persisted_in_session_metadata(tmp_path: 
     }
     assert response.session.metadata["provider_usage"] == expected_usage
     assert replay.session.metadata["provider_usage"] == expected_usage
+
+
+def test_runtime_context_pressure_uses_provider_usage_when_available(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("tiny\n", encoding="utf-8")
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderTurnResult(
+                        tool_call=ToolCall("read_file", {"filePath": "sample.txt"}),
+                        usage=ProviderTokenUsage(input_tokens=75, output_tokens=5),
+                    ),
+                    ProviderTurnResult(output="done"),
+                ),
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                model_context_window_tokens=100,
+                context_pressure_threshold=0.7,
+            ),
+        ),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="read sample.txt"))
+
+    pressure_events = [
+        event for event in response.events if event.event_type == RUNTIME_CONTEXT_PRESSURE
+    ]
+    assert response.session.status == "completed"
+    assert len(pressure_events) == 1
+    payload = pressure_events[0].payload
+    assert payload["reason"] == "provider_usage_ratio_exceeded"
+    assert payload["token_estimate_source"] == "provider_usage"
+    assert payload["provider_total_tokens"] == 80
+    assert payload["estimated_tokens"] == 80
+    assert payload["budget_max_tokens"] == 100
+    assert cast(float, payload["pressure_ratio"]) == 0.8
+
+
+def test_runtime_context_pressure_keeps_local_fallback_when_provider_usage_is_low(
+    tmp_path: Path,
+) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("x" * 300, encoding="utf-8")
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderTurnResult(
+                        tool_call=ToolCall("read_file", {"filePath": "sample.txt"}),
+                        usage=ProviderTokenUsage(input_tokens=1, output_tokens=1),
+                    ),
+                    ProviderTurnResult(output="done"),
+                ),
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                max_tool_result_tokens=1,
+                model_context_window_tokens=100,
+                context_pressure_threshold=0.7,
+            ),
+        ),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="read sample.txt"))
+
+    pressure_events = [
+        event for event in response.events if event.event_type == RUNTIME_CONTEXT_PRESSURE
+    ]
+    assert response.session.status == "completed"
+    assert len(pressure_events) == 1
+    payload = pressure_events[0].payload
+    assert payload["reason"] == "token_budget_ratio_exceeded"
+    assert payload["token_estimate_source"] != "provider_usage"
+    assert "provider_total_tokens" not in payload
 
 
 def test_runtime_rejects_provider_engine_without_model(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -9929,6 +9929,7 @@ def test_runtime_provider_turn_usage_is_persisted_in_session_metadata(tmp_path: 
             "cache_read_tokens": 0,
         },
         "latest_run_id": latest_run_id,
+        "latest_provider_attempt": 0,
         "cumulative": {
             "input_tokens": 10,
             "output_tokens": 3,
@@ -9958,6 +9959,7 @@ def test_runtime_context_pressure_ignores_stale_provider_usage(tmp_path: Path) -
                     "cache_read_tokens": 0,
                 },
                 "latest_run_id": "previous-run",
+                "latest_provider_attempt": 0,
                 "cumulative": {
                     "input_tokens": 90,
                     "output_tokens": 10,
@@ -9982,6 +9984,95 @@ def test_runtime_context_pressure_ignores_stale_provider_usage(tmp_path: Path) -
     )
 
     assert payload is None
+
+
+def test_runtime_context_pressure_ignores_previous_provider_attempt_usage(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+    coordinator = runtime._run_loop_coordinator  # pyright: ignore[reportPrivateUsage]
+    session = SessionState(
+        session=SessionRef("stale-provider-attempt"),
+        status="running",
+        metadata={
+            "runtime_state": {"run_id": "current-run"},
+            "provider_attempt": 1,
+            "provider_usage": {
+                "latest": {
+                    "input_tokens": 90,
+                    "output_tokens": 10,
+                    "cache_creation_tokens": 0,
+                    "cache_read_tokens": 0,
+                },
+                "latest_run_id": "current-run",
+                "latest_provider_attempt": 0,
+                "cumulative": {
+                    "input_tokens": 90,
+                    "output_tokens": 10,
+                    "cache_creation_tokens": 0,
+                    "cache_read_tokens": 0,
+                },
+                "turn_count": 1,
+            },
+        },
+    )
+    context_window = RuntimeContextWindow(
+        prompt="fallback prompt",
+        model_context_window_tokens=100,
+        original_tool_result_count=0,
+        retained_tool_result_count=0,
+    )
+
+    payload = coordinator._build_context_pressure_payload(  # pyright: ignore[reportPrivateUsage]
+        session=session,
+        context_window=context_window,
+        threshold=0.7,
+    )
+
+    assert payload is None
+
+
+def test_runtime_context_pressure_emits_after_single_turn_provider_usage(
+    tmp_path: Path,
+) -> None:
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderTurnResult(
+                        output="done",
+                        usage=ProviderTokenUsage(input_tokens=75, output_tokens=5),
+                    ),
+                ),
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                model_context_window_tokens=100,
+                context_pressure_threshold=0.7,
+            ),
+        ),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="summarize"))
+
+    pressure_events = [
+        event for event in response.events if event.event_type == RUNTIME_CONTEXT_PRESSURE
+    ]
+    assert response.session.status == "completed"
+    assert response.output == "done"
+    assert len(pressure_events) == 1
+    payload = pressure_events[0].payload
+    assert payload["reason"] == "provider_usage_ratio_exceeded"
+    assert payload["provider_total_tokens"] == 80
+    assert payload["budget_max_tokens"] == 100
 
 
 def test_runtime_context_pressure_uses_provider_usage_when_available(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -9918,14 +9918,17 @@ def test_runtime_provider_turn_usage_is_persisted_in_session_metadata(tmp_path: 
 
     response = runtime.run(RuntimeRequest(prompt="summarize", session_id="usage-session"))
     replay = runtime.resume("usage-session")
+    provider_usage = cast(dict[str, object], response.session.metadata["provider_usage"])
+    latest_run_id = provider_usage["latest_run_id"]
 
-    expected_usage = {
+    expected_usage: dict[str, object] = {
         "latest": {
             "input_tokens": 10,
             "output_tokens": 3,
             "cache_creation_tokens": 0,
             "cache_read_tokens": 0,
         },
+        "latest_run_id": latest_run_id,
         "cumulative": {
             "input_tokens": 10,
             "output_tokens": 3,
@@ -9934,8 +9937,51 @@ def test_runtime_provider_turn_usage_is_persisted_in_session_metadata(tmp_path: 
         },
         "turn_count": 1,
     }
+    assert isinstance(latest_run_id, str)
     assert response.session.metadata["provider_usage"] == expected_usage
     assert replay.session.metadata["provider_usage"] == expected_usage
+
+
+def test_runtime_context_pressure_ignores_stale_provider_usage(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+    coordinator = runtime._run_loop_coordinator  # pyright: ignore[reportPrivateUsage]
+    session = SessionState(
+        session=SessionRef("stale-provider-usage"),
+        status="running",
+        metadata={
+            "runtime_state": {"run_id": "current-run"},
+            "provider_usage": {
+                "latest": {
+                    "input_tokens": 90,
+                    "output_tokens": 10,
+                    "cache_creation_tokens": 0,
+                    "cache_read_tokens": 0,
+                },
+                "latest_run_id": "previous-run",
+                "cumulative": {
+                    "input_tokens": 90,
+                    "output_tokens": 10,
+                    "cache_creation_tokens": 0,
+                    "cache_read_tokens": 0,
+                },
+                "turn_count": 1,
+            },
+        },
+    )
+    context_window = RuntimeContextWindow(
+        prompt="new prompt",
+        model_context_window_tokens=100,
+        original_tool_result_count=0,
+        retained_tool_result_count=0,
+    )
+
+    payload = coordinator._build_context_pressure_payload(  # pyright: ignore[reportPrivateUsage]
+        session=session,
+        context_window=context_window,
+        threshold=0.7,
+    )
+
+    assert payload is None
 
 
 def test_runtime_context_pressure_uses_provider_usage_when_available(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add provider-usage-driven `runtime.context_pressure` payloads when the latest provider token usage exceeds the configured model window budget.
- Preserve the existing local tool-result estimate fallback when provider usage is absent or below threshold.
- Fix marker-patch same-path move validation so raw identical paths are rejected before path expansion.

## Verification
- `uv run --extra dev ruff check .`
- `uv run --extra dev basedpyright`
- `uv run pytest` (1847 passed)