### PR TITLE
refactor(runtime): extract tool scoping policy

### DIFF
--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -250,7 +250,11 @@ from .todos import (
     todo_event_payload,
     todo_state_payload,
 )
-from .tool_provider import BuiltinToolProvider
+from .tool_provider import (
+    BuiltinToolProvider,
+    scoped_tool_registry_for_agent,
+    tool_name_matches_patterns,
+)
 
 if TYPE_CHECKING:
     from ..tools.lsp import FormatTool
@@ -322,33 +326,6 @@ _ACP_CONNECTIVITY_ERRORS = frozenset(
     {
         "ACP adapter is not connected",
         "ACP transport is not connected",
-    }
-)
-_BUILTIN_TOOL_NAMES = frozenset(
-    {
-        "apply_patch",
-        "ast_grep_preview",
-        "ast_grep_replace",
-        "ast_grep_search",
-        "background_cancel",
-        "background_output",
-        "code_search",
-        "edit",
-        "format_file",
-        "glob",
-        "grep",
-        "list",
-        "lsp",
-        "multi_edit",
-        "read_file",
-        "question",
-        "shell_exec",
-        "skill",
-        "task",
-        "todo_write",
-        "web_fetch",
-        "web_search",
-        "write_file",
     }
 )
 _EXTERNAL_PATH_PRECHECK_KEYS: Mapping[str, tuple[str, ...]] = {
@@ -1301,24 +1278,7 @@ class VoidCodeRuntime:
         self,
         effective_config: EffectiveRuntimeConfig,
     ) -> ToolRegistry:
-        agent = effective_config.agent
-        if agent is None:
-            return self._tool_registry
-
-        scoped_registry = self._tool_registry
-        manifest = get_builtin_agent_manifest(agent.preset)
-        if manifest is not None and manifest.tool_allowlist:
-            scoped_registry = scoped_registry.filtered(manifest.tool_allowlist)
-
-        if agent.tools is not None:
-            if agent.tools.builtin is not None and agent.tools.builtin.enabled is False:
-                scoped_registry = scoped_registry.excluding(_BUILTIN_TOOL_NAMES)
-            if agent.tools.allowlist is not None:
-                scoped_registry = scoped_registry.filtered(agent.tools.allowlist)
-            if agent.tools.default is not None:
-                scoped_registry = scoped_registry.filtered(agent.tools.default)
-
-        return scoped_registry
+        return scoped_tool_registry_for_agent(self._tool_registry, agent=effective_config.agent)
 
     def _delegation_tool_policy_error(
         self,
@@ -1338,7 +1298,7 @@ class VoidCodeRuntime:
         manifest = get_builtin_agent_manifest(agent.preset)
         if manifest is None or not manifest.tool_allowlist:
             return None
-        if self._tool_name_matches_patterns(tool_name, manifest.tool_allowlist):
+        if tool_name_matches_patterns(tool_name, manifest.tool_allowlist):
             return None
         if tool_name not in self._base_tool_registry.tools:
             return None
@@ -1347,10 +1307,6 @@ class VoidCodeRuntime:
             f"'{tool_name}' for child preset '{agent.preset}'; this preset may only call "
             "tools allowed by its manifest tool_allowlist"
         )
-
-    @staticmethod
-    def _tool_name_matches_patterns(tool_name: str, patterns: Iterable[str]) -> bool:
-        return any(fnmatchcase(tool_name, pattern) for pattern in patterns if pattern)
 
     def current_lsp_state(self) -> LspManagerState:
         return self._lsp_manager.current_state()

--- a/src/voidcode/runtime/tool_provider.py
+++ b/src/voidcode/runtime/tool_provider.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
+from fnmatch import fnmatchcase
 from typing import Protocol
 
+from ..agent import get_builtin_agent_manifest
 from ..hook.config import RuntimeHooksConfig
 from ..skills.models import SkillMetadata
 from ..tools.contracts import Tool
@@ -15,6 +17,77 @@ from ..tools.shell_exec import ShellExecTool
 from ..tools.web_fetch import WebFetchTool
 from ..tools.web_search import WebSearchTool
 from ..tools.write_file import WriteFileTool
+from .config import RuntimeAgentConfig
+
+BUILTIN_TOOL_NAMES = frozenset(
+    {
+        "apply_patch",
+        "ast_grep_preview",
+        "ast_grep_replace",
+        "ast_grep_search",
+        "background_cancel",
+        "background_output",
+        "code_search",
+        "edit",
+        "format_file",
+        "glob",
+        "grep",
+        "list",
+        "lsp",
+        "multi_edit",
+        "read_file",
+        "question",
+        "shell_exec",
+        "skill",
+        "task",
+        "todo_write",
+        "web_fetch",
+        "web_search",
+        "write_file",
+    }
+)
+
+
+class ScopedToolRegistry(Protocol):
+    tools: dict[str, Tool]
+
+    def filtered[ToolRegistryT: "ScopedToolRegistry"](
+        self: ToolRegistryT,
+        patterns: Iterable[str],
+    ) -> ToolRegistryT: ...
+
+    def excluding[ToolRegistryT: "ScopedToolRegistry"](
+        self: ToolRegistryT,
+        tool_names: Iterable[str],
+    ) -> ToolRegistryT: ...
+
+
+def scoped_tool_registry_for_agent[ToolRegistryT: ScopedToolRegistry](
+    registry: ToolRegistryT,
+    *,
+    agent: RuntimeAgentConfig | None,
+) -> ToolRegistryT:
+    if agent is None:
+        return registry
+
+    scoped_registry = registry
+    manifest = get_builtin_agent_manifest(agent.preset)
+    if manifest is not None and manifest.tool_allowlist:
+        scoped_registry = scoped_registry.filtered(manifest.tool_allowlist)
+
+    if agent.tools is not None:
+        if agent.tools.builtin is not None and agent.tools.builtin.enabled is False:
+            scoped_registry = scoped_registry.excluding(BUILTIN_TOOL_NAMES)
+        if agent.tools.allowlist is not None:
+            scoped_registry = scoped_registry.filtered(agent.tools.allowlist)
+        if agent.tools.default is not None:
+            scoped_registry = scoped_registry.filtered(agent.tools.default)
+
+    return scoped_registry
+
+
+def tool_name_matches_patterns(tool_name: str, patterns: Iterable[str]) -> bool:
+    return any(fnmatchcase(tool_name, pattern) for pattern in patterns if pattern)
 
 
 class _NoArgToolFactory(Protocol):

--- a/tests/unit/runtime/test_tool_provider.py
+++ b/tests/unit/runtime/test_tool_provider.py
@@ -12,7 +12,12 @@ import pytest
 from voidcode.graph.contracts import GraphEvent, GraphStep
 from voidcode.hook.config import RuntimeFormatterPresetConfig, RuntimeHooksConfig
 from voidcode.mcp import McpToolSafety
-from voidcode.runtime.config import RuntimeConfig
+from voidcode.runtime.config import (
+    RuntimeAgentConfig,
+    RuntimeConfig,
+    RuntimeToolsBuiltinConfig,
+    RuntimeToolsConfig,
+)
 from voidcode.runtime.mcp import (
     McpConfigState,
     McpManagerState,
@@ -27,7 +32,7 @@ from voidcode.runtime.service import (
     ToolRegistry,
     VoidCodeRuntime,
 )
-from voidcode.runtime.tool_provider import BuiltinToolProvider
+from voidcode.runtime.tool_provider import BuiltinToolProvider, scoped_tool_registry_for_agent
 from voidcode.tools import (
     AstGrepPreviewTool,
     AstGrepReplaceTool,
@@ -296,6 +301,56 @@ def test_tool_registry_accepts_tools_from_provider_output() -> None:
     for tool_name in optional_tools:
         if tool_name in registry.tools:
             assert registry.resolve(tool_name).definition.name == tool_name
+
+
+def test_scoped_tool_registry_returns_original_registry_without_agent() -> None:
+    registry = ToolRegistry.from_tools(BuiltinToolProvider().provide_tools())
+
+    scoped = scoped_tool_registry_for_agent(registry, agent=None)
+
+    assert scoped is registry
+
+
+def test_scoped_tool_registry_applies_manifest_allowlist() -> None:
+    registry = ToolRegistry.from_tools(BuiltinToolProvider().provide_tools())
+
+    scoped = scoped_tool_registry_for_agent(registry, agent=RuntimeAgentConfig(preset="explore"))
+
+    assert "read_file" in scoped.tools
+    assert "grep" in scoped.tools
+    assert "write_file" not in scoped.tools
+    assert "task" not in scoped.tools
+
+
+def test_scoped_tool_registry_can_exclude_builtins() -> None:
+    registry = ToolRegistry.from_tools(BuiltinToolProvider().provide_tools())
+
+    scoped = scoped_tool_registry_for_agent(
+        registry,
+        agent=RuntimeAgentConfig(
+            preset="leader",
+            tools=RuntimeToolsConfig(builtin=RuntimeToolsBuiltinConfig(enabled=False)),
+        ),
+    )
+
+    assert scoped.tools == {}
+
+
+def test_scoped_tool_registry_applies_agent_allowlist_and_default_filters() -> None:
+    registry = ToolRegistry.from_tools(BuiltinToolProvider().provide_tools())
+
+    scoped = scoped_tool_registry_for_agent(
+        registry,
+        agent=RuntimeAgentConfig(
+            preset="leader",
+            tools=RuntimeToolsConfig(
+                allowlist=("read_file", "grep", "write_file"),
+                default=("read_file", "grep"),
+            ),
+        ),
+    )
+
+    assert set(scoped.tools) == {"read_file", "grep"}
 
 
 def test_default_runtime_scopes_tools_to_leader_manifest(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Move agent-aware tool registry scoping from `VoidCodeRuntime` into `runtime.tool_provider`
- Keep `service.py` as the runtime wiring layer while preserving existing manifest/tool filtering behavior
- Add focused unit coverage for manifest allowlists, disabled builtins, and agent allowlist/default filters

## Verification
- `mise run lint`
- `mise run typecheck` (`uv run ty check src`)
- `uv run python -X utf8 -m pytest tests/unit/runtime/test_tool_provider.py tests/unit/runtime/test_runtime_service_extensions.py -k 'tool or registry'`
- `mise run test:fast`