### PR TITLE
fix(runtime): respect gitignore in review tree

### DIFF
--- a/src/voidcode/runtime/review.py
+++ b/src/voidcode/runtime/review.py
@@ -218,11 +218,12 @@ class WorkspaceReviewService:
             tree_root,
             "check-ignore",
             "--quiet",
-            "--no-index",
             "--",
             relative_path,
         )
         if git_check.returncode == 0:
+            if is_directory and self._has_tracked_tree_path(tree_root, relative_path):
+                return False
             return True
         if git_check.returncode == 1:
             return False
@@ -231,6 +232,10 @@ class WorkspaceReviewService:
             self._ignore_patterns_for_tree_root(tree_root),
             is_directory=is_directory,
         )
+
+    def _has_tracked_tree_path(self, tree_root: Path, relative_path: str) -> bool:
+        tracked = self._run_git(tree_root, "ls-files", "--", f"{relative_path}/")
+        return tracked.returncode == 0 and bool(tracked.stdout.strip())
 
     def _ignore_patterns_for_tree_root(self, tree_root: Path) -> tuple[str, ...]:
         cached = self._tree_ignore_patterns.get(tree_root)

--- a/src/voidcode/runtime/review.py
+++ b/src/voidcode/runtime/review.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import shlex
 import subprocess
 from dataclasses import dataclass
+from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Literal
 
@@ -14,19 +15,7 @@ from .contracts import (
     WorkspaceReviewSnapshot,
 )
 
-_EXCLUDED_TREE_DIRECTORY_NAMES = frozenset(
-    {
-        ".git",
-        ".mypy_cache",
-        ".playwright-mcp",
-        ".pytest_cache",
-        ".ruff_cache",
-        ".sisyphus",
-        ".venv",
-        "__pycache__",
-        "node_modules",
-    }
-)
+_VCS_TREE_DIRECTORY_NAMES = frozenset({".git", ".hg", ".svn"})
 
 type ReviewChangeType = Literal[
     "added",
@@ -50,6 +39,7 @@ class GitCommandResult:
 class WorkspaceReviewService:
     def __init__(self, *, workspace: Path) -> None:
         self._workspace = workspace.resolve()
+        self._tree_ignore_patterns: dict[Path, tuple[str, ...]] = {}
 
     def snapshot(self, *, git: GitStatusSnapshot) -> WorkspaceReviewSnapshot:
         root = Path(git.root).resolve() if git.root is not None else self._workspace
@@ -208,10 +198,55 @@ class WorkspaceReviewService:
         return path.relative_to(root).as_posix()
 
     def _should_exclude_from_tree(self, path: Path, tree_root: Path) -> bool:
-        if not path.is_dir():
+        if path.is_dir() and path.name in _VCS_TREE_DIRECTORY_NAMES:
+            return True
+        relative_path = self._relative_to_root(path, tree_root)
+        return self._is_ignored_tree_path(
+            tree_root,
+            relative_path,
+            is_directory=path.is_dir(),
+        )
+
+    def _is_ignored_tree_path(
+        self,
+        tree_root: Path,
+        relative_path: str,
+        *,
+        is_directory: bool,
+    ) -> bool:
+        git_check = self._run_git(
+            tree_root,
+            "check-ignore",
+            "--quiet",
+            "--no-index",
+            "--",
+            relative_path,
+        )
+        if git_check.returncode == 0:
+            return True
+        if git_check.returncode == 1:
             return False
-        relative_parts = path.relative_to(tree_root).parts
-        return any(part in _EXCLUDED_TREE_DIRECTORY_NAMES for part in relative_parts)
+        return _matches_gitignore_path(
+            relative_path,
+            self._ignore_patterns_for_tree_root(tree_root),
+            is_directory=is_directory,
+        )
+
+    def _ignore_patterns_for_tree_root(self, tree_root: Path) -> tuple[str, ...]:
+        cached = self._tree_ignore_patterns.get(tree_root)
+        if cached is not None:
+            return cached
+        gitignore = tree_root / ".gitignore"
+        if gitignore.is_file():
+            patterns = tuple(
+                line.strip()
+                for line in gitignore.read_text(encoding="utf-8").splitlines()
+                if line.strip() and not line.lstrip().startswith("#")
+            )
+        else:
+            patterns = ()
+        self._tree_ignore_patterns[tree_root] = patterns
+        return patterns
 
     def _should_descend_into(self, path: Path, root: Path) -> bool:
         if not path.is_symlink():
@@ -286,3 +321,73 @@ class WorkspaceReviewService:
             stdout=result.stdout,
             stderr=result.stderr,
         )
+
+
+def _matches_gitignore_path(
+    relative_path: str,
+    patterns: tuple[str, ...],
+    *,
+    is_directory: bool,
+) -> bool:
+    normalized = relative_path.strip("/")
+    if not normalized:
+        return False
+    ignored = False
+    for pattern in patterns:
+        normalized_pattern = pattern.strip()
+        if not normalized_pattern or normalized_pattern.startswith("#"):
+            continue
+        negated = normalized_pattern.startswith("!")
+        if negated:
+            normalized_pattern = normalized_pattern[1:]
+        if _matches_gitignore_pattern(
+            normalized,
+            normalized_pattern,
+            is_directory=is_directory,
+        ):
+            ignored = not negated
+    return ignored
+
+
+def _matches_gitignore_pattern(
+    relative_path: str,
+    pattern: str,
+    *,
+    is_directory: bool,
+) -> bool:
+    normalized_pattern = pattern.strip()
+    if not normalized_pattern or normalized_pattern.startswith("#"):
+        return False
+    if normalized_pattern.startswith("!"):
+        return False
+
+    directory_only = normalized_pattern.endswith("/")
+    if directory_only and not is_directory:
+        return False
+    anchored = normalized_pattern.startswith("/")
+    normalized_pattern = normalized_pattern.strip("/")
+    if not normalized_pattern:
+        return False
+
+    path_parts = Path(relative_path).parts
+    if "/" not in normalized_pattern:
+        if directory_only:
+            return normalized_pattern in path_parts
+        return any(fnmatchcase(part, normalized_pattern) for part in path_parts)
+
+    if anchored:
+        if directory_only:
+            return relative_path == normalized_pattern or relative_path.startswith(
+                f"{normalized_pattern}/"
+            )
+        return fnmatchcase(relative_path, normalized_pattern)
+    if directory_only:
+        return (
+            relative_path == normalized_pattern
+            or relative_path.endswith(f"/{normalized_pattern}")
+            or f"/{normalized_pattern}/" in f"/{relative_path}/"
+        )
+    return fnmatchcase(relative_path, normalized_pattern) or fnmatchcase(
+        relative_path,
+        f"*/{normalized_pattern}",
+    )

--- a/src/voidcode/runtime/review.py
+++ b/src/voidcode/runtime/review.py
@@ -57,7 +57,12 @@ class WorkspaceReviewService:
                 error=git.error,
             ),
             changed_files=changed_files,
-            tree=self._tree(tree_root, tree_root=tree_root, changed_paths=changed_paths),
+            tree=self._tree(
+                tree_root,
+                tree_root=tree_root,
+                changed_paths=changed_paths,
+                use_git_ignore=git.state == "git_ready",
+            ),
         )
 
     def diff(self, *, path: str, git: GitStatusSnapshot) -> ReviewFileDiff:
@@ -163,15 +168,21 @@ class WorkspaceReviewService:
         *,
         tree_root: Path,
         changed_paths: set[str],
+        use_git_ignore: bool,
     ) -> tuple[ReviewTreeNode, ...]:
         children: list[ReviewTreeNode] = []
         for entry in sorted(
             root.iterdir(), key=lambda item: (not item.is_dir(), item.name.lower())
         ):
-            if self._should_exclude_from_tree(entry, tree_root):
+            if self._should_exclude_from_tree(entry, tree_root, use_git_ignore=use_git_ignore):
                 continue
             if entry.is_dir() and self._should_descend_into(entry, tree_root):
-                descendants = self._tree(entry, tree_root=tree_root, changed_paths=changed_paths)
+                descendants = self._tree(
+                    entry,
+                    tree_root=tree_root,
+                    changed_paths=changed_paths,
+                    use_git_ignore=use_git_ignore,
+                )
                 is_changed = any(child.changed for child in descendants)
                 children.append(
                     ReviewTreeNode(
@@ -197,7 +208,13 @@ class WorkspaceReviewService:
     def _relative_to_root(self, path: Path, root: Path) -> str:
         return path.relative_to(root).as_posix()
 
-    def _should_exclude_from_tree(self, path: Path, tree_root: Path) -> bool:
+    def _should_exclude_from_tree(
+        self,
+        path: Path,
+        tree_root: Path,
+        *,
+        use_git_ignore: bool,
+    ) -> bool:
         if path.is_dir() and path.name in _VCS_TREE_DIRECTORY_NAMES:
             return True
         relative_path = self._relative_to_root(path, tree_root)
@@ -205,6 +222,7 @@ class WorkspaceReviewService:
             tree_root,
             relative_path,
             is_directory=path.is_dir(),
+            use_git_ignore=use_git_ignore,
         )
 
     def _is_ignored_tree_path(
@@ -213,20 +231,22 @@ class WorkspaceReviewService:
         relative_path: str,
         *,
         is_directory: bool,
+        use_git_ignore: bool,
     ) -> bool:
-        git_check = self._run_git(
-            tree_root,
-            "check-ignore",
-            "--quiet",
-            "--",
-            relative_path,
-        )
-        if git_check.returncode == 0:
-            if is_directory and self._has_tracked_tree_path(tree_root, relative_path):
+        if use_git_ignore:
+            git_check = self._run_git(
+                tree_root,
+                "check-ignore",
+                "--quiet",
+                "--",
+                relative_path,
+            )
+            if git_check.returncode == 0:
+                if is_directory and self._has_tracked_tree_path(tree_root, relative_path):
+                    return False
+                return True
+            if git_check.returncode == 1:
                 return False
-            return True
-        if git_check.returncode == 1:
-            return False
         return _matches_gitignore_path(
             relative_path,
             self._ignore_patterns_for_tree_root(tree_root),
@@ -385,14 +405,22 @@ def _matches_gitignore_pattern(
             return relative_path == normalized_pattern or relative_path.startswith(
                 f"{normalized_pattern}/"
             )
-        return fnmatchcase(relative_path, normalized_pattern)
+        return _matches_path_segments(relative_path, normalized_pattern)
     if directory_only:
         return (
             relative_path == normalized_pattern
             or relative_path.endswith(f"/{normalized_pattern}")
             or f"/{normalized_pattern}/" in f"/{relative_path}/"
         )
-    return fnmatchcase(relative_path, normalized_pattern) or fnmatchcase(
-        relative_path,
-        f"*/{normalized_pattern}",
+    return _matches_path_segments(relative_path, normalized_pattern)
+
+
+def _matches_path_segments(relative_path: str, pattern: str) -> bool:
+    path_parts = Path(relative_path).parts
+    pattern_parts = Path(pattern).parts
+    if len(path_parts) != len(pattern_parts):
+        return False
+    return all(
+        fnmatchcase(path_part, pattern_part)
+        for path_part, pattern_part in zip(path_parts, pattern_parts, strict=True)
     )

--- a/tests/unit/runtime/test_review.py
+++ b/tests/unit/runtime/test_review.py
@@ -76,6 +76,10 @@ def test_review_snapshot_does_not_descend_into_out_of_root_symlinked_directory(
 
 
 def test_review_snapshot_excludes_generated_and_internal_directories(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text(
+        ".venv/\n.sisyphus/\nnode_modules/\n",
+        encoding="utf-8",
+    )
     (tmp_path / ".venv" / "bin").mkdir(parents=True)
     (tmp_path / ".venv" / "bin" / "python").write_text("python\n", encoding="utf-8")
     (tmp_path / ".sisyphus" / "plans").mkdir(parents=True)
@@ -137,12 +141,19 @@ def test_review_snapshot_excludes_generated_and_internal_directories(tmp_path: P
                 ),
             ),
         ),
+        ReviewTreeNode(
+            path=".gitignore",
+            name=".gitignore",
+            kind="file",
+            changed=False,
+        ),
     )
 
 
 def test_review_snapshot_keeps_changed_files_when_tree_excludes_internal_directory(
     tmp_path: Path,
 ) -> None:
+    (tmp_path / ".gitignore").write_text(".venv/\n", encoding="utf-8")
     (tmp_path / "src").mkdir()
     (tmp_path / "src" / "app.py").write_text("print('ok')\n", encoding="utf-8")
     (tmp_path / ".venv" / "bin").mkdir(parents=True)
@@ -173,6 +184,109 @@ def test_review_snapshot_keeps_changed_files_when_tree_excludes_internal_directo
                 ),
             ),
         ),
+        ReviewTreeNode(
+            path=".gitignore",
+            name=".gitignore",
+            kind="file",
+            changed=False,
+        ),
+    )
+
+
+def test_review_snapshot_uses_gitignore_rules_for_non_git_workspace(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text(
+        "cache/\nlogs/*.tmp\n!important.tmp\n/build\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "cache" / "nested").mkdir(parents=True)
+    (tmp_path / "cache" / "nested" / "data.txt").write_text("cache\n", encoding="utf-8")
+    (tmp_path / "logs").mkdir()
+    (tmp_path / "logs" / "debug.tmp").write_text("tmp\n", encoding="utf-8")
+    (tmp_path / "logs" / "important.tmp").write_text("keep\n", encoding="utf-8")
+    (tmp_path / "build").mkdir()
+    (tmp_path / "build" / "artifact.txt").write_text("build\n", encoding="utf-8")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('ok')\n", encoding="utf-8")
+
+    snapshot = WorkspaceReviewService(workspace=tmp_path).snapshot(
+        git=GitStatusSnapshot(state="not_git_repo")
+    )
+
+    assert snapshot.tree == (
+        ReviewTreeNode(
+            path="logs",
+            name="logs",
+            kind="directory",
+            changed=False,
+            children=(
+                ReviewTreeNode(
+                    path="logs/important.tmp",
+                    name="important.tmp",
+                    kind="file",
+                    changed=False,
+                ),
+            ),
+        ),
+        ReviewTreeNode(
+            path="src",
+            name="src",
+            kind="directory",
+            changed=False,
+            children=(
+                ReviewTreeNode(
+                    path="src/app.py",
+                    name="app.py",
+                    kind="file",
+                    changed=False,
+                ),
+            ),
+        ),
+        ReviewTreeNode(
+            path=".gitignore",
+            name=".gitignore",
+            kind="file",
+            changed=False,
+        ),
+    )
+
+
+def test_review_snapshot_uses_git_check_ignore_for_git_workspace(tmp_path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    (tmp_path / ".gitignore").write_text("generated/\n", encoding="utf-8")
+    (tmp_path / "generated").mkdir()
+    (tmp_path / "generated" / "out.txt").write_text("generated\n", encoding="utf-8")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('ok')\n", encoding="utf-8")
+
+    snapshot = WorkspaceReviewService(workspace=tmp_path).snapshot(
+        git=GitStatusSnapshot(state="git_ready", root=str(tmp_path))
+    )
+
+    assert snapshot.tree == (
+        ReviewTreeNode(
+            path="src",
+            name="src",
+            kind="directory",
+            changed=True,
+            children=(
+                ReviewTreeNode(
+                    path="src/app.py",
+                    name="app.py",
+                    kind="file",
+                    changed=True,
+                ),
+            ),
+        ),
+        ReviewTreeNode(
+            path=".gitignore",
+            name=".gitignore",
+            kind="file",
+            changed=True,
+        ),
+    )
+    assert (
+        ReviewChangedFile(path="generated/out.txt", change_type="untracked")
+        not in snapshot.changed_files
     )
 
 

--- a/tests/unit/runtime/test_review.py
+++ b/tests/unit/runtime/test_review.py
@@ -290,6 +290,48 @@ def test_review_snapshot_uses_git_check_ignore_for_git_workspace(tmp_path: Path)
     )
 
 
+def test_review_snapshot_keeps_tracked_gitignored_files_in_git_workspace(
+    tmp_path: Path,
+) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    (tmp_path / ".gitignore").write_text("generated/\n", encoding="utf-8")
+    (tmp_path / "generated").mkdir()
+    (tmp_path / "generated" / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "add", "-f", "generated/tracked.txt"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+    snapshot = WorkspaceReviewService(workspace=tmp_path).snapshot(
+        git=GitStatusSnapshot(state="git_ready", root=str(tmp_path))
+    )
+
+    assert snapshot.tree == (
+        ReviewTreeNode(
+            path="generated",
+            name="generated",
+            kind="directory",
+            changed=True,
+            children=(
+                ReviewTreeNode(
+                    path="generated/tracked.txt",
+                    name="tracked.txt",
+                    kind="file",
+                    changed=True,
+                ),
+            ),
+        ),
+        ReviewTreeNode(
+            path=".gitignore",
+            name=".gitignore",
+            kind="file",
+            changed=True,
+        ),
+    )
+
+
 def test_review_diff_reads_untracked_file_from_nested_workspace_under_git_root(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_review.py
+++ b/tests/unit/runtime/test_review.py
@@ -203,6 +203,8 @@ def test_review_snapshot_uses_gitignore_rules_for_non_git_workspace(tmp_path: Pa
     (tmp_path / "logs").mkdir()
     (tmp_path / "logs" / "debug.tmp").write_text("tmp\n", encoding="utf-8")
     (tmp_path / "logs" / "important.tmp").write_text("keep\n", encoding="utf-8")
+    (tmp_path / "logs" / "archive").mkdir()
+    (tmp_path / "logs" / "archive" / "error.tmp").write_text("keep\n", encoding="utf-8")
     (tmp_path / "build").mkdir()
     (tmp_path / "build" / "artifact.txt").write_text("build\n", encoding="utf-8")
     (tmp_path / "src").mkdir()
@@ -220,6 +222,20 @@ def test_review_snapshot_uses_gitignore_rules_for_non_git_workspace(tmp_path: Pa
             changed=False,
             children=(
                 ReviewTreeNode(
+                    path="logs/archive",
+                    name="archive",
+                    kind="directory",
+                    changed=False,
+                    children=(
+                        ReviewTreeNode(
+                            path="logs/archive/error.tmp",
+                            name="error.tmp",
+                            kind="file",
+                            changed=False,
+                        ),
+                    ),
+                ),
+                ReviewTreeNode(
                     path="logs/important.tmp",
                     name="important.tmp",
                     kind="file",
@@ -227,6 +243,41 @@ def test_review_snapshot_uses_gitignore_rules_for_non_git_workspace(tmp_path: Pa
                 ),
             ),
         ),
+        ReviewTreeNode(
+            path="src",
+            name="src",
+            kind="directory",
+            changed=False,
+            children=(
+                ReviewTreeNode(
+                    path="src/app.py",
+                    name="app.py",
+                    kind="file",
+                    changed=False,
+                ),
+            ),
+        ),
+        ReviewTreeNode(
+            path=".gitignore",
+            name=".gitignore",
+            kind="file",
+            changed=False,
+        ),
+    )
+
+
+def test_review_snapshot_does_not_probe_git_for_non_git_workspace(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("ignored/\n", encoding="utf-8")
+    (tmp_path / "ignored").mkdir()
+    (tmp_path / "ignored" / "cache.txt").write_text("cache\n", encoding="utf-8")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('ok')\n", encoding="utf-8")
+
+    service = WorkspaceReviewService(workspace=tmp_path)
+    with patch.object(service, "_run_git", side_effect=AssertionError("git should not run")):
+        snapshot = service.snapshot(git=GitStatusSnapshot(state="not_git_repo"))
+
+    assert snapshot.tree == (
         ReviewTreeNode(
             path="src",
             name="src",


### PR DESCRIPTION
## Summary
- Replace the review tree's hard-coded generated-directory exclusion list with gitignore-aware filtering
- Use `git check-ignore --no-index` when possible and fall back to the workspace `.gitignore` rules for non-git snapshots
- Keep VCS metadata directories out of the review tree and preserve changed-file reporting separately

## Verification
- `uv run python -X utf8 -m pytest tests/unit/runtime/test_review.py`
- `uv run python -X utf8 -m pytest tests/unit/runtime/test_review.py tests/unit/runtime/test_backend_contracts.py`
- `mise run lint`
- `mise run typecheck`