### PR TITLE
fix(runtime): retry transient provider failures

### DIFF
--- a/src/voidcode/provider/config.py
+++ b/src/voidcode/provider/config.py
@@ -206,6 +206,7 @@ class _ProviderConfigsPayload(_ProviderPayloadModel):
     google: _GoogleProviderConfigPayload | None = None
     copilot: _CopilotProviderConfigPayload | None = None
     litellm: _LiteLLMProviderConfigPayload | None = None
+    opencode: _LiteLLMProviderConfigPayload | None = None
     deepseek: _SimplifiedProviderConfigPayload | None = None
     glm: _SimplifiedProviderConfigPayload | None = None
     grok: _SimplifiedProviderConfigPayload | None = None
@@ -536,6 +537,7 @@ class ProviderConfigs:
     google: GoogleProviderConfig | None = None
     copilot: CopilotProviderConfig | None = None
     litellm: LiteLLMProviderConfig | None = None
+    opencode: LiteLLMProviderConfig | None = None
     deepseek: SimplifiedProviderConfig | None = None
     glm: SimplifiedProviderConfig | None = None
     grok: SimplifiedProviderConfig | None = None
@@ -661,6 +663,7 @@ def merge_provider_configs(
         google=_merge_google_provider_config(primary.google, fallback.google),
         copilot=_merge_copilot_provider_config(primary.copilot, fallback.copilot),
         litellm=_merge_litellm_provider_config(primary.litellm, fallback.litellm),
+        opencode=_merge_litellm_provider_config(primary.opencode, fallback.opencode),
         deepseek=_merge_simplified_provider_config(primary.deepseek, fallback.deepseek),
         glm=_merge_simplified_provider_config(primary.glm, fallback.glm),
         grok=_merge_simplified_provider_config(primary.grok, fallback.grok),
@@ -819,6 +822,7 @@ def _provider_configs_has_entries(providers: ProviderConfigs) -> bool:
             providers.google,
             providers.copilot,
             providers.litellm,
+            providers.opencode,
             providers.deepseek,
             providers.glm,
             providers.grok,
@@ -948,6 +952,11 @@ def parse_provider_configs_payload(
             field_path=_nested_config_field(source, "litellm"),
             env=environment,
         ),
+        opencode=_parse_litellm_provider_config(
+            payload.opencode,
+            field_path=_nested_config_field(source, "opencode"),
+            env=environment,
+        ),
         deepseek=_parse_simplified_provider_config(
             payload.deepseek,
             field_path=_nested_config_field(source, "deepseek"),
@@ -1030,6 +1039,11 @@ def serialize_provider_configs(
     if providers.litellm is not None:
         serialized["litellm"] = _serialize_litellm_provider_config(
             providers.litellm,
+            include_secrets=include_secrets,
+        )
+    if providers.opencode is not None:
+        serialized["opencode"] = _serialize_litellm_provider_config(
+            providers.opencode,
             include_secrets=include_secrets,
         )
     if providers.deepseek is not None:

--- a/src/voidcode/provider/config.py
+++ b/src/voidcode/provider/config.py
@@ -38,6 +38,30 @@ def _parse_optional_boundary_positive_int(value: object) -> int | None:
     return value
 
 
+def _parse_optional_boundary_nonnegative_int(value: object) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError("must be an integer greater than or equal to 0 when provided")
+    return value
+
+
+def _parse_optional_boundary_nonnegative_float(value: object) -> float | None:
+    if value is None:
+        return None
+    if not isinstance(value, int | float) or isinstance(value, bool) or value < 0:
+        raise ValueError("must be a number greater than or equal to 0 when provided")
+    return float(value)
+
+
+def _parse_optional_boundary_bool(value: object) -> bool | None:
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise ValueError("must be a boolean when provided")
+    return value
+
+
 def _parse_boundary_string_list(value: object) -> tuple[str, ...]:
     if value is None:
         return ()
@@ -76,6 +100,13 @@ BoundaryOptionalTimeout = Annotated[float | None, BeforeValidator(_parse_optiona
 BoundaryOptionalPositiveInt = Annotated[
     int | None, BeforeValidator(_parse_optional_boundary_positive_int)
 ]
+BoundaryOptionalNonnegativeInt = Annotated[
+    int | None, BeforeValidator(_parse_optional_boundary_nonnegative_int)
+]
+BoundaryOptionalNonnegativeFloat = Annotated[
+    float | None, BeforeValidator(_parse_optional_boundary_nonnegative_float)
+]
+BoundaryOptionalBool = Annotated[bool | None, BeforeValidator(_parse_optional_boundary_bool)]
 BoundaryStringList = Annotated[tuple[str, ...], BeforeValidator(_parse_boundary_string_list)]
 BoundaryStringMapping = Annotated[dict[str, str], BeforeValidator(_parse_boundary_string_mapping)]
 
@@ -88,6 +119,13 @@ class _ProviderPayloadModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class _ProviderTransientRetryConfigPayload(_ProviderPayloadModel):
+    max_retries: BoundaryOptionalNonnegativeInt = None
+    base_delay_ms: BoundaryOptionalNonnegativeFloat = None
+    max_delay_ms: BoundaryOptionalNonnegativeFloat = None
+    jitter: BoundaryOptionalBool = None
+
+
 class _OpenAIProviderConfigPayload(_ProviderPayloadModel):
     api_key: BoundaryOptionalString = None
     base_url: BoundaryOptionalString = None
@@ -95,6 +133,7 @@ class _OpenAIProviderConfigPayload(_ProviderPayloadModel):
     organization: BoundaryOptionalString = None
     project: BoundaryOptionalString = None
     timeout_seconds: BoundaryOptionalTimeout = None
+    transient_retry: _ProviderTransientRetryConfigPayload | None = None
 
 
 class _AnthropicProviderConfigPayload(_ProviderPayloadModel):
@@ -104,6 +143,7 @@ class _AnthropicProviderConfigPayload(_ProviderPayloadModel):
     version: BoundaryOptionalString = None
     beta_headers: BoundaryStringList = ()
     timeout_seconds: BoundaryOptionalTimeout = None
+    transient_retry: _ProviderTransientRetryConfigPayload | None = None
 
 
 class _GoogleProviderAuthConfigPayload(_ProviderPayloadModel):
@@ -120,6 +160,7 @@ class _GoogleProviderConfigPayload(_ProviderPayloadModel):
     project: BoundaryOptionalString = None
     region: BoundaryOptionalString = None
     timeout_seconds: BoundaryOptionalTimeout = None
+    transient_retry: _ProviderTransientRetryConfigPayload | None = None
 
 
 class _CopilotProviderAuthConfigPayload(_ProviderPayloadModel):
@@ -134,6 +175,7 @@ class _CopilotProviderConfigPayload(_ProviderPayloadModel):
     auth: _CopilotProviderAuthConfigPayload | None = None
     base_url: BoundaryOptionalString = None
     timeout_seconds: BoundaryOptionalTimeout = None
+    transient_retry: _ProviderTransientRetryConfigPayload | None = None
 
 
 class _LiteLLMProviderConfigPayload(_ProviderPayloadModel):
@@ -145,6 +187,7 @@ class _LiteLLMProviderConfigPayload(_ProviderPayloadModel):
     auth_scheme: BoundaryOptionalString = None
     timeout_seconds: BoundaryOptionalTimeout = None
     model_map: BoundaryStringMapping = Field(default_factory=dict)
+    transient_retry: _ProviderTransientRetryConfigPayload | None = None
 
 
 class _SimplifiedProviderConfigPayload(_ProviderPayloadModel):
@@ -154,6 +197,7 @@ class _SimplifiedProviderConfigPayload(_ProviderPayloadModel):
     discovery_base_url: BoundaryOptionalString = None
     timeout_seconds: BoundaryOptionalTimeout = None
     model_map: BoundaryStringMapping = Field(default_factory=dict)
+    transient_retry: _ProviderTransientRetryConfigPayload | None = None
 
 
 class _ProviderConfigsPayload(_ProviderPayloadModel):
@@ -184,6 +228,27 @@ class _ProviderFallbackPayload(_ProviderPayloadModel):
 
 
 @dataclass(frozen=True, slots=True)
+class ProviderTransientRetryConfig:
+    max_retries: int = 2
+    base_delay_ms: float = 1000.0
+    max_delay_ms: float = 10_000.0
+    jitter: bool = True
+
+    def __post_init__(self) -> None:
+        if self.max_retries < 0:
+            raise ValueError("max_retries must be greater than or equal to 0")
+        if self.base_delay_ms < 0:
+            raise ValueError("base_delay_ms must be greater than or equal to 0")
+        if self.max_delay_ms < 0:
+            raise ValueError("max_delay_ms must be greater than or equal to 0")
+        if self.max_delay_ms < self.base_delay_ms:
+            raise ValueError("max_delay_ms must be greater than or equal to base_delay_ms")
+
+
+DEFAULT_PROVIDER_TRANSIENT_RETRY_CONFIG = ProviderTransientRetryConfig()
+
+
+@dataclass(frozen=True, slots=True)
 class SimplifiedProviderConfig:
     """Simplified provider configuration for Chinese AI providers.
 
@@ -197,6 +262,7 @@ class SimplifiedProviderConfig:
     discovery_base_url: str | None = None
     timeout_seconds: float | None = None
     model_map: dict[str, str] = field(default_factory=dict)
+    transient_retry: ProviderTransientRetryConfig | None = None
 
 
 _SIMPLIFIED_DEFAULTS: dict[str, tuple[str, str | None, dict[str, str]]] = {
@@ -384,6 +450,7 @@ class OpenAIProviderConfig:
     organization: str | None = None
     project: str | None = None
     timeout_seconds: float | None = None
+    transient_retry: ProviderTransientRetryConfig | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -394,6 +461,7 @@ class AnthropicProviderConfig:
     version: str | None = None
     beta_headers: tuple[str, ...] = ()
     timeout_seconds: float | None = None
+    transient_retry: ProviderTransientRetryConfig | None = None
     beta_headers_explicit: bool = field(default=False, compare=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -420,6 +488,7 @@ class GoogleProviderConfig:
     project: str | None = None
     region: str | None = None
     timeout_seconds: float | None = None
+    transient_retry: ProviderTransientRetryConfig | None = None
 
 
 type CopilotAuthMethod = Literal["token", "oauth"]
@@ -439,6 +508,7 @@ class CopilotProviderConfig:
     auth: CopilotProviderAuthConfig | None = None
     base_url: str | None = None
     timeout_seconds: float | None = None
+    transient_retry: ProviderTransientRetryConfig | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -451,6 +521,7 @@ class LiteLLMProviderConfig:
     auth_scheme: Literal["bearer", "token", "none"] = "bearer"
     timeout_seconds: float | None = None
     model_map: dict[str, str] = field(default_factory=dict)
+    transient_retry: ProviderTransientRetryConfig | None = None
     auth_scheme_explicit: bool = field(default=False, compare=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -619,6 +690,7 @@ def _merge_openai_provider_config(
         organization=_prefer_primary(primary.organization, fallback.organization),
         project=_prefer_primary(primary.project, fallback.project),
         timeout_seconds=_prefer_primary(primary.timeout_seconds, fallback.timeout_seconds),
+        transient_retry=_prefer_primary(primary.transient_retry, fallback.transient_retry),
     )
 
 
@@ -640,6 +712,7 @@ def _merge_anthropic_provider_config(
         ),
         beta_headers_explicit=primary.beta_headers_explicit or fallback.beta_headers_explicit,
         timeout_seconds=_prefer_primary(primary.timeout_seconds, fallback.timeout_seconds),
+        transient_retry=_prefer_primary(primary.transient_retry, fallback.transient_retry),
     )
 
 
@@ -658,6 +731,7 @@ def _merge_google_provider_config(
         project=_prefer_primary(primary.project, fallback.project),
         region=_prefer_primary(primary.region, fallback.region),
         timeout_seconds=_prefer_primary(primary.timeout_seconds, fallback.timeout_seconds),
+        transient_retry=_prefer_primary(primary.transient_retry, fallback.transient_retry),
     )
 
 
@@ -673,6 +747,7 @@ def _merge_copilot_provider_config(
         auth=_prefer_primary(primary.auth, fallback.auth),
         base_url=_prefer_primary(primary.base_url, fallback.base_url),
         timeout_seconds=_prefer_primary(primary.timeout_seconds, fallback.timeout_seconds),
+        transient_retry=_prefer_primary(primary.transient_retry, fallback.transient_retry),
     )
 
 
@@ -694,6 +769,7 @@ def _merge_litellm_provider_config(
         auth_scheme_explicit=primary.auth_scheme_explicit or fallback.auth_scheme_explicit,
         timeout_seconds=_prefer_primary(primary.timeout_seconds, fallback.timeout_seconds),
         model_map={**fallback.model_map, **primary.model_map},
+        transient_retry=_prefer_primary(primary.transient_retry, fallback.transient_retry),
     )
 
 
@@ -712,6 +788,7 @@ def _merge_simplified_provider_config(
         discovery_base_url=_prefer_primary(primary.discovery_base_url, fallback.discovery_base_url),
         timeout_seconds=_prefer_primary(primary.timeout_seconds, fallback.timeout_seconds),
         model_map={**fallback.model_map, **primary.model_map},
+        transient_retry=_prefer_primary(primary.transient_retry, fallback.transient_retry),
     )
 
 
@@ -1063,6 +1140,10 @@ def _parse_openai_provider_config(
         organization=payload.organization,
         project=payload.project,
         timeout_seconds=payload.timeout_seconds,
+        transient_retry=_parse_transient_retry_config(
+            payload.transient_retry,
+            field_path=_nested_config_field(field_path, "transient_retry"),
+        ),
     )
 
 
@@ -1095,6 +1176,10 @@ def _parse_anthropic_provider_config(
         beta_headers=payload.beta_headers,
         beta_headers_explicit="beta_headers" in payload.model_fields_set,
         timeout_seconds=payload.timeout_seconds,
+        transient_retry=_parse_transient_retry_config(
+            payload.transient_retry,
+            field_path=_nested_config_field(field_path, "transient_retry"),
+        ),
     )
 
 
@@ -1128,6 +1213,10 @@ def _parse_google_provider_config(
         project=payload.project,
         region=payload.region,
         timeout_seconds=payload.timeout_seconds,
+        transient_retry=_parse_transient_retry_config(
+            payload.transient_retry,
+            field_path=_nested_config_field(field_path, "transient_retry"),
+        ),
     )
 
 
@@ -1244,6 +1333,10 @@ def _parse_copilot_provider_config(
         auth=auth,
         base_url=payload.base_url,
         timeout_seconds=payload.timeout_seconds,
+        transient_retry=_parse_transient_retry_config(
+            payload.transient_retry,
+            field_path=_nested_config_field(field_path, "transient_retry"),
+        ),
     )
 
 
@@ -1370,6 +1463,10 @@ def _parse_litellm_provider_config(
         auth_scheme_explicit=raw_auth_scheme is not None,
         timeout_seconds=payload.timeout_seconds,
         model_map=payload.model_map,
+        transient_retry=_parse_transient_retry_config(
+            payload.transient_retry,
+            field_path=_nested_config_field(field_path, "transient_retry"),
+        ),
     )
 
 
@@ -1411,6 +1508,57 @@ def _parse_simplified_provider_config(
         discovery_base_url=payload.discovery_base_url,
         timeout_seconds=payload.timeout_seconds,
         model_map=payload.model_map,
+        transient_retry=_parse_transient_retry_config(
+            payload.transient_retry,
+            field_path=_nested_config_field(field_path, "transient_retry"),
+        ),
+    )
+
+
+def _parse_transient_retry_config(
+    raw_value: object,
+    *,
+    field_path: str,
+) -> ProviderTransientRetryConfig | None:
+    if raw_value is None:
+        return None
+    payload = (
+        raw_value
+        if isinstance(raw_value, _ProviderTransientRetryConfigPayload)
+        else _validate_provider_payload_model(
+            raw_value,
+            field_path=field_path,
+            model_type=_ProviderTransientRetryConfigPayload,
+        )
+    )
+    base_delay_ms = (
+        DEFAULT_PROVIDER_TRANSIENT_RETRY_CONFIG.base_delay_ms
+        if payload.base_delay_ms is None
+        else payload.base_delay_ms
+    )
+    max_delay_ms = (
+        DEFAULT_PROVIDER_TRANSIENT_RETRY_CONFIG.max_delay_ms
+        if payload.max_delay_ms is None
+        else payload.max_delay_ms
+    )
+    if max_delay_ms < base_delay_ms:
+        raise ValueError(
+            f"{_nested_config_field(field_path, 'max_delay_ms')} "
+            "must be greater than or equal to base_delay_ms"
+        )
+    return ProviderTransientRetryConfig(
+        max_retries=(
+            DEFAULT_PROVIDER_TRANSIENT_RETRY_CONFIG.max_retries
+            if payload.max_retries is None
+            else payload.max_retries
+        ),
+        base_delay_ms=base_delay_ms,
+        max_delay_ms=max_delay_ms,
+        jitter=(
+            DEFAULT_PROVIDER_TRANSIENT_RETRY_CONFIG.jitter
+            if payload.jitter is None
+            else payload.jitter
+        ),
     )
 
 
@@ -1432,6 +1580,8 @@ def _serialize_openai_provider_config(
         payload["project"] = provider.project
     if provider.timeout_seconds is not None:
         payload["timeout_seconds"] = provider.timeout_seconds
+    if provider.transient_retry is not None:
+        payload["transient_retry"] = _serialize_transient_retry_config(provider.transient_retry)
     return payload
 
 
@@ -1453,6 +1603,8 @@ def _serialize_anthropic_provider_config(
         payload["beta_headers"] = list(provider.beta_headers)
     if provider.timeout_seconds is not None:
         payload["timeout_seconds"] = provider.timeout_seconds
+    if provider.transient_retry is not None:
+        payload["transient_retry"] = _serialize_transient_retry_config(provider.transient_retry)
     return payload
 
 
@@ -1476,6 +1628,8 @@ def _serialize_google_provider_config(
         payload["region"] = provider.region
     if provider.timeout_seconds is not None:
         payload["timeout_seconds"] = provider.timeout_seconds
+    if provider.transient_retry is not None:
+        payload["transient_retry"] = _serialize_transient_retry_config(provider.transient_retry)
     return payload
 
 
@@ -1509,6 +1663,8 @@ def _serialize_copilot_provider_config(
         payload["base_url"] = provider.base_url
     if provider.timeout_seconds is not None:
         payload["timeout_seconds"] = provider.timeout_seconds
+    if provider.transient_retry is not None:
+        payload["transient_retry"] = _serialize_transient_retry_config(provider.transient_retry)
     return payload
 
 
@@ -1550,6 +1706,8 @@ def _serialize_litellm_provider_config(
         payload["timeout_seconds"] = provider.timeout_seconds
     if provider.model_map:
         payload["model_map"] = dict(provider.model_map)
+    if provider.transient_retry is not None:
+        payload["transient_retry"] = _serialize_transient_retry_config(provider.transient_retry)
     return payload
 
 
@@ -1571,7 +1729,20 @@ def _serialize_simplified_provider_config(
         payload["timeout_seconds"] = provider.timeout_seconds
     if provider.model_map:
         payload["model_map"] = dict(provider.model_map)
+    if provider.transient_retry is not None:
+        payload["transient_retry"] = _serialize_transient_retry_config(provider.transient_retry)
     return payload
+
+
+def _serialize_transient_retry_config(
+    retry_config: ProviderTransientRetryConfig,
+) -> dict[str, object]:
+    return {
+        "max_retries": retry_config.max_retries,
+        "base_delay_ms": retry_config.base_delay_ms,
+        "max_delay_ms": retry_config.max_delay_ms,
+        "jitter": retry_config.jitter,
+    }
 
 
 def _parse_custom_litellm_provider_configs(

--- a/src/voidcode/provider/errors.py
+++ b/src/voidcode/provider/errors.py
@@ -392,6 +392,19 @@ def format_fallback_exhausted_error(*, provider_name: str, model_name: str, atte
     )
 
 
+def format_provider_retry_exhausted_error(
+    *,
+    provider_name: str,
+    model_name: str,
+    retry_attempts: int,
+) -> str:
+    return (
+        f"transient provider error on {provider_name}/{model_name}; "
+        "same-target retry exhausted after "
+        f"{retry_attempts} retries and no fallback target available"
+    )
+
+
 def classify_provider_error(exc: Exception) -> SingleAgentProviderError | None:
     message = str(exc).lower()
     context_limit_markers = (

--- a/src/voidcode/runtime/events.py
+++ b/src/voidcode/runtime/events.py
@@ -12,6 +12,7 @@ type ExistingEventType = Literal[
     "runtime.skills_loaded",
     "runtime.skills_applied",
     "runtime.provider_fallback",
+    "runtime.provider_transient_retry",
     "runtime.category_model_diagnostic",
     "runtime.acp_connected",
     "runtime.acp_disconnected",
@@ -90,6 +91,7 @@ RUNTIME_REQUEST_RECEIVED: Final[ExistingEventType] = "runtime.request_received"
 RUNTIME_SKILLS_LOADED: Final[ExistingEventType] = "runtime.skills_loaded"
 RUNTIME_SKILLS_APPLIED: Final[ExistingEventType] = "runtime.skills_applied"
 RUNTIME_PROVIDER_FALLBACK: Final[ExistingEventType] = "runtime.provider_fallback"
+RUNTIME_PROVIDER_TRANSIENT_RETRY: Final[ExistingEventType] = "runtime.provider_transient_retry"
 RUNTIME_CATEGORY_MODEL_DIAGNOSTIC: Final[ExistingEventType] = "runtime.category_model_diagnostic"
 RUNTIME_ACP_CONNECTED: Final[ExistingEventType] = "runtime.acp_connected"
 RUNTIME_ACP_DISCONNECTED: Final[ExistingEventType] = "runtime.acp_disconnected"
@@ -178,6 +180,7 @@ EMITTED_EVENT_TYPES: Final[tuple[ExistingEventType, ...]] = (
     RUNTIME_SKILLS_LOADED,
     RUNTIME_SKILLS_APPLIED,
     RUNTIME_PROVIDER_FALLBACK,
+    RUNTIME_PROVIDER_TRANSIENT_RETRY,
     RUNTIME_CATEGORY_MODEL_DIAGNOSTIC,
     RUNTIME_ACP_CONNECTED,
     RUNTIME_ACP_DISCONNECTED,

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -925,6 +925,7 @@ class RuntimeRunLoopCoordinator:
                     tool_results=tuple(tool_results),
                     session=session,
                 )
+                provider_retry_attempt = 0
             except Exception as exc:
                 current_provider_attempt = runtime._provider_attempt_from_metadata(
                     {"provider_attempt": provider_attempt}
@@ -1226,6 +1227,13 @@ class RuntimeRunLoopCoordinator:
                 session,
                 getattr(graph_step, "provider_usage", None),
             )
+            if runtime._provider_retry_attempt_from_metadata(session.metadata) != 0:
+                session = SessionState(
+                    session=session.session,
+                    status=session.status,
+                    turn=session.turn,
+                    metadata={**session.metadata, "provider_retry_attempt": 0},
+                )
             pressure_payload = None
             if getattr(graph_step, "provider_usage", None) is not None:
                 pressure_payload = self._build_context_pressure_payload(

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import logging
 import queue
+import random
 import threading
+import time
 from collections.abc import Generator, Iterator, Mapping
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, cast
@@ -15,6 +17,7 @@ from ..provider.errors import (
     SingleAgentContextLimitError,
     classify_provider_error,
     format_fallback_exhausted_error,
+    format_provider_retry_exhausted_error,
 )
 from ..provider.protocol import (
     ProviderAbortSignal,
@@ -44,6 +47,7 @@ from .contracts import RuntimeProviderContextPolicyDecision, RuntimeStreamChunk
 from .events import (
     RUNTIME_CONTEXT_PRESSURE,
     RUNTIME_MEMORY_REFRESHED,
+    RUNTIME_PROVIDER_TRANSIENT_RETRY,
     RUNTIME_QUESTION_REQUESTED,
     RUNTIME_SKILL_LOADED,
     RUNTIME_TODO_UPDATED,
@@ -63,6 +67,20 @@ logger = logging.getLogger(__name__)
 
 _TOOL_PROGRESS_QUEUE_MAX_ITEMS = 128
 _TOOL_PROGRESS_POLL_SECONDS = 0.05
+_PROVIDER_TRANSIENT_RETRYABLE_KINDS = frozenset({"rate_limit", "transient_failure"})
+
+
+def _provider_transient_retry_delay_ms(
+    *,
+    retry_attempt: int,
+    base_delay_ms: float,
+    max_delay_ms: float,
+    jitter: bool,
+) -> int:
+    capped_delay = min(base_delay_ms * (2 ** max(retry_attempt - 1, 0)), max_delay_ms)
+    if jitter and capped_delay > 0:
+        capped_delay = random.uniform(0, capped_delay)
+    return max(0, int(round(capped_delay)))
 
 
 @dataclass(frozen=True, slots=True)
@@ -658,6 +676,9 @@ class RuntimeRunLoopCoordinator:
         active_permission_policy = permission_policy or runtime._permission_policy
         continuity_to_reinject: RuntimeContinuityState | None = preserved_continuity_state
         provider_attempt = runtime._provider_attempt_from_metadata(graph_request.metadata)
+        provider_retry_attempt: int = runtime._provider_retry_attempt_from_metadata(
+            graph_request.metadata
+        )
         reasoning_capture_state = runtime._reasoning_capture_state()
         active_graph_request: GraphRunRequest = graph_request
         while True:
@@ -950,6 +971,87 @@ class RuntimeRunLoopCoordinator:
                         provider_attempt=current_provider_attempt,
                     )
                     next_attempt = current_provider_attempt + 1
+                    transient_retry_config = runtime._provider_transient_retry_config(
+                        provider_name=provider_error.provider_name,
+                        session_metadata=session.metadata,
+                    )
+                    current_provider_retry_attempt: int = int(provider_retry_attempt)
+                    if (
+                        provider_error.kind in _PROVIDER_TRANSIENT_RETRYABLE_KINDS
+                        and current_provider_retry_attempt < transient_retry_config.max_retries
+                    ):
+                        retry_attempt: int = current_provider_retry_attempt + 1
+                        delay_ms = _provider_transient_retry_delay_ms(
+                            retry_attempt=retry_attempt,
+                            base_delay_ms=transient_retry_config.base_delay_ms,
+                            max_delay_ms=transient_retry_config.max_delay_ms,
+                            jitter=transient_retry_config.jitter,
+                        )
+                        logger.info(
+                            (
+                                "provider transient retry for session %s: %s/%s "
+                                "(reason=%s, retry_attempt=%s, max_retries=%s, delay_ms=%s)"
+                            ),
+                            session.session.id,
+                            provider_error.provider_name,
+                            provider_error.model_name,
+                            provider_error.kind,
+                            retry_attempt,
+                            transient_retry_config.max_retries,
+                            delay_ms,
+                        )
+                        sequence += 1
+                        yield RuntimeStreamChunk(
+                            kind="event",
+                            session=session,
+                            event=EventEnvelope(
+                                session_id=session.session.id,
+                                sequence=sequence,
+                                event_type=RUNTIME_PROVIDER_TRANSIENT_RETRY,
+                                source="runtime",
+                                payload={
+                                    "reason": provider_error.kind,
+                                    "provider": provider_error.provider_name,
+                                    "model": provider_error.model_name,
+                                    "retry_attempt": retry_attempt,
+                                    "max_retries": transient_retry_config.max_retries,
+                                    "delay_ms": delay_ms,
+                                    **(
+                                        {"provider_error_details": provider_error.details}
+                                        if provider_error.details is not None
+                                        else {}
+                                    ),
+                                },
+                            ),
+                        )
+                        if delay_ms > 0:
+                            time.sleep(delay_ms / 1000.0)
+                        provider_retry_attempt = int(retry_attempt)
+                        retry_metadata: dict[str, object] = {
+                            **current_metadata,
+                            "provider_attempt": current_provider_attempt,
+                            "provider_retry_attempt": provider_retry_attempt,
+                        }
+                        session = SessionState(
+                            session=session.session,
+                            status=session.status,
+                            turn=session.turn,
+                            metadata={
+                                **session.metadata,
+                                "provider_attempt": current_provider_attempt,
+                                "provider_retry_attempt": provider_retry_attempt,
+                            },
+                        )
+                        active_graph_request = GraphRunRequest(
+                            session=session,
+                            prompt=current_prompt,
+                            available_tools=current_available_tools,
+                            context_window=context_window,
+                            assembled_context=active_graph_request.assembled_context,
+                            metadata=retry_metadata,
+                            abort_signal=current_abort_signal,
+                        )
+                        continue
                     if fallback_selection is not None:
                         next_target = fallback_selection.provider_target
                         logger.info(
@@ -990,6 +1092,7 @@ class RuntimeRunLoopCoordinator:
                             ),
                         )
                         provider_attempt = fallback_selection.provider_attempt
+                        provider_retry_attempt = 0
                         fallback_prompt: str = current_prompt
                         fallback_available_tools: tuple[ToolDefinition, ...] = (
                             current_available_tools
@@ -1001,13 +1104,18 @@ class RuntimeRunLoopCoordinator:
                         fallback_metadata: dict[str, object] = {
                             **current_metadata,
                             "provider_attempt": provider_attempt,
+                            "provider_retry_attempt": provider_retry_attempt,
                         }
                         fallback_abort_signal: ProviderAbortSignal | None = current_abort_signal
                         session = SessionState(
                             session=session.session,
                             status=session.status,
                             turn=session.turn,
-                            metadata={**session.metadata, "provider_attempt": provider_attempt},
+                            metadata={
+                                **session.metadata,
+                                "provider_attempt": provider_attempt,
+                                "provider_retry_attempt": provider_retry_attempt,
+                            },
                         )
                         graph = fallback_selection.graph
                         active_graph_request = GraphRunRequest(
@@ -1031,16 +1139,32 @@ class RuntimeRunLoopCoordinator:
                         yield runtime._failed_chunk(
                             session=session,
                             sequence=sequence + 1,
-                            error=format_fallback_exhausted_error(
-                                provider_name=provider_error.provider_name,
-                                model_name=provider_error.model_name,
-                                attempt=next_attempt,
+                            error=(
+                                format_provider_retry_exhausted_error(
+                                    provider_name=provider_error.provider_name,
+                                    model_name=provider_error.model_name,
+                                    retry_attempts=provider_retry_attempt,
+                                )
+                                if provider_error.kind in _PROVIDER_TRANSIENT_RETRYABLE_KINDS
+                                else format_fallback_exhausted_error(
+                                    provider_name=provider_error.provider_name,
+                                    model_name=provider_error.model_name,
+                                    attempt=next_attempt,
+                                )
                             ),
                             payload={
                                 "provider_error_kind": provider_error.kind,
                                 "provider": provider_error.provider_name,
                                 "model": provider_error.model_name,
                                 "fallback_exhausted": True,
+                                **(
+                                    {
+                                        "provider_retry_exhausted": True,
+                                        "provider_retry_attempts": provider_retry_attempt,
+                                    }
+                                    if provider_error.kind in _PROVIDER_TRANSIENT_RETRYABLE_KINDS
+                                    else {}
+                                ),
                                 **(
                                     {"provider_error_details": provider_error.details}
                                     if provider_error.details is not None

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -37,6 +37,10 @@ from ..provider.auth import (
     ProviderAuthResolutionError,
     ProviderAuthResolver,
 )
+from ..provider.config import (
+    DEFAULT_PROVIDER_TRANSIENT_RETRY_CONFIG,
+    ProviderTransientRetryConfig,
+)
 from ..provider.errors import format_invalid_provider_config_error, guidance_for_provider_error_kind
 from ..provider.model_catalog import (
     ProviderModelCatalog,
@@ -5677,6 +5681,52 @@ class VoidCodeRuntime:
         # Referenced via extracted collaborators.
         raw_provider_attempt = metadata.get("provider_attempt", 0)
         return raw_provider_attempt if isinstance(raw_provider_attempt, int) else 0
+
+    @staticmethod
+    def _provider_retry_attempt_from_metadata(metadata: dict[str, object]) -> int:
+        raw_provider_retry_attempt = metadata.get("provider_retry_attempt", 0)
+        return raw_provider_retry_attempt if isinstance(raw_provider_retry_attempt, int) else 0
+
+    def _provider_transient_retry_config(
+        self,
+        *,
+        provider_name: str,
+        session_metadata: dict[str, object],
+    ) -> ProviderTransientRetryConfig:
+        _ = session_metadata
+        providers = self._config.providers
+        if providers is None:
+            return DEFAULT_PROVIDER_TRANSIENT_RETRY_CONFIG
+        provider_config = None
+        if provider_name == "opencode-go":
+            provider_config = providers.opencode_go
+        elif provider_name == "openai":
+            provider_config = providers.openai
+        elif provider_name == "anthropic":
+            provider_config = providers.anthropic
+        elif provider_name == "google":
+            provider_config = providers.google
+        elif provider_name == "copilot":
+            provider_config = providers.copilot
+        elif provider_name == "litellm":
+            provider_config = providers.litellm
+        elif provider_name == "deepseek":
+            provider_config = providers.deepseek
+        elif provider_name == "glm":
+            provider_config = providers.glm
+        elif provider_name == "grok":
+            provider_config = providers.grok
+        elif provider_name == "minimax":
+            provider_config = providers.minimax
+        elif provider_name == "kimi":
+            provider_config = providers.kimi
+        elif provider_name == "qwen":
+            provider_config = providers.qwen
+        else:
+            provider_config = providers.custom.get(provider_name)
+        if provider_config is None or provider_config.transient_retry is None:
+            return DEFAULT_PROVIDER_TRANSIENT_RETRY_CONFIG
+        return provider_config.transient_retry
 
     @staticmethod
     def _context_window_config_from_policy(

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -106,16 +106,19 @@ from .config import (
     RuntimeContextWindowConfig,
     RuntimeHooksConfig,
     RuntimeProviderFallbackConfig,
+    RuntimeProvidersConfig,
     RuntimeSkillsConfig,
     RuntimeWebSettings,
     load_global_web_settings,
     load_runtime_config,
+    parse_provider_configs_payload,
     parse_provider_fallback_payload,
     parse_runtime_agent_payload,
     parse_runtime_agents_payload,
     parse_runtime_categories_payload,
     parse_runtime_context_window_payload,
     save_global_web_settings,
+    serialize_provider_configs,
     serialize_provider_fallback_config,
     serialize_runtime_agent_config,
     serialize_runtime_agents_config,
@@ -266,6 +269,7 @@ _PERSISTED_RUNTIME_CONFIG_KEYS = frozenset(
         "tool_timeout_seconds",
         "reasoning_effort",
         "model",
+        "providers",
         "provider_fallback",
         "resolved_provider",
         "agent",
@@ -326,6 +330,7 @@ _SKILL_BINDING_SCOPE_KEYS = (
     "tool_timeout_seconds",
     "reasoning_effort",
     "model",
+    "providers",
     "provider_fallback",
     "resolved_provider",
     "agent",
@@ -759,6 +764,7 @@ class VoidCodeRuntime:
             max_steps=self._config.max_steps,
             tool_timeout_seconds=self._config.tool_timeout_seconds,
             provider_fallback=initial_provider_fallback,
+            providers=self._config.providers,
             resolved_provider=self._resolved_provider_config,
             agent=initial_agent,
             context_window=initial_context_window,
@@ -1080,6 +1086,7 @@ class VoidCodeRuntime:
                 tool_timeout_seconds=resolved.tool_timeout_seconds,
                 reasoning_effort=resolved.reasoning_effort,
                 provider_fallback=resolved.provider_fallback,
+                providers=resolved.providers,
                 resolved_provider=resolved.resolved_provider,
                 agent=resolved.agent,
                 context_window=resolved.context_window,
@@ -1094,6 +1101,7 @@ class VoidCodeRuntime:
                 tool_timeout_seconds=resolved.tool_timeout_seconds,
                 reasoning_effort=request_reasoning_effort,
                 provider_fallback=resolved.provider_fallback,
+                providers=resolved.providers,
                 resolved_provider=resolved.resolved_provider,
                 agent=resolved.agent,
                 context_window=resolved.context_window,
@@ -4228,6 +4236,7 @@ class VoidCodeRuntime:
             max_steps=self._config.max_steps,
             tool_timeout_seconds=self._config.tool_timeout_seconds,
             provider_fallback=initial_provider_fallback,
+            providers=self._config.providers,
             resolved_provider=self._resolved_provider_config,
             agent=initial_agent,
             context_window=self._config.context_window,
@@ -5693,8 +5702,7 @@ class VoidCodeRuntime:
         provider_name: str,
         session_metadata: dict[str, object],
     ) -> ProviderTransientRetryConfig:
-        _ = session_metadata
-        providers = self._config.providers
+        providers = self._effective_runtime_config_from_metadata(session_metadata).providers
         if providers is None:
             return DEFAULT_PROVIDER_TRANSIENT_RETRY_CONFIG
         provider_config = None
@@ -5710,6 +5718,8 @@ class VoidCodeRuntime:
             provider_config = providers.copilot
         elif provider_name == "litellm":
             provider_config = providers.litellm
+        elif provider_name == "opencode":
+            provider_config = providers.opencode
         elif provider_name == "deepseek":
             provider_config = providers.deepseek
         elif provider_name == "glm":
@@ -6421,6 +6431,10 @@ class VoidCodeRuntime:
             ),
             "resolved_provider": resolved_provider_snapshot(effective_config.resolved_provider),
         }
+        serialized_providers = serialize_provider_configs(effective_config.providers)
+        serialized_runtime_providers = _runtime_provider_config_metadata(serialized_providers)
+        if serialized_runtime_providers:
+            runtime_config_metadata["providers"] = serialized_runtime_providers
         serialized_context_window = serialize_runtime_context_window_config(
             effective_config.context_window
         )
@@ -6546,6 +6560,7 @@ class VoidCodeRuntime:
             tool_timeout_seconds=resolved.tool_timeout_seconds,
             reasoning_effort=resolved.reasoning_effort,
             provider_fallback=provider_fallback,
+            providers=resolved.providers,
             resolved_provider=resolved_provider,
             agent=merged_agent,
             context_window=resolved.context_window,
@@ -7117,6 +7132,7 @@ class VoidCodeRuntime:
         execution_engine = self._config.execution_engine
         max_steps = self._config.max_steps
         reasoning_effort = self._config.reasoning_effort
+        providers = self._config.providers
         provider_fallback = self._config.provider_fallback
         agent = self._config.agent
         if agent is None and execution_engine == "provider":
@@ -7181,6 +7197,7 @@ class VoidCodeRuntime:
                 tool_timeout_seconds=self._config.tool_timeout_seconds,
                 reasoning_effort=reasoning_effort,
                 provider_fallback=provider_fallback,
+                providers=providers,
                 resolved_provider=resolved_provider,
                 agent=agent,
                 context_window=context_window,
@@ -7241,6 +7258,19 @@ class VoidCodeRuntime:
                 raise ValueError(
                     "persisted runtime_config reasoning_effort must be a non-empty string"
                 )
+        if "providers" in runtime_config:
+            try:
+                providers = parse_provider_configs_payload(
+                    runtime_config.get("providers"),
+                    source="persisted runtime_config.providers",
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    format_invalid_provider_config_error(
+                        "persisted runtime_config.providers",
+                        str(exc),
+                    )
+                ) from exc
         provider_fallback = None
         if "provider_fallback" in runtime_config:
             try:
@@ -7309,6 +7339,7 @@ class VoidCodeRuntime:
             tool_timeout_seconds=tool_timeout_seconds,
             reasoning_effort=reasoning_effort,
             provider_fallback=provider_fallback,
+            providers=providers,
             resolved_provider=resolved_provider,
             agent=agent,
             context_window=context_window,
@@ -7334,6 +7365,7 @@ class VoidCodeRuntime:
             and effective_config.reasoning_effort == self._initial_effective_config.reasoning_effort
             and effective_config.provider_fallback
             == self._initial_effective_config.provider_fallback
+            and effective_config.providers == self._initial_effective_config.providers
             and effective_config.agent == self._initial_effective_config.agent
             and effective_config.context_window == self._initial_effective_config.context_window
         ):
@@ -7502,6 +7534,36 @@ def _parse_persisted_external_permission_rules(
     return tuple(parsed) if parsed else default
 
 
+def _runtime_provider_config_metadata(
+    serialized_providers: dict[str, object] | None,
+) -> dict[str, object] | None:
+    if not serialized_providers:
+        return None
+    retained: dict[str, object] = {}
+    for provider_name, raw_provider in serialized_providers.items():
+        if provider_name == "custom":
+            if not isinstance(raw_provider, dict):
+                continue
+            retained_custom: dict[str, object] = {}
+            for custom_name, raw_custom_provider in cast(dict[str, object], raw_provider).items():
+                if not isinstance(raw_custom_provider, dict):
+                    continue
+                custom_provider_payload = cast(dict[str, object], raw_custom_provider)
+                if "transient_retry" in custom_provider_payload:
+                    retained_custom[custom_name] = {
+                        "transient_retry": custom_provider_payload["transient_retry"]
+                    }
+            if retained_custom:
+                retained[provider_name] = retained_custom
+            continue
+        if not isinstance(raw_provider, dict):
+            continue
+        provider_payload = cast(dict[str, object], raw_provider)
+        if "transient_retry" in provider_payload:
+            retained[provider_name] = {"transient_retry": provider_payload["transient_retry"]}
+    return retained or None
+
+
 @dataclass(frozen=True, slots=True)
 class EffectiveRuntimeConfig:
     approval_mode: PermissionDecision
@@ -7512,6 +7574,7 @@ class EffectiveRuntimeConfig:
     tool_timeout_seconds: int | None = None
     reasoning_effort: str | None = None
     provider_fallback: RuntimeProviderFallbackConfig | None = None
+    providers: RuntimeProvidersConfig | None = None
     resolved_provider: ResolvedProviderConfig = field(default_factory=ResolvedProviderConfig)
     agent: RuntimeAgentConfig | None = None
     context_window: RuntimeContextWindowConfig | None = None

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -1983,13 +1983,11 @@ def test_provider_runtime_falls_back_to_next_provider_target(tmp_path: Path) -> 
                     fallback_models=("custom/demo",),
                 ),
                 providers=config_module.RuntimeProvidersConfig(
-                    custom={
-                        "opencode": provider_config_module.LiteLLMProviderConfig(
-                            transient_retry=provider_config_module.ProviderTransientRetryConfig(
-                                max_retries=0,
-                            )
-                        ),
-                    }
+                    opencode=provider_config_module.LiteLLMProviderConfig(
+                        transient_retry=provider_config_module.ProviderTransientRetryConfig(
+                            max_retries=0,
+                        )
+                    )
                 ),
             ),
             permission_policy=permission_module.PermissionPolicy(mode="allow"),

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -1966,6 +1966,7 @@ def test_provider_runtime_falls_back_to_next_provider_target(tmp_path: Path) -> 
     permission_module = importlib.import_module("voidcode.runtime.permission")
     config_module = importlib.import_module("voidcode.runtime.config")
     model_provider_module = importlib.import_module("voidcode.provider.registry")
+    provider_config_module = importlib.import_module("voidcode.provider.config")
     provider_protocol_module = importlib.import_module("voidcode.runtime.provider_protocol")
     service_module = importlib.import_module("voidcode.runtime.service")
 
@@ -1980,6 +1981,15 @@ def test_provider_runtime_falls_back_to_next_provider_target(tmp_path: Path) -> 
                 provider_fallback=config_module.RuntimeProviderFallbackConfig(
                     preferred_model="opencode/gpt-5.4",
                     fallback_models=("custom/demo",),
+                ),
+                providers=config_module.RuntimeProvidersConfig(
+                    custom={
+                        "opencode": provider_config_module.LiteLLMProviderConfig(
+                            transient_retry=provider_config_module.ProviderTransientRetryConfig(
+                                max_retries=0,
+                            )
+                        ),
+                    }
                 ),
             ),
             permission_policy=permission_module.PermissionPolicy(mode="allow"),
@@ -2024,6 +2034,176 @@ def test_provider_runtime_falls_back_to_next_provider_target(tmp_path: Path) -> 
         "reason": "rate_limit",
         "from_provider": "opencode",
         "from_model": "gpt-5.4",
+        "to_provider": "custom",
+        "to_model": "demo",
+        "attempt": 1,
+    }
+
+
+def test_provider_runtime_retries_transient_error_on_same_target(tmp_path: Path) -> None:
+    runtime_request, _ = _load_runtime_types()
+    permission_module = importlib.import_module("voidcode.runtime.permission")
+    config_module = importlib.import_module("voidcode.runtime.config")
+    model_provider_module = importlib.import_module("voidcode.provider.registry")
+    provider_config_module = importlib.import_module("voidcode.provider.config")
+    provider_protocol_module = importlib.import_module("voidcode.runtime.provider_protocol")
+    service_module = importlib.import_module("voidcode.runtime.service")
+
+    runtime = cast(
+        RuntimeRunner,
+        service_module.VoidCodeRuntime(
+            workspace=tmp_path,
+            config=config_module.RuntimeConfig(
+                approval_mode="allow",
+                execution_engine="provider",
+                model="opencode-go/glm-5.1",
+                providers=config_module.RuntimeProvidersConfig(
+                    opencode_go=provider_config_module.SimplifiedProviderConfig(
+                        transient_retry=provider_config_module.ProviderTransientRetryConfig(
+                            max_retries=2,
+                            base_delay_ms=0,
+                            max_delay_ms=0,
+                            jitter=False,
+                        )
+                    )
+                ),
+            ),
+            permission_policy=permission_module.PermissionPolicy(mode="allow"),
+            model_provider_registry=model_provider_module.ModelProviderRegistry(
+                providers={
+                    "opencode-go": _ScriptedModelProvider(
+                        name="opencode-go",
+                        outcomes=(
+                            provider_protocol_module.ProviderExecutionError(
+                                kind="transient_failure",
+                                provider_name="opencode-go",
+                                model_name="glm-5.1",
+                                message="temporary ssl failure",
+                            ),
+                            provider_protocol_module.ProviderTurnResult(output="retry ok"),
+                        ),
+                    ),
+                }
+            ),
+        ),
+    )
+
+    response = runtime.run(runtime_request(prompt="read sample.txt", session_id="retry-run"))
+
+    assert response.session.status == "completed"
+    assert response.output == "retry ok"
+    assert [event.event_type for event in response.events] == [
+        "runtime.request_received",
+        "runtime.skills_loaded",
+        "runtime.provider_transient_retry",
+        "graph.loop_step",
+        "graph.model_turn",
+        "graph.loop_step",
+        "graph.response_ready",
+    ]
+    assert response.events[2].payload == {
+        "reason": "transient_failure",
+        "provider": "opencode-go",
+        "model": "glm-5.1",
+        "retry_attempt": 1,
+        "max_retries": 2,
+        "delay_ms": 0,
+    }
+
+
+def test_provider_runtime_falls_back_after_same_target_retry_budget(
+    tmp_path: Path,
+) -> None:
+    runtime_request, _ = _load_runtime_types()
+    permission_module = importlib.import_module("voidcode.runtime.permission")
+    config_module = importlib.import_module("voidcode.runtime.config")
+    model_provider_module = importlib.import_module("voidcode.provider.registry")
+    provider_config_module = importlib.import_module("voidcode.provider.config")
+    provider_protocol_module = importlib.import_module("voidcode.runtime.provider_protocol")
+    service_module = importlib.import_module("voidcode.runtime.service")
+
+    runtime = cast(
+        RuntimeRunner,
+        service_module.VoidCodeRuntime(
+            workspace=tmp_path,
+            config=config_module.RuntimeConfig(
+                approval_mode="allow",
+                execution_engine="provider",
+                model="opencode-go/glm-5.1",
+                provider_fallback=config_module.RuntimeProviderFallbackConfig(
+                    preferred_model="opencode-go/glm-5.1",
+                    fallback_models=("custom/demo",),
+                ),
+                providers=config_module.RuntimeProvidersConfig(
+                    opencode_go=provider_config_module.SimplifiedProviderConfig(
+                        transient_retry=provider_config_module.ProviderTransientRetryConfig(
+                            max_retries=1,
+                            base_delay_ms=0,
+                            max_delay_ms=0,
+                            jitter=False,
+                        )
+                    )
+                ),
+            ),
+            permission_policy=permission_module.PermissionPolicy(mode="allow"),
+            model_provider_registry=model_provider_module.ModelProviderRegistry(
+                providers={
+                    "opencode-go": _ScriptedModelProvider(
+                        name="opencode-go",
+                        outcomes=(
+                            provider_protocol_module.ProviderExecutionError(
+                                kind="transient_failure",
+                                provider_name="opencode-go",
+                                model_name="glm-5.1",
+                                message="first ssl failure",
+                            ),
+                            provider_protocol_module.ProviderExecutionError(
+                                kind="transient_failure",
+                                provider_name="opencode-go",
+                                model_name="glm-5.1",
+                                message="second ssl failure",
+                            ),
+                        ),
+                    ),
+                    "custom": _ScriptedModelProvider(
+                        name="custom",
+                        outcomes=(
+                            provider_protocol_module.ProviderTurnResult(output="fallback ok"),
+                        ),
+                    ),
+                }
+            ),
+        ),
+    )
+
+    response = runtime.run(
+        runtime_request(prompt="read sample.txt", session_id="retry-then-fallback-run")
+    )
+
+    assert response.session.status == "completed"
+    assert response.output == "fallback ok"
+    assert [event.event_type for event in response.events] == [
+        "runtime.request_received",
+        "runtime.skills_loaded",
+        "runtime.provider_transient_retry",
+        "runtime.provider_fallback",
+        "graph.loop_step",
+        "graph.model_turn",
+        "graph.loop_step",
+        "graph.response_ready",
+    ]
+    assert response.events[2].payload == {
+        "reason": "transient_failure",
+        "provider": "opencode-go",
+        "model": "glm-5.1",
+        "retry_attempt": 1,
+        "max_retries": 1,
+        "delay_ms": 0,
+    }
+    assert response.events[3].payload == {
+        "reason": "transient_failure",
+        "from_provider": "opencode-go",
+        "from_model": "glm-5.1",
         "to_provider": "custom",
         "to_model": "demo",
         "attempt": 1,

--- a/tests/unit/provider/test_provider_config_parser.py
+++ b/tests/unit/provider/test_provider_config_parser.py
@@ -12,6 +12,7 @@ from voidcode.provider.config import (
     OpenAIProviderConfig,
     ProviderConfigs,
     ProviderFallbackConfig,
+    ProviderTransientRetryConfig,
     SimplifiedProviderConfig,
     merge_provider_configs,
     parse_provider_configs_payload,
@@ -43,6 +44,12 @@ def test_parse_provider_configs_payload_parses_provider_blocks_directly() -> Non
                 "auth_scheme": "token",
                 "api_key_env_var": "LITELLM_KEY",
                 "model_map": {"gpt-4o": "openrouter/openai/gpt-4o"},
+                "transient_retry": {
+                    "max_retries": 3,
+                    "base_delay_ms": 250,
+                    "max_delay_ms": 2000,
+                    "jitter": False,
+                },
             },
             "custom": {
                 "llama-local": {
@@ -89,6 +96,12 @@ def test_parse_provider_configs_payload_parses_provider_blocks_directly() -> Non
             base_url="http://localhost:4000",
             auth_scheme="token",
             model_map={"gpt-4o": "openrouter/openai/gpt-4o"},
+            transient_retry=ProviderTransientRetryConfig(
+                max_retries=3,
+                base_delay_ms=250.0,
+                max_delay_ms=2000.0,
+                jitter=False,
+            ),
         ),
         custom={
             "llama-local": LiteLLMProviderConfig(
@@ -98,6 +111,56 @@ def test_parse_provider_configs_payload_parses_provider_blocks_directly() -> Non
             )
         },
     )
+
+
+def test_parse_provider_configs_payload_parses_transient_retry_for_simplified_provider() -> None:
+    parsed = parse_provider_configs_payload(
+        {
+            "opencode-go": {
+                "api_key_env_var": "OPENCODE_API_KEY",
+                "transient_retry": {
+                    "max_retries": 4,
+                    "base_delay_ms": 500,
+                    "max_delay_ms": 4000,
+                    "jitter": False,
+                },
+            }
+        },
+        source="runtime config field 'providers'",
+    )
+
+    assert parsed == ProviderConfigs(
+        opencode_go=SimplifiedProviderConfig(
+            api_key_env_var="OPENCODE_API_KEY",
+            transient_retry=ProviderTransientRetryConfig(
+                max_retries=4,
+                base_delay_ms=500.0,
+                max_delay_ms=4000.0,
+                jitter=False,
+            ),
+        )
+    )
+
+
+def test_parse_provider_configs_payload_rejects_invalid_transient_retry_delay_order() -> None:
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"runtime config field 'providers\.opencode-go\.transient_retry\.max_delay_ms' "
+            r"must be greater than or equal to base_delay_ms"
+        ),
+    ):
+        _ = parse_provider_configs_payload(
+            {
+                "opencode-go": {
+                    "transient_retry": {
+                        "base_delay_ms": 2000,
+                        "max_delay_ms": 1000,
+                    }
+                }
+            },
+            source="runtime config field 'providers'",
+        )
 
 
 def test_parse_provider_configs_payload_rejects_unknown_provider_block() -> None:

--- a/tests/unit/provider/test_provider_config_parser.py
+++ b/tests/unit/provider/test_provider_config_parser.py
@@ -51,6 +51,10 @@ def test_parse_provider_configs_payload_parses_provider_blocks_directly() -> Non
                     "jitter": False,
                 },
             },
+            "opencode": {
+                "auth_scheme": "none",
+                "transient_retry": {"max_retries": 0},
+            },
             "custom": {
                 "llama-local": {
                     "base_url": "http://localhost:11434/v1",
@@ -102,6 +106,11 @@ def test_parse_provider_configs_payload_parses_provider_blocks_directly() -> Non
                 max_delay_ms=2000.0,
                 jitter=False,
             ),
+        ),
+        opencode=LiteLLMProviderConfig(
+            auth_scheme="none",
+            auth_scheme_explicit=True,
+            transient_retry=ProviderTransientRetryConfig(max_retries=0),
         ),
         custom={
             "llama-local": LiteLLMProviderConfig(

--- a/tests/unit/runtime/test_runtime_events.py
+++ b/tests/unit/runtime/test_runtime_events.py
@@ -27,6 +27,7 @@ from voidcode.runtime.events import (
     RUNTIME_LSP_SERVER_STOPPED,
     RUNTIME_MCP_SERVER_FAILED,
     RUNTIME_MEMORY_REFRESHED,
+    RUNTIME_PROVIDER_TRANSIENT_RETRY,
     RUNTIME_REASONING_DIAGNOSTIC,
     RUNTIME_REASONING_PART,
     RUNTIME_SESSION_ENDED,
@@ -63,6 +64,7 @@ def test_runtime_event_types_include_stable_emitted_events() -> None:
     assert RUNTIME_MCP_SERVER_FAILED in EMITTED_EVENT_TYPES
     assert "runtime.plan_created" not in EMITTED_EVENT_TYPES
     assert RUNTIME_TOOL_STARTED in EMITTED_EVENT_TYPES
+    assert RUNTIME_PROVIDER_TRANSIENT_RETRY in EMITTED_EVENT_TYPES
 
 
 def test_future_additive_event_types_cover_async_lifecycle_surfaces() -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -28,6 +28,8 @@ from voidcode.provider.config import (
     CopilotProviderAuthConfig,
     CopilotProviderConfig,
     LiteLLMProviderConfig,
+    OpenAIProviderConfig,
+    ProviderTransientRetryConfig,
 )
 from voidcode.provider.model_catalog import ProviderModelCatalog, ProviderModelMetadata
 from voidcode.provider.protocol import ProviderErrorKind
@@ -1762,6 +1764,13 @@ def test_runtime_background_rate_limit_retry_precedes_provider_fallback(
                 preferred_model="opencode/gpt-5.4",
                 fallback_models=("custom/demo",),
             ),
+            providers=RuntimeProvidersConfig(
+                custom={
+                    "opencode": LiteLLMProviderConfig(
+                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                    ),
+                }
+            ),
         ),
     )
 
@@ -2269,7 +2278,17 @@ def test_runtime_session_debug_snapshot_classifies_provider_failure(tmp_path: Pa
     )
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
-        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            providers=RuntimeProvidersConfig(
+                custom={
+                    "opencode": LiteLLMProviderConfig(
+                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                    ),
+                }
+            ),
+        ),
         model_provider_registry=registry,
     )
 
@@ -9422,7 +9441,17 @@ def test_runtime_classifies_provider_context_limit_failures(tmp_path: Path) -> N
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
         graph=_FailingProviderGraph(),
-        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            providers=RuntimeProvidersConfig(
+                custom={
+                    "opencode": LiteLLMProviderConfig(
+                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                    ),
+                }
+            ),
+        ),
     )
 
     response = runtime.run(RuntimeRequest(prompt="read sample.txt", session_id="provider-limit"))
@@ -10009,7 +10038,17 @@ def test_runtime_provider_turn_usage_is_persisted_in_session_metadata(tmp_path: 
     )
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
-        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            providers=RuntimeProvidersConfig(
+                custom={
+                    "opencode": LiteLLMProviderConfig(
+                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                    ),
+                }
+            ),
+        ),
         model_provider_registry=registry,
     )
 
@@ -13051,6 +13090,13 @@ def test_runtime_downgrades_to_next_provider_target_on_provider_failures(
                 preferred_model="opencode/gpt-5.4",
                 fallback_models=("custom/demo",),
             ),
+            providers=RuntimeProvidersConfig(
+                custom={
+                    "opencode": LiteLLMProviderConfig(
+                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                    ),
+                }
+            ),
         ),
         model_provider_registry=registry,
     )
@@ -13119,7 +13165,17 @@ def test_runtime_provider_streaming_emits_ordered_provider_stream_events(
     )
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
-        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            providers=RuntimeProvidersConfig(
+                custom={
+                    "opencode": LiteLLMProviderConfig(
+                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                    ),
+                }
+            ),
+        ),
         model_provider_registry=registry,
     )
 
@@ -13163,7 +13219,17 @@ def test_runtime_provider_streaming_persists_reasoning_as_runtime_part(
     )
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
-        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            providers=RuntimeProvidersConfig(
+                custom={
+                    "opencode": LiteLLMProviderConfig(
+                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                    ),
+                }
+            ),
+        ),
         model_provider_registry=registry,
     )
 
@@ -13222,7 +13288,17 @@ def test_runtime_reasoning_capture_has_aggregate_limit(tmp_path: Path) -> None:
     )
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
-        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            providers=RuntimeProvidersConfig(
+                custom={
+                    "opencode": LiteLLMProviderConfig(
+                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                    ),
+                }
+            ),
+        ),
         model_provider_registry=registry,
     )
 
@@ -13278,7 +13354,17 @@ def test_runtime_reasoning_capture_limit_spans_provider_turns(tmp_path: Path) ->
     )
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
-        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            providers=RuntimeProvidersConfig(
+                custom={
+                    "opencode": LiteLLMProviderConfig(
+                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                    ),
+                }
+            ),
+        ),
         model_provider_registry=registry,
     )
 
@@ -13423,7 +13509,17 @@ def test_runtime_run_stream_preserves_streamed_tool_requests(tmp_path: Path) -> 
     )
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
-        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            providers=RuntimeProvidersConfig(
+                custom={
+                    "opencode": LiteLLMProviderConfig(
+                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                    ),
+                }
+            ),
+        ),
         model_provider_registry=registry,
     )
 
@@ -13525,6 +13621,13 @@ def test_runtime_provider_stream_error_maps_to_fallback_when_retryable(
                 preferred_model="opencode/gpt-5.4",
                 fallback_models=("custom/demo",),
             ),
+            providers=RuntimeProvidersConfig(
+                custom={
+                    "opencode": LiteLLMProviderConfig(
+                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                    ),
+                }
+            ),
         ),
         model_provider_registry=registry,
     )
@@ -13578,6 +13681,13 @@ def test_runtime_provider_stream_json_error_payload_maps_to_context_limit_withou
             provider_fallback=RuntimeProviderFallbackConfig(
                 preferred_model="opencode/gpt-5.4",
                 fallback_models=("custom/demo",),
+            ),
+            providers=RuntimeProvidersConfig(
+                custom={
+                    "opencode": LiteLLMProviderConfig(
+                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                    ),
+                }
             ),
         ),
         model_provider_registry=registry,
@@ -13650,7 +13760,17 @@ def test_runtime_provider_transient_failure_after_tool_is_resumable(
     )
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
-        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            providers=RuntimeProvidersConfig(
+                custom={
+                    "opencode": LiteLLMProviderConfig(
+                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                    ),
+                }
+            ),
+        ),
         model_provider_registry=registry,
     )
 
@@ -13720,7 +13840,17 @@ def test_runtime_provider_failure_resume_reconciles_parent_background_tasks(
     )
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
-        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            providers=RuntimeProvidersConfig(
+                custom={
+                    "opencode": LiteLLMProviderConfig(
+                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                    ),
+                }
+            ),
+        ),
         model_provider_registry=registry,
     )
     parent_session_id = "provider-parent-retry-session"
@@ -13898,7 +14028,17 @@ def test_runtime_provider_failure_resume_finalizes_background_task_and_releases_
     mcp_manager = _RecordingMcpManager()
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
-        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            providers=RuntimeProvidersConfig(
+                custom={
+                    "opencode": LiteLLMProviderConfig(
+                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                    ),
+                }
+            ),
+        ),
         model_provider_registry=registry,
         mcp_manager=mcp_manager,
     )
@@ -13994,7 +14134,17 @@ def test_runtime_provider_failure_resume_persists_failed_chunk_when_loop_raises(
     )
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
-        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            providers=RuntimeProvidersConfig(
+                custom={
+                    "opencode": LiteLLMProviderConfig(
+                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                    ),
+                }
+            ),
+        ),
         model_provider_registry=registry,
     )
     task_id = "bg-provider-failure-raise"
@@ -14106,6 +14256,13 @@ def test_runtime_fallback_event_preserves_provider_error_details(tmp_path: Path)
             provider_fallback=RuntimeProviderFallbackConfig(
                 preferred_model="opencode/gpt-5.4",
                 fallback_models=("custom/demo",),
+            ),
+            providers=RuntimeProvidersConfig(
+                custom={
+                    "opencode": LiteLLMProviderConfig(
+                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                    ),
+                }
             ),
         ),
         model_provider_registry=registry,
@@ -14500,6 +14657,16 @@ def test_runtime_provider_fallback_exhaustion_after_three_targets_reports_termin
             provider_fallback=RuntimeProviderFallbackConfig(
                 preferred_model="opencode/gpt-5.4",
                 fallback_models=("openai/gpt-4.1", "anthropic/claude-3-7-sonnet"),
+            ),
+            providers=RuntimeProvidersConfig(
+                openai=OpenAIProviderConfig(
+                    transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                ),
+                custom={
+                    "opencode": LiteLLMProviderConfig(
+                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                    ),
+                },
             ),
         ),
         model_provider_registry=registry,

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1765,11 +1765,9 @@ def test_runtime_background_rate_limit_retry_precedes_provider_fallback(
                 fallback_models=("custom/demo",),
             ),
             providers=RuntimeProvidersConfig(
-                custom={
-                    "opencode": LiteLLMProviderConfig(
-                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
-                    ),
-                }
+                opencode=LiteLLMProviderConfig(
+                    transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                )
             ),
         ),
     )
@@ -2282,11 +2280,9 @@ def test_runtime_session_debug_snapshot_classifies_provider_failure(tmp_path: Pa
             execution_engine="provider",
             model="opencode/gpt-5.4",
             providers=RuntimeProvidersConfig(
-                custom={
-                    "opencode": LiteLLMProviderConfig(
-                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
-                    ),
-                }
+                opencode=LiteLLMProviderConfig(
+                    transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                )
             ),
         ),
         model_provider_registry=registry,
@@ -9445,11 +9441,9 @@ def test_runtime_classifies_provider_context_limit_failures(tmp_path: Path) -> N
             execution_engine="provider",
             model="opencode/gpt-5.4",
             providers=RuntimeProvidersConfig(
-                custom={
-                    "opencode": LiteLLMProviderConfig(
-                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
-                    ),
-                }
+                opencode=LiteLLMProviderConfig(
+                    transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                )
             ),
         ),
     )
@@ -10042,11 +10036,9 @@ def test_runtime_provider_turn_usage_is_persisted_in_session_metadata(tmp_path: 
             execution_engine="provider",
             model="opencode/gpt-5.4",
             providers=RuntimeProvidersConfig(
-                custom={
-                    "opencode": LiteLLMProviderConfig(
-                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
-                    ),
-                }
+                opencode=LiteLLMProviderConfig(
+                    transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                )
             ),
         ),
         model_provider_registry=registry,
@@ -13091,11 +13083,9 @@ def test_runtime_downgrades_to_next_provider_target_on_provider_failures(
                 fallback_models=("custom/demo",),
             ),
             providers=RuntimeProvidersConfig(
-                custom={
-                    "opencode": LiteLLMProviderConfig(
-                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
-                    ),
-                }
+                opencode=LiteLLMProviderConfig(
+                    transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                )
             ),
         ),
         model_provider_registry=registry,
@@ -13169,11 +13159,9 @@ def test_runtime_provider_streaming_emits_ordered_provider_stream_events(
             execution_engine="provider",
             model="opencode/gpt-5.4",
             providers=RuntimeProvidersConfig(
-                custom={
-                    "opencode": LiteLLMProviderConfig(
-                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
-                    ),
-                }
+                opencode=LiteLLMProviderConfig(
+                    transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                )
             ),
         ),
         model_provider_registry=registry,
@@ -13223,11 +13211,9 @@ def test_runtime_provider_streaming_persists_reasoning_as_runtime_part(
             execution_engine="provider",
             model="opencode/gpt-5.4",
             providers=RuntimeProvidersConfig(
-                custom={
-                    "opencode": LiteLLMProviderConfig(
-                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
-                    ),
-                }
+                opencode=LiteLLMProviderConfig(
+                    transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                )
             ),
         ),
         model_provider_registry=registry,
@@ -13292,11 +13278,9 @@ def test_runtime_reasoning_capture_has_aggregate_limit(tmp_path: Path) -> None:
             execution_engine="provider",
             model="opencode/gpt-5.4",
             providers=RuntimeProvidersConfig(
-                custom={
-                    "opencode": LiteLLMProviderConfig(
-                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
-                    ),
-                }
+                opencode=LiteLLMProviderConfig(
+                    transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                )
             ),
         ),
         model_provider_registry=registry,
@@ -13358,11 +13342,9 @@ def test_runtime_reasoning_capture_limit_spans_provider_turns(tmp_path: Path) ->
             execution_engine="provider",
             model="opencode/gpt-5.4",
             providers=RuntimeProvidersConfig(
-                custom={
-                    "opencode": LiteLLMProviderConfig(
-                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
-                    ),
-                }
+                opencode=LiteLLMProviderConfig(
+                    transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                )
             ),
         ),
         model_provider_registry=registry,
@@ -13513,11 +13495,9 @@ def test_runtime_run_stream_preserves_streamed_tool_requests(tmp_path: Path) -> 
             execution_engine="provider",
             model="opencode/gpt-5.4",
             providers=RuntimeProvidersConfig(
-                custom={
-                    "opencode": LiteLLMProviderConfig(
-                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
-                    ),
-                }
+                opencode=LiteLLMProviderConfig(
+                    transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                )
             ),
         ),
         model_provider_registry=registry,
@@ -13622,11 +13602,9 @@ def test_runtime_provider_stream_error_maps_to_fallback_when_retryable(
                 fallback_models=("custom/demo",),
             ),
             providers=RuntimeProvidersConfig(
-                custom={
-                    "opencode": LiteLLMProviderConfig(
-                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
-                    ),
-                }
+                opencode=LiteLLMProviderConfig(
+                    transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                )
             ),
         ),
         model_provider_registry=registry,
@@ -13643,6 +13621,77 @@ def test_runtime_provider_stream_error_maps_to_fallback_when_retryable(
     ]
     assert len(fallback_events) == 1
     assert fallback_events[0].payload["reason"] == "transient_failure"
+
+
+def test_runtime_provider_retry_uses_persisted_session_provider_config(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            provider_fallback=RuntimeProviderFallbackConfig(
+                preferred_model="opencode/gpt-5.4",
+                fallback_models=("custom/demo",),
+            ),
+            providers=RuntimeProvidersConfig(
+                opencode=LiteLLMProviderConfig(
+                    transient_retry=ProviderTransientRetryConfig(max_retries=2)
+                )
+            ),
+        ),
+        model_provider_registry=ModelProviderRegistry(
+            providers={
+                "opencode": _ScriptedModelProvider(name="opencode", outcomes=()),
+                "custom": _ScriptedModelProvider(name="custom", outcomes=()),
+            }
+        ),
+    )
+    retry_config = runtime._provider_transient_retry_config(  # pyright: ignore[reportPrivateUsage]
+        provider_name="opencode",
+        session_metadata={
+            "runtime_config": {
+                "approval_mode": "ask",
+                "permission": {},
+                "execution_engine": "provider",
+                "max_steps": None,
+                "tool_timeout_seconds": None,
+                "model": "opencode/gpt-5.4",
+                "provider_fallback": {
+                    "preferred_model": "opencode/gpt-5.4",
+                    "fallback_models": ["custom/demo"],
+                },
+                "providers": {
+                    "opencode": {
+                        "auth_scheme": "bearer",
+                        "transient_retry": {"max_retries": 0},
+                    }
+                },
+                "resolved_provider": {
+                    "active_target": {
+                        "raw_model": "opencode/gpt-5.4",
+                        "provider": "opencode",
+                        "model": "gpt-5.4",
+                    },
+                    "targets": [
+                        {
+                            "raw_model": "opencode/gpt-5.4",
+                            "provider": "opencode",
+                            "model": "gpt-5.4",
+                        },
+                        {
+                            "raw_model": "custom/demo",
+                            "provider": "custom",
+                            "model": "demo",
+                        },
+                    ],
+                },
+            }
+        },
+    )
+
+    assert retry_config.max_retries == 0
 
 
 def test_runtime_provider_stream_json_error_payload_maps_to_context_limit_without_fallback(
@@ -13683,11 +13732,9 @@ def test_runtime_provider_stream_json_error_payload_maps_to_context_limit_withou
                 fallback_models=("custom/demo",),
             ),
             providers=RuntimeProvidersConfig(
-                custom={
-                    "opencode": LiteLLMProviderConfig(
-                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
-                    ),
-                }
+                opencode=LiteLLMProviderConfig(
+                    transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                )
             ),
         ),
         model_provider_registry=registry,
@@ -13764,11 +13811,9 @@ def test_runtime_provider_transient_failure_after_tool_is_resumable(
             execution_engine="provider",
             model="opencode/gpt-5.4",
             providers=RuntimeProvidersConfig(
-                custom={
-                    "opencode": LiteLLMProviderConfig(
-                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
-                    ),
-                }
+                opencode=LiteLLMProviderConfig(
+                    transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                )
             ),
         ),
         model_provider_registry=registry,
@@ -13844,11 +13889,9 @@ def test_runtime_provider_failure_resume_reconciles_parent_background_tasks(
             execution_engine="provider",
             model="opencode/gpt-5.4",
             providers=RuntimeProvidersConfig(
-                custom={
-                    "opencode": LiteLLMProviderConfig(
-                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
-                    ),
-                }
+                opencode=LiteLLMProviderConfig(
+                    transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                )
             ),
         ),
         model_provider_registry=registry,
@@ -14032,11 +14075,9 @@ def test_runtime_provider_failure_resume_finalizes_background_task_and_releases_
             execution_engine="provider",
             model="opencode/gpt-5.4",
             providers=RuntimeProvidersConfig(
-                custom={
-                    "opencode": LiteLLMProviderConfig(
-                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
-                    ),
-                }
+                opencode=LiteLLMProviderConfig(
+                    transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                )
             ),
         ),
         model_provider_registry=registry,
@@ -14138,11 +14179,9 @@ def test_runtime_provider_failure_resume_persists_failed_chunk_when_loop_raises(
             execution_engine="provider",
             model="opencode/gpt-5.4",
             providers=RuntimeProvidersConfig(
-                custom={
-                    "opencode": LiteLLMProviderConfig(
-                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
-                    ),
-                }
+                opencode=LiteLLMProviderConfig(
+                    transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                )
             ),
         ),
         model_provider_registry=registry,
@@ -14258,11 +14297,9 @@ def test_runtime_fallback_event_preserves_provider_error_details(tmp_path: Path)
                 fallback_models=("custom/demo",),
             ),
             providers=RuntimeProvidersConfig(
-                custom={
-                    "opencode": LiteLLMProviderConfig(
-                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
-                    ),
-                }
+                opencode=LiteLLMProviderConfig(
+                    transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                )
             ),
         ),
         model_provider_registry=registry,
@@ -14659,14 +14696,12 @@ def test_runtime_provider_fallback_exhaustion_after_three_targets_reports_termin
                 fallback_models=("openai/gpt-4.1", "anthropic/claude-3-7-sonnet"),
             ),
             providers=RuntimeProvidersConfig(
+                opencode=LiteLLMProviderConfig(
+                    transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                ),
                 openai=OpenAIProviderConfig(
                     transient_retry=ProviderTransientRetryConfig(max_retries=0)
                 ),
-                custom={
-                    "opencode": LiteLLMProviderConfig(
-                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
-                    ),
-                },
             ),
         ),
         model_provider_registry=registry,

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -19,6 +19,7 @@ from unittest.mock import Mock
 import pytest
 
 import voidcode.runtime.background_tasks as runtime_background_tasks_module
+import voidcode.runtime.run_loop as runtime_run_loop_module
 import voidcode.runtime.service as runtime_service_module
 from voidcode.acp import AcpRequestEnvelope, AcpResponseEnvelope
 from voidcode.agent import LEADER_AGENT_MANIFEST, get_builtin_agent_manifest, render_agent_prompt
@@ -74,6 +75,7 @@ from voidcode.runtime.events import (
     RUNTIME_MCP_SERVER_STARTED,
     RUNTIME_MCP_SERVER_STOPPED,
     RUNTIME_MEMORY_REFRESHED,
+    RUNTIME_PROVIDER_TRANSIENT_RETRY,
     RUNTIME_SESSION_ENDED,
     RUNTIME_SESSION_IDLE,
     RUNTIME_SESSION_STARTED,
@@ -903,6 +905,40 @@ class _RateLimitOnceTurnProvider:
                 message="rate limited once",
             )
         return ProviderTurnResult(output="primary recovered")
+
+
+class _TwoEpisodeTransientModelProvider:
+    def __init__(self, *, name: str) -> None:
+        self.name = name
+        self.calls = 0
+
+    def turn_provider(self) -> _TwoEpisodeTransientTurnProvider:
+        return _TwoEpisodeTransientTurnProvider(model_provider=self)
+
+
+@dataclass(slots=True)
+class _TwoEpisodeTransientTurnProvider:
+    model_provider: _TwoEpisodeTransientModelProvider
+
+    @property
+    def name(self) -> str:
+        return self.model_provider.name
+
+    def propose_turn(self, request: object) -> ProviderTurnResult:
+        turn_request = cast(ProviderTurnRequest, request)
+        self.model_provider.calls += 1
+        if self.model_provider.calls in {1, 3}:
+            raise ProviderExecutionError(
+                kind="transient_failure",
+                provider_name=self.name,
+                model_name=turn_request.model_name or "gpt-5.4",
+                message=f"transient failure episode {self.model_provider.calls}",
+            )
+        if not turn_request.tool_results:
+            return ProviderTurnResult(
+                tool_call=ToolCall(tool_name="read_file", arguments={"filePath": "sample.txt"})
+            )
+        return ProviderTurnResult(output="recovered twice")
 
 
 class _UnexpectedFallbackModelProvider:
@@ -13692,6 +13728,57 @@ def test_runtime_provider_retry_uses_persisted_session_provider_config(
     )
 
     assert retry_config.max_retries == 0
+
+
+def test_runtime_provider_retry_attempt_resets_after_successful_provider_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "sample.txt").write_text("sample contents", encoding="utf-8")
+    primary = _TwoEpisodeTransientModelProvider(name="opencode")
+    fallback = _UnexpectedFallbackModelProvider(name="custom")
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            provider_fallback=RuntimeProviderFallbackConfig(
+                preferred_model="opencode/gpt-5.4",
+                fallback_models=("custom/demo",),
+            ),
+            providers=RuntimeProvidersConfig(
+                opencode=LiteLLMProviderConfig(
+                    transient_retry=ProviderTransientRetryConfig(max_retries=1)
+                )
+            ),
+        ),
+        model_provider_registry=ModelProviderRegistry(
+            providers={"opencode": primary, "custom": fallback}
+        ),
+    )
+
+    monkeypatch.setattr(
+        runtime_run_loop_module,
+        "_provider_transient_retry_delay_ms",
+        lambda *, retry_attempt, base_delay_ms, max_delay_ms, jitter: 0,
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="retry fresh episodes"))
+
+    retry_events = [
+        event for event in response.events if event.event_type == RUNTIME_PROVIDER_TRANSIENT_RETRY
+    ]
+    fallback_events = [
+        event for event in response.events if event.event_type == "runtime.provider_fallback"
+    ]
+
+    assert response.session.status == "completed"
+    assert response.output == "recovered twice"
+    assert primary.calls == 4
+    assert fallback.calls == 0
+    assert [event.payload["retry_attempt"] for event in retry_events] == [1, 1]
+    assert fallback_events == []
+    assert response.session.metadata["provider_retry_attempt"] == 0
 
 
 def test_runtime_provider_stream_json_error_payload_maps_to_context_limit_without_fallback(


### PR DESCRIPTION
## Summary
- Add typed provider `transient_retry` config with conservative default same-target retries.
- Emit `runtime.provider_transient_retry` and retry `rate_limit`/`transient_failure` before provider fallback exhaustion.
- Cover same-target retry success, retry-before-fallback ordering, config parsing, and legacy zero-retry opt-out paths.

Fixes #371

## Verification
- `uv run ruff check .`
- `uv run basedpyright --warnings src`
- `uv run pytest -n auto` (1879 passed)
- `uv build` (artifacts cleaned after build)

## Notes
- `mise run lint/typecheck` was not used because the new worktree's `mise.toml` is untrusted; equivalent underlying commands were run directly.