### PR TITLE
feat(runtime): expose hook preset snapshots

### DIFF
--- a/src/voidcode/cli.py
+++ b/src/voidcode/cli.py
@@ -67,6 +67,7 @@ from .runtime.contracts import (
     ProviderInspectResult,
     ProviderModelMetadata,
     ProviderReadinessResult,
+    RuntimeHookPresetSnapshot,
     RuntimeProviderContextSnapshot,
     RuntimeRequest,
     RuntimeSessionDebugSnapshot,
@@ -936,8 +937,22 @@ def _serialize_session_debug_snapshot(
             else None
         ),
         "provider_context": _serialize_provider_context_snapshot(snapshot.provider_context),
+        "hook_presets": _serialize_hook_preset_snapshot(snapshot.hook_presets),
         "suggested_operator_action": snapshot.suggested_operator_action,
         "operator_guidance": snapshot.operator_guidance,
+    }
+
+
+def _serialize_hook_preset_snapshot(
+    snapshot: RuntimeHookPresetSnapshot | None,
+) -> dict[str, object] | None:
+    if snapshot is None:
+        return None
+    return {
+        "refs": list(snapshot.refs),
+        "kinds": list(snapshot.kinds),
+        "source": snapshot.source,
+        "count": snapshot.count,
     }
 
 

--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -829,6 +829,14 @@ class RuntimeProviderContextSnapshot:
 
 
 @dataclass(frozen=True, slots=True)
+class RuntimeHookPresetSnapshot:
+    refs: tuple[str, ...]
+    kinds: tuple[str, ...]
+    source: str
+    count: int
+
+
+@dataclass(frozen=True, slots=True)
 class RuntimeSessionDebugSnapshot:
     session: SessionState
     prompt: str
@@ -848,6 +856,7 @@ class RuntimeSessionDebugSnapshot:
     failure: RuntimeSessionDebugFailure | None = None
     last_tool: RuntimeSessionDebugToolSummary | None = None
     provider_context: RuntimeProviderContextSnapshot | None = None
+    hook_presets: RuntimeHookPresetSnapshot | None = None
     suggested_operator_action: str = "inspect_session"
     operator_guidance: str = "Inspect the persisted session state."
 

--- a/src/voidcode/runtime/events.py
+++ b/src/voidcode/runtime/events.py
@@ -11,6 +11,7 @@ type ExistingEventType = Literal[
     "runtime.request_received",
     "runtime.skills_loaded",
     "runtime.skills_applied",
+    "runtime.hook_presets_loaded",
     "runtime.provider_fallback",
     "runtime.provider_transient_retry",
     "runtime.category_model_diagnostic",
@@ -117,6 +118,7 @@ def _parse_delegated_lifecycle_status(value: object) -> DelegatedLifecycleStatus
 RUNTIME_REQUEST_RECEIVED: Final[ExistingEventType] = "runtime.request_received"
 RUNTIME_SKILLS_LOADED: Final[ExistingEventType] = "runtime.skills_loaded"
 RUNTIME_SKILLS_APPLIED: Final[ExistingEventType] = "runtime.skills_applied"
+RUNTIME_HOOK_PRESETS_LOADED: Final[ExistingEventType] = "runtime.hook_presets_loaded"
 RUNTIME_PROVIDER_FALLBACK: Final[ExistingEventType] = "runtime.provider_fallback"
 RUNTIME_PROVIDER_TRANSIENT_RETRY: Final[ExistingEventType] = "runtime.provider_transient_retry"
 RUNTIME_CATEGORY_MODEL_DIAGNOSTIC: Final[ExistingEventType] = "runtime.category_model_diagnostic"
@@ -206,6 +208,7 @@ EMITTED_EVENT_TYPES: Final[tuple[ExistingEventType, ...]] = (
     RUNTIME_REQUEST_RECEIVED,
     RUNTIME_SKILLS_LOADED,
     RUNTIME_SKILLS_APPLIED,
+    RUNTIME_HOOK_PRESETS_LOADED,
     RUNTIME_PROVIDER_FALLBACK,
     RUNTIME_PROVIDER_TRANSIENT_RETRY,
     RUNTIME_CATEGORY_MODEL_DIAGNOSTIC,

--- a/src/voidcode/runtime/http.py
+++ b/src/voidcode/runtime/http.py
@@ -29,6 +29,7 @@ from .contracts import (
     ReviewChangedFile,
     ReviewFileDiff,
     ReviewTreeNode,
+    RuntimeHookPresetSnapshot,
     RuntimeNotification,
     RuntimeProviderContextSnapshot,
     RuntimeRequest,
@@ -1999,8 +2000,24 @@ class RuntimeTransportApp:
             "provider_context": RuntimeTransportApp._serialize_provider_context_snapshot(
                 snapshot.provider_context
             ),
+            "hook_presets": RuntimeTransportApp._serialize_hook_preset_snapshot(
+                snapshot.hook_presets
+            ),
             "suggested_operator_action": snapshot.suggested_operator_action,
             "operator_guidance": snapshot.operator_guidance,
+        }
+
+    @staticmethod
+    def _serialize_hook_preset_snapshot(
+        snapshot: RuntimeHookPresetSnapshot | None,
+    ) -> dict[str, object] | None:
+        if snapshot is None:
+            return None
+        return {
+            "refs": list(snapshot.refs),
+            "kinds": list(snapshot.kinds),
+            "source": snapshot.source,
+            "count": snapshot.count,
         }
 
     @staticmethod

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -153,6 +153,7 @@ from .contracts import (
     ProviderValidationResult,
     ReviewFileDiff,
     RuntimeBackgroundTaskStatusSnapshot,
+    RuntimeHookPresetSnapshot,
     RuntimeNotification,
     RuntimeProviderContextPolicyDecision,
     RuntimeProviderContextSnapshot,
@@ -186,6 +187,7 @@ from .events import (
     RUNTIME_ACP_FAILED,
     RUNTIME_APPROVAL_REQUESTED,
     RUNTIME_CATEGORY_MODEL_DIAGNOSTIC,
+    RUNTIME_HOOK_PRESETS_LOADED,
     RUNTIME_LSP_SERVER_FAILED,
     RUNTIME_LSP_SERVER_REUSED,
     RUNTIME_LSP_SERVER_STARTED,
@@ -1969,6 +1971,23 @@ class VoidCodeRuntime:
                 ),
             )
 
+        hook_preset_snapshot = self._hook_preset_event_payload_from_session_metadata(
+            session.metadata
+        )
+        if hook_preset_snapshot is not None:
+            sequence += 1
+            yield RuntimeStreamChunk(
+                kind="event",
+                session=session,
+                event=EventEnvelope(
+                    session_id=session.session.id,
+                    sequence=sequence,
+                    event_type=RUNTIME_HOOK_PRESETS_LOADED,
+                    source="runtime",
+                    payload=hook_preset_snapshot,
+                ),
+            )
+
         active_agent = effective_config.agent
 
         graph_request = GraphRunRequest(
@@ -2882,6 +2901,7 @@ class VoidCodeRuntime:
             failure=failure,
             last_tool=last_tool,
             provider_context=provider_context,
+            hook_presets=self._debug_hook_preset_snapshot(result.session.metadata),
             suggested_operator_action=suggested_operator_action,
             operator_guidance=operator_guidance,
         )
@@ -7063,7 +7083,11 @@ class VoidCodeRuntime:
             },
         )
 
-    def _runtime_state_metadata(self, *, run_id: str | None = None) -> dict[str, object]:
+    def _runtime_state_metadata(
+        self,
+        *,
+        run_id: str | None = None,
+    ) -> dict[str, object]:
         acp_state = self._acp_adapter.current_state()
         return {
             **({"run_id": run_id} if run_id is not None else {}),
@@ -7083,6 +7107,53 @@ class VoidCodeRuntime:
                 ),
             },
         }
+
+    @staticmethod
+    def _resolved_hook_preset_snapshot_from_session_metadata(
+        metadata: dict[str, object],
+    ) -> ResolvedHookPresetSnapshot | None:
+        raw_snapshot = metadata.get("resolved_hook_presets")
+        if isinstance(raw_snapshot, dict):
+            return hook_preset_snapshot_from_payload(cast(dict[object, object], raw_snapshot))
+        raw_runtime_config = metadata.get("runtime_config")
+        if not isinstance(raw_runtime_config, dict):
+            return None
+        runtime_config_payload = cast(dict[object, object], raw_runtime_config)
+        nested_snapshot = runtime_config_payload.get("resolved_hook_presets")
+        if not isinstance(nested_snapshot, dict):
+            return None
+        return hook_preset_snapshot_from_payload(cast(dict[object, object], nested_snapshot))
+
+    @classmethod
+    def _hook_preset_event_payload_from_session_metadata(
+        cls,
+        metadata: dict[str, object],
+    ) -> dict[str, object] | None:
+        snapshot = cls._resolved_hook_preset_snapshot_from_session_metadata(metadata)
+        if snapshot is None or not snapshot.presets:
+            return None
+        kinds = [preset["kind"] for preset in snapshot.presets]
+        return {
+            "refs": list(snapshot.refs),
+            "kinds": kinds,
+            "source": "builtin",
+            "count": len(snapshot.presets),
+        }
+
+    @classmethod
+    def _debug_hook_preset_snapshot(
+        cls,
+        metadata: dict[str, object],
+    ) -> RuntimeHookPresetSnapshot | None:
+        payload = cls._hook_preset_event_payload_from_session_metadata(metadata)
+        if payload is None:
+            return None
+        return RuntimeHookPresetSnapshot(
+            refs=tuple(cast(list[str], payload["refs"])),
+            kinds=tuple(cast(list[str], payload["kinds"])),
+            source=cast(str, payload["source"]),
+            count=cast(int, payload["count"]),
+        )
 
     @staticmethod
     def _envelopes_for_lsp_events(

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -3663,8 +3663,15 @@ def test_provider_runtime_executes_read_path_and_persists_config(tmp_path: Path)
         "tool_timeout_seconds": None,
     }
     runtime_state = cast(dict[str, object], result.session.metadata["runtime_state"])
-    assert set(runtime_state) == {"acp", "hook_presets", "run_id"}
-    assert runtime_state["hook_presets"] == _LEADER_HOOK_PRESET_SNAPSHOT
+    assert set(runtime_state) == {"acp", "run_id"}
+    persisted_hook_presets = cast(
+        dict[str, object], result.session.metadata["resolved_hook_presets"]
+    )
+    assert persisted_hook_presets["refs"] == _LEADER_HOOK_PRESET_SNAPSHOT["refs"]
+    assert persisted_hook_presets["source"] == "builtin"
+    assert persisted_hook_presets["version"] == 1
+    presets = cast(list[dict[str, object]], persisted_hook_presets["presets"])
+    assert [preset["kind"] for preset in presets] == _LEADER_HOOK_PRESET_SNAPSHOT["kinds"]
     assert runtime_state["acp"] == {
         "available": False,
         "configured_enabled": False,

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -26,6 +26,17 @@ _DEFAULT_PERMISSION_METADATA = {
     "external_directory_read": {"*": "ask"},
     "external_directory_write": {"*": "deny"},
 }
+_LEADER_HOOK_PRESET_SNAPSHOT = {
+    "refs": [
+        "role_reminder",
+        "delegation_guard",
+        "background_output_quality_guidance",
+        "todo_continuation_guidance",
+    ],
+    "kinds": ["guidance", "guard", "guidance", "continuation"],
+    "source": "builtin",
+    "count": 4,
+}
 
 
 @pytest.fixture
@@ -2022,13 +2033,15 @@ def test_provider_runtime_falls_back_to_next_provider_target(tmp_path: Path) -> 
     assert [event.event_type for event in response.events] == [
         "runtime.request_received",
         "runtime.skills_loaded",
+        "runtime.hook_presets_loaded",
         "runtime.provider_fallback",
         "graph.loop_step",
         "graph.model_turn",
         "graph.loop_step",
         "graph.response_ready",
     ]
-    assert response.events[2].payload == {
+    assert response.events[2].payload == _LEADER_HOOK_PRESET_SNAPSHOT
+    assert response.events[3].payload == {
         "reason": "rate_limit",
         "from_provider": "opencode",
         "from_model": "gpt-5.4",
@@ -2093,13 +2106,15 @@ def test_provider_runtime_retries_transient_error_on_same_target(tmp_path: Path)
     assert [event.event_type for event in response.events] == [
         "runtime.request_received",
         "runtime.skills_loaded",
+        "runtime.hook_presets_loaded",
         "runtime.provider_transient_retry",
         "graph.loop_step",
         "graph.model_turn",
         "graph.loop_step",
         "graph.response_ready",
     ]
-    assert response.events[2].payload == {
+    assert response.events[2].payload == _LEADER_HOOK_PRESET_SNAPSHOT
+    assert response.events[3].payload == {
         "reason": "transient_failure",
         "provider": "opencode-go",
         "model": "glm-5.1",
@@ -2183,6 +2198,7 @@ def test_provider_runtime_falls_back_after_same_target_retry_budget(
     assert [event.event_type for event in response.events] == [
         "runtime.request_received",
         "runtime.skills_loaded",
+        "runtime.hook_presets_loaded",
         "runtime.provider_transient_retry",
         "runtime.provider_fallback",
         "graph.loop_step",
@@ -2190,7 +2206,8 @@ def test_provider_runtime_falls_back_after_same_target_retry_budget(
         "graph.loop_step",
         "graph.response_ready",
     ]
-    assert response.events[2].payload == {
+    assert response.events[2].payload == _LEADER_HOOK_PRESET_SNAPSHOT
+    assert response.events[3].payload == {
         "reason": "transient_failure",
         "provider": "opencode-go",
         "model": "glm-5.1",
@@ -2198,7 +2215,7 @@ def test_provider_runtime_falls_back_after_same_target_retry_budget(
         "max_retries": 1,
         "delay_ms": 0,
     }
-    assert response.events[3].payload == {
+    assert response.events[4].payload == {
         "reason": "transient_failure",
         "from_provider": "opencode-go",
         "from_model": "glm-5.1",
@@ -3646,7 +3663,8 @@ def test_provider_runtime_executes_read_path_and_persists_config(tmp_path: Path)
         "tool_timeout_seconds": None,
     }
     runtime_state = cast(dict[str, object], result.session.metadata["runtime_state"])
-    assert set(runtime_state) == {"acp", "run_id"}
+    assert set(runtime_state) == {"acp", "hook_presets", "run_id"}
+    assert runtime_state["hook_presets"] == _LEADER_HOOK_PRESET_SNAPSHOT
     assert runtime_state["acp"] == {
         "available": False,
         "configured_enabled": False,
@@ -3658,7 +3676,7 @@ def test_provider_runtime_executes_read_path_and_persists_config(tmp_path: Path)
         "mode": "disabled",
         "status": "disconnected",
     }
-    assert result.events[3].payload["mode"] == "provider"
+    assert result.events[4].payload["mode"] == "provider"
     assert replay.output == result.output
 
 
@@ -3705,7 +3723,7 @@ def test_provider_runtime_requests_and_resumes_write_approval(tmp_path: Path) ->
     )
 
     assert waiting.session.status == "waiting"
-    assert waiting.events[3].payload["mode"] == "provider"
+    assert waiting.events[4].payload["mode"] == "provider"
     assert waiting.events[-1].event_type == "runtime.approval_requested"
     assert resumed.session.status == "completed"
     assert resumed.output == "Wrote file successfully: danger.txt"

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -70,6 +70,7 @@ from voidcode.runtime.events import (
     RUNTIME_BACKGROUND_TASK_FAILED,
     RUNTIME_BACKGROUND_TASK_WAITING_APPROVAL,
     RUNTIME_CONTEXT_PRESSURE,
+    RUNTIME_HOOK_PRESETS_LOADED,
     RUNTIME_MCP_SERVER_FAILED,
     RUNTIME_MCP_SERVER_STARTED,
     RUNTIME_MCP_SERVER_STOPPED,
@@ -3342,7 +3343,12 @@ def test_runtime_constructs_with_builtin_agent_hook_refs(tmp_path: Path) -> None
     response = runtime.run(RuntimeRequest(prompt="custom hook refs", session_id="hook-refs"))
 
     runtime_config = response.session.metadata["runtime_config"]
+    resolved_hook_presets = response.session.metadata["resolved_hook_presets"]
+    hook_event = next(
+        event for event in response.events if event.event_type == RUNTIME_HOOK_PRESETS_LOADED
+    )
     assert isinstance(runtime_config, dict)
+    assert isinstance(resolved_hook_presets, dict)
     assert runtime_config["agent"] == {
         "preset": "leader",
         "prompt_profile": "researcher",
@@ -3352,6 +3358,106 @@ def test_runtime_constructs_with_builtin_agent_hook_refs(tmp_path: Path) -> None
         "hook_refs": ["role_reminder"],
         "execution_engine": "provider",
     }
+    assert resolved_hook_presets["refs"] == ["role_reminder"]
+    assert hook_event.payload == {
+        "refs": ["role_reminder"],
+        "kinds": ["guidance"],
+        "source": "builtin",
+        "count": 1,
+    }
+
+
+def test_runtime_snapshots_manifest_default_hook_refs(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_BackgroundTaskSuccessGraph(),
+        config=RuntimeConfig(
+            agent=RuntimeAgentConfig(preset="leader", execution_engine="provider"),
+        ),
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="manifest hook refs", session_id="manifest-hooks"))
+
+    resolved_hook_presets = response.session.metadata["resolved_hook_presets"]
+    assert isinstance(resolved_hook_presets, dict)
+    assert resolved_hook_presets["refs"] == [
+        "role_reminder",
+        "delegation_guard",
+        "background_output_quality_guidance",
+        "todo_continuation_guidance",
+    ]
+    hook_event = next(
+        event for event in response.events if event.event_type == RUNTIME_HOOK_PRESETS_LOADED
+    )
+    assert hook_event.payload == {
+        "refs": [
+            "role_reminder",
+            "delegation_guard",
+            "background_output_quality_guidance",
+            "todo_continuation_guidance",
+        ],
+        "kinds": ["guidance", "guard", "guidance", "continuation"],
+        "source": "builtin",
+        "count": 4,
+    }
+
+
+def test_runtime_debug_uses_persisted_hook_preset_snapshot_not_formatter_presets(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_BackgroundTaskSuccessGraph(),
+        config=RuntimeConfig(
+            hooks=RuntimeHooksConfig(
+                formatter_presets={
+                    "role_reminder": RuntimeHooksConfig().formatter_presets["python"]
+                }
+            ),
+            agent=RuntimeAgentConfig(
+                preset="leader",
+                hook_refs=("delegation_guard",),
+                execution_engine="provider",
+            ),
+        ),
+    )
+
+    _ = runtime.run(RuntimeRequest(prompt="debug hook refs", session_id="hook-debug"))
+    snapshot = runtime.session_debug_snapshot(session_id="hook-debug")
+
+    assert snapshot.hook_presets is not None
+    assert snapshot.hook_presets.refs == ("delegation_guard",)
+    assert snapshot.hook_presets.kinds == ("guard",)
+    assert snapshot.hook_presets.source == "builtin"
+    assert snapshot.hook_presets.count == 1
+
+
+def test_hook_preset_snapshot_does_not_change_agent_tool_permissions(tmp_path: Path) -> None:
+    runtime_without_hooks = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_BackgroundTaskSuccessGraph(),
+        config=RuntimeConfig(
+            agent=RuntimeAgentConfig(preset="leader", execution_engine="provider")
+        ),
+    )
+    runtime_with_hooks = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_BackgroundTaskSuccessGraph(),
+        config=RuntimeConfig(
+            agent=RuntimeAgentConfig(
+                preset="leader",
+                hook_refs=("role_reminder", "delegation_guard"),
+                execution_engine="provider",
+            )
+        ),
+    )
+
+    no_hook_config = runtime_without_hooks._effective_runtime_config_from_metadata(None)  # pyright: ignore[reportPrivateUsage]
+    hook_config = runtime_with_hooks._effective_runtime_config_from_metadata(None)  # pyright: ignore[reportPrivateUsage]
+    no_hook_tools = runtime_without_hooks._tool_registry_for_effective_config(no_hook_config)  # pyright: ignore[reportPrivateUsage]
+    hook_tools = runtime_with_hooks._tool_registry_for_effective_config(hook_config)  # pyright: ignore[reportPrivateUsage]
+
+    assert tuple(no_hook_tools.tools) == tuple(hook_tools.tools)
 
 
 def test_runtime_category_routing_resolves_real_child_agent_and_persists_identity(


### PR DESCRIPTION
## Summary
- Persist active hook preset snapshots in runtime state and emit `runtime.hook_presets_loaded` for run observability.
- Expose persisted hook preset truth through session debug snapshots plus CLI/HTTP serializers.
- Cover explicit refs, manifest-default refs, formatter-preset non-derivation, and permission invariance.

## Verification
- `mise run lint`
- `mise run typecheck`
- `uv run pytest tests/unit/runtime/test_runtime_service_extensions.py -q`

Closes #381