### PR TITLE
feat(hook): add builtin hook preset catalog

### DIFF
--- a/docs/agent-boundary.md
+++ b/docs/agent-boundary.md
@@ -44,7 +44,7 @@
 
 这些内容应当保持为**声明式配置或类型化定义**，供 runtime 解析与消费。
 
-当前仓库里已经存在的 `src/voidcode/agent/README.md` 与 `src/voidcode/agent/<role>/README.md`，应被理解为这层声明边界的文档化外壳，而不是独立 agent runtime 的证据。
+当前仓库里已经存在的 `src/voidcode/agent/README.md` 与 `src/voidcode/agent/<role>/README.md`，应被理解为这层声明边界的文档化外壳，而不是独立 agent runtime 的证据。`preset_hook_refs` 现在由 `src/voidcode/hook/presets.py` 中的 builtin hook preset catalog 校验，表达的是角色 guidance / guard / continuation intent，不是 runtime lifecycle hook command。
 
 ## 哪些东西必须继续留在 `runtime/`
 
@@ -111,13 +111,13 @@
 
 这些文件用于描述角色 preset、本地权限倾向、建议 skills / hooks / MCP profile 以及与 runtime 的边界，但不代表这些角色当前已经拥有独立 runtime 实现。
 
-同样，这里的“建议 hooks”也应理解为未来 preset intent，而不是表示 runtime 今天已经支持 session-start/session-end、background completion notification 或 message transform 等 richer phases。
+同样，这里的“建议 hooks”也应理解为 preset intent。当前 builtin agent 的 `preset_hook_refs` 已经必须引用 hook preset catalog 中存在的 ref；但这些 ref 仍不等价于 session-start/session-end、background completion notification 或 message transform 等 runtime lifecycle hook command。
 
 ### Phase 2：由 runtime 解析 agent preset
 
 让 runtime 在现有 execution path 中能够解析和应用 agent preset，同时继续保持 runtime 对 approval、permission、event、persistence 的控制。
 
-当前实现已经完成 runtime 对 agent preset 的第一阶段落地：`leader` 作为默认顶层 active preset 进入 provider-backed 主路径，`product` 可以作为显式顶层 planning preset 被选择。runtime 会向 provider 注入所选 preset 的 `prompt_profile` / `prompt_materialization`，应用 agent-scoped model / execution engine / provider fallback，收窄可见与可调用工具，并让 manifest `skill_refs` / agent-scoped skills 进入本次运行的 runtime-managed skill application。相关可执行配置会持久化到 session runtime config，以便 resume 保持同一 agent truth。`advisor`、`explore`、`product`、`researcher`、`worker` 现在也可以作为 delegated child preset 进入 runtime-owned child execution，但除 `leader` 与 `product` 外，它们仍不能被当作任意顶层 active agent 直接启动。
+当前实现已经完成 runtime 对 agent preset 的第一阶段落地：`leader` 作为默认顶层 active preset 进入 provider-backed 主路径，`product` 可以作为显式顶层 planning preset 被选择。runtime 会向 provider 注入所选 preset 的 `prompt_profile` / `prompt_materialization`，应用 agent-scoped model / execution engine / provider fallback，收窄可见与可调用工具，校验 agent hook preset refs，并让 manifest `skill_refs` / agent-scoped skills 进入本次运行的 runtime-managed skill application。相关可执行配置会持久化到 session runtime config，以便 resume 保持同一 agent truth。`advisor`、`explore`、`product`、`researcher`、`worker` 现在也可以作为 delegated child preset 进入 runtime-owned child execution，但除 `leader` 与 `product` 外，它们仍不能被当作任意顶层 active agent 直接启动。
 
 ### Phase 3：再评估 multi-agent orchestration
 

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -30,6 +30,7 @@
 - [`approval-flow.md`](./approval-flow.md) — 受控执行与审批语义
 - [`agent-tool-calling.md`](./agent-tool-calling.md) — 面向 agent 的工具调用、参数、返回、审批与选择指南
 - [`agent-tool-enforcement.md`](./agent-tool-enforcement.md) — agent preset 中 tool allowlist/default tool set 如何进入 runtime enforcement
+- [`agent-hook-presets.md`](./agent-hook-presets.md) — agent preset hook refs 如何通过 builtin hook preset catalog 校验与表达角色 intent
 - [`runtime-config.md`](./runtime-config.md) — MVP 配置界面及优先级
 - [`runtime-lifecycle-hooks.md`](./runtime-lifecycle-hooks.md) — richer lifecycle hook phases 的 runtime-owned 执行契约
 - [`background-task-delegation.md`](./background-task-delegation.md) — delegated/background task parent/child linkage、结果读取、retry/cancel 与 fake-provider/fake-MCP 验证立场
@@ -48,6 +49,7 @@
 - #169 runtime enforcement of agent tool allowlists/default tool sets
 - #170 richer runtime lifecycle hook execution
 - #289 delegated child execution E2E baseline
+- #379 builtin hook preset catalog
 
 ## 相关代码
 
@@ -55,6 +57,7 @@
 - `src/voidcode/runtime/events.py`
 - `src/voidcode/runtime/session.py`
 - `src/voidcode/runtime/service.py`
+- `src/voidcode/hook/presets.py`
 - `src/voidcode/graph/contracts.py`
 - `src/voidcode/tools/contracts.py`
 - `src/voidcode/cli.py`

--- a/docs/contracts/agent-hook-presets.md
+++ b/docs/contracts/agent-hook-presets.md
@@ -1,0 +1,94 @@
+# Agent Hook Preset Contract
+
+## 状态
+
+当前仓库已经引入 builtin agent hook preset catalog。它为 `AgentManifest.preset_hook_refs` 与 runtime config 中的 `agent.hook_refs` 提供类型化、可校验的引用集合。
+
+这份契约定义的是 **agent preset intent**：一个 agent 角色默认希望携带哪些 guidance / guard / continuation 关注点。它不是 lifecycle hook execution contract；真实 hook 执行时机仍由 runtime 与 [`runtime-lifecycle-hooks.md`](./runtime-lifecycle-hooks.md) 管理。
+
+## 目的
+
+在引入 hook preset catalog 之前，`agent.hook_refs` 曾借用 formatter preset 名称做校验，这会把“agent role guidance intent”和“formatter/hook command config”混在一起。
+
+现在的目标是把两者拆开：
+
+- `src/voidcode/hook/presets.py` 负责声明 builtin hook preset catalog；
+- `src/voidcode/agent/builtin.py` 负责校验 builtin agent manifest 的 `preset_hook_refs`；
+- `src/voidcode/runtime/config.py` 负责校验用户/runtime config 中的 `agent.hook_refs`；
+- runtime 仍然拥有是否、何时、如何 materialize 或执行这些 preset 的最终控制权。
+
+## 当前 builtin presets
+
+当前 builtin hook preset refs 是：
+
+| Ref | Kind | 语义 |
+|-----|------|------|
+| `role_reminder` | `guidance` | 提醒 active agent 遵守当前角色边界、工具范围与输出责任。 |
+| `delegation_guard` | `guard` | 约束 delegation 必须通过 runtime-owned task routing、child preset 与治理路径。 |
+| `background_output_quality_guidance` | `guidance` | 引导 agent 有界读取 background output，并先总结再行动。 |
+| `todo_continuation_guidance` | `continuation` | 引导多步任务保持 todo 状态，并用剩余 todo 继续下一步。 |
+
+## 输入来源
+
+runtime 可以从两个位置看到 agent hook preset refs：
+
+1. builtin agent manifest 的 `preset_hook_refs`
+2. runtime config / request metadata 解析后的 `RuntimeAgentConfig.hook_refs`
+
+这些 refs 必须能被 builtin hook preset catalog 解析。未知 ref 应 fail fast，而不是被静默当作 formatter preset、shell command、lifecycle hook surface 或自由文本。
+
+## 与 runtime lifecycle hooks 的区别
+
+`agent hook preset` 与 `runtime lifecycle hook` 是两个不同层次：
+
+- agent hook preset：声明某个 agent role 希望携带的 guidance / guard / continuation intent；
+- runtime lifecycle hook：在具体 runtime phase 上执行用户配置的 command，并发出 runtime event。
+
+因此：
+
+- `role_reminder` 不是一个 `session_start` command；
+- `delegation_guard` 不是一个 agent-to-agent bus；
+- `todo_continuation_guidance` 不是自动 continuation loop；
+- hook preset catalog 不能绕过 session、approval、permission、tool registry 或 background task truth。
+
+## 合并与 materialization 规则
+
+当前实现只负责 catalog 与 validation。后续 materialization 必须遵守以下规则：
+
+1. builtin manifest refs 与 runtime config refs 都只能引用 catalog 中存在的 preset；
+2. runtime 可以把 resolved preset snapshot 持久化到 session metadata 或 provider context，但不能让 agent 层决定执行时机；
+3. materialized guidance 只能收窄或提醒角色行为，不能扩大 tool allowlist、permission 或 delegation budget；
+4. replay 应展示历史 truth，不能用新的 hook preset catalog 重新解释旧 session；
+5. 如果未来支持用户自定义 hook preset，必须先定义独立 schema 与 precedence，不能复用 formatter preset 命名空间。
+
+## 非目标
+
+这份契约不定义：
+
+- 任意拓扑 multi-agent orchestration；
+- agent-to-agent messaging；
+- lifecycle hook command execution；
+- formatter preset 配置；
+- skill loading 语义；
+- MCP / ACP lifecycle；
+- 自动 continuation loop。
+
+## 验收检查点
+
+实现满足这份契约时，至少应能验证：
+
+1. builtin hook preset catalog 暴露稳定 ref 集合；
+2. builtin agent manifest 的 `preset_hook_refs` 引用未知 preset 时 fail fast；
+3. runtime config 的 `agent.hook_refs` 引用未知 preset 时 fail fast；
+4. `agent.hook_refs` 不再依赖 `hooks.formatter_presets`；
+5. hook preset API 可从 `voidcode.hook` 导入。
+
+## 相关代码
+
+- `src/voidcode/hook/presets.py`
+- `src/voidcode/hook/__init__.py`
+- `src/voidcode/agent/builtin.py`
+- `src/voidcode/runtime/config.py`
+- `tests/unit/hook/test_presets.py`
+- `tests/unit/agent/test_builtin.py`
+- `tests/unit/runtime/test_runtime_config.py`

--- a/src/voidcode/agent/README.md
+++ b/src/voidcode/agent/README.md
@@ -62,7 +62,7 @@
 - `explore`：delegated local-code exploration preset；可进入 child execution，但不作为任意顶层 active agent 直接运行
 - `researcher`：delegated external research preset；可进入 child execution，但不作为任意顶层 active agent 直接运行
 
-当前 builtin preset 都有 agent-owned prompt profile；active / delegated agent 的 manifest allowlist 会收窄 provider 可见的 `available_tools`，并且同一边界也会约束实际 tool lookup / invocation。builtin `prompt_profile` 由 `src/voidcode/agent/` 统一 materialize 后进入 provider system message，`model_preference` / `execution_engine` 会作为 manifest live defaults 被 runtime 解析，manifest `skill_refs` 会作为默认 skill selection 进入 runtime skill application，`agent.skills` 会覆盖本次运行使用的 runtime-managed skill discovery / application policy。
+当前 builtin preset 都有 agent-owned prompt profile；active / delegated agent 的 manifest allowlist 会收窄 provider 可见的 `available_tools`，并且同一边界也会约束实际 tool lookup / invocation。builtin `prompt_profile` 由 `src/voidcode/agent/` 统一 materialize 后进入 provider system message，`model_preference` / `execution_engine` 会作为 manifest live defaults 被 runtime 解析，manifest `skill_refs` 会作为默认 skill selection 进入 runtime skill application，agent manifest 的 `preset_hook_refs` 必须引用 `src/voidcode/hook/presets.py` 中的 builtin hook preset catalog，`agent.skills` 会覆盖本次运行使用的 runtime-managed skill discovery / application policy。
 
 `prompt_materialization` 是 prompt 审计元数据：它声明 builtin prompt profile、materialization version、source/format，以及可选的 `model_family_overrides`。当前 builtin agents 仍共享各自默认 profile，但这个结构允许后续在不改变执行拓扑的前提下，为特定模型族选择不同 profile。profile 选择规则属于 agent declaration 层；最终 provider system message 的组装仍由 runtime/provider 路径负责。
 
@@ -76,12 +76,12 @@
 
 当前 agent manifest 内部也区分了两类语义：
 
-- **live defaults**：`prompt_profile`、`prompt_materialization`、`top_level_selectable`、`execution_engine`、`model_preference`、`tool_allowlist`、`skill_refs`。这些字段要么已经被 runtime 直接消费，要么作为 active agent 的默认值进入 runtime config truth。`top_level_selectable` 是 declaration，runtime enforcement 仍由 `_EXECUTABLE_AGENT_PRESETS` 持有；`prompt_materialization` 是 declaration，runtime/provider materialization 仍使用 agent 层导出的 prompt rendering helper。
+- **live defaults**：`prompt_profile`、`prompt_materialization`、`top_level_selectable`、`execution_engine`、`model_preference`、`tool_allowlist`、`skill_refs`、`preset_hook_refs`。这些字段要么已经被 runtime 直接消费，要么作为 active agent 的默认值进入 runtime config truth。`top_level_selectable` 是 declaration，runtime enforcement 仍由 `_EXECUTABLE_AGENT_PRESETS` 持有；`prompt_materialization` 是 declaration，runtime/provider materialization 仍使用 agent 层导出的 prompt rendering helper；`preset_hook_refs` 是对 hook preset catalog 的声明式引用，不是 lifecycle hook command。
 - **intent metadata**：`routing_hints`。它仍属于声明层元数据，不是 runtime execution governance truth。
 
 最终的执行真相仍然由 `voidcode.runtime` 持有。
 
-这也意味着：本目录中出现的“建议 hooks / 建议能力”只是在描述 preset intent，不代表 runtime 会把治理权让渡给 agent 层。当前现实里，background task、child-session、notification、result retrieval、tool enforcement、approval 与持久化仍全部由 runtime 持有。
+这也意味着：本目录中出现的“建议 hooks / 建议能力”只是在描述 preset intent，不代表 runtime 会把治理权让渡给 agent 层。当前现实里，background task、child-session、notification、result retrieval、tool enforcement、approval 与持久化仍全部由 runtime 持有。hook preset catalog 只为这些 intent 提供可校验名称与 guidance 元数据；真正何时注入或执行仍属于 runtime。
 
 从 OMO/OMOA 的经验看，更值得借鉴的是以下结构判断，而不是直接照搬执行语义：
 
@@ -95,4 +95,5 @@
 
 - [`docs/agent-architecture.md`](../../../docs/agent-architecture.md)
 - [`docs/agent-boundary.md`](../../../docs/agent-boundary.md)
+- [`docs/contracts/agent-hook-presets.md`](../../../docs/contracts/agent-hook-presets.md)
 - [`docs/architecture.md`](../../../docs/architecture.md)

--- a/src/voidcode/agent/builtin.py
+++ b/src/voidcode/agent/builtin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from types import MappingProxyType
 
+from ..hook.presets import validate_hook_preset_refs
 from .models import AgentManifest, AgentManifestId, AgentPromptMaterialization
 from .prompts import render_builtin_prompt_profile
 
@@ -240,6 +241,10 @@ def validate_builtin_agent_manifests(
                 raise ValueError(
                     f"builtin agent manifest '{manifest.id}' preset hook refs must be non-empty"
                 )
+        validate_hook_preset_refs(
+            manifest.preset_hook_refs,
+            field_path=f"builtin agent manifest '{manifest.id}' preset_hook_refs",
+        )
         if manifest.mode == "primary" and not manifest.top_level_selectable:
             raise ValueError(
                 f"builtin agent manifest '{manifest.id}' has mode='primary' but is not "

--- a/src/voidcode/hook/README.md
+++ b/src/voidcode/hook/README.md
@@ -4,11 +4,12 @@
 
 ## 定位
 
-`voidcode.hook` 承载 hook 配置与执行器逻辑，为 runtime 提供一致的 lifecycle / tool hook 扩展点。
+`voidcode.hook` 承载 hook 配置、hook preset catalog 与执行器逻辑，为 runtime 提供一致的 lifecycle / tool hook 扩展点。
 
 ## 负责什么
 
 - hook 配置模型
+- builtin hook preset catalog，用于校验 agent preset hook refs
 - hook 执行器与执行协议
 - 与格式化 preset 相关的 hook 支撑逻辑
 - 当前 runtime-owned `pre_tool` / `post_tool` 执行面
@@ -20,13 +21,21 @@
 - 客户端事件协议设计
 - tool/provider/skill 的具体业务语义
 - background task orchestration 与 leader notification
+- agent role 执行、delegation routing 或 multi-agent orchestration
 
 ## 边界关系
 
-runtime 负责决定何时执行 hook、如何把 hook 纳入审批/恢复语义；`voidcode.hook` 负责提供可复用的 hook primitives、配置模型与执行能力。
+runtime 负责决定何时执行 hook、如何把 hook 纳入审批/恢复语义；`voidcode.hook` 负责提供可复用的 hook primitives、配置模型、agent hook preset catalog 与执行能力。
+
+需要区分两类 hook 概念：
+
+- **hook preset**：`src/voidcode/hook/presets.py` 中的 builtin guidance / guard / continuation catalog，供 `AgentManifest.preset_hook_refs` 与 runtime `agent.hook_refs` 校验使用；
+- **runtime lifecycle hook**：`RuntimeHooksConfig` 中的 `session_start`、`pre_tool`、`background_task_completed` 等 command execution surface。
+
+hook preset 表达的是 agent 角色 intent，不自动执行 shell command，也不替代 runtime lifecycle hook surface。
 
 当前需要特别注意的是：本层已经具备 `session_start`、`session_end`、`session_idle`、`background_task_completed`、`background_task_failed`、`background_task_cancelled` 与 `delegated_result_available` 这些 richer lifecycle hook phases 的**配置边界**；但它们并不自动等价于完整的 async agent substrate。对于未来 async agent 设计，hook 仍然只能是通知与干预面，不能替代 background task / session lifecycle substrate。
 
 ## 当前状态
 
-hook 已经是相对独立的能力层，是后续 capability-layer 文档化的参考样板之一。
+hook 已经是相对独立的能力层，是后续 capability-layer 文档化的参考样板之一。agent hook preset contract 见 [`docs/contracts/agent-hook-presets.md`](../../../docs/contracts/agent-hook-presets.md)。

--- a/src/voidcode/hook/__init__.py
+++ b/src/voidcode/hook/__init__.py
@@ -9,15 +9,31 @@ from .executor import (
     run_lifecycle_hooks,
     run_tool_hooks,
 )
+from .presets import (
+    HookPreset,
+    HookPresetKind,
+    HookPresetRef,
+    get_builtin_hook_preset,
+    is_builtin_hook_preset_ref,
+    list_builtin_hook_presets,
+    validate_hook_preset_refs,
+)
 
 __all__ = [
     "HookExecutionEvent",
     "HookExecutionOutcome",
     "HookExecutionRequest",
+    "HookPreset",
+    "HookPresetKind",
+    "HookPresetRef",
     "LifecycleHookExecutionRequest",
     "RuntimeFormatterPresetConfig",
     "RuntimeHookSurface",
     "RuntimeHooksConfig",
+    "get_builtin_hook_preset",
+    "is_builtin_hook_preset_ref",
+    "list_builtin_hook_presets",
     "run_lifecycle_hooks",
     "run_tool_hooks",
+    "validate_hook_preset_refs",
 ]

--- a/src/voidcode/hook/presets.py
+++ b/src/voidcode/hook/presets.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Literal
+
+type HookPresetRef = Literal[
+    "role_reminder",
+    "delegation_guard",
+    "background_output_quality_guidance",
+    "todo_continuation_guidance",
+]
+
+type HookPresetKind = Literal["guidance", "guard", "continuation"]
+
+
+@dataclass(frozen=True, slots=True)
+class HookPreset:
+    ref: HookPresetRef
+    kind: HookPresetKind
+    description: str
+    guidance: str
+
+    def __post_init__(self) -> None:
+        if not self.ref.strip():
+            raise ValueError("HookPreset.ref must be a non-empty string")
+        if not self.description.strip():
+            raise ValueError("HookPreset.description must be a non-empty string")
+        if not self.guidance.strip():
+            raise ValueError("HookPreset.guidance must be a non-empty string")
+
+
+_BUILTIN_HOOK_PRESETS: Mapping[HookPresetRef, HookPreset] = MappingProxyType(
+    {
+        "role_reminder": HookPreset(
+            ref="role_reminder",
+            kind="guidance",
+            description="Remind the active agent to follow its selected role boundary.",
+            guidance=(
+                "Follow the active agent preset exactly: preserve its responsibility boundary, "
+                "tool scope, and output obligations for this run."
+            ),
+        ),
+        "delegation_guard": HookPreset(
+            ref="delegation_guard",
+            kind="guard",
+            description="Keep delegated work inside runtime-owned routing and preset limits.",
+            guidance=(
+                "Delegate only through runtime-owned task routing, respect supported child "
+                "presets, and never bypass runtime tool, approval, or session governance."
+            ),
+        ),
+        "background_output_quality_guidance": HookPreset(
+            ref="background_output_quality_guidance",
+            kind="guidance",
+            description="Encourage bounded, useful background task result retrieval.",
+            guidance=(
+                "When reading background task output, request only the detail needed for the "
+                "current decision and summarize results before acting on them."
+            ),
+        ),
+        "todo_continuation_guidance": HookPreset(
+            ref="todo_continuation_guidance",
+            kind="continuation",
+            description="Keep multi-step work tracked and continued through explicit todos.",
+            guidance=(
+                "For multi-step work, keep todos current, complete finished items immediately, "
+                "and use remaining todos to resume the next concrete action."
+            ),
+        ),
+    }
+)
+
+
+def get_builtin_hook_preset(ref: str) -> HookPreset | None:
+    hook_ref = _parse_builtin_hook_preset_ref(ref)
+    if hook_ref is None:
+        return None
+    return _BUILTIN_HOOK_PRESETS[hook_ref]
+
+
+def list_builtin_hook_presets() -> tuple[HookPreset, ...]:
+    return tuple(_BUILTIN_HOOK_PRESETS.values())
+
+
+def is_builtin_hook_preset_ref(ref: str) -> bool:
+    return _parse_builtin_hook_preset_ref(ref) is not None
+
+
+def _parse_builtin_hook_preset_ref(ref: str) -> HookPresetRef | None:
+    if ref == "role_reminder":
+        return "role_reminder"
+    if ref == "delegation_guard":
+        return "delegation_guard"
+    if ref == "background_output_quality_guidance":
+        return "background_output_quality_guidance"
+    if ref == "todo_continuation_guidance":
+        return "todo_continuation_guidance"
+    return None
+
+
+def validate_hook_preset_refs(
+    refs: tuple[str, ...],
+    *,
+    field_path: str,
+) -> tuple[str, ...]:
+    for ref in refs:
+        if not ref.strip():
+            raise ValueError(f"{field_path} entries must be non-empty strings")
+        if not is_builtin_hook_preset_ref(ref):
+            valid_refs = ", ".join(preset.ref for preset in list_builtin_hook_presets())
+            raise ValueError(
+                f"{field_path} references unknown hook preset: {ref}; "
+                f"valid presets are: {valid_refs}"
+            )
+    return refs

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -17,6 +17,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from ..agent import AgentManifestId, get_builtin_agent_manifest, list_builtin_agent_manifests
 from ..agent.prompts import has_builtin_prompt_profile
 from ..hook.config import FormatterCwdPolicy, RuntimeFormatterPresetConfig, RuntimeHooksConfig
+from ..hook.presets import validate_hook_preset_refs
 from ..lsp import LspServerConfigOverride as RuntimeLspServerConfig
 from ..lsp import derive_workspace_lsp_defaults, has_builtin_lsp_server_preset
 from ..provider import config as provider_config
@@ -2082,15 +2083,8 @@ def _parse_agent_hook_refs(
     hook_refs = _parse_string_list(raw_hook_refs, field_path="agent.hook_refs")
     if not hook_refs:
         return ()
-    available_hook_refs = set((hooks or RuntimeHooksConfig()).formatter_presets)
-    for hook_ref in hook_refs:
-        if hook_ref not in available_hook_refs:
-            valid_refs = ", ".join(sorted(available_hook_refs))
-            raise ValueError(
-                "runtime config field 'agent.hook_refs' references unknown hook preset: "
-                f"{hook_ref}; valid presets are: {valid_refs}"
-            )
-    return hook_refs
+    _ = hooks
+    return validate_hook_preset_refs(hook_refs, field_path="runtime config field 'agent.hook_refs'")
 
 
 def _parse_agent_provider_fallback_config(

--- a/tests/unit/agent/test_builtin.py
+++ b/tests/unit/agent/test_builtin.py
@@ -238,6 +238,25 @@ def test_builtin_agent_manifests_use_explicit_preset_hook_refs_not_formatter_ref
     assert worker.preset_hook_refs == ("role_reminder", "delegation_guard")
 
 
+def test_validate_builtin_agent_manifests_rejects_unknown_preset_hook_ref() -> None:
+    with pytest.raises(ValueError, match="references unknown hook preset"):
+        _ = validate_builtin_agent_manifests(
+            (
+                AgentManifest(
+                    id="leader",
+                    name="Leader",
+                    mode="primary",
+                    description="Primary preset",
+                    prompt_profile="leader",
+                    execution_engine="provider",
+                    preset_hook_refs=("missing_hook",),
+                    top_level_selectable=True,
+                    prompt_materialization=AgentPromptMaterialization(profile="leader"),
+                ),
+            )
+        )
+
+
 def test_validate_builtin_agent_manifests_rejects_unknown_prompt_profile() -> None:
     with pytest.raises(ValueError, match="references unknown prompt profile"):
         _ = validate_builtin_agent_manifests(

--- a/tests/unit/hook/test_presets.py
+++ b/tests/unit/hook/test_presets.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+
+from voidcode.hook.presets import (
+    get_builtin_hook_preset,
+    is_builtin_hook_preset_ref,
+    list_builtin_hook_presets,
+    validate_hook_preset_refs,
+)
+
+
+def test_builtin_hook_preset_catalog_contains_agent_manifest_refs() -> None:
+    refs = tuple(preset.ref for preset in list_builtin_hook_presets())
+
+    assert refs == (
+        "role_reminder",
+        "delegation_guard",
+        "background_output_quality_guidance",
+        "todo_continuation_guidance",
+    )
+    assert all(get_builtin_hook_preset(ref) is not None for ref in refs)
+
+
+def test_builtin_hook_presets_carry_guidance_metadata() -> None:
+    role_reminder = get_builtin_hook_preset("role_reminder")
+
+    assert role_reminder is not None
+    assert role_reminder.kind == "guidance"
+    assert "role" in role_reminder.description.lower()
+    assert "active agent preset" in role_reminder.guidance
+
+
+def test_hook_preset_ref_helpers_reject_unknown_refs() -> None:
+    assert is_builtin_hook_preset_ref("delegation_guard") is True
+    assert is_builtin_hook_preset_ref("python") is False
+
+    with pytest.raises(ValueError, match="references unknown hook preset: python"):
+        _ = validate_hook_preset_refs(("python",), field_path="agent.hook_refs")

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -1338,7 +1338,7 @@ def test_runtime_agent_payload_parses_prompt_and_hook_references() -> None:
             "preset": "leader",
             "prompt_ref": "advisor",
             "prompt_source": "builtin",
-            "hook_refs": ["python", "typescript"],
+            "hook_refs": ["role_reminder", "delegation_guard"],
         },
         source="test payload",
     )
@@ -1348,7 +1348,7 @@ def test_runtime_agent_payload_parses_prompt_and_hook_references() -> None:
         prompt_profile="advisor",
         prompt_ref="advisor",
         prompt_source="builtin",
-        hook_refs=("python", "typescript"),
+        hook_refs=("role_reminder", "delegation_guard"),
         execution_engine="provider",
     )
 
@@ -1486,25 +1486,17 @@ def test_runtime_config_parses_agents_map_with_custom_keys(tmp_path: Path) -> No
     )
 
 
-def test_runtime_config_parses_agent_references_against_workspace_hooks(
+def test_runtime_config_parses_agent_references_against_hook_preset_catalog(
     tmp_path: Path,
 ) -> None:
     runtime_config_path(tmp_path).write_text(
         json.dumps(
             {
-                "hooks": {
-                    "formatter_presets": {
-                        "customfmt": {
-                            "command": ["customfmt", "--write"],
-                            "extensions": [".custom"],
-                        }
-                    }
-                },
                 "agent": {
                     "preset": "leader",
                     "prompt_ref": "researcher",
                     "prompt_source": "builtin",
-                    "hook_refs": ["customfmt"],
+                    "hook_refs": ["role_reminder"],
                 },
             }
         ),
@@ -1518,7 +1510,7 @@ def test_runtime_config_parses_agent_references_against_workspace_hooks(
         prompt_profile="researcher",
         prompt_ref="researcher",
         prompt_source="builtin",
-        hook_refs=("customfmt",),
+        hook_refs=("role_reminder",),
         execution_engine="provider",
     )
 

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -48,7 +48,6 @@ from voidcode.runtime.config import (
     RuntimeCategoryConfig,
     RuntimeConfig,
     RuntimeContextWindowConfig,
-    RuntimeFormatterPresetConfig,
     RuntimeHooksConfig,
     RuntimeLspConfig,
     RuntimeLspServerConfig,
@@ -3089,7 +3088,7 @@ def test_runtime_missing_delegated_force_loaded_skill_fails_without_child_result
     assert runtime.list_sessions() == ()
 
 
-def test_runtime_constructs_with_custom_agent_hook_refs(tmp_path: Path) -> None:
+def test_runtime_constructs_with_builtin_agent_hook_refs(tmp_path: Path) -> None:
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
         graph=_BackgroundTaskSuccessGraph(),
@@ -3099,16 +3098,8 @@ def test_runtime_constructs_with_custom_agent_hook_refs(tmp_path: Path) -> None:
                 prompt_profile="researcher",
                 prompt_ref="researcher",
                 prompt_source="builtin",
-                hook_refs=("customfmt",),
+                hook_refs=("role_reminder",),
                 execution_engine="provider",
-            ),
-            hooks=RuntimeHooksConfig(
-                formatter_presets={
-                    "customfmt": RuntimeFormatterPresetConfig(
-                        command=("customfmt", "--write"),
-                        extensions=(".custom",),
-                    )
-                }
             ),
         ),
     )
@@ -3123,7 +3114,7 @@ def test_runtime_constructs_with_custom_agent_hook_refs(tmp_path: Path) -> None:
         "prompt_materialization": _prompt_materialization_payload("researcher"),
         "prompt_ref": "researcher",
         "prompt_source": "builtin",
-        "hook_refs": ["customfmt"],
+        "hook_refs": ["role_reminder"],
         "execution_engine": "provider",
     }
 


### PR DESCRIPTION
## Summary
- Add a typed builtin hook preset catalog for agent preset hook refs
- Validate builtin agent manifests and runtime `agent.hook_refs` against hook presets instead of formatter presets
- Cover hook preset lookup/validation plus updated agent/runtime config behavior

## Verification
- `mise run lint`
- `mise run typecheck` (`uv run ty check src`)
- `uv run python -X utf8 -m pytest tests/unit/hook/test_presets.py tests/unit/hook/test_executor.py tests/unit/agent/test_builtin.py tests/unit/runtime/test_runtime_config.py tests/unit/runtime/test_runtime_service_extensions.py -k 'hook or agent or preset'`
- `mise run test:fast`

## Follow-up issue candidates
- Materialize hook preset guidance into runtime/provider context
- Add contract docs for agent hook presets
- Emit active hook preset snapshots for debug/replay
- Harden role docs around hook refs, skill refs, and tool boundaries