### PR TITLE
fix(agent): reduce leader QA false confidence

### DIFF
--- a/src/voidcode/agent/leader/base.txt
+++ b/src/voidcode/agent/leader/base.txt
@@ -88,6 +88,8 @@ No evidence means not complete.
 - Run diagnostics or typecheck for changed code when available.
 - Run build or the nearest executable validation for non-trivial changes.
 - For user-visible or command-visible behavior, exercise it when practical instead of saying "should work".
+- When you create a runnable program or script, run the exact command you intend to give the user whenever the environment permits it. If that command fails because of working directory, assets, display, network, credentials, or another runtime precondition, either fix the project or report the command as unverified/failed with the concrete error.
+- Distinguish compile/build checks from runtime behavior checks. A successful build, lint, unit test, or artifact validation does not prove a graphical app, server, CLI, or script actually runs correctly.
 - When reporting completion, distinguish between verified facts and remaining risks.
 </verification>
 

--- a/src/voidcode/agent/leader/base.txt
+++ b/src/voidcode/agent/leader/base.txt
@@ -88,8 +88,7 @@ No evidence means not complete.
 - Run diagnostics or typecheck for changed code when available.
 - Run build or the nearest executable validation for non-trivial changes.
 - For user-visible or command-visible behavior, exercise it when practical instead of saying "should work".
-- When you create a runnable program or script, run the exact command you intend to give the user whenever the environment permits it. If that command fails because of working directory, assets, display, network, credentials, or another runtime precondition, either fix the project or report the command as unverified/failed with the concrete error.
-- Distinguish compile/build checks from runtime behavior checks. A successful build, lint, unit test, or artifact validation does not prove a graphical app, server, CLI, or script actually runs correctly.
+- Match verification to the claim: do not infer broader correctness from adjacent checks, and report any unexercised behavior as a remaining risk instead of verified fact.
 - When reporting completion, distinguish between verified facts and remaining risks.
 </verification>
 

--- a/src/voidcode/tools/todo_write.py
+++ b/src/voidcode/tools/todo_write.py
@@ -75,7 +75,7 @@ class TodoWriteTool:
         input_schema={
             "todos": {"type": "array", "description": "Array of {content, status, priority}"},
         },
-        read_only=False,
+        read_only=True,
     )
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:

--- a/tests/unit/tools/test_todo_write_tool.py
+++ b/tests/unit/tools/test_todo_write_tool.py
@@ -8,6 +8,10 @@ import pytest
 from voidcode.tools import TodoWriteTool, ToolCall
 
 
+def test_todo_write_is_read_only_session_state_tool() -> None:
+    assert TodoWriteTool.definition.read_only is True
+
+
 def test_todo_write_returns_session_metadata_without_workspace_artifact(tmp_path: Path) -> None:
     tool = TodoWriteTool()
     result = tool.invoke(


### PR DESCRIPTION
## Summary
- Treat `todo_write` as read-only session-state bookkeeping so approval-gated runs do not block on hidden todo updates.
- Tighten leader verification guidance to require exercising runnable outputs when practical and to separate build/artifact checks from runtime behavior claims.

## QA context
- Follow-up from the Vulkan triangle leader QA run.
- Does not address #357; shell external path classification is intentionally left to the existing #357 work.

## Verification
- `uv run pytest tests/unit/tools/test_todo_write_tool.py tests/unit/runtime/test_tool_provider.py -q`
- `uv run ty check src/voidcode/tools/todo_write.py tests/unit/tools/test_todo_write_tool.py`