### PR TITLE
feat(command): add minimal builtin prompt commands

### DIFF
--- a/src/voidcode/command/README.md
+++ b/src/voidcode/command/README.md
@@ -30,11 +30,19 @@ Review $1 with full context: $ARGUMENTS
 
 Templates currently support `$ARGUMENTS` and `$1` through `$9`. Argument splitting uses `shlex` so quoted arguments are preserved.
 
-## Current builtin surface
+## Builtin prompt commands
 
-The code currently ships only a small builtin prompt-command baseline:
+The minimal builtin set provides exactly six product commands. These commands package common
+workflow intent into prompts; they do not directly call tools or bypass runtime approval/session
+governance.
 
-- `/help` — explain command/tool/UI surfaces.
-- `/review` — review a requested target and report findings.
+| Command | Arguments | Execution mode | Default behavior | Verification guidance |
+|---------|-----------|----------------|------------------|-----------------------|
+| `/review [target]` | File, directory, PR/diff target, or empty for current changes | Default runtime prompt | Read-only | Report missing/unreadable targets instead of generic reviews |
+| `/fix [problem]` | Concrete failing test, lint/type error, review comment, or bug | Default runtime prompt | May edit | Locate root cause, minimally edit, and run targeted checks |
+| `/explain [target]` | File, module, stack trace, error, or behavior | Default runtime prompt | Read-only | State clearly when the target cannot be found or read |
+| `/plan [goal]` | Implementation goal, acceptance criteria request, or issue shape | `product` agent | Read-only | Produce plan, risks, acceptance criteria, and verification strategy |
+| `/test [target]` | Code or behavior to test, or failing test output | Default runtime prompt | May edit tests | Prefer targeted tests before broad suites; never delete/weaken tests |
+| `/commit [context]` | Optional commit intent/context | Default runtime prompt | Read-only | Inspect status/diff; report clean tree instead of inventing a message |
 
-Issue #390 tracks the next productization step: defining a minimal user-facing command set (`/review`, `/fix`, `/explain`, `/plan`, `/test`, `/commit`) without turning commands into a marketplace or a large taxonomy.
+Commands render templates into runtime prompts through `CommandRegistry` → `resolve_prompt_command()` → `render_command_template()`. The rendered prompt replaces the slash command line before graph or provider execution. Builtins are defined in `loader.py` as `_BUILTIN_COMMANDS` and can be overridden by project-local `commands/**/*.md` files.

--- a/src/voidcode/command/loader.py
+++ b/src/voidcode/command/loader.py
@@ -8,18 +8,75 @@ from .registry import CommandRegistry
 
 _BUILTIN_COMMANDS: tuple[CommandDefinition, ...] = (
     CommandDefinition(
-        name="help",
-        description="Explain the available VoidCode command surfaces and how to use them.",
+        name="commit",
+        description="Analyze staged changes and generate a Conventional Commits message.",
         template=(
-            "Explain the available VoidCode prompt commands, runtime tools, and TUI commands. "
-            "Include any user-provided focus: $ARGUMENTS"
+            "Workflow: inspect current git status and diff, then draft a focused Conventional "
+            "Commits message using the repository's style. Arguments are optional context for "
+            "the intended commit: $ARGUMENTS. Read-only by default: do not create commits, "
+            "amend history, or push unless explicitly instructed. Verification: if there are "
+            "no staged or unstaged changes, report that clearly instead of inventing a message."
         ),
         source="builtin",
     ),
     CommandDefinition(
+        name="explain",
+        description="Explain code, concepts, architecture, or errors with clarity.",
+        template=(
+            "Workflow: read the requested target, error, stack trace, or behavior and explain it "
+            "with concrete examples where helpful. Arguments identify the target to explain: "
+            "$ARGUMENTS. Read-only by default: do not modify any files or run destructive "
+            "commands. Verification: if the target cannot be found or read, say so clearly "
+            "and do not hallucinate file contents."
+        ),
+        source="builtin",
+    ),
+    CommandDefinition(
+        name="fix",
+        description="Fix a code issue or bug with a concrete, verifiable patch.",
+        template=(
+            "Workflow: locate the root cause, make the smallest safe code change, and verify "
+            "the fix. Arguments describe the concrete problem to diagnose: $ARGUMENTS. "
+            "Execution mode: editing is allowed when needed, but preserve runtime/tool/approval "
+            "governance. Verification: run targeted tests, lint, or type checks that cover the "
+            "fix; if verification still fails, report the remaining failure clearly."
+        ),
+        source="builtin",
+    ),
+    CommandDefinition(
+        name="plan",
+        description="Create an implementation plan before writing code.",
+        template=(
+            "Workflow: produce an implementation plan, acceptance criteria, risks, and a "
+            "verification strategy for the requested goal. Arguments describe the planning "
+            "target: $ARGUMENTS. Target agent: product. Read-only by default: do not write "
+            "code or modify files unless explicitly instructed after the plan is accepted."
+        ),
+        source="builtin",
+        agent="product",
+    ),
+    CommandDefinition(
         name="review",
         description="Review the requested code or change set.",
-        template="Review the following target and report findings with severity: $ARGUMENTS",
+        template=(
+            "Workflow: review the requested file, directory, diff, PR, or current changes and "
+            "report findings by severity with actionable fixes. Arguments identify the review "
+            "target; if empty, review the current working tree changes: $ARGUMENTS. Read-only "
+            "by default: do not modify files. Verification: if the target is empty, missing, "
+            "or unreadable, explain that instead of producing a generic review."
+        ),
+        source="builtin",
+    ),
+    CommandDefinition(
+        name="test",
+        description="Generate and/or run tests with verification guidance.",
+        template=(
+            "Workflow: add focused tests, run relevant tests, or explain test failures for the "
+            "requested target. Arguments identify the code or behavior under test: $ARGUMENTS. "
+            "Execution mode: editing test files is allowed when adding coverage, but do not "
+            "delete or weaken existing tests. Verification: prefer targeted test commands before "
+            "broad suites; if no test framework is detected, explain the setup steps."
+        ),
         source="builtin",
     ),
 )

--- a/src/voidcode/provider/protocol.py
+++ b/src/voidcode/provider/protocol.py
@@ -5,7 +5,6 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Literal, Protocol, cast, runtime_checkable
 
-from ..command.resolver import resolve_tool_instruction
 from ..runtime.context_window import normalize_read_file_output
 from ..tools.contracts import ToolCall, ToolDefinition, ToolResult
 from .model_catalog import ProviderModelMetadata
@@ -349,6 +348,8 @@ class StubTurnProvider:
                 raise ValueError("request must contain at least one actionable command")
             last_result = assembled_context.tool_results[-1]
             return ProviderTurnResult(output=_normalize_tool_output(last_result.content))
+
+        from ..command.resolver import resolve_tool_instruction  # lazy to avoid circular import
 
         resolution = resolve_tool_instruction(
             commands[step_index],

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -5577,6 +5577,7 @@ class VoidCodeRuntime:
         prompt, metadata = self._resolve_prompt_command_for_request(
             prompt=request.prompt,
             metadata=metadata,
+            allow_internal_fields=allow_internal_metadata,
         )
 
         return RuntimeRequest(
@@ -5592,6 +5593,7 @@ class VoidCodeRuntime:
         *,
         prompt: str,
         metadata: RuntimeRequestMetadataPayload,
+        allow_internal_fields: bool,
     ) -> tuple[str, RuntimeRequestMetadataPayload]:
         if "command" in metadata or not is_prompt_command(prompt):
             return prompt, metadata
@@ -5613,8 +5615,12 @@ class VoidCodeRuntime:
             "raw_arguments": resolution.invocation.raw_arguments,
             "original_prompt": resolution.invocation.original_prompt,
         }
-        return resolution.invocation.rendered_prompt, cast(
-            RuntimeRequestMetadataPayload, normalized
+        command_agent = resolution.definition.agent
+        if command_agent is not None and "agent" not in normalized:
+            normalized["agent"] = {"preset": command_agent}
+        return resolution.invocation.rendered_prompt, validate_runtime_request_metadata(
+            normalized,
+            allow_internal_fields=allow_internal_fields,
         )
 
     def _metadata_with_delegation_governance(

--- a/tests/unit/command/test_command_registry.py
+++ b/tests/unit/command/test_command_registry.py
@@ -7,11 +7,13 @@ import pytest
 from voidcode.command import (
     CommandDefinition,
     CommandRegistry,
+    builtin_commands,
     load_command_registry,
     load_markdown_commands,
     resolve_prompt_command,
     resolve_tool_instruction,
 )
+from voidcode.command.templating import render_command_template, split_command_arguments
 from voidcode.tools.contracts import ToolDefinition
 
 
@@ -97,3 +99,185 @@ def test_template_rendering_does_not_rewrite_inserted_arguments_or_dollar_litera
         "Cost $100; first=target; second=; missing=; "
         "args=price=$2 literal; literal=$ARGUMENTS_suffix"
     )
+
+
+class TestBuiltinCommandDiscovery:
+    _EXPECTED_NAMES = ("commit", "explain", "fix", "plan", "review", "test")
+
+    def test_exactly_six_expected_builtins_present(self) -> None:
+        commands = builtin_commands()
+        names = tuple(c.name for c in commands)
+        assert names == self._EXPECTED_NAMES, f"expected {self._EXPECTED_NAMES}, got {names}"
+
+    def test_every_builtin_has_source_and_template(self) -> None:
+        for cmd in builtin_commands():
+            assert cmd.source == "builtin", f"/{cmd.name} source should be builtin"
+            assert cmd.template.strip(), f"/{cmd.name} template must be non-empty"
+            assert "$ARGUMENTS" in cmd.template, f"/{cmd.name} template must contain $ARGUMENTS"
+            assert cmd.description.strip(), f"/{cmd.name} description must be non-empty"
+            assert cmd.enabled, f"/{cmd.name} must be enabled by default"
+
+    def test_commands_registered_in_correct_order(self) -> None:
+        ordered = [c.name for c in builtin_commands()]
+        assert ordered == list(self._EXPECTED_NAMES), f"wrong order: {ordered}"
+
+    def test_plan_command_targets_product_agent(self) -> None:
+        plan = [c for c in builtin_commands() if c.name == "plan"][0]
+        assert plan.agent == "product", f"/plan agent should be product, got {plan.agent}"
+
+    def test_commands_are_disabled_when_hidden_flag_set(self) -> None:
+        registry = CommandRegistry(builtin_commands())
+        hidden_cmd = CommandDefinition("hidden_cmd", "Hidden", "echo $ARGUMENTS", hidden=True)
+        registry.register(hidden_cmd)
+        visible = registry.list()
+        assert all(c.name != "hidden_cmd" for c in visible)
+        all_cmds = registry.list(include_hidden=True)
+        assert any(c.name == "hidden_cmd" for c in all_cmds)
+
+
+class TestBuiltinCommandRendering:
+    def test_fix_renders_arguments_correctly(self) -> None:
+        cmd = [c for c in builtin_commands() if c.name == "fix"][0]
+        rendered = render_command_template(
+            cmd.template,
+            raw_arguments="the null pointer bug in utils.py",
+            arguments=split_command_arguments("the null pointer bug in utils.py"),
+        )
+        assert "null pointer bug in utils.py" in rendered
+        assert "root cause" in rendered
+        assert "smallest safe code change" in rendered
+        assert "run targeted tests" in rendered
+        assert "$ARGUMENTS" not in rendered
+
+    def test_explain_renders_read_only_guidance(self) -> None:
+        cmd = [c for c in builtin_commands() if c.name == "explain"][0]
+        rendered = render_command_template(
+            cmd.template,
+            raw_arguments="the auth.py module",
+            arguments=split_command_arguments("the auth.py module"),
+        )
+        assert "auth.py module" in rendered
+        assert "do not modify any files" in rendered
+        assert "do not hallucinate" in rendered
+
+    def test_plan_renders_no_code_guidance(self) -> None:
+        cmd = [c for c in builtin_commands() if c.name == "plan"][0]
+        rendered = render_command_template(
+            cmd.template,
+            raw_arguments="add dark mode support",
+            arguments=split_command_arguments("add dark mode support"),
+        )
+        assert "dark mode support" in rendered
+        assert "do not write code" in rendered
+        assert "Target agent: product" in rendered
+        assert "acceptance criteria" in rendered
+
+    def test_commit_renders_conventional_commits_guidance(self) -> None:
+        cmd = [c for c in builtin_commands() if c.name == "commit"][0]
+        rendered = render_command_template(
+            cmd.template,
+            raw_arguments="ci pipeline fixes",
+            arguments=split_command_arguments("ci pipeline fixes"),
+        )
+        assert "ci pipeline fixes" in rendered
+        assert "Conventional Commits" in rendered
+        assert "do not create commits" in rendered
+        assert "no staged or unstaged changes" in rendered
+
+    def test_test_renders_verification_guidance(self) -> None:
+        cmd = [c for c in builtin_commands() if c.name == "test"][0]
+        rendered = render_command_template(
+            cmd.template,
+            raw_arguments="src/auth.py",
+            arguments=split_command_arguments("src/auth.py"),
+        )
+        assert "src/auth.py" in rendered
+        assert "verification" in rendered.lower()
+        assert "do not delete or weaken existing tests" in rendered
+        assert "no test framework" in rendered
+
+    def test_review_renders_arguments_and_severity(self) -> None:
+        cmd = [c for c in builtin_commands() if c.name == "review"][0]
+        rendered = render_command_template(
+            cmd.template,
+            raw_arguments="src/app.py",
+            arguments=split_command_arguments("src/app.py"),
+        )
+        assert "src/app.py" in rendered
+        assert "severity" in rendered
+        assert "Read-only by default" in rendered
+        assert "unreadable" in rendered
+
+    def test_dollar_placeholder_substitution_uses_shlex_splitting(self) -> None:
+        cmd = [c for c in builtin_commands() if c.name == "fix"][0]
+        args = split_command_arguments('"path with spaces/file.py" --flag')
+        rendered = render_command_template(
+            cmd.template,
+            raw_arguments='"path with spaces/file.py" --flag',
+            arguments=args,
+        )
+        assert "path with spaces/file.py" in rendered
+        assert args == ("path with spaces/file.py", "--flag")
+
+
+class TestBuiltinCommandProjectOverride:
+    def test_project_fix_overrides_builtin_fix(self, tmp_path: Path) -> None:
+        commands_dir = tmp_path / "commands"
+        commands_dir.mkdir()
+        (commands_dir / "fix.md").write_text(
+            "---\n"
+            "description: Custom project fix command\n"
+            "agent: worker\n"
+            "---\n"
+            "Apply a targeted fix for $1 and verify with tests\n",
+            encoding="utf-8",
+        )
+
+        registry = load_command_registry(workspace=tmp_path)
+        cmd = registry.get("fix")
+        assert cmd is not None
+        assert cmd.source == "project"
+        assert cmd.agent == "worker"
+        resolution = resolve_prompt_command("/fix the login timeout bug", registry)
+        assert resolution is not None
+        assert "targeted fix" in resolution.invocation.rendered_prompt
+        assert "verify with tests" in resolution.invocation.rendered_prompt
+
+    def test_project_override_preserves_other_builtins(self, tmp_path: Path) -> None:
+        commands_dir = tmp_path / "commands"
+        commands_dir.mkdir()
+        (commands_dir / "fix.md").write_text(
+            "---\ndescription: Custom fix\n---\nFix $ARGUMENTS\n",
+            encoding="utf-8",
+        )
+
+        registry = load_command_registry(workspace=tmp_path)
+        fix_cmd = registry.get("fix")
+        assert fix_cmd is not None
+        assert fix_cmd.source == "project"
+        for name in ("review", "explain", "plan", "test", "commit"):
+            cmd = registry.get(name)
+            assert cmd is not None, f"{name} should still be registered"
+            assert cmd.source == "builtin", (
+                f"/{name} source should still be builtin, got {cmd.source}"
+            )
+
+    def test_project_disabled_command_not_listed(self, tmp_path: Path) -> None:
+        commands_dir = tmp_path / "commands"
+        commands_dir.mkdir()
+        (commands_dir / "fix.md").write_text(
+            "---\ndescription: Disabled fix\nenabled: false\n---\nFix $ARGUMENTS\n",
+            encoding="utf-8",
+        )
+
+        registry = load_command_registry(workspace=tmp_path)
+        cmd = registry.get("fix")
+        assert cmd is not None
+        assert not cmd.enabled
+        visible = registry.list()
+        assert not any(c.name == "fix" for c in visible)
+
+    def test_nonexistent_slash_command_still_raises(self, tmp_path: Path) -> None:
+        registry = load_command_registry(workspace=tmp_path)
+        with pytest.raises(ValueError, match="unknown command"):
+            _ = resolve_prompt_command("/nonexistent target", registry)

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -2716,7 +2716,7 @@ def test_commands_list_outputs_discovered_project_commands_json() -> None:
     command_names = {command["name"] for command in payload["commands"]}
     assert result.returncode == 0
     assert payload["workspace"] == str(workspace)
-    assert {"help", "review", "explain"}.issubset(command_names)
+    assert {"commit", "explain", "fix", "plan", "review", "test"}.issubset(command_names)
 
 
 def test_commands_show_outputs_project_command_json() -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -11625,6 +11625,46 @@ def test_runtime_request_metadata_agent_override_persists_and_restores_agent_con
     )
 
 
+def test_runtime_prompt_command_agent_metadata_selects_agent_preset(tmp_path: Path) -> None:
+    created_providers: list[_ScriptedTurnProvider] = []
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(ProviderTurnResult(output="plan complete"),),
+                created_providers=created_providers,
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="/plan add command presets"))
+
+    assert response.session.status == "completed"
+    assert response.output == "plan complete"
+    assert response.session.metadata["command"] == {
+        "name": "plan",
+        "source": "builtin",
+        "arguments": ["add", "command", "presets"],
+        "raw_arguments": "add command presets",
+        "original_prompt": "/plan add command presets",
+    }
+    assert response.session.metadata["agent"] == {"preset": "product"}
+    assert created_providers[-1].requests[0].agent_preset == {
+        "preset": "product",
+        "prompt_profile": "product",
+        "prompt_materialization": _prompt_materialization_payload("product"),
+        "model": "opencode/gpt-5.4",
+        "execution_engine": "provider",
+    }
+    runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
+    assert runtime_config["agent"] == created_providers[-1].requests[0].agent_preset
+
+
 def test_runtime_partial_request_agent_override_preserves_inherited_agent_fields(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- Adds the exact six builtin prompt commands requested in #390: `/review`, `/fix`, `/explain`, `/plan`, `/test`, and `/commit`.
- Encodes argument behavior, read-only/editing defaults, target agent metadata, and verification guidance in command templates that render into runtime prompts.
- Documents the minimal command set and expands command registry tests for discovery, rendering, argument substitution, and project-local override behavior.

## Verification
- `uv run pytest tests/unit/command/ tests/unit/runtime/test_command_resolution.py -q`
- `uv run voidcode commands list --workspace .`
- `uv run voidcode commands show /review --workspace .`
- `mise run lint`
- `mise run typecheck`
- `mise run test:fast` (1283 passed; existing background-task failure log is emitted inside a passing test lane)
- LSP diagnostics clean for modified Python files; markdown LSP unavailable in this environment

Closes #390