### PR TITLE
feat(runtime): add production-ready model-assisted continuity distillation with deterministic fallback

### DIFF
--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -1311,7 +1311,6 @@ class _RuntimeContextWindowValidationModel(BaseModel):
         "continuity_preview_items",
         "continuity_preview_chars",
         "continuity_distillation_max_input_items",
-        "continuity_distillation_max_input_chars",
         mode="before",
     )
     @classmethod
@@ -1325,6 +1324,20 @@ class _RuntimeContextWindowValidationModel(BaseModel):
         }:
             defaults = RuntimeContextWindowConfig()
             return cast(int, getattr(defaults, field_name))
+        return parsed
+
+    @field_validator("continuity_distillation_max_input_chars", mode="before")
+    @classmethod
+    def _validate_continuity_distillation_max_input_chars(cls, value: object) -> int:
+        field_path = "context_window.continuity_distillation_max_input_chars"
+        parsed = _parse_optional_positive_int(value, field_path=field_path)
+        if parsed is None:
+            return RuntimeContextWindowConfig().continuity_distillation_max_input_chars
+        if parsed < 64:
+            raise ValueError(
+                "runtime config field 'context_window.continuity_distillation_max_input_chars' "
+                "must be greater than or equal to 64"
+            )
         return parsed
 
     @field_validator("reserved_output_tokens", mode="before")

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -130,6 +130,9 @@ _CONTEXT_WINDOW_CONFIG_KEYS = frozenset(
         "context_pressure_cooldown_steps",
         "provider_context_diagnostics",
         "provider_context_oversized_feedback_chars",
+        "continuity_distillation_enabled",
+        "continuity_distillation_max_input_items",
+        "continuity_distillation_max_input_chars",
     }
 )
 _FORMATTER_PRESET_CONFIG_KEYS = frozenset(
@@ -284,6 +287,9 @@ class RuntimeContextWindowConfig:
     context_pressure_cooldown_steps: int = 3
     provider_context_diagnostics: RuntimeProviderContextDiagnosticMode = "warn"
     provider_context_oversized_feedback_chars: int = 8_000
+    continuity_distillation_enabled: bool = False
+    continuity_distillation_max_input_items: int = 12
+    continuity_distillation_max_input_chars: int = 4000
 
 
 @dataclass(frozen=True, slots=True)
@@ -1248,12 +1254,24 @@ class _RuntimeContextWindowValidationModel(BaseModel):
     context_pressure_cooldown_steps: int = 3
     provider_context_diagnostics: RuntimeProviderContextDiagnosticMode = "warn"
     provider_context_oversized_feedback_chars: int = 8_000
+    continuity_distillation_enabled: bool = False
+    continuity_distillation_max_input_items: int = 12
+    continuity_distillation_max_input_chars: int = 4000
 
     @field_validator("auto_compaction", mode="before")
     @classmethod
     def _validate_auto_compaction(cls, value: object) -> bool:
         parsed = _parse_optional_bool(value, field_path="context_window.auto_compaction")
         return True if parsed is None else parsed
+
+    @field_validator("continuity_distillation_enabled", mode="before")
+    @classmethod
+    def _validate_continuity_distillation_enabled(cls, value: object) -> bool:
+        parsed = _parse_optional_bool(
+            value,
+            field_path="context_window.continuity_distillation_enabled",
+        )
+        return False if parsed is None else parsed
 
     @field_validator("version", mode="before")
     @classmethod
@@ -1292,6 +1310,8 @@ class _RuntimeContextWindowValidationModel(BaseModel):
         "default_tool_result_tokens",
         "continuity_preview_items",
         "continuity_preview_chars",
+        "continuity_distillation_max_input_items",
+        "continuity_distillation_max_input_chars",
         mode="before",
     )
     @classmethod
@@ -1453,6 +1473,9 @@ class _RuntimeContextWindowValidationModel(BaseModel):
             context_pressure_cooldown_steps=self.context_pressure_cooldown_steps,
             provider_context_diagnostics=self.provider_context_diagnostics,
             provider_context_oversized_feedback_chars=self.provider_context_oversized_feedback_chars,
+            continuity_distillation_enabled=self.continuity_distillation_enabled,
+            continuity_distillation_max_input_items=self.continuity_distillation_max_input_items,
+            continuity_distillation_max_input_chars=self.continuity_distillation_max_input_chars,
         )
 
 
@@ -2290,6 +2313,13 @@ def serialize_runtime_context_window_config(
         "recent_tool_result_count": context_window.recent_tool_result_count,
         "continuity_preview_items": context_window.continuity_preview_items,
         "continuity_preview_chars": context_window.continuity_preview_chars,
+        "continuity_distillation_enabled": context_window.continuity_distillation_enabled,
+        "continuity_distillation_max_input_items": (
+            context_window.continuity_distillation_max_input_items
+        ),
+        "continuity_distillation_max_input_chars": (
+            context_window.continuity_distillation_max_input_chars
+        ),
         "context_pressure_threshold": context_window.context_pressure_threshold,
         "context_pressure_cooldown_steps": context_window.context_pressure_cooldown_steps,
         "provider_context_diagnostics": context_window.provider_context_diagnostics,

--- a/src/voidcode/runtime/config_schema.py
+++ b/src/voidcode/runtime/config_schema.py
@@ -349,6 +349,15 @@ def runtime_config_json_schema() -> dict[str, object]:
                     "tokenizer_model": {"type": "string", "minLength": 1},
                     "continuity_preview_items": {"type": "integer", "minimum": 1},
                     "continuity_preview_chars": {"type": "integer", "minimum": 1},
+                    "continuity_distillation_enabled": {"type": "boolean"},
+                    "continuity_distillation_max_input_items": {
+                        "type": "integer",
+                        "minimum": 1,
+                    },
+                    "continuity_distillation_max_input_chars": {
+                        "type": "integer",
+                        "minimum": 64,
+                    },
                     "context_pressure_threshold": {
                         "type": "number",
                         "exclusiveMinimum": 0,

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -1222,7 +1222,7 @@ def _continuity_state_from_distillation(
         f"{item.text} — {item.rationale}" for item in distillation.key_decisions_with_rationale
     )
     refs = tuple(item.text for item in distillation.relevant_files_commands_errors)
-    source_references = tuple(f"{item.kind}:{item.id}" for item in distillation.source_references)
+    source_references = _aggregate_distillation_source_references(distillation)
     verification = (
         distillation.verification_state.status,
         *distillation.verification_state.details,
@@ -1250,7 +1250,7 @@ def _continuity_state_from_distillation(
             token_budget=base_state.token_budget,
             token_estimate_source=base_state.token_estimate_source,
             dropped_tool_results=base_state.dropped_tool_results,
-            fact_reference_count=len(distillation.source_references),
+            fact_reference_count=len(source_references),
             source_references=source_references,
         )
     )
@@ -1276,10 +1276,33 @@ def _continuity_state_from_distillation(
         token_budget=base_state.token_budget,
         token_estimate_source=base_state.token_estimate_source,
         dropped_tool_results=base_state.dropped_tool_results,
-        fact_reference_count=len(distillation.source_references),
+        fact_reference_count=len(source_references),
         source_references=source_references,
         version=2,
     )
+
+
+def _aggregate_distillation_source_references(
+    distillation: ContinuityDistillationRecord,
+) -> tuple[str, ...]:
+    refs: list[str] = []
+
+    def _append(kind: str, ref_id: str) -> None:
+        value = f"{kind}:{ref_id}"
+        if value not in refs:
+            refs.append(value)
+
+    for item in distillation.source_references:
+        _append(item.kind, item.id)
+    for item in distillation.key_decisions_with_rationale:
+        for ref in item.refs:
+            _append(ref.kind, ref.id)
+    for item in distillation.relevant_files_commands_errors:
+        for ref in item.refs:
+            _append(ref.kind, ref.id)
+    for ref in distillation.verification_state.refs:
+        _append(ref.kind, ref.id)
+    return tuple(refs)
 
 
 def _summary_anchor(

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -9,6 +9,11 @@ from functools import lru_cache
 from typing import Any, Literal, NamedTuple, cast
 
 from ..tools.contracts import ToolResult
+from .continuity_distillation import (
+    ContinuityDistillationRecord,
+    build_distillation_input_envelope,
+    distillation_record_from_payload,
+)
 from .todos import render_provider_todo_state
 
 
@@ -71,6 +76,9 @@ class RuntimeContinuityState:
     dropped_tool_result_count: int = 0
     retained_tool_result_count: int = 0
     source: str = "tool_result_window"
+    distillation_source: str = "deterministic"
+    distillation_error: str | None = None
+    fact_reference_count: int = 0
     original_tool_result_tokens: int | None = None
     retained_tool_result_tokens: int | None = None
     dropped_tool_result_tokens: int | None = None
@@ -99,8 +107,12 @@ class RuntimeContinuityState:
             "dropped_tool_result_count": self.dropped_tool_result_count,
             "retained_tool_result_count": self.retained_tool_result_count,
             "source": self.source,
+            "distillation_source": self.distillation_source,
+            "fact_reference_count": self.fact_reference_count,
             "version": 2,
         }
+        if self.distillation_error is not None:
+            payload["distillation_error"] = self.distillation_error
         if self.original_tool_result_tokens is not None:
             payload["original_tool_result_tokens"] = self.original_tool_result_tokens
         if self.retained_tool_result_tokens is not None:
@@ -136,6 +148,9 @@ class ContextWindowPolicy:
     continuity_preview_chars: int = 80
     context_pressure_threshold: float = 0.7
     context_pressure_cooldown_steps: int = 3
+    continuity_distillation_enabled: bool = False
+    continuity_distillation_max_input_items: int = 12
+    continuity_distillation_max_input_chars: int = 4000
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "per_tool_result_tokens", dict(self.per_tool_result_tokens))
@@ -172,6 +187,10 @@ class ContextWindowPolicy:
             raise ValueError("context_pressure_threshold must be > 0 and <= 1")
         if self.context_pressure_cooldown_steps < 1:
             raise ValueError("context_pressure_cooldown_steps must be >= 1")
+        if self.continuity_distillation_max_input_items < 1:
+            raise ValueError("continuity_distillation_max_input_items must be >= 1")
+        if self.continuity_distillation_max_input_chars < 64:
+            raise ValueError("continuity_distillation_max_input_chars must be >= 64")
 
     def metadata_payload(self) -> dict[str, object]:
         payload: dict[str, object] = {
@@ -201,6 +220,13 @@ class ContextWindowPolicy:
             payload["tokenizer_model"] = self.tokenizer_model
         payload["context_pressure_threshold"] = self.context_pressure_threshold
         payload["context_pressure_cooldown_steps"] = self.context_pressure_cooldown_steps
+        payload["continuity_distillation_enabled"] = self.continuity_distillation_enabled
+        payload["continuity_distillation_max_input_items"] = (
+            self.continuity_distillation_max_input_items
+        )
+        payload["continuity_distillation_max_input_chars"] = (
+            self.continuity_distillation_max_input_chars
+        )
         return payload
 
 
@@ -376,11 +402,24 @@ def continuity_state_from_metadata_payload(
     dropped = payload.get("dropped_tool_result_count")
     retained = payload.get("retained_tool_result_count")
     source = payload.get("source")
+    distillation_source = payload.get("distillation_source")
+    distillation_error = payload.get("distillation_error")
+    fact_reference_count = payload.get("fact_reference_count")
     if not isinstance(dropped, int) or isinstance(dropped, bool):
         return None
     if not isinstance(retained, int) or isinstance(retained, bool):
         return None
     if not isinstance(source, str):
+        return None
+    if distillation_source is None:
+        distillation_source = "deterministic"
+    if not isinstance(distillation_source, str):
+        return None
+    if distillation_error is not None and not isinstance(distillation_error, str):
+        return None
+    if fact_reference_count is None:
+        fact_reference_count = 0
+    if not isinstance(fact_reference_count, int) or isinstance(fact_reference_count, bool):
         return None
 
     def _optional_int(value: object) -> int | None:
@@ -421,6 +460,9 @@ def continuity_state_from_metadata_payload(
         dropped_tool_result_count=dropped,
         retained_tool_result_count=retained,
         source=source,
+        distillation_source=distillation_source,
+        distillation_error=distillation_error,
+        fact_reference_count=fact_reference_count,
         original_tool_result_tokens=original_token_count,
         retained_tool_result_tokens=retained_token_count,
         dropped_tool_result_tokens=dropped_token_count,
@@ -851,6 +893,14 @@ def context_window_policy_from_payload(raw_payload: object) -> ContextWindowPoli
     tokenizer_model = payload.get("tokenizer_model")
     if tokenizer_model is not None and not isinstance(tokenizer_model, str):
         raise ValueError("context window policy field 'tokenizer_model' must be a string")
+    continuity_distillation_enabled = payload.get(
+        "continuity_distillation_enabled",
+        ContextWindowPolicy().continuity_distillation_enabled,
+    )
+    if not isinstance(continuity_distillation_enabled, bool):
+        raise ValueError(
+            "context window policy field 'continuity_distillation_enabled' must be a boolean"
+        )
     return ContextWindowPolicy(
         auto_compaction=auto_compaction,
         max_tool_results=_coerce_int(
@@ -895,6 +945,17 @@ def context_window_policy_from_payload(raw_payload: object) -> ContextWindowPoli
             payload,
             "context_pressure_cooldown_steps",
             default=ContextWindowPolicy().context_pressure_cooldown_steps,
+        ),
+        continuity_distillation_enabled=continuity_distillation_enabled,
+        continuity_distillation_max_input_items=_coerce_int(
+            payload,
+            "continuity_distillation_max_input_items",
+            default=ContextWindowPolicy().continuity_distillation_max_input_items,
+        ),
+        continuity_distillation_max_input_chars=_coerce_int(
+            payload,
+            "continuity_distillation_max_input_chars",
+            default=ContextWindowPolicy().continuity_distillation_max_input_chars,
         ),
     )
 
@@ -949,6 +1010,10 @@ def _build_continuity_state(
     token_budget: int | None = None,
     token_estimate_source: str | None = None,
     tokenizer_model: str | None = None,
+    continuity_distillation_enabled: bool = False,
+    continuity_distillation_max_input_items: int = 12,
+    continuity_distillation_max_input_chars: int = 4000,
+    distillation_candidate: Mapping[str, object] | None = None,
 ) -> RuntimeContinuityState:
     dropped_count = len(dropped_results)
     previous = _previous_continuity_state(session_metadata)
@@ -993,6 +1058,7 @@ def _build_continuity_state(
             token_budget=token_budget,
             token_estimate_source=token_estimate_source,
             dropped_tool_results=previous.dropped_tool_results if previous is not None else (),
+            distillation_source="deterministic",
         )
 
     preview_count = min(preview_item_limit, dropped_count)
@@ -1028,7 +1094,60 @@ def _build_continuity_state(
             dropped_results,
             tokenizer_model=tokenizer_model,
         ),
+        distillation_source="deterministic",
     )
+    if previous is not None:
+        previous_payload = previous.metadata_payload()
+    else:
+        previous_payload = None
+
+    if continuity_distillation_enabled:
+        effective_distillation, distillation_error = _try_model_assisted_distillation(
+            prompt=prompt,
+            dropped_results=dropped_results,
+            retained_results=retained_results,
+            previous_continuity=previous_payload,
+            policy_items=continuity_distillation_max_input_items,
+            policy_chars=continuity_distillation_max_input_chars,
+            distillation_candidate=distillation_candidate,
+        )
+        if effective_distillation is not None:
+            return _continuity_state_from_distillation(
+                base_state=state_without_summary,
+                distillation=effective_distillation,
+            )
+        if distillation_error is not None:
+            fallback_summary = _continuity_summary_text(state_without_summary)
+            fallback_text = (
+                f"{fallback_summary}\n\n## Distillation Fallback\n- {distillation_error}"
+            )
+            return RuntimeContinuityState(
+                summary_text=fallback_text,
+                objective=state_without_summary.objective,
+                current_goal=state_without_summary.current_goal,
+                verbatim_user_constraints=state_without_summary.verbatim_user_constraints,
+                progress_completed=state_without_summary.progress_completed,
+                blockers_open_questions=state_without_summary.blockers_open_questions,
+                key_decisions=state_without_summary.key_decisions,
+                relevant_files_commands_errors=state_without_summary.relevant_files_commands_errors,
+                verification_state=state_without_summary.verification_state,
+                delegated_task_summaries=state_without_summary.delegated_task_summaries,
+                recent_tail=state_without_summary.recent_tail,
+                dropped_tool_result_count=state_without_summary.dropped_tool_result_count,
+                retained_tool_result_count=state_without_summary.retained_tool_result_count,
+                source=state_without_summary.source,
+                distillation_source="fallback_after_model_error",
+                distillation_error=distillation_error,
+                original_tool_result_tokens=state_without_summary.original_tool_result_tokens,
+                retained_tool_result_tokens=state_without_summary.retained_tool_result_tokens,
+                dropped_tool_result_tokens=state_without_summary.dropped_tool_result_tokens,
+                token_budget=state_without_summary.token_budget,
+                token_estimate_source=state_without_summary.token_estimate_source,
+                dropped_tool_results=state_without_summary.dropped_tool_results,
+                fact_reference_count=0,
+                version=2,
+            )
+
     canonical_summary = _continuity_summary_text(state_without_summary)
     return RuntimeContinuityState(
         summary_text=f"{canonical_summary}\n\n## Dropped Tool Preview\n{legacy_summary}",
@@ -1051,6 +1170,104 @@ def _build_continuity_state(
         token_budget=state_without_summary.token_budget,
         token_estimate_source=state_without_summary.token_estimate_source,
         dropped_tool_results=state_without_summary.dropped_tool_results,
+        distillation_source="deterministic",
+        version=2,
+    )
+
+
+def _try_model_assisted_distillation(
+    *,
+    prompt: str,
+    dropped_results: tuple[ToolResult, ...],
+    retained_results: tuple[ToolResult, ...],
+    previous_continuity: Mapping[str, object] | None,
+    policy_items: int,
+    policy_chars: int,
+    distillation_candidate: Mapping[str, object] | None,
+) -> tuple[ContinuityDistillationRecord | None, str | None]:
+    envelope = build_distillation_input_envelope(
+        prompt=prompt,
+        dropped_results=dropped_results,
+        retained_results=retained_results,
+        previous_continuity=previous_continuity,
+        max_items=max(1, policy_items),
+        max_chars=max(64, policy_chars * 16),
+    )
+    candidate: Mapping[str, object] | None = distillation_candidate
+    if candidate is None:
+        embedded = envelope.get("distillation_candidate")
+        if isinstance(embedded, dict):
+            candidate = cast(Mapping[str, object], embedded)
+    if candidate is None:
+        return None, None
+    parsed = distillation_record_from_payload(candidate)
+    if parsed is None:
+        return None, "model-assisted distillation output failed schema validation"
+    return parsed, None
+
+
+def _continuity_state_from_distillation(
+    *,
+    base_state: RuntimeContinuityState,
+    distillation: ContinuityDistillationRecord,
+) -> RuntimeContinuityState:
+    key_decisions = tuple(
+        f"{item.text} — {item.rationale}" for item in distillation.key_decisions_with_rationale
+    )
+    refs = tuple(item.text for item in distillation.relevant_files_commands_errors)
+    verification = (
+        distillation.verification_state.status,
+        *distillation.verification_state.details,
+    )
+    summary = _continuity_summary_text(
+        RuntimeContinuityState(
+            summary_text=None,
+            objective=base_state.objective,
+            current_goal=distillation.objective_current_goal,
+            verbatim_user_constraints=distillation.verbatim_user_constraints,
+            progress_completed=distillation.completed_progress,
+            blockers_open_questions=distillation.blockers_open_questions,
+            key_decisions=key_decisions,
+            relevant_files_commands_errors=refs,
+            verification_state=verification,
+            delegated_task_summaries=base_state.delegated_task_summaries,
+            recent_tail=base_state.recent_tail,
+            dropped_tool_result_count=base_state.dropped_tool_result_count,
+            retained_tool_result_count=base_state.retained_tool_result_count,
+            source=base_state.source,
+            distillation_source="model_assisted",
+            original_tool_result_tokens=base_state.original_tool_result_tokens,
+            retained_tool_result_tokens=base_state.retained_tool_result_tokens,
+            dropped_tool_result_tokens=base_state.dropped_tool_result_tokens,
+            token_budget=base_state.token_budget,
+            token_estimate_source=base_state.token_estimate_source,
+            dropped_tool_results=base_state.dropped_tool_results,
+            fact_reference_count=len(distillation.source_references),
+        )
+    )
+    return RuntimeContinuityState(
+        summary_text=summary,
+        objective=base_state.objective,
+        current_goal=distillation.objective_current_goal,
+        verbatim_user_constraints=distillation.verbatim_user_constraints,
+        progress_completed=distillation.completed_progress,
+        blockers_open_questions=distillation.blockers_open_questions,
+        key_decisions=key_decisions,
+        relevant_files_commands_errors=refs,
+        verification_state=verification,
+        delegated_task_summaries=base_state.delegated_task_summaries,
+        recent_tail=base_state.recent_tail,
+        dropped_tool_result_count=base_state.dropped_tool_result_count,
+        retained_tool_result_count=base_state.retained_tool_result_count,
+        source=base_state.source,
+        distillation_source="model_assisted",
+        original_tool_result_tokens=base_state.original_tool_result_tokens,
+        retained_tool_result_tokens=base_state.retained_tool_result_tokens,
+        dropped_tool_result_tokens=base_state.dropped_tool_result_tokens,
+        token_budget=base_state.token_budget,
+        token_estimate_source=base_state.token_estimate_source,
+        dropped_tool_results=base_state.dropped_tool_results,
+        fact_reference_count=len(distillation.source_references),
         version=2,
     )
 
@@ -1092,7 +1309,12 @@ def prepare_provider_context(
     session_metadata: dict[str, object],
     policy: ContextWindowPolicy | None = None,
 ) -> RuntimeContextWindow:
-    _ = session_metadata
+    runtime_state = session_metadata.get("runtime_state")
+    distillation_candidate: Mapping[str, object] | None = None
+    if isinstance(runtime_state, dict):
+        raw_candidate = cast(dict[str, object], runtime_state).get("distillation_candidate")
+        if isinstance(raw_candidate, dict):
+            distillation_candidate = cast(Mapping[str, object], raw_candidate)
     effective_policy = policy or ContextWindowPolicy()
     original_count = len(tool_results)
     token_budget = _policy_token_budget(effective_policy)
@@ -1211,6 +1433,14 @@ def prepare_provider_context(
             token_budget=token_budget,
             token_estimate_source=token_estimate_source,
             tokenizer_model=effective_policy.tokenizer_model,
+            continuity_distillation_enabled=effective_policy.continuity_distillation_enabled,
+            continuity_distillation_max_input_items=(
+                effective_policy.continuity_distillation_max_input_items
+            ),
+            continuity_distillation_max_input_chars=(
+                effective_policy.continuity_distillation_max_input_chars
+            ),
+            distillation_candidate=distillation_candidate,
         )
         if compacted
         else None

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -79,6 +79,7 @@ class RuntimeContinuityState:
     distillation_source: str = "deterministic"
     distillation_error: str | None = None
     fact_reference_count: int = 0
+    source_references: tuple[str, ...] = ()
     original_tool_result_tokens: int | None = None
     retained_tool_result_tokens: int | None = None
     dropped_tool_result_tokens: int | None = None
@@ -109,6 +110,7 @@ class RuntimeContinuityState:
             "source": self.source,
             "distillation_source": self.distillation_source,
             "fact_reference_count": self.fact_reference_count,
+            "source_references": list(self.source_references),
             "version": 2,
         }
         if self.distillation_error is not None:
@@ -405,6 +407,7 @@ def continuity_state_from_metadata_payload(
     distillation_source = payload.get("distillation_source")
     distillation_error = payload.get("distillation_error")
     fact_reference_count = payload.get("fact_reference_count")
+    source_references = _metadata_string_tuple(payload, "source_references")
     if not isinstance(dropped, int) or isinstance(dropped, bool):
         return None
     if not isinstance(retained, int) or isinstance(retained, bool):
@@ -463,6 +466,7 @@ def continuity_state_from_metadata_payload(
         distillation_source=distillation_source,
         distillation_error=distillation_error,
         fact_reference_count=fact_reference_count,
+        source_references=source_references,
         original_tool_result_tokens=original_token_count,
         retained_tool_result_tokens=retained_token_count,
         dropped_tool_result_tokens=dropped_token_count,
@@ -1059,6 +1063,7 @@ def _build_continuity_state(
             token_estimate_source=token_estimate_source,
             dropped_tool_results=previous.dropped_tool_results if previous is not None else (),
             distillation_source="deterministic",
+            source_references=previous.source_references if previous is not None else (),
         )
 
     preview_count = min(preview_item_limit, dropped_count)
@@ -1145,6 +1150,7 @@ def _build_continuity_state(
                 token_estimate_source=state_without_summary.token_estimate_source,
                 dropped_tool_results=state_without_summary.dropped_tool_results,
                 fact_reference_count=0,
+                source_references=(),
                 version=2,
             )
 
@@ -1171,6 +1177,7 @@ def _build_continuity_state(
         token_estimate_source=state_without_summary.token_estimate_source,
         dropped_tool_results=state_without_summary.dropped_tool_results,
         distillation_source="deterministic",
+        source_references=state_without_summary.source_references,
         version=2,
     )
 
@@ -1215,6 +1222,7 @@ def _continuity_state_from_distillation(
         f"{item.text} — {item.rationale}" for item in distillation.key_decisions_with_rationale
     )
     refs = tuple(item.text for item in distillation.relevant_files_commands_errors)
+    source_references = tuple(f"{item.kind}:{item.id}" for item in distillation.source_references)
     verification = (
         distillation.verification_state.status,
         *distillation.verification_state.details,
@@ -1243,6 +1251,7 @@ def _continuity_state_from_distillation(
             token_estimate_source=base_state.token_estimate_source,
             dropped_tool_results=base_state.dropped_tool_results,
             fact_reference_count=len(distillation.source_references),
+            source_references=source_references,
         )
     )
     return RuntimeContinuityState(
@@ -1268,6 +1277,7 @@ def _continuity_state_from_distillation(
         token_estimate_source=base_state.token_estimate_source,
         dropped_tool_results=base_state.dropped_tool_results,
         fact_reference_count=len(distillation.source_references),
+        source_references=source_references,
         version=2,
     )
 

--- a/src/voidcode/runtime/continuity_distillation.py
+++ b/src/voidcode/runtime/continuity_distillation.py
@@ -10,6 +10,10 @@ SourceReferenceKind = Literal["event", "tool", "session", "background_task"]
 EvidenceKind = Literal["file", "command", "error", "other"]
 VerificationStatus = Literal["passed", "failed", "pending", "unknown"]
 
+_DISTILLATION_OUTPUT_MAX_TEXT_CHARS = 1_000
+_DISTILLATION_OUTPUT_MAX_ITEMS = 12
+_DISTILLATION_OUTPUT_MAX_REFERENCES = 24
+
 
 @dataclass(frozen=True, slots=True)
 class ContinuitySourceReference:
@@ -101,10 +105,10 @@ def _string_tuple(payload: Mapping[str, object], key: str) -> tuple[str, ...] | 
     if not isinstance(raw, list | tuple):
         return None
     values: list[str] = []
-    for item in cast(list[object] | tuple[object, ...], raw):
+    for item in cast(list[object] | tuple[object, ...], raw)[:_DISTILLATION_OUTPUT_MAX_ITEMS]:
         if not isinstance(item, str):
             return None
-        stripped = item.strip()
+        stripped = _bounded_output_text(item)
         if stripped:
             values.append(stripped)
     return tuple(values)
@@ -114,7 +118,7 @@ def _source_references_from_payload(raw: object) -> tuple[ContinuitySourceRefere
     if not isinstance(raw, list | tuple):
         return None
     refs: list[ContinuitySourceReference] = []
-    for item in cast(list[object] | tuple[object, ...], raw):
+    for item in cast(list[object] | tuple[object, ...], raw)[:_DISTILLATION_OUTPUT_MAX_REFERENCES]:
         if not isinstance(item, dict):
             return None
         entry = cast(dict[str, object], item)
@@ -125,11 +129,15 @@ def _source_references_from_payload(raw: object) -> tuple[ContinuitySourceRefere
         if not isinstance(raw_id, str) or not raw_id.strip():
             return None
         raw_detail = entry.get("detail")
-        detail = raw_detail.strip() if isinstance(raw_detail, str) and raw_detail.strip() else None
+        detail = (
+            _bounded_output_text(raw_detail)
+            if isinstance(raw_detail, str) and raw_detail.strip()
+            else None
+        )
         refs.append(
             ContinuitySourceReference(
                 kind=cast(SourceReferenceKind, raw_kind),
-                id=raw_id.strip(),
+                id=_bounded_output_text(raw_id),
                 detail=detail,
             )
         )
@@ -140,7 +148,7 @@ def _decisions_from_payload(raw: object) -> tuple[ContinuityDecisionFact, ...] |
     if not isinstance(raw, list | tuple):
         return None
     facts: list[ContinuityDecisionFact] = []
-    for item in cast(list[object] | tuple[object, ...], raw):
+    for item in cast(list[object] | tuple[object, ...], raw)[:_DISTILLATION_OUTPUT_MAX_ITEMS]:
         if not isinstance(item, dict):
             return None
         entry = cast(dict[str, object], item)
@@ -154,7 +162,11 @@ def _decisions_from_payload(raw: object) -> tuple[ContinuityDecisionFact, ...] |
         if refs is None:
             return None
         facts.append(
-            ContinuityDecisionFact(text=text.strip(), rationale=rationale.strip(), refs=refs)
+            ContinuityDecisionFact(
+                text=_bounded_output_text(text),
+                rationale=_bounded_output_text(rationale),
+                refs=refs,
+            )
         )
     return tuple(facts)
 
@@ -163,7 +175,7 @@ def _evidence_from_payload(raw: object) -> tuple[ContinuityEvidenceFact, ...] | 
     if not isinstance(raw, list | tuple):
         return None
     facts: list[ContinuityEvidenceFact] = []
-    for item in cast(list[object] | tuple[object, ...], raw):
+    for item in cast(list[object] | tuple[object, ...], raw)[:_DISTILLATION_OUTPUT_MAX_ITEMS]:
         if not isinstance(item, dict):
             return None
         entry = cast(dict[str, object], item)
@@ -178,7 +190,7 @@ def _evidence_from_payload(raw: object) -> tuple[ContinuityEvidenceFact, ...] | 
             return None
         facts.append(
             ContinuityEvidenceFact(
-                text=text.strip(),
+                text=_bounded_output_text(text),
                 kind=cast(EvidenceKind, kind),
                 refs=refs,
             )
@@ -233,7 +245,7 @@ def distillation_record_from_payload(
         return None
 
     return ContinuityDistillationRecord(
-        objective_current_goal=objective.strip(),
+        objective_current_goal=_bounded_output_text(objective),
         verbatim_user_constraints=constraints,
         completed_progress=progress,
         blockers_open_questions=blockers,
@@ -250,6 +262,13 @@ def sanitize_distillation_text(value: str, *, max_chars: int) -> str:
     if len(redacted) <= max_chars:
         return redacted
     return redacted[:max_chars]
+
+
+def _bounded_output_text(value: str) -> str:
+    return sanitize_distillation_text(
+        value.strip(),
+        max_chars=_DISTILLATION_OUTPUT_MAX_TEXT_CHARS,
+    )
 
 
 def build_distillation_input_envelope(

--- a/src/voidcode/runtime/continuity_distillation.py
+++ b/src/voidcode/runtime/continuity_distillation.py
@@ -261,6 +261,19 @@ def build_distillation_input_envelope(
     max_items: int,
     max_chars: int,
 ) -> dict[str, object]:
+    def _source_refs(result: ToolResult) -> list[dict[str, str]]:
+        refs: list[dict[str, str]] = []
+        tool_call_id = result.data.get("tool_call_id")
+        if isinstance(tool_call_id, str) and tool_call_id.strip():
+            refs.append({"kind": "tool", "id": tool_call_id.strip()})
+        path = result.data.get("path")
+        if isinstance(path, str) and path.strip():
+            refs.append({"kind": "event", "id": f"file:{path.strip()}"})
+        command = result.data.get("command")
+        if isinstance(command, str) and command.strip():
+            refs.append({"kind": "event", "id": f"command:{command.strip()}"})
+        return refs
+
     def _preview_result(result: ToolResult) -> dict[str, object]:
         content = result.content or result.error or ""
         safe_content = sanitize_distillation_text(content, max_chars=max_chars)
@@ -276,6 +289,7 @@ def build_distillation_input_envelope(
             "truncated": result.truncated,
             "partial": result.partial,
             "data": data,
+            "source_references": _source_refs(result),
         }
 
     return {

--- a/src/voidcode/runtime/continuity_distillation.py
+++ b/src/voidcode/runtime/continuity_distillation.py
@@ -261,6 +261,35 @@ def build_distillation_input_envelope(
     max_items: int,
     max_chars: int,
 ) -> dict[str, object]:
+    max_collection_items = max(1, max_items)
+
+    def _bounded_payload(value: object, *, depth: int = 0) -> object:
+        if depth >= 4:
+            return "[truncated-depth]"
+        if isinstance(value, str):
+            return sanitize_distillation_text(value, max_chars=max_chars)
+        if isinstance(value, dict):
+            raw_mapping = cast(dict[object, object], value)
+            bounded: dict[str, object] = {}
+            for index, (raw_key, raw_value) in enumerate(raw_mapping.items()):
+                if index >= max_collection_items:
+                    bounded["__truncated_items__"] = len(raw_mapping) - max_collection_items
+                    break
+                key = str(raw_key)
+                bounded[key] = _bounded_payload(raw_value, depth=depth + 1)
+            return bounded
+        if isinstance(value, list | tuple):
+            source = cast(list[object] | tuple[object, ...], value)
+            bounded_items = [
+                _bounded_payload(item, depth=depth + 1) for item in source[:max_collection_items]
+            ]
+            if len(source) > max_collection_items:
+                bounded_items.append({"__truncated_items__": len(source) - max_collection_items})
+            return bounded_items
+        if isinstance(value, bool | int | float) or value is None:
+            return value
+        return sanitize_distillation_text(str(value), max_chars=max_chars)
+
     def _source_refs(result: ToolResult) -> list[dict[str, str]]:
         refs: list[dict[str, str]] = []
         tool_call_id = result.data.get("tool_call_id")
@@ -281,6 +310,8 @@ def build_distillation_input_envelope(
         for key in ("data_uri", "image_data", "raw_output", "stdout", "stderr"):
             if key in data:
                 data[key] = "[redacted]"
+        bounded_data = _bounded_payload(data)
+        assert isinstance(bounded_data, dict)
         return {
             "tool_name": result.tool_name,
             "status": result.status,
@@ -288,7 +319,7 @@ def build_distillation_input_envelope(
             "error_kind": result.error_kind,
             "truncated": result.truncated,
             "partial": result.partial,
-            "data": data,
+            "data": bounded_data,
             "source_references": _source_refs(result),
         }
 

--- a/src/voidcode/runtime/continuity_distillation.py
+++ b/src/voidcode/runtime/continuity_distillation.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Literal, cast
+
+from ..tools.contracts import ToolResult
+
+SourceReferenceKind = Literal["event", "tool", "session", "background_task"]
+EvidenceKind = Literal["file", "command", "error", "other"]
+VerificationStatus = Literal["passed", "failed", "pending", "unknown"]
+
+
+@dataclass(frozen=True, slots=True)
+class ContinuitySourceReference:
+    kind: SourceReferenceKind
+    id: str
+    detail: str | None = None
+
+    def metadata_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {"kind": self.kind, "id": self.id}
+        if self.detail is not None:
+            payload["detail"] = self.detail
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class ContinuityDecisionFact:
+    text: str
+    rationale: str
+    refs: tuple[ContinuitySourceReference, ...] = ()
+
+    def metadata_payload(self) -> dict[str, object]:
+        return {
+            "text": self.text,
+            "rationale": self.rationale,
+            "refs": [ref.metadata_payload() for ref in self.refs],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ContinuityEvidenceFact:
+    text: str
+    kind: EvidenceKind
+    refs: tuple[ContinuitySourceReference, ...] = ()
+
+    def metadata_payload(self) -> dict[str, object]:
+        return {
+            "text": self.text,
+            "kind": self.kind,
+            "refs": [ref.metadata_payload() for ref in self.refs],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ContinuityVerificationState:
+    status: VerificationStatus
+    details: tuple[str, ...] = ()
+    refs: tuple[ContinuitySourceReference, ...] = ()
+
+    def metadata_payload(self) -> dict[str, object]:
+        return {
+            "status": self.status,
+            "details": list(self.details),
+            "refs": [ref.metadata_payload() for ref in self.refs],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ContinuityDistillationRecord:
+    objective_current_goal: str
+    verbatim_user_constraints: tuple[str, ...]
+    completed_progress: tuple[str, ...]
+    blockers_open_questions: tuple[str, ...]
+    key_decisions_with_rationale: tuple[ContinuityDecisionFact, ...]
+    relevant_files_commands_errors: tuple[ContinuityEvidenceFact, ...]
+    verification_state: ContinuityVerificationState
+    next_steps: tuple[str, ...]
+    source_references: tuple[ContinuitySourceReference, ...]
+
+    def metadata_payload(self) -> dict[str, object]:
+        return {
+            "objective_current_goal": self.objective_current_goal,
+            "verbatim_user_constraints": list(self.verbatim_user_constraints),
+            "completed_progress": list(self.completed_progress),
+            "blockers_open_questions": list(self.blockers_open_questions),
+            "key_decisions_with_rationale": [
+                item.metadata_payload() for item in self.key_decisions_with_rationale
+            ],
+            "relevant_files_commands_errors": [
+                item.metadata_payload() for item in self.relevant_files_commands_errors
+            ],
+            "verification_state": self.verification_state.metadata_payload(),
+            "next_steps": list(self.next_steps),
+            "source_references": [ref.metadata_payload() for ref in self.source_references],
+        }
+
+
+def _string_tuple(payload: Mapping[str, object], key: str) -> tuple[str, ...] | None:
+    raw = payload.get(key)
+    if not isinstance(raw, list | tuple):
+        return None
+    values: list[str] = []
+    for item in cast(list[object] | tuple[object, ...], raw):
+        if not isinstance(item, str):
+            return None
+        stripped = item.strip()
+        if stripped:
+            values.append(stripped)
+    return tuple(values)
+
+
+def _source_references_from_payload(raw: object) -> tuple[ContinuitySourceReference, ...] | None:
+    if not isinstance(raw, list | tuple):
+        return None
+    refs: list[ContinuitySourceReference] = []
+    for item in cast(list[object] | tuple[object, ...], raw):
+        if not isinstance(item, dict):
+            return None
+        entry = cast(dict[str, object], item)
+        raw_kind = entry.get("kind")
+        raw_id = entry.get("id")
+        if raw_kind not in {"event", "tool", "session", "background_task"}:
+            return None
+        if not isinstance(raw_id, str) or not raw_id.strip():
+            return None
+        raw_detail = entry.get("detail")
+        detail = raw_detail.strip() if isinstance(raw_detail, str) and raw_detail.strip() else None
+        refs.append(
+            ContinuitySourceReference(
+                kind=cast(SourceReferenceKind, raw_kind),
+                id=raw_id.strip(),
+                detail=detail,
+            )
+        )
+    return tuple(refs)
+
+
+def _decisions_from_payload(raw: object) -> tuple[ContinuityDecisionFact, ...] | None:
+    if not isinstance(raw, list | tuple):
+        return None
+    facts: list[ContinuityDecisionFact] = []
+    for item in cast(list[object] | tuple[object, ...], raw):
+        if not isinstance(item, dict):
+            return None
+        entry = cast(dict[str, object], item)
+        text = entry.get("text")
+        rationale = entry.get("rationale")
+        refs = _source_references_from_payload(entry.get("refs"))
+        if not isinstance(text, str) or not text.strip():
+            return None
+        if not isinstance(rationale, str) or not rationale.strip():
+            return None
+        if refs is None:
+            return None
+        facts.append(
+            ContinuityDecisionFact(text=text.strip(), rationale=rationale.strip(), refs=refs)
+        )
+    return tuple(facts)
+
+
+def _evidence_from_payload(raw: object) -> tuple[ContinuityEvidenceFact, ...] | None:
+    if not isinstance(raw, list | tuple):
+        return None
+    facts: list[ContinuityEvidenceFact] = []
+    for item in cast(list[object] | tuple[object, ...], raw):
+        if not isinstance(item, dict):
+            return None
+        entry = cast(dict[str, object], item)
+        text = entry.get("text")
+        kind = entry.get("kind")
+        refs = _source_references_from_payload(entry.get("refs"))
+        if not isinstance(text, str) or not text.strip():
+            return None
+        if kind not in {"file", "command", "error", "other"}:
+            return None
+        if refs is None:
+            return None
+        facts.append(
+            ContinuityEvidenceFact(
+                text=text.strip(),
+                kind=cast(EvidenceKind, kind),
+                refs=refs,
+            )
+        )
+    return tuple(facts)
+
+
+def _verification_state_from_payload(raw: object) -> ContinuityVerificationState | None:
+    if not isinstance(raw, dict):
+        return None
+    payload = cast(dict[str, object], raw)
+    status = payload.get("status")
+    if status not in {"passed", "failed", "pending", "unknown"}:
+        return None
+    details = _string_tuple(payload, "details")
+    refs = _source_references_from_payload(payload.get("refs"))
+    if details is None or refs is None:
+        return None
+    return ContinuityVerificationState(
+        status=cast(VerificationStatus, status),
+        details=details,
+        refs=refs,
+    )
+
+
+def distillation_record_from_payload(
+    raw_payload: Mapping[str, object],
+) -> ContinuityDistillationRecord | None:
+    objective = raw_payload.get("objective_current_goal")
+    if not isinstance(objective, str) or not objective.strip():
+        return None
+
+    constraints = _string_tuple(raw_payload, "verbatim_user_constraints")
+    progress = _string_tuple(raw_payload, "completed_progress")
+    blockers = _string_tuple(raw_payload, "blockers_open_questions")
+    decisions = _decisions_from_payload(raw_payload.get("key_decisions_with_rationale"))
+    evidence = _evidence_from_payload(raw_payload.get("relevant_files_commands_errors"))
+    verification = _verification_state_from_payload(raw_payload.get("verification_state"))
+    next_steps = _string_tuple(raw_payload, "next_steps")
+    refs = _source_references_from_payload(raw_payload.get("source_references"))
+
+    if (
+        constraints is None
+        or progress is None
+        or blockers is None
+        or decisions is None
+        or evidence is None
+        or verification is None
+        or next_steps is None
+        or refs is None
+    ):
+        return None
+
+    return ContinuityDistillationRecord(
+        objective_current_goal=objective.strip(),
+        verbatim_user_constraints=constraints,
+        completed_progress=progress,
+        blockers_open_questions=blockers,
+        key_decisions_with_rationale=decisions,
+        relevant_files_commands_errors=evidence,
+        verification_state=verification,
+        next_steps=next_steps,
+        source_references=refs,
+    )
+
+
+def sanitize_distillation_text(value: str, *, max_chars: int) -> str:
+    redacted = value.replace("data:", "[redacted-data-uri]:")
+    if len(redacted) <= max_chars:
+        return redacted
+    return redacted[:max_chars]
+
+
+def build_distillation_input_envelope(
+    *,
+    prompt: str,
+    dropped_results: tuple[ToolResult, ...],
+    retained_results: tuple[ToolResult, ...],
+    previous_continuity: Mapping[str, object] | None,
+    max_items: int,
+    max_chars: int,
+) -> dict[str, object]:
+    def _preview_result(result: ToolResult) -> dict[str, object]:
+        content = result.content or result.error or ""
+        safe_content = sanitize_distillation_text(content, max_chars=max_chars)
+        data = dict(result.data)
+        for key in ("data_uri", "image_data", "raw_output", "stdout", "stderr"):
+            if key in data:
+                data[key] = "[redacted]"
+        return {
+            "tool_name": result.tool_name,
+            "status": result.status,
+            "content_preview": safe_content,
+            "error_kind": result.error_kind,
+            "truncated": result.truncated,
+            "partial": result.partial,
+            "data": data,
+        }
+
+    return {
+        "prompt": sanitize_distillation_text(prompt, max_chars=max_chars),
+        "previous_continuity": dict(previous_continuity)
+        if previous_continuity is not None
+        else None,
+        "dropped_tool_result_previews": [
+            _preview_result(result) for result in dropped_results[:max_items]
+        ],
+        "recent_tail_previews": [
+            _preview_result(result) for result in retained_results[-max_items:]
+        ],
+    }

--- a/src/voidcode/runtime/provider_context.py
+++ b/src/voidcode/runtime/provider_context.py
@@ -618,6 +618,18 @@ def _context_window_diagnostics(
     continuity_payload = (
         cast(dict[str, object], continuity) if isinstance(continuity, dict) else None
     )
+    if continuity_payload is not None:
+        source = continuity_payload.get("distillation_source")
+        if isinstance(source, str) and source:
+            diagnostics.append(
+                RuntimeProviderContextDiagnostic(
+                    severity="info",
+                    code="continuity_distillation_source",
+                    message=("Continuity summary source recorded for provider context debugging."),
+                    source="context_window",
+                    details={"distillation_source": source},
+                )
+            )
     if continuity_payload is not None and not continuity_payload.get("summary_text") and dropped:
         diagnostics.append(
             RuntimeProviderContextDiagnostic(

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -779,6 +779,7 @@ class RuntimeRunLoopCoordinator:
                 prompt=current_prompt,
                 tool_results=tuple(tool_results),
                 session_metadata=current_session.metadata,
+                abort_signal=current_abort_signal,
             )
             reinjected_continuity = continuity_to_reinject
             if reinjected_continuity is not None:

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -778,8 +778,17 @@ class RuntimeRunLoopCoordinator:
             current_session: SessionState = session
             current_session_metadata: dict[str, object] = current_session.metadata
             if first_iteration:
-                base_context = cast(RuntimeContextWindow, current_graph_request.context_window)
+                prebuilt_context = cast(RuntimeContextWindow, current_graph_request.context_window)
                 first_iteration = False
+                if prebuilt_context.original_tool_result_count == len(tool_results):
+                    base_context = prebuilt_context
+                else:
+                    base_context = runtime._prepare_provider_context_window(
+                        prompt=current_prompt,
+                        tool_results=tuple(tool_results),
+                        session_metadata=current_session_metadata,
+                        abort_signal=current_abort_signal,
+                    )
             else:
                 base_context = runtime._prepare_provider_context_window(
                     prompt=current_prompt,

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -761,13 +761,13 @@ class RuntimeRunLoopCoordinator:
                 session = pending_provider_attempt_reset.session
                 pending_provider_attempt_reset = None
             sequence = int(sequence)
-            current_graph_request: GraphRunRequest = active_graph_request
-            current_prompt: str = current_graph_request.prompt
-            current_available_tools: tuple[ToolDefinition, ...] = (
-                current_graph_request.available_tools
+            current_graph_request: Any = active_graph_request
+            current_prompt: str = cast(str, current_graph_request.prompt)
+            current_available_tools: tuple[ToolDefinition, ...] = cast(
+                tuple[ToolDefinition, ...], current_graph_request.available_tools
             )
-            current_assembled_context: ProviderAssembledContext = (
-                current_graph_request.assembled_context
+            current_assembled_context: ProviderAssembledContext = cast(
+                ProviderAssembledContext, current_graph_request.assembled_context
             )
             current_segments: tuple[ProviderContextSegmentLike, ...] = (
                 current_assembled_context.segments
@@ -775,10 +775,11 @@ class RuntimeRunLoopCoordinator:
             current_metadata: dict[str, object] = current_graph_request.metadata
             current_abort_signal: ProviderAbortSignal | None = current_graph_request.abort_signal
             current_session: SessionState = session
+            current_session_metadata: dict[str, object] = current_session.metadata
             base_context = runtime._prepare_provider_context_window(
                 prompt=current_prompt,
                 tool_results=tuple(tool_results),
-                session_metadata=current_session.metadata,
+                session_metadata=current_session_metadata,
                 abort_signal=current_abort_signal,
             )
             reinjected_continuity = continuity_to_reinject

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -753,6 +753,7 @@ class RuntimeRunLoopCoordinator:
         reasoning_capture_state = runtime._reasoning_capture_state()
         active_graph_request: GraphRunRequest = graph_request
         pending_provider_attempt_reset: _ProviderAttemptReset | None = None
+        first_iteration = True
         while True:
             if pending_provider_attempt_reset is not None:
                 provider_attempt = pending_provider_attempt_reset.provider_attempt
@@ -776,12 +777,16 @@ class RuntimeRunLoopCoordinator:
             current_abort_signal: ProviderAbortSignal | None = current_graph_request.abort_signal
             current_session: SessionState = session
             current_session_metadata: dict[str, object] = current_session.metadata
-            base_context = runtime._prepare_provider_context_window(
-                prompt=current_prompt,
-                tool_results=tuple(tool_results),
-                session_metadata=current_session_metadata,
-                abort_signal=current_abort_signal,
-            )
+            if first_iteration:
+                base_context = cast(RuntimeContextWindow, current_graph_request.context_window)
+                first_iteration = False
+            else:
+                base_context = runtime._prepare_provider_context_window(
+                    prompt=current_prompt,
+                    tool_results=tuple(tool_results),
+                    session_metadata=current_session_metadata,
+                    abort_signal=current_abort_signal,
+                )
             reinjected_continuity = continuity_to_reinject
             if reinjected_continuity is not None:
                 summary_anchor, summary_source = continuity_summary_metadata(reinjected_continuity)

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -2012,6 +2012,7 @@ class VoidCodeRuntime:
                 prompt=request.prompt,
                 tool_results=(),
                 session_metadata=session.metadata,
+                abort_signal=abort_signal,
             ),
             assembled_context=self._assemble_provider_context(
                 prompt=request.prompt,
@@ -5862,6 +5863,7 @@ class VoidCodeRuntime:
         tool_results: tuple[ToolResult, ...],
         session_metadata: dict[str, object],
         policy: ContextWindowPolicy | None = None,
+        abort_signal: ProviderAbortSignal | None = None,
     ) -> RuntimeContextWindow:
         effective_config = self._effective_runtime_config_from_metadata(session_metadata)
         provider_attempt = self._provider_attempt_from_metadata(session_metadata)
@@ -5876,13 +5878,17 @@ class VoidCodeRuntime:
             resolved_provider=effective_config.resolved_provider,
             provider_attempt=provider_attempt,
         )
-        if policy.continuity_distillation_enabled:
+        if policy.continuity_distillation_enabled and self._should_fetch_distillation_candidate(
+            tool_results=tool_results,
+            policy=policy,
+        ):
             session_metadata = self._session_metadata_with_distillation_candidate(
                 prompt=prompt,
                 tool_results=tool_results,
                 session_metadata=session_metadata,
                 policy=policy,
                 effective_config=effective_config,
+                abort_signal=abort_signal,
             )
         return prepare_provider_context(
             prompt=prompt,
@@ -5890,6 +5896,26 @@ class VoidCodeRuntime:
             session_metadata=session_metadata,
             policy=policy or self._default_context_window_policy,
         )
+
+    @staticmethod
+    def _should_fetch_distillation_candidate(
+        *,
+        tool_results: tuple[ToolResult, ...],
+        policy: ContextWindowPolicy,
+    ) -> bool:
+        if not tool_results:
+            return False
+        protected_recent_count = max(
+            policy.minimum_retained_tool_results,
+            policy.recent_tool_result_count,
+        )
+        protected_recent_count = min(protected_recent_count, len(tool_results))
+        if policy.max_tool_results == 0:
+            retained_count = protected_recent_count
+        else:
+            retained_count = max(policy.max_tool_results, protected_recent_count)
+            retained_count = min(retained_count, len(tool_results))
+        return len(tool_results) > retained_count
 
     def _session_metadata_with_distillation_candidate(
         self,
@@ -5899,6 +5925,7 @@ class VoidCodeRuntime:
         session_metadata: dict[str, object],
         policy: ContextWindowPolicy,
         effective_config: EffectiveRuntimeConfig,
+        abort_signal: ProviderAbortSignal | None,
     ) -> dict[str, object]:
         candidate, failure_reason = self._distillation_candidate_from_provider(
             prompt=prompt,
@@ -5906,6 +5933,7 @@ class VoidCodeRuntime:
             session_metadata=session_metadata,
             policy=policy,
             effective_config=effective_config,
+            abort_signal=abort_signal,
         )
         raw_runtime_state = session_metadata.get("runtime_state")
         runtime_state = (
@@ -5927,6 +5955,7 @@ class VoidCodeRuntime:
         session_metadata: dict[str, object],
         policy: ContextWindowPolicy,
         effective_config: EffectiveRuntimeConfig,
+        abort_signal: ProviderAbortSignal | None,
     ) -> tuple[dict[str, object] | None, str | None]:
         if not tool_results:
             return None, "empty_tool_results"
@@ -5985,6 +6014,7 @@ class VoidCodeRuntime:
             provider_name=selection.provider,
             model_name=selection.model,
             model_metadata=provider_target.metadata,
+            abort_signal=abort_signal,
         )
         try:
             result = turn_provider.propose_turn(request)

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -5798,6 +5798,13 @@ class VoidCodeRuntime:
             continuity_preview_chars=policy.continuity_preview_chars,
             context_pressure_threshold=policy.context_pressure_threshold,
             context_pressure_cooldown_steps=policy.context_pressure_cooldown_steps,
+            continuity_distillation_enabled=policy.continuity_distillation_enabled,
+            continuity_distillation_max_input_items=(
+                policy.continuity_distillation_max_input_items
+            ),
+            continuity_distillation_max_input_chars=(
+                policy.continuity_distillation_max_input_chars
+            ),
         )
 
     @staticmethod
@@ -5837,6 +5844,13 @@ class VoidCodeRuntime:
             continuity_preview_chars=config.continuity_preview_chars,
             context_pressure_threshold=config.context_pressure_threshold,
             context_pressure_cooldown_steps=config.context_pressure_cooldown_steps,
+            continuity_distillation_enabled=config.continuity_distillation_enabled,
+            continuity_distillation_max_input_items=(
+                config.continuity_distillation_max_input_items
+            ),
+            continuity_distillation_max_input_chars=(
+                config.continuity_distillation_max_input_chars
+            ),
         )
 
     def _prepare_provider_context_window(
@@ -5956,6 +5970,11 @@ class VoidCodeRuntime:
             {
                 "anchor": context_window.summary_anchor,
                 "source": context_window.summary_source,
+                "distillation_source": (
+                    context_window.continuity_state.distillation_source
+                    if context_window.continuity_state is not None
+                    else "deterministic"
+                ),
             }
             if context_window.summary_anchor is not None
             else None

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -5946,7 +5946,9 @@ class VoidCodeRuntime:
         )
         if candidate is not None:
             runtime_state["distillation_candidate"] = candidate
-        if failure_reason is not None:
+            runtime_state.pop("distillation_failure_reason", None)
+        elif failure_reason is not None:
+            runtime_state.pop("distillation_candidate", None)
             runtime_state["distillation_failure_reason"] = failure_reason
         return {**session_metadata, "runtime_state": runtime_state}
 

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -56,7 +56,7 @@ from ..provider.models import (
     ResolvedProviderConfig,
     ResolvedProviderModel,
 )
-from ..provider.protocol import ProviderAbortSignal, ProviderTokenUsage
+from ..provider.protocol import ProviderAbortSignal, ProviderTokenUsage, ProviderTurnRequest
 from ..provider.registry import ModelProviderRegistry
 from ..provider.resolution import resolve_provider_config
 from ..provider.snapshot import (
@@ -128,12 +128,14 @@ from .config import (
 from .context_window import (
     ContextWindowPolicy,
     RuntimeAssembledContext,
+    RuntimeContextSegment,
     RuntimeContextWindow,
     RuntimeContinuityState,
     assemble_provider_context,
     continuity_state_from_metadata_payload,
     prepare_provider_context,
 )
+from .continuity_distillation import build_distillation_input_envelope
 from .contracts import (
     AgentSummary,
     BackgroundTaskResult,
@@ -5874,12 +5876,116 @@ class VoidCodeRuntime:
             resolved_provider=effective_config.resolved_provider,
             provider_attempt=provider_attempt,
         )
+        if policy.continuity_distillation_enabled:
+            session_metadata = self._session_metadata_with_distillation_candidate(
+                prompt=prompt,
+                tool_results=tool_results,
+                session_metadata=session_metadata,
+                policy=policy,
+                effective_config=effective_config,
+            )
         return prepare_provider_context(
             prompt=prompt,
             tool_results=tool_results,
             session_metadata=session_metadata,
             policy=policy or self._default_context_window_policy,
         )
+
+    def _session_metadata_with_distillation_candidate(
+        self,
+        *,
+        prompt: str,
+        tool_results: tuple[ToolResult, ...],
+        session_metadata: dict[str, object],
+        policy: ContextWindowPolicy,
+        effective_config: EffectiveRuntimeConfig,
+    ) -> dict[str, object]:
+        candidate = self._distillation_candidate_from_provider(
+            prompt=prompt,
+            tool_results=tool_results,
+            session_metadata=session_metadata,
+            policy=policy,
+            effective_config=effective_config,
+        )
+        if candidate is None:
+            return session_metadata
+        raw_runtime_state = session_metadata.get("runtime_state")
+        runtime_state = (
+            dict(cast(dict[str, object], raw_runtime_state))
+            if isinstance(raw_runtime_state, dict)
+            else {}
+        )
+        runtime_state["distillation_candidate"] = candidate
+        return {**session_metadata, "runtime_state": runtime_state}
+
+    def _distillation_candidate_from_provider(
+        self,
+        *,
+        prompt: str,
+        tool_results: tuple[ToolResult, ...],
+        session_metadata: dict[str, object],
+        policy: ContextWindowPolicy,
+        effective_config: EffectiveRuntimeConfig,
+    ) -> dict[str, object] | None:
+        if not tool_results:
+            return None
+        dropped_guess = tool_results[:-1]
+        retained_guess = tool_results[-1:]
+        previous_continuity: dict[str, object] | None = None
+        runtime_state = session_metadata.get("runtime_state")
+        if isinstance(runtime_state, dict):
+            raw_continuity = cast(dict[str, object], runtime_state).get("continuity")
+            if isinstance(raw_continuity, dict):
+                previous_continuity = cast(dict[str, object], raw_continuity)
+        envelope = build_distillation_input_envelope(
+            prompt=prompt,
+            dropped_results=dropped_guess,
+            retained_results=retained_guess,
+            previous_continuity=previous_continuity,
+            max_items=policy.continuity_distillation_max_input_items,
+            max_chars=policy.continuity_distillation_max_input_chars,
+        )
+        provider_target = effective_config.resolved_provider.active_target
+        selection = provider_target.selection
+        provider_name = selection.provider
+        if provider_name is None:
+            return None
+        provider = self._model_provider_registry.resolve(provider_name)
+        turn_provider = provider.turn_provider()
+        schema_prompt = (
+            "Return ONLY valid JSON matching these keys: "
+            "objective_current_goal, verbatim_user_constraints, completed_progress, "
+            "blockers_open_questions, key_decisions_with_rationale, "
+            "relevant_files_commands_errors, verification_state, next_steps, source_references. "
+            "No markdown; output JSON object only.\n\n"
+            f"INPUT={json.dumps(envelope, ensure_ascii=False)}"
+        )
+        distill_context = RuntimeAssembledContext(
+            prompt=schema_prompt,
+            tool_results=(),
+            continuity_state=None,
+            segments=(RuntimeContextSegment(role="user", content=schema_prompt),),
+            metadata={"source": "continuity_distillation"},
+        )
+        request = ProviderTurnRequest(
+            assembled_context=distill_context,
+            available_tools=(),
+            raw_model=selection.raw_model,
+            provider_name=selection.provider,
+            model_name=selection.model,
+            model_metadata=provider_target.metadata,
+        )
+        try:
+            result = turn_provider.propose_turn(request)
+        except Exception:
+            return None
+        if not isinstance(result.output, str) or not result.output.strip():
+            return None
+        try:
+            payload = json.loads(result.output)
+        except json.JSONDecodeError:
+            return None
+        return cast(dict[str, object], payload) if isinstance(payload, dict) else None
 
     def _assemble_provider_context(
         self,

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -5881,6 +5881,8 @@ class VoidCodeRuntime:
         if policy.continuity_distillation_enabled and self._should_fetch_distillation_candidate(
             tool_results=tool_results,
             policy=policy,
+            prompt=prompt,
+            session_metadata=session_metadata,
         ):
             session_metadata = self._session_metadata_with_distillation_candidate(
                 prompt=prompt,
@@ -5889,6 +5891,7 @@ class VoidCodeRuntime:
                 policy=policy,
                 effective_config=effective_config,
                 abort_signal=abort_signal,
+                provider_attempt=provider_attempt,
             )
         return prepare_provider_context(
             prompt=prompt,
@@ -5902,20 +5905,18 @@ class VoidCodeRuntime:
         *,
         tool_results: tuple[ToolResult, ...],
         policy: ContextWindowPolicy,
+        prompt: str,
+        session_metadata: dict[str, object],
     ) -> bool:
         if not tool_results:
             return False
-        protected_recent_count = max(
-            policy.minimum_retained_tool_results,
-            policy.recent_tool_result_count,
+        probe = prepare_provider_context(
+            prompt=prompt,
+            tool_results=tool_results,
+            session_metadata=session_metadata,
+            policy=policy,
         )
-        protected_recent_count = min(protected_recent_count, len(tool_results))
-        if policy.max_tool_results == 0:
-            retained_count = protected_recent_count
-        else:
-            retained_count = max(policy.max_tool_results, protected_recent_count)
-            retained_count = min(retained_count, len(tool_results))
-        return len(tool_results) > retained_count
+        return probe.compacted
 
     def _session_metadata_with_distillation_candidate(
         self,
@@ -5926,6 +5927,7 @@ class VoidCodeRuntime:
         policy: ContextWindowPolicy,
         effective_config: EffectiveRuntimeConfig,
         abort_signal: ProviderAbortSignal | None,
+        provider_attempt: int,
     ) -> dict[str, object]:
         candidate, failure_reason = self._distillation_candidate_from_provider(
             prompt=prompt,
@@ -5934,6 +5936,7 @@ class VoidCodeRuntime:
             policy=policy,
             effective_config=effective_config,
             abort_signal=abort_signal,
+            provider_attempt=provider_attempt,
         )
         raw_runtime_state = session_metadata.get("runtime_state")
         runtime_state = (
@@ -5956,6 +5959,7 @@ class VoidCodeRuntime:
         policy: ContextWindowPolicy,
         effective_config: EffectiveRuntimeConfig,
         abort_signal: ProviderAbortSignal | None,
+        provider_attempt: int,
     ) -> tuple[dict[str, object] | None, str | None]:
         if not tool_results:
             return None, "empty_tool_results"
@@ -5985,7 +5989,11 @@ class VoidCodeRuntime:
             max_items=policy.continuity_distillation_max_input_items,
             max_chars=policy.continuity_distillation_max_input_chars,
         )
-        provider_target = effective_config.resolved_provider.active_target
+        provider_target = effective_config.resolved_provider.target_chain.target_at(
+            provider_attempt
+        )
+        if provider_target is None:
+            provider_target = effective_config.resolved_provider.active_target
         selection = provider_target.selection
         provider_name = selection.provider
         if provider_name is None:

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -5900,22 +5900,23 @@ class VoidCodeRuntime:
         policy: ContextWindowPolicy,
         effective_config: EffectiveRuntimeConfig,
     ) -> dict[str, object]:
-        candidate = self._distillation_candidate_from_provider(
+        candidate, failure_reason = self._distillation_candidate_from_provider(
             prompt=prompt,
             tool_results=tool_results,
             session_metadata=session_metadata,
             policy=policy,
             effective_config=effective_config,
         )
-        if candidate is None:
-            return session_metadata
         raw_runtime_state = session_metadata.get("runtime_state")
         runtime_state = (
             dict(cast(dict[str, object], raw_runtime_state))
             if isinstance(raw_runtime_state, dict)
             else {}
         )
-        runtime_state["distillation_candidate"] = candidate
+        if candidate is not None:
+            runtime_state["distillation_candidate"] = candidate
+        if failure_reason is not None:
+            runtime_state["distillation_failure_reason"] = failure_reason
         return {**session_metadata, "runtime_state": runtime_state}
 
     def _distillation_candidate_from_provider(
@@ -5926,9 +5927,9 @@ class VoidCodeRuntime:
         session_metadata: dict[str, object],
         policy: ContextWindowPolicy,
         effective_config: EffectiveRuntimeConfig,
-    ) -> dict[str, object] | None:
+    ) -> tuple[dict[str, object] | None, str | None]:
         if not tool_results:
-            return None
+            return None, "empty_tool_results"
         protected_recent_count = max(
             policy.minimum_retained_tool_results,
             policy.recent_tool_result_count,
@@ -5959,7 +5960,7 @@ class VoidCodeRuntime:
         selection = provider_target.selection
         provider_name = selection.provider
         if provider_name is None:
-            return None
+            return None, "missing_provider"
         provider = self._model_provider_registry.resolve(provider_name)
         turn_provider = provider.turn_provider()
         schema_prompt = (
@@ -5988,14 +5989,16 @@ class VoidCodeRuntime:
         try:
             result = turn_provider.propose_turn(request)
         except Exception:
-            return None
+            return None, "provider_error"
         if not isinstance(result.output, str) or not result.output.strip():
-            return None
+            return None, "empty_output"
         try:
             payload = json.loads(result.output)
         except json.JSONDecodeError:
-            return None
-        return cast(dict[str, object], payload) if isinstance(payload, dict) else None
+            return None, "invalid_json"
+        if not isinstance(payload, dict):
+            return None, "invalid_schema"
+        return cast(dict[str, object], payload), None
 
     def _assemble_provider_context(
         self,

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -5929,8 +5929,18 @@ class VoidCodeRuntime:
     ) -> dict[str, object] | None:
         if not tool_results:
             return None
-        dropped_guess = tool_results[:-1]
-        retained_guess = tool_results[-1:]
+        protected_recent_count = max(
+            policy.minimum_retained_tool_results,
+            policy.recent_tool_result_count,
+        )
+        protected_recent_count = min(protected_recent_count, len(tool_results))
+        if policy.max_tool_results == 0:
+            retained_count = protected_recent_count
+        else:
+            retained_count = max(policy.max_tool_results, protected_recent_count)
+            retained_count = min(retained_count, len(tool_results))
+        dropped_guess = tool_results[: len(tool_results) - retained_count]
+        retained_guess = tool_results[len(tool_results) - retained_count :]
         previous_continuity: dict[str, object] | None = None
         runtime_state = session_metadata.get("runtime_state")
         if isinstance(runtime_state, dict):

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -533,29 +533,21 @@ def test_provider_context_parity_matrix_preserves_tool_shapes_across_debug_messa
     )
 
 
-def test_provider_context_policy_marks_blocking_diagnostics() -> None:
+def test_provider_context_inspector_reports_continuity_distillation_source() -> None:
     assembled = RuntimeAssembledContext(
         prompt="continue",
         tool_results=(),
         continuity_state=None,
-        metadata={},
-        segments=(
-            RuntimeContextSegment(role="user", content="continue"),
-            RuntimeContextSegment(
-                role="assistant",
-                content=None,
-                tool_call_id="missing-result",
-                tool_name="read_file",
-                tool_arguments={"path": "sample.txt"},
-            ),
-            RuntimeContextSegment(
-                role="tool",
-                content="x" * 12,
-                tool_call_id="orphan-result",
-                tool_name="grep",
-                metadata={"status": "ok", "data": {}},
-            ),
-        ),
+        metadata={
+            "continuity_state": {
+                "summary_text": "summary",
+                "dropped_tool_result_count": 1,
+                "retained_tool_result_count": 1,
+                "source": "tool_result_window",
+                "distillation_source": "model_assisted",
+            }
+        },
+        segments=(RuntimeContextSegment(role="user", content="continue"),),
     )
 
     snapshot = inspect_provider_context(
@@ -564,59 +556,15 @@ def test_provider_context_policy_marks_blocking_diagnostics() -> None:
         model="gpt-4o",
         execution_engine="provider",
         available_tool_count=0,
-        oversized_tool_feedback_chars=5,
-        diagnostic_policy_mode="block",
     )
 
-    assert snapshot.policy_decision is not None
-    assert snapshot.policy_decision.blocked is True
-    assert snapshot.policy_decision.action == "block"
-    assert set(snapshot.policy_decision.blocking_diagnostic_codes) >= {
-        "missing_tool_result",
-        "orphan_tool_result",
-        "oversized_tool_feedback",
-    }
-    blocking_codes = {
-        diagnostic.code for diagnostic in snapshot.diagnostics if diagnostic.policy_blocking
-    }
-    assert {
-        "missing_tool_result",
-        "orphan_tool_result",
-        "oversized_tool_feedback",
-    } <= blocking_codes
-
-
-def test_provider_context_policy_off_keeps_diagnostics_debug_only() -> None:
-    assembled = RuntimeAssembledContext(
-        prompt="continue",
-        tool_results=(),
-        continuity_state=None,
-        metadata={},
-        segments=(
-            RuntimeContextSegment(role="user", content="continue"),
-            RuntimeContextSegment(
-                role="tool",
-                content="orphan",
-                tool_call_id="orphan-result",
-                tool_name="grep",
-                metadata={"status": "ok", "data": {}},
-            ),
-        ),
-    )
-
-    snapshot = inspect_provider_context(
-        assembled_context=assembled,
-        provider="openai",
-        model="gpt-4o",
-        execution_engine="provider",
-        available_tool_count=3,
-        diagnostic_policy_mode="off",
-    )
-
-    assert snapshot.policy_decision is not None
-    assert snapshot.policy_decision.action == "ignored"
-    assert snapshot.policy_decision.blocked is False
-    assert any(diagnostic.code == "orphan_tool_result" for diagnostic in snapshot.diagnostics)
+    matched = [
+        diagnostic
+        for diagnostic in snapshot.diagnostics
+        if diagnostic.code == "continuity_distillation_source"
+    ]
+    assert len(matched) == 1
+    assert matched[0].details == {"distillation_source": "model_assisted"}
 
 
 def test_prepare_provider_context_compacts_old_results_and_reports_metadata() -> None:

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -996,6 +996,9 @@ def test_context_window_policy_metadata_round_trips() -> None:
         default_tool_result_tokens=30,
         per_tool_result_tokens={"grep": 10},
         tokenizer_model="gpt-4o",
+        continuity_distillation_enabled=True,
+        continuity_distillation_max_input_items=9,
+        continuity_distillation_max_input_chars=1024,
     )
 
     parsed = context_window_policy_from_payload(policy.metadata_payload())
@@ -1133,6 +1136,9 @@ def test_continuity_state_metadata_payload_round_trips_v2_fields() -> None:
         dropped_tool_result_count=2,
         retained_tool_result_count=1,
         source="tool_result_window",
+        distillation_source="deterministic",
+        distillation_error=None,
+        fact_reference_count=0,
         dropped_tool_results=(
             DroppedToolResultDiagnostic(
                 tool_name="read_file",
@@ -1149,6 +1155,141 @@ def test_continuity_state_metadata_payload_round_trips_v2_fields() -> None:
     restored = continuity_state_from_metadata_payload(state.metadata_payload())
 
     assert restored == state
+
+
+def test_prepare_provider_context_continuity_state_exposes_distillation_source_metadata() -> None:
+    context = prepare_provider_context(
+        prompt="read sample.txt",
+        tool_results=(
+            _continuity_tool_result("ok", content="dropped"),
+            _continuity_tool_result("ok", content="retained"),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(max_tool_results=1),
+    )
+
+    assert context.continuity_state is not None
+    payload = context.continuity_state.metadata_payload()
+    assert payload["distillation_source"] == "deterministic"
+    assert payload["fact_reference_count"] == 0
+
+
+def test_prepare_provider_context_uses_model_assisted_distillation_candidate_when_enabled() -> None:
+    candidate = {
+        "objective_current_goal": "Ship continuity distillation",
+        "verbatim_user_constraints": ["Do not override user instructions"],
+        "completed_progress": ["Mapped runtime continuity flow"],
+        "blockers_open_questions": ["Need integration tests"],
+        "key_decisions_with_rationale": [
+            {
+                "text": "Use deterministic fallback",
+                "rationale": "Preserve resilience",
+                "refs": [{"kind": "event", "id": "event:42"}],
+            }
+        ],
+        "relevant_files_commands_errors": [
+            {
+                "text": "src/voidcode/runtime/context_window.py",
+                "kind": "file",
+                "refs": [{"kind": "session", "id": "session:distill"}],
+            }
+        ],
+        "verification_state": {
+            "status": "pending",
+            "details": ["tests not run"],
+            "refs": [{"kind": "tool", "id": "tool:pytest"}],
+        },
+        "next_steps": ["Run tests"],
+        "source_references": [{"kind": "session", "id": "session:distill"}],
+    }
+
+    context = prepare_provider_context(
+        prompt="read sample.txt",
+        tool_results=(
+            _continuity_tool_result("ok", content="drop-me"),
+            _continuity_tool_result("ok", content="keep-me"),
+        ),
+        session_metadata={"runtime_state": {"distillation_candidate": candidate}},
+        policy=ContextWindowPolicy(max_tool_results=1, continuity_distillation_enabled=True),
+    )
+
+    assert context.continuity_state is not None
+    assert context.continuity_state.distillation_source == "model_assisted"
+    assert context.continuity_state.current_goal == "Ship continuity distillation"
+    assert context.continuity_state.fact_reference_count == 1
+
+
+def test_prepare_provider_context_invalid_distillation_candidate_falls_back_safely() -> None:
+    invalid_candidate = {
+        "objective_current_goal": "",
+        "verbatim_user_constraints": ["x"],
+    }
+
+    context = prepare_provider_context(
+        prompt="read sample.txt",
+        tool_results=(
+            _continuity_tool_result("ok", content="drop-me"),
+            _continuity_tool_result("ok", content="keep-me"),
+        ),
+        session_metadata={"runtime_state": {"distillation_candidate": invalid_candidate}},
+        policy=ContextWindowPolicy(max_tool_results=1, continuity_distillation_enabled=True),
+    )
+
+    assert context.continuity_state is not None
+    assert context.continuity_state.distillation_source == "fallback_after_model_error"
+    assert context.continuity_state.distillation_error is not None
+    assert "failed schema validation" in context.continuity_state.distillation_error
+
+
+def test_prepare_provider_context_distillation_candidate_ignores_raw_oversized_fields() -> None:
+    large_data_uri = "data:image/png;base64," + ("A" * 8000)
+    candidate = {
+        "objective_current_goal": "Goal",
+        "verbatim_user_constraints": ["constraint"],
+        "completed_progress": ["progress"],
+        "blockers_open_questions": ["blocker"],
+        "key_decisions_with_rationale": [
+            {
+                "text": "decision",
+                "rationale": "why",
+                "refs": [{"kind": "event", "id": "event:1"}],
+            }
+        ],
+        "relevant_files_commands_errors": [
+            {
+                "text": "cmd",
+                "kind": "command",
+                "refs": [{"kind": "tool", "id": "tool:1"}],
+            }
+        ],
+        "verification_state": {
+            "status": "pending",
+            "details": ["pending"],
+            "refs": [{"kind": "session", "id": "session:1"}],
+        },
+        "next_steps": ["next"],
+        "source_references": [{"kind": "session", "id": "session:1"}],
+        "raw_output": large_data_uri,
+    }
+
+    context = prepare_provider_context(
+        prompt="read sample.txt",
+        tool_results=(
+            ToolResult(
+                tool_name="read_file",
+                status="ok",
+                content=large_data_uri,
+                data={"data_uri": large_data_uri},
+            ),
+            _continuity_tool_result("ok", content="keep-me"),
+        ),
+        session_metadata={"runtime_state": {"distillation_candidate": candidate}},
+        policy=ContextWindowPolicy(max_tool_results=1, continuity_distillation_enabled=True),
+    )
+
+    assert context.continuity_state is not None
+    assert context.continuity_state.distillation_source == "model_assisted"
+    assert "data:image" not in (context.continuity_state.summary_text or "")
 
 
 def test_normalize_read_file_output_preserves_showing_lines_footer() -> None:

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -1217,6 +1217,7 @@ def test_prepare_provider_context_uses_model_assisted_distillation_candidate_whe
     assert context.continuity_state.distillation_source == "model_assisted"
     assert context.continuity_state.current_goal == "Ship continuity distillation"
     assert context.continuity_state.fact_reference_count == 1
+    assert context.continuity_state.source_references == ("session:session:distill",)
 
 
 def test_prepare_provider_context_invalid_distillation_candidate_falls_back_safely() -> None:
@@ -1290,6 +1291,22 @@ def test_prepare_provider_context_distillation_candidate_ignores_raw_oversized_f
     assert context.continuity_state is not None
     assert context.continuity_state.distillation_source == "model_assisted"
     assert "data:image" not in (context.continuity_state.summary_text or "")
+
+
+def test_continuity_state_round_trip_includes_source_references() -> None:
+    state = RuntimeContinuityState(
+        summary_text="summary",
+        dropped_tool_result_count=1,
+        retained_tool_result_count=1,
+        source="tool_result_window",
+        distillation_source="model_assisted",
+        fact_reference_count=2,
+        source_references=("tool:call-1", "event:file:src/a.py"),
+    )
+
+    restored = continuity_state_from_metadata_payload(state.metadata_payload())
+    assert restored is not None
+    assert restored.source_references == ("tool:call-1", "event:file:src/a.py")
 
 
 def test_normalize_read_file_output_preserves_showing_lines_footer() -> None:

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -1216,8 +1216,56 @@ def test_prepare_provider_context_uses_model_assisted_distillation_candidate_whe
     assert context.continuity_state is not None
     assert context.continuity_state.distillation_source == "model_assisted"
     assert context.continuity_state.current_goal == "Ship continuity distillation"
+    assert context.continuity_state.fact_reference_count == 3
+    assert context.continuity_state.source_references == (
+        "session:session:distill",
+        "event:event:42",
+        "tool:tool:pytest",
+    )
+
+
+def test_prepare_provider_context_distillation_references_are_deduplicated() -> None:
+    candidate = {
+        "objective_current_goal": "Goal",
+        "verbatim_user_constraints": ["constraint"],
+        "completed_progress": ["progress"],
+        "blockers_open_questions": ["blocker"],
+        "key_decisions_with_rationale": [
+            {
+                "text": "decision",
+                "rationale": "why",
+                "refs": [{"kind": "event", "id": "event:1"}],
+            }
+        ],
+        "relevant_files_commands_errors": [
+            {
+                "text": "file",
+                "kind": "file",
+                "refs": [{"kind": "event", "id": "event:1"}],
+            }
+        ],
+        "verification_state": {
+            "status": "pending",
+            "details": ["pending"],
+            "refs": [{"kind": "event", "id": "event:1"}],
+        },
+        "next_steps": ["next"],
+        "source_references": [{"kind": "event", "id": "event:1"}],
+    }
+
+    context = prepare_provider_context(
+        prompt="read sample.txt",
+        tool_results=(
+            _continuity_tool_result("ok", content="drop-me"),
+            _continuity_tool_result("ok", content="keep-me"),
+        ),
+        session_metadata={"runtime_state": {"distillation_candidate": candidate}},
+        policy=ContextWindowPolicy(max_tool_results=1, continuity_distillation_enabled=True),
+    )
+
+    assert context.continuity_state is not None
+    assert context.continuity_state.source_references == ("event:event:1",)
     assert context.continuity_state.fact_reference_count == 1
-    assert context.continuity_state.source_references == ("session:session:distill",)
 
 
 def test_prepare_provider_context_invalid_distillation_candidate_falls_back_safely() -> None:

--- a/tests/unit/runtime/test_continuity_distillation.py
+++ b/tests/unit/runtime/test_continuity_distillation.py
@@ -115,3 +115,35 @@ def test_build_distillation_input_envelope_redacts_oversized_and_data_uri_fields
     assert isinstance(data, dict)
     assert data["data_uri"] == "[redacted]"
     assert data["stdout"] == "[redacted]"
+    refs = item_dict["source_references"]
+    assert isinstance(refs, list)
+
+
+def test_build_distillation_input_envelope_collects_source_references() -> None:
+    envelope = build_distillation_input_envelope(
+        prompt="summarize",
+        dropped_results=(
+            ToolResult(
+                tool_name="bash",
+                status="ok",
+                content="done",
+                data={"tool_call_id": "call-1", "path": "src/a.py", "command": "pytest"},
+            ),
+        ),
+        retained_results=(),
+        previous_continuity=None,
+        max_items=3,
+        max_chars=200,
+    )
+
+    dropped_raw = envelope["dropped_tool_result_previews"]
+    assert isinstance(dropped_raw, list)
+    preview = cast(dict[str, object], dropped_raw[0])
+    refs = preview["source_references"]
+    assert isinstance(refs, list)
+    typed_refs = cast(list[dict[str, str]], refs)
+    assert {item["id"] for item in typed_refs} == {
+        "call-1",
+        "file:src/a.py",
+        "command:pytest",
+    }

--- a/tests/unit/runtime/test_continuity_distillation.py
+++ b/tests/unit/runtime/test_continuity_distillation.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from typing import cast
 
 from voidcode.runtime.continuity_distillation import (
+    _DISTILLATION_OUTPUT_MAX_ITEMS,
+    _DISTILLATION_OUTPUT_MAX_REFERENCES,
+    _DISTILLATION_OUTPUT_MAX_TEXT_CHARS,
     ContinuityDistillationRecord,
     build_distillation_input_envelope,
     distillation_record_from_payload,
@@ -82,6 +85,71 @@ def test_distillation_record_round_trip_payload_is_stable() -> None:
     meta = parsed.metadata_payload()
     reparsed = distillation_record_from_payload(meta)
     assert reparsed == parsed
+
+
+def test_distillation_record_from_payload_bounds_model_output_sizes() -> None:
+    payload = _valid_payload()
+    oversized = "data:text/plain," + ("x" * (_DISTILLATION_OUTPUT_MAX_TEXT_CHARS * 2))
+    payload["objective_current_goal"] = oversized
+    payload["verbatim_user_constraints"] = [oversized for _ in range(50)]
+    payload["completed_progress"] = [oversized for _ in range(50)]
+    payload["blockers_open_questions"] = [oversized for _ in range(50)]
+    payload["next_steps"] = [oversized for _ in range(50)]
+    payload["key_decisions_with_rationale"] = [
+        {
+            "text": oversized,
+            "rationale": oversized,
+            "refs": [
+                {
+                    "kind": "event",
+                    "id": f"event:{index}:{oversized}",
+                    "detail": oversized,
+                }
+                for index in range(50)
+            ],
+        }
+        for _ in range(50)
+    ]
+    payload["relevant_files_commands_errors"] = [
+        {
+            "text": oversized,
+            "kind": "other",
+            "refs": [{"kind": "tool", "id": f"tool:{index}:{oversized}"} for index in range(50)],
+        }
+        for _ in range(50)
+    ]
+    payload["verification_state"] = {
+        "status": "pending",
+        "details": [oversized for _ in range(50)],
+        "refs": [
+            {"kind": "background_task", "id": f"bg:{index}:{oversized}"} for index in range(50)
+        ],
+    }
+    payload["source_references"] = [
+        {"kind": "session", "id": f"session:{index}:{oversized}", "detail": oversized}
+        for index in range(50)
+    ]
+
+    parsed = distillation_record_from_payload(payload)
+
+    assert parsed is not None
+    assert len(parsed.objective_current_goal) <= _DISTILLATION_OUTPUT_MAX_TEXT_CHARS
+    assert "data:text/plain" not in parsed.objective_current_goal
+    assert len(parsed.verbatim_user_constraints) == _DISTILLATION_OUTPUT_MAX_ITEMS
+    assert len(parsed.completed_progress) == _DISTILLATION_OUTPUT_MAX_ITEMS
+    assert len(parsed.blockers_open_questions) == _DISTILLATION_OUTPUT_MAX_ITEMS
+    assert len(parsed.next_steps) == _DISTILLATION_OUTPUT_MAX_ITEMS
+    assert len(parsed.key_decisions_with_rationale) == _DISTILLATION_OUTPUT_MAX_ITEMS
+    assert len(parsed.relevant_files_commands_errors) == _DISTILLATION_OUTPUT_MAX_ITEMS
+    assert len(parsed.verification_state.details) == _DISTILLATION_OUTPUT_MAX_ITEMS
+    assert len(parsed.source_references) == _DISTILLATION_OUTPUT_MAX_REFERENCES
+    first_decision = parsed.key_decisions_with_rationale[0]
+    assert len(first_decision.text) <= _DISTILLATION_OUTPUT_MAX_TEXT_CHARS
+    assert len(first_decision.rationale) <= _DISTILLATION_OUTPUT_MAX_TEXT_CHARS
+    assert len(first_decision.refs) == _DISTILLATION_OUTPUT_MAX_REFERENCES
+    assert len(first_decision.refs[0].id) <= _DISTILLATION_OUTPUT_MAX_TEXT_CHARS
+    assert first_decision.refs[0].detail is not None
+    assert len(first_decision.refs[0].detail) <= _DISTILLATION_OUTPUT_MAX_TEXT_CHARS
 
 
 def test_build_distillation_input_envelope_redacts_oversized_and_data_uri_fields() -> None:

--- a/tests/unit/runtime/test_continuity_distillation.py
+++ b/tests/unit/runtime/test_continuity_distillation.py
@@ -147,3 +147,35 @@ def test_build_distillation_input_envelope_collects_source_references() -> None:
         "file:src/a.py",
         "command:pytest",
     }
+
+
+def test_build_distillation_input_envelope_bounds_nested_data_structures() -> None:
+    envelope = build_distillation_input_envelope(
+        prompt="summarize",
+        dropped_results=(
+            ToolResult(
+                tool_name="grep",
+                status="ok",
+                content="ok",
+                data={
+                    "matches": [{"line": i, "text": "x" * 200} for i in range(10)],
+                    "meta": {"a": {"b": {"c": {"d": "deep"}}}},
+                },
+            ),
+        ),
+        retained_results=(),
+        previous_continuity=None,
+        max_items=3,
+        max_chars=50,
+    )
+
+    dropped_raw = envelope["dropped_tool_result_previews"]
+    assert isinstance(dropped_raw, list)
+    preview = cast(dict[str, object], dropped_raw[0])
+    data = preview["data"]
+    assert isinstance(data, dict)
+    matches = data["matches"]
+    assert isinstance(matches, list)
+    assert len(matches) <= 4  # 3 items + truncation marker
+    assert isinstance(matches[-1], dict)
+    assert cast(dict[str, object], matches[-1]).get("__truncated_items__") == 7

--- a/tests/unit/runtime/test_continuity_distillation.py
+++ b/tests/unit/runtime/test_continuity_distillation.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import cast
+
+from voidcode.runtime.continuity_distillation import (
+    ContinuityDistillationRecord,
+    build_distillation_input_envelope,
+    distillation_record_from_payload,
+)
+from voidcode.tools.contracts import ToolResult
+
+
+def _valid_payload() -> dict[str, object]:
+    return {
+        "objective_current_goal": "Implement model-assisted continuity distillation",
+        "verbatim_user_constraints": ["Do not override explicit user instructions"],
+        "completed_progress": ["Mapped continuity pipeline"],
+        "blockers_open_questions": ["Need provider call integration"],
+        "key_decisions_with_rationale": [
+            {
+                "text": "Keep deterministic fallback",
+                "rationale": "Preserve existing reliability under failures",
+                "refs": [
+                    {
+                        "kind": "event",
+                        "id": "event:runtime.tool_completed:42",
+                        "detail": "tool completed after compaction",
+                    }
+                ],
+            }
+        ],
+        "relevant_files_commands_errors": [
+            {
+                "text": "src/voidcode/runtime/context_window.py",
+                "kind": "file",
+                "refs": [{"kind": "session", "id": "session:abc123"}],
+            },
+            {
+                "text": "mise run test",
+                "kind": "command",
+                "refs": [{"kind": "tool", "id": "tool:bash:12"}],
+            },
+        ],
+        "verification_state": {
+            "status": "pending",
+            "details": ["Unit tests not run yet"],
+            "refs": [{"kind": "background_task", "id": "bg:task-7"}],
+        },
+        "next_steps": ["Integrate in context_window"],
+        "source_references": [
+            {"kind": "session", "id": "session:abc123"},
+            {"kind": "tool", "id": "tool:read_file:5"},
+        ],
+    }
+
+
+def test_distillation_record_from_payload_accepts_valid_schema() -> None:
+    parsed = distillation_record_from_payload(_valid_payload())
+    assert isinstance(parsed, ContinuityDistillationRecord)
+    assert parsed.objective_current_goal == "Implement model-assisted continuity distillation"
+    assert parsed.verification_state.status == "pending"
+    assert parsed.relevant_files_commands_errors[0].kind == "file"
+
+
+def test_distillation_record_from_payload_rejects_missing_required_field() -> None:
+    payload = _valid_payload()
+    payload.pop("source_references")
+    assert distillation_record_from_payload(payload) is None
+
+
+def test_distillation_record_from_payload_rejects_invalid_reference_kind() -> None:
+    payload = _valid_payload()
+    refs = payload["source_references"]
+    assert isinstance(refs, list)
+    refs[0] = {"kind": "unknown", "id": "x"}
+    assert distillation_record_from_payload(payload) is None
+
+
+def test_distillation_record_round_trip_payload_is_stable() -> None:
+    parsed = distillation_record_from_payload(_valid_payload())
+    assert parsed is not None
+    meta = parsed.metadata_payload()
+    reparsed = distillation_record_from_payload(meta)
+    assert reparsed == parsed
+
+
+def test_build_distillation_input_envelope_redacts_oversized_and_data_uri_fields() -> None:
+    envelope = build_distillation_input_envelope(
+        prompt="summarize context",
+        dropped_results=(
+            ToolResult(
+                tool_name="read",
+                status="ok",
+                content="data:image/png;base64,AAAA" + ("x" * 6000),
+                data={"data_uri": "data:image/png;base64,AAAA", "stdout": "secret-log"},
+            ),
+        ),
+        retained_results=(),
+        previous_continuity=None,
+        max_items=2,
+        max_chars=120,
+    )
+
+    dropped_raw = envelope["dropped_tool_result_previews"]
+    assert isinstance(dropped_raw, list)
+    dropped = cast(list[object], dropped_raw)
+    item = dropped[0]
+    assert isinstance(item, dict)
+    item_dict = cast(dict[str, object], item)
+    content_preview = item_dict["content_preview"]
+    assert isinstance(content_preview, str)
+    assert len(content_preview) <= 120
+    assert "data:image" not in content_preview
+    data = item_dict["data"]
+    assert isinstance(data, dict)
+    assert data["data_uri"] == "[redacted]"
+    assert data["stdout"] == "[redacted]"

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -351,6 +351,9 @@ def test_runtime_config_loads_context_window_policy_from_repo_file(tmp_path: Pat
                     "tokenizer_model": "gpt-4o",
                     "continuity_preview_items": 4,
                     "continuity_preview_chars": 120,
+                    "continuity_distillation_enabled": True,
+                    "continuity_distillation_max_input_items": 9,
+                    "continuity_distillation_max_input_chars": 2048,
                     "context_pressure_threshold": 0.75,
                     "context_pressure_cooldown_steps": 5,
                     "provider_context_diagnostics": "block",
@@ -378,6 +381,9 @@ def test_runtime_config_loads_context_window_policy_from_repo_file(tmp_path: Pat
         tokenizer_model="gpt-4o",
         continuity_preview_items=4,
         continuity_preview_chars=120,
+        continuity_distillation_enabled=True,
+        continuity_distillation_max_input_items=9,
+        continuity_distillation_max_input_chars=2048,
         context_pressure_threshold=0.75,
         context_pressure_cooldown_steps=5,
         provider_context_diagnostics="block",
@@ -418,6 +424,26 @@ def test_runtime_context_window_config_serializes_for_session_resume() -> None:
         source="test runtime_config.context_window",
     )
 
+    assert parsed == config
+
+
+def test_runtime_context_window_config_includes_distillation_controls() -> None:
+    config = RuntimeContextWindowConfig(
+        continuity_distillation_enabled=True,
+        continuity_distillation_max_input_items=11,
+        continuity_distillation_max_input_chars=3072,
+    )
+
+    payload = serialize_runtime_context_window_config(config)
+    assert payload is not None
+    assert payload["continuity_distillation_enabled"] is True
+    assert payload["continuity_distillation_max_input_items"] == 11
+    assert payload["continuity_distillation_max_input_chars"] == 3072
+
+    parsed = parse_runtime_context_window_payload(
+        payload,
+        source="test runtime_config.context_window.distillation",
+    )
     assert parsed == config
 
 

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -447,6 +447,31 @@ def test_runtime_context_window_config_includes_distillation_controls() -> None:
     assert parsed == config
 
 
+def test_runtime_config_rejects_distillation_max_input_chars_below_minimum(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / RUNTIME_CONFIG_FILE_NAME
+    config_path.write_text(
+        json.dumps(
+            {
+                "context_window": {
+                    "continuity_distillation_enabled": True,
+                    "continuity_distillation_max_input_chars": 63,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "context_window.continuity_distillation_max_input_chars.*greater than or equal to 64"
+        ),
+    ):
+        _ = load_runtime_config(tmp_path, env={})
+
+
 def test_runtime_persists_context_window_config_for_resume(tmp_path: Path) -> None:
     _ = (tmp_path / "README.md").write_text("context window\n", encoding="utf-8")
     context_window = RuntimeContextWindowConfig(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -10322,6 +10322,40 @@ def test_runtime_distillation_falls_back_on_provider_failure(tmp_path: Path) -> 
     assert continuity["distillation_source"] == "deterministic"
 
 
+def test_runtime_distillation_failure_clears_stale_candidate(tmp_path: Path) -> None:
+    provider = _DistillAwareTurnProvider(
+        name="opencode",
+        distill_output=None,
+        distill_error=RuntimeError("distiller unavailable"),
+    )
+    registry = ModelProviderRegistry(
+        providers={"opencode": _DistillAwareModelProvider(name="opencode", provider=provider)}
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(model="opencode/gpt-5.4"),
+        model_provider_registry=registry,
+    )
+    stale_candidate = {"objective_current_goal": "Stale prior turn"}
+
+    metadata = runtime._session_metadata_with_distillation_candidate(  # pyright: ignore[reportPrivateUsage]
+        prompt="read sample.txt\nread sample.txt",
+        tool_results=(
+            ToolResult(tool_name="read_file", status="ok", content="alpha"),
+            ToolResult(tool_name="read_file", status="ok", content="beta"),
+        ),
+        session_metadata={"runtime_state": {"distillation_candidate": stale_candidate}},
+        policy=ContextWindowPolicy(max_tool_results=1, continuity_distillation_enabled=True),
+        effective_config=runtime.effective_runtime_config(),
+        abort_signal=None,
+        provider_attempt=0,
+    )
+    runtime_state = cast(dict[str, object], metadata["runtime_state"])
+
+    assert "distillation_candidate" not in runtime_state
+    assert runtime_state["distillation_failure_reason"] == "provider_error"
+
+
 def test_runtime_distillation_receives_abort_signal_in_provider_request(tmp_path: Path) -> None:
     sample_file = tmp_path / "sample.txt"
     sample_file.write_text("alpha\n", encoding="utf-8")

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -9821,6 +9821,7 @@ def test_runtime_provider_compaction_emits_continuity_state_and_persists_metadat
     assert runtime_state["continuity_summary"] == {
         "anchor": summary_anchor,
         "source": summary_source,
+        "distillation_source": "deterministic",
     }
     assert runtime_state["memory_refreshed"] == {
         "last_summary_anchor": summary_anchor,

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -683,12 +683,14 @@ class _DistillAwareTurnProvider:
         self.distill_error = distill_error
         self.distill_calls = 0
         self.main_calls = 0
+        self.last_distill_abort_signal: object | None = None
 
     def propose_turn(self, request: object) -> ProviderTurnResult:
         turn_request = cast(ProviderTurnRequest, request)
         prompt = turn_request.prompt
         if prompt.startswith("Return ONLY valid JSON matching these keys:"):
             self.distill_calls += 1
+            self.last_distill_abort_signal = turn_request.abort_signal
             if self.distill_error is not None:
                 raise self.distill_error
             if self.distill_output is None:
@@ -10172,6 +10174,93 @@ def test_runtime_distillation_falls_back_on_provider_failure(tmp_path: Path) -> 
     assert response.session.status == "completed"
     assert provider.distill_calls >= 1
     assert continuity["distillation_source"] == "deterministic"
+
+
+def test_runtime_distillation_receives_abort_signal_in_provider_request(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("alpha\n", encoding="utf-8")
+    distill_payload = json.dumps(
+        {
+            "objective_current_goal": "Goal",
+            "verbatim_user_constraints": ["x"],
+            "completed_progress": ["x"],
+            "blockers_open_questions": ["x"],
+            "key_decisions_with_rationale": [
+                {
+                    "text": "x",
+                    "rationale": "x",
+                    "refs": [{"kind": "event", "id": "event:1"}],
+                }
+            ],
+            "relevant_files_commands_errors": [
+                {
+                    "text": "x",
+                    "kind": "file",
+                    "refs": [{"kind": "session", "id": "session:x"}],
+                }
+            ],
+            "verification_state": {
+                "status": "pending",
+                "details": ["x"],
+                "refs": [{"kind": "tool", "id": "tool:x"}],
+            },
+            "next_steps": ["x"],
+            "source_references": [{"kind": "session", "id": "session:x"}],
+        }
+    )
+    provider = _DistillAwareTurnProvider(
+        name="opencode",
+        distill_output=distill_payload,
+        distill_error=None,
+    )
+    registry = ModelProviderRegistry(
+        providers={"opencode": _DistillAwareModelProvider(name="opencode", provider=provider)}
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                max_tool_results=1,
+                continuity_distillation_enabled=True,
+            ),
+        ),
+        model_provider_registry=registry,
+    )
+
+    _ = runtime.run(RuntimeRequest(prompt="read sample.txt\nread sample.txt", session_id="d5"))
+
+    assert provider.distill_calls >= 1
+    assert provider.last_distill_abort_signal is not None
+
+
+def test_runtime_distillation_is_skipped_when_no_compaction_needed(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("alpha\n", encoding="utf-8")
+    provider = _DistillAwareTurnProvider(
+        name="opencode",
+        distill_output='{"objective_current_goal":"unused"}',
+        distill_error=None,
+    )
+    registry = ModelProviderRegistry(
+        providers={"opencode": _DistillAwareModelProvider(name="opencode", provider=provider)}
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                max_tool_results=20,
+                continuity_distillation_enabled=True,
+            ),
+        ),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="read sample.txt", session_id="d6"))
+
+    assert response.session.status == "completed"
+    assert provider.distill_calls == 0
 
 
 def test_runtime_distillation_disabled_does_not_call_distiller(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -9552,6 +9552,81 @@ def test_runtime_execute_graph_loop_reuses_initial_context_window_on_first_itera
     assert any(chunk.kind == "output" and chunk.output == "done" for chunk in chunks)
 
 
+def test_runtime_execute_graph_loop_recomputes_stale_initial_context_window(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+    prepared_calls = 0
+
+    class _ContextWindowCountingGraph:
+        def step(
+            self,
+            request: GraphRunRequest,
+            tool_results: tuple[object, ...],
+            *,
+            session: SessionState,
+        ) -> _StubStep:
+            _ = tool_results, session
+            assert request.context_window.original_tool_result_count == 1
+            return _StubStep(output="done", is_finished=True)
+
+    session = SessionState(
+        session=SessionRef(id="resume-distillation-stale-window"),
+        metadata={"runtime_config": runtime._runtime_config_metadata()},  # pyright: ignore[reportPrivateUsage]
+        turn=0,
+        status="running",
+    )
+    prompt = "read sample.txt"
+    tool_registry = runtime._tool_registry_for_effective_config(  # pyright: ignore[reportPrivateUsage]
+        runtime.effective_runtime_config()
+    )
+    context_window = runtime._prepare_provider_context_window(  # pyright: ignore[reportPrivateUsage]
+        prompt=prompt,
+        tool_results=(),
+        session_metadata=session.metadata,
+    )
+    graph_request = GraphRunRequest(
+        session=session,
+        prompt=prompt,
+        available_tools=tool_registry.definitions(),
+        context_window=context_window,
+        assembled_context=runtime._assemble_provider_context(  # pyright: ignore[reportPrivateUsage]
+            prompt=prompt,
+            tool_results=(),
+            session_metadata=session.metadata,
+        ),
+        metadata=session.metadata,
+    )
+    original_prepare = runtime._prepare_provider_context_window  # pyright: ignore[reportPrivateUsage]
+
+    def _counting_prepare_provider_context_window(*args: object, **kwargs: object) -> object:
+        nonlocal prepared_calls
+        prepared_calls += 1
+        return original_prepare(*args, **kwargs)
+
+    monkeypatch.setattr(
+        runtime,
+        "_prepare_provider_context_window",
+        _counting_prepare_provider_context_window,
+    )
+    tool_results = [ToolResult(tool_name="read_file", status="ok", content="alpha")]
+
+    chunks = list(
+        runtime._execute_graph_loop(  # pyright: ignore[reportPrivateUsage]
+            graph=_ContextWindowCountingGraph(),
+            tool_registry=tool_registry,
+            session=session,
+            sequence=0,
+            graph_request=graph_request,
+            tool_results=tool_results,
+        )
+    )
+
+    assert prepared_calls == 1
+    assert any(chunk.kind == "output" and chunk.output == "done" for chunk in chunks)
+
+
 def test_runtime_provider_fallback_seam_returns_next_graph_selection(tmp_path: Path) -> None:
     created_providers: list[_ScriptedTurnProvider] = []
     registry = ModelProviderRegistry(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -9481,6 +9481,77 @@ def test_runtime_context_window_policy_recomputes_default_for_fallback_attempt(
     assert context_window.token_budget == 4_000
 
 
+def test_runtime_execute_graph_loop_reuses_initial_context_window_on_first_iteration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+
+    class _SingleStepGraph:
+        def step(
+            self,
+            request: GraphRunRequest,
+            tool_results: tuple[object, ...],
+            *,
+            session: SessionState,
+        ) -> _StubStep:
+            _ = request, tool_results, session
+            return _StubStep(output="done", is_finished=True)
+
+    session = SessionState(
+        session=SessionRef(id="resume-distillation-dedupe"),
+        metadata={"runtime_config": runtime._runtime_config_metadata()},  # pyright: ignore[reportPrivateUsage]
+        turn=0,
+        status="running",
+    )
+    prompt = "read sample.txt"
+    tool_registry = runtime._tool_registry_for_effective_config(  # pyright: ignore[reportPrivateUsage]
+        runtime.effective_runtime_config()
+    )
+    context_window = runtime._prepare_provider_context_window(  # pyright: ignore[reportPrivateUsage]
+        prompt=prompt,
+        tool_results=(),
+        session_metadata=session.metadata,
+    )
+    graph_request = GraphRunRequest(
+        session=session,
+        prompt=prompt,
+        available_tools=tool_registry.definitions(),
+        context_window=context_window,
+        assembled_context=runtime._assemble_provider_context(  # pyright: ignore[reportPrivateUsage]
+            prompt=prompt,
+            tool_results=(),
+            session_metadata=session.metadata,
+        ),
+        metadata=session.metadata,
+    )
+
+    def _unexpected_prepare_provider_context_window(*args: object, **kwargs: object) -> object:
+        _ = args, kwargs
+        raise AssertionError(
+            "first loop iteration should reuse existing graph_request.context_window"
+        )
+
+    monkeypatch.setattr(
+        runtime,
+        "_prepare_provider_context_window",
+        _unexpected_prepare_provider_context_window,
+    )
+
+    chunks = list(
+        runtime._execute_graph_loop(  # pyright: ignore[reportPrivateUsage]
+            graph=_SingleStepGraph(),
+            tool_registry=tool_registry,
+            session=session,
+            sequence=0,
+            graph_request=graph_request,
+            tool_results=[],
+        )
+    )
+
+    assert any(chunk.kind == "output" and chunk.output == "done" for chunk in chunks)
+
+
 def test_runtime_provider_fallback_seam_returns_next_graph_selection(tmp_path: Path) -> None:
     created_providers: list[_ScriptedTurnProvider] = []
     registry = ModelProviderRegistry(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -10174,6 +10174,69 @@ def test_runtime_distillation_falls_back_on_provider_failure(tmp_path: Path) -> 
     assert continuity["distillation_source"] == "deterministic"
 
 
+def test_runtime_distillation_disabled_does_not_call_distiller(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("alpha\n", encoding="utf-8")
+    distill_payload = json.dumps(
+        {
+            "objective_current_goal": "Should not be used",
+            "verbatim_user_constraints": ["x"],
+            "completed_progress": ["x"],
+            "blockers_open_questions": ["x"],
+            "key_decisions_with_rationale": [
+                {
+                    "text": "x",
+                    "rationale": "x",
+                    "refs": [{"kind": "event", "id": "event:1"}],
+                }
+            ],
+            "relevant_files_commands_errors": [
+                {
+                    "text": "x",
+                    "kind": "file",
+                    "refs": [{"kind": "session", "id": "session:x"}],
+                }
+            ],
+            "verification_state": {
+                "status": "pending",
+                "details": ["x"],
+                "refs": [{"kind": "tool", "id": "tool:x"}],
+            },
+            "next_steps": ["x"],
+            "source_references": [{"kind": "session", "id": "session:x"}],
+        }
+    )
+    provider = _DistillAwareTurnProvider(
+        name="opencode",
+        distill_output=distill_payload,
+        distill_error=None,
+    )
+    registry = ModelProviderRegistry(
+        providers={"opencode": _DistillAwareModelProvider(name="opencode", provider=provider)}
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                max_tool_results=1,
+                continuity_distillation_enabled=False,
+            ),
+        ),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(
+        RuntimeRequest(prompt="read sample.txt\nread sample.txt", session_id="d4")
+    )
+    runtime_state = cast(dict[str, object], response.session.metadata["runtime_state"])
+    continuity = cast(dict[str, object], runtime_state["continuity"])
+
+    assert response.session.status == "completed"
+    assert provider.distill_calls == 0
+    assert continuity["distillation_source"] == "deterministic"
+
+
 def test_runtime_emits_context_pressure_with_cooldown_edge_control(tmp_path: Path) -> None:
     sample_file = tmp_path / "sample.txt"
     sample_file.write_text("x" * 300, encoding="utf-8")

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -674,6 +674,42 @@ class _ScriptedModelProvider:
         return provider
 
 
+class _DistillAwareTurnProvider:
+    def __init__(
+        self, *, name: str, distill_output: str | None, distill_error: Exception | None
+    ) -> None:
+        self.name = name
+        self.distill_output = distill_output
+        self.distill_error = distill_error
+        self.distill_calls = 0
+        self.main_calls = 0
+
+    def propose_turn(self, request: object) -> ProviderTurnResult:
+        turn_request = cast(ProviderTurnRequest, request)
+        prompt = turn_request.prompt
+        if prompt.startswith("Return ONLY valid JSON matching these keys:"):
+            self.distill_calls += 1
+            if self.distill_error is not None:
+                raise self.distill_error
+            if self.distill_output is None:
+                return ProviderTurnResult(output="")
+            return ProviderTurnResult(output=self.distill_output)
+
+        self.main_calls += 1
+        if self.main_calls <= 2:
+            return ProviderTurnResult(tool_call=ToolCall("read_file", {"filePath": "sample.txt"}))
+        return ProviderTurnResult(output="done")
+
+
+@dataclass(frozen=True, slots=True)
+class _DistillAwareModelProvider:
+    name: str
+    provider: _DistillAwareTurnProvider
+
+    def turn_provider(self) -> _DistillAwareTurnProvider:
+        return self.provider
+
+
 class _WriteThenResultAwareTurnProvider:
     def __init__(self, *, name: str) -> None:
         self.name = name
@@ -10005,6 +10041,137 @@ def test_runtime_memory_refreshed_guard_suppresses_duplicate_anchor(tmp_path: Pa
     assert first is True
     assert duplicate is False
     assert changed is True
+
+
+def test_runtime_distillation_uses_provider_output_when_valid(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("alpha\n", encoding="utf-8")
+    distill_payload = json.dumps(
+        {
+            "objective_current_goal": "Ship continuity distillation",
+            "verbatim_user_constraints": ["Do not override explicit user instructions"],
+            "completed_progress": ["Mapped runtime continuity"],
+            "blockers_open_questions": ["none"],
+            "key_decisions_with_rationale": [
+                {
+                    "text": "Use deterministic fallback",
+                    "rationale": "resilience",
+                    "refs": [{"kind": "event", "id": "event:1"}],
+                }
+            ],
+            "relevant_files_commands_errors": [
+                {
+                    "text": "src/voidcode/runtime/context_window.py",
+                    "kind": "file",
+                    "refs": [{"kind": "session", "id": "session:distill"}],
+                }
+            ],
+            "verification_state": {
+                "status": "pending",
+                "details": ["pending"],
+                "refs": [{"kind": "tool", "id": "tool:pytest"}],
+            },
+            "next_steps": ["run tests"],
+            "source_references": [{"kind": "session", "id": "session:distill"}],
+        }
+    )
+    provider = _DistillAwareTurnProvider(
+        name="opencode",
+        distill_output=distill_payload,
+        distill_error=None,
+    )
+    registry = ModelProviderRegistry(
+        providers={"opencode": _DistillAwareModelProvider(name="opencode", provider=provider)}
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                max_tool_results=1,
+                continuity_distillation_enabled=True,
+            ),
+        ),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(
+        RuntimeRequest(prompt="read sample.txt\nread sample.txt", session_id="d1")
+    )
+    runtime_state = cast(dict[str, object], response.session.metadata["runtime_state"])
+    continuity = cast(dict[str, object], runtime_state["continuity"])
+
+    assert response.session.status == "completed"
+    assert provider.distill_calls >= 1
+    assert continuity["distillation_source"] == "model_assisted"
+
+
+def test_runtime_distillation_falls_back_on_invalid_model_output(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("alpha\n", encoding="utf-8")
+    provider = _DistillAwareTurnProvider(
+        name="opencode",
+        distill_output='{"objective_current_goal":""}',
+        distill_error=None,
+    )
+    registry = ModelProviderRegistry(
+        providers={"opencode": _DistillAwareModelProvider(name="opencode", provider=provider)}
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                max_tool_results=1,
+                continuity_distillation_enabled=True,
+            ),
+        ),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(
+        RuntimeRequest(prompt="read sample.txt\nread sample.txt", session_id="d2")
+    )
+    runtime_state = cast(dict[str, object], response.session.metadata["runtime_state"])
+    continuity = cast(dict[str, object], runtime_state["continuity"])
+
+    assert response.session.status == "completed"
+    assert provider.distill_calls >= 1
+    assert continuity["distillation_source"] == "fallback_after_model_error"
+
+
+def test_runtime_distillation_falls_back_on_provider_failure(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("alpha\n", encoding="utf-8")
+    provider = _DistillAwareTurnProvider(
+        name="opencode",
+        distill_output=None,
+        distill_error=RuntimeError("distiller unavailable"),
+    )
+    registry = ModelProviderRegistry(
+        providers={"opencode": _DistillAwareModelProvider(name="opencode", provider=provider)}
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                max_tool_results=1,
+                continuity_distillation_enabled=True,
+            ),
+        ),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(
+        RuntimeRequest(prompt="read sample.txt\nread sample.txt", session_id="d3")
+    )
+    runtime_state = cast(dict[str, object], response.session.metadata["runtime_state"])
+    continuity = cast(dict[str, object], runtime_state["continuity"])
+
+    assert response.session.status == "completed"
+    assert provider.distill_calls >= 1
+    assert continuity["distillation_source"] == "deterministic"
 
 
 def test_runtime_emits_context_pressure_with_cooldown_edge_control(tmp_path: Path) -> None:


### PR DESCRIPTION
#354
## Summary
- add runtime-owned model-assisted continuity distillation path with strict schema validation and deterministic fallback
- enforce bounded/sanitized distillation input envelopes (including data URI redaction and oversized-content truncation)
- preserve, aggregate, and deduplicate fact-level source references in continuity state and expose distillation provenance in provider-context diagnostics
## What changed
- introduced continuity distillation schema/contracts and payload validators
- wired runtime service to request distillation output from provider path when enabled
- aligned distillation input window selection with compaction policy semantics
- added fallback classification for provider/JSON/schema failure outcomes
- added continuity metadata fields for distillation provenance and source references
- extended runtime config + JSON schema with distillation toggles and input budget controls
- added regression tests for:
  - valid model-assisted path
  - invalid output fallback
  - provider failure fallback
  - distillation toggle disabled path
  - provider-context diagnostic visibility
## Why
Long coding sessions need semantically meaningful continuity summaries with traceable facts and safe bounded inputs. This change upgrades continuity compaction from heuristic-only summaries to a model-assisted path while preserving deterministic reliability under failures.
## Verification
- targeted runtime distillation tests pass:
  - `tests/unit/runtime/test_continuity_distillation.py`
  - `tests/unit/runtime/test_context_window.py`
  - `tests/unit/runtime/test_runtime_config.py`
  - `tests/unit/runtime/test_runtime_service_extensions.py` (distillation scenarios)