### PR TITLE
Fix LiteLLM SSL config and bound tool feedback

### DIFF
--- a/docs/session-continuity-memory-design.md
+++ b/docs/session-continuity-memory-design.md
@@ -89,7 +89,7 @@ Session Continuity Memory 必须继续由 **runtime** 拥有。
 当前行为可概括为：
 
 1. 当前 runtime 的 provider context-window preparation path 会接收 prompt 与全部 tool results。
-2. 它根据 `ContextWindowPolicy.max_tool_results` 只保留最后 N 个 tool results。
+2. 它根据 `ContextWindowPolicy.max_tool_results`、总 token budget 与默认/按工具 token cap 收缩 provider-facing tool feedback。
 3. 如果发生截断，则 `RuntimeContextWindow.compacted == True`。
 4. `runtime/service.py` 在图执行前发出 `runtime.memory_refreshed`。
 

--- a/src/voidcode/provider/README.md
+++ b/src/voidcode/provider/README.md
@@ -160,9 +160,11 @@ runtime 仍统一注入工具 schema、审批与会话状态。
 
 - 使用 `providers.custom.<provider_name>` 定义任意自定义 provider（名称必须不包含 `/`）。
 - `providers.custom.<provider_name>` 不能与内置 provider 名称冲突（`openai` / `anthropic` / `google` / `copilot` / `litellm` / `opencode`）。
-- 每个自定义 provider 都复用 LiteLLM 后端调用路径，支持与 `providers.litellm` 相同的字段：
+- 对用户可见配置，给真实后端起一个明确名称放在 `providers.custom` 下；LiteLLM 只是内部兼容调用层，不作为推荐的用户配置入口。
+- 每个自定义 provider 都复用 OpenAI-compatible 后端调用路径，支持：
   - `api_key` / `api_key_env_var`
   - `base_url`
+  - `ssl_verify`（可选；仅在确需连接自签名或私有 CA HTTPS 端点时显式设为 `false`）
   - `auth_scheme` + `auth_header`
   - `model_map`
 - 在模型配置中使用 `model: "<provider_name>/<model_alias_or_raw_model>"` 即可路由到对应自定义 provider。
@@ -192,17 +194,12 @@ runtime 仍统一注入工具 schema、审批与会话状态。
 }
 ```
 
-### LiteLLM 开箱即用
+### OpenAI-compatible 后端与证书校验
 
-- 默认基地址支持 `LITELLM_BASE_URL` / `LITELLM_PROXY_URL`，未配置时回退到 `http://127.0.0.1:4000`。
-- 通过 `model: "litellm/<model>"` 可直接走 LiteLLM OpenAI-Compatible `/v1/chat/completions`。
-- 支持 `providers.litellm.auth_scheme`（`bearer` / `token` / `none`）和 `auth_header` 自定义认证头。
-- 支持 `providers.litellm.model_map` 做别名映射（例如将 `gpt-4o` 映射到 `openrouter/openai/gpt-4o`）。
-
-### `providers.litellm` vs `providers.custom`
-
-- `providers.litellm`：用于配置默认 LiteLLM 兼容后端（provider 名称固定为 `litellm`）。
-- `providers.custom`：用于定义任意自定义 provider 名称（如 `llama-local`、`openrouter-team-a`），每个条目都复用 LiteLLM-compatible 配置结构。
+- 对具名 OpenAI-compatible 后端，使用 `providers.custom.<name>`；例如本地代理、OpenRouter team gateway、内部模型网关等。
+- `ssl_verify: false` 是 HTTPS 证书校验问题的显式逃生口；优先使用 `http://` 本地代理 `base_url` 或修复 CA 信任链，只有在受控环境中才禁用校验。
+- 对内置具体 provider（例如 `opencode-go`），也可以在对应 provider block 上设置 `ssl_verify: false`。
+- 当前该字段作用于实际模型调用路径；模型列表刷新仍走独立 discovery HTTP 路径，不应依赖它绕过 discovery 证书校验。
 
 ### 可用模型列表动态刷新（端点/API 驱动）
 
@@ -210,14 +207,14 @@ runtime 仍统一注入工具 schema、审批与会话状态。
   - `voidcode provider models <provider>`：读取当前缓存
   - `voidcode provider models <provider> --refresh`：主动请求 provider `/v1/models` 刷新
 - provider-specific 端点策略（与 opencode 的 provider 分层思路对齐）：
-  - `openai` / `litellm` / 自定义 OpenAI-compatible：`<base>/v1/models`
+  - `openai` / 自定义 OpenAI-compatible：`<base>/v1/models`
   - `anthropic`：`<base>/v1/models`，并带 `anthropic-version` + `x-api-key`
   - `google`：`<base>/v1beta/models?key=...`（读取 `models[].name`）
 - 刷新结果会融合三类来源并去重：
   1. `model_map` 的别名键（便于用户直接选别名）
   2. provider 端点返回的真实模型 ID
   3. `model_map` 的映射目标值（便于调试真实路由）
-- 对于 OpenAI/LiteLLM 默认支持 endpoint 探测；自定义 provider 若配置了 `base_url` 也会走同样的 OpenAI-compatible `/v1/models` 探测路径。
+- 对于 OpenAI 默认支持 endpoint 探测；自定义 provider 若配置了 `base_url` 也会走同样的 OpenAI-compatible `/v1/models` 探测路径。
 
 ## 流式传输 (Streaming)
 

--- a/src/voidcode/provider/config.py
+++ b/src/voidcode/provider/config.py
@@ -185,6 +185,7 @@ class _LiteLLMProviderConfigPayload(_ProviderPayloadModel):
     discovery_base_url: BoundaryOptionalString = None
     auth_header: BoundaryOptionalString = None
     auth_scheme: BoundaryOptionalString = None
+    ssl_verify: BoundaryOptionalBool = None
     timeout_seconds: BoundaryOptionalTimeout = None
     model_map: BoundaryStringMapping = Field(default_factory=dict)
     transient_retry: _ProviderTransientRetryConfigPayload | None = None
@@ -195,6 +196,7 @@ class _SimplifiedProviderConfigPayload(_ProviderPayloadModel):
     api_key_env_var: BoundaryOptionalString = None
     base_url: BoundaryOptionalString = None
     discovery_base_url: BoundaryOptionalString = None
+    ssl_verify: BoundaryOptionalBool = None
     timeout_seconds: BoundaryOptionalTimeout = None
     model_map: BoundaryStringMapping = Field(default_factory=dict)
     transient_retry: _ProviderTransientRetryConfigPayload | None = None
@@ -261,6 +263,7 @@ class SimplifiedProviderConfig:
     api_key_env_var: str | None = None
     base_url: str | None = None
     discovery_base_url: str | None = None
+    ssl_verify: bool | None = None
     timeout_seconds: float | None = None
     model_map: dict[str, str] = field(default_factory=dict)
     transient_retry: ProviderTransientRetryConfig | None = None
@@ -418,6 +421,7 @@ def simplified_config_to_litellm(
         api_key=config.api_key,
         base_url=config.base_url if config.base_url else default_base_url,
         discovery_base_url=discovery_base_url,
+        ssl_verify=config.ssl_verify,
         timeout_seconds=config.timeout_seconds,
         model_map=dict(config.model_map) if config.model_map else default_model_map,
     )
@@ -521,6 +525,7 @@ class LiteLLMProviderConfig:
     discovery_base_url: str | None = None
     auth_header: str | None = None
     auth_scheme: LiteLLMAuthScheme = "bearer"
+    ssl_verify: bool | None = None
     timeout_seconds: float | None = None
     model_map: dict[str, str] = field(default_factory=dict)
     transient_retry: ProviderTransientRetryConfig | None = None
@@ -804,6 +809,7 @@ def _merge_litellm_provider_config(
         auth_header=_prefer_primary(primary.auth_header, fallback.auth_header),
         auth_scheme=(primary.auth_scheme if primary.auth_scheme_explicit else fallback.auth_scheme),
         auth_scheme_explicit=primary.auth_scheme_explicit or fallback.auth_scheme_explicit,
+        ssl_verify=_prefer_primary(primary.ssl_verify, fallback.ssl_verify),
         timeout_seconds=_prefer_primary(primary.timeout_seconds, fallback.timeout_seconds),
         model_map={**fallback.model_map, **primary.model_map},
         transient_retry=_prefer_primary(primary.transient_retry, fallback.transient_retry),
@@ -823,6 +829,7 @@ def _merge_simplified_provider_config(
         api_key_env_var=_prefer_primary(primary.api_key_env_var, fallback.api_key_env_var),
         base_url=_prefer_primary(primary.base_url, fallback.base_url),
         discovery_base_url=_prefer_primary(primary.discovery_base_url, fallback.discovery_base_url),
+        ssl_verify=_prefer_primary(primary.ssl_verify, fallback.ssl_verify),
         timeout_seconds=_prefer_primary(primary.timeout_seconds, fallback.timeout_seconds),
         model_map={**fallback.model_map, **primary.model_map},
         transient_retry=_prefer_primary(primary.transient_retry, fallback.transient_retry),
@@ -1496,6 +1503,7 @@ def _parse_litellm_provider_config(
         auth_header=payload.auth_header,
         auth_scheme=auth_scheme,
         auth_scheme_explicit=raw_auth_scheme is not None,
+        ssl_verify=payload.ssl_verify,
         timeout_seconds=payload.timeout_seconds,
         model_map=payload.model_map,
         transient_retry=_parse_transient_retry_config(
@@ -1541,6 +1549,7 @@ def _parse_simplified_provider_config(
         api_key_env_var=api_key_env,
         base_url=payload.base_url,
         discovery_base_url=payload.discovery_base_url,
+        ssl_verify=payload.ssl_verify,
         timeout_seconds=payload.timeout_seconds,
         model_map=payload.model_map,
         transient_retry=_parse_transient_retry_config(
@@ -1737,6 +1746,8 @@ def _serialize_litellm_provider_config(
     if provider.auth_header is not None:
         payload["auth_header"] = provider.auth_header
     payload["auth_scheme"] = provider.auth_scheme
+    if provider.ssl_verify is not None:
+        payload["ssl_verify"] = provider.ssl_verify
     if provider.timeout_seconds is not None:
         payload["timeout_seconds"] = provider.timeout_seconds
     if provider.model_map:
@@ -1760,6 +1771,8 @@ def _serialize_simplified_provider_config(
         payload["base_url"] = provider.base_url
     if provider.discovery_base_url is not None:
         payload["discovery_base_url"] = provider.discovery_base_url
+    if provider.ssl_verify is not None:
+        payload["ssl_verify"] = provider.ssl_verify
     if provider.timeout_seconds is not None:
         payload["timeout_seconds"] = provider.timeout_seconds
     if provider.model_map:

--- a/src/voidcode/provider/litellm_backend.py
+++ b/src/voidcode/provider/litellm_backend.py
@@ -508,17 +508,20 @@ class LiteLLMBackendSingleAgentProvider:
 
     @contextmanager
     def _litellm_ssl_verify_context(self) -> Iterator[None]:
-        if self.config is None or self.config.ssl_verify is None or litellm_module is None:
+        if litellm_module is None:
             yield
             return
         with _LITELLM_SSL_VERIFY_LOCK:
             module_any = cast(Any, litellm_module)
             previous = getattr(module_any, "ssl_verify", True)
-            module_any.ssl_verify = self.config.ssl_verify
+            configured_ssl_verify = self.config.ssl_verify if self.config is not None else None
+            if configured_ssl_verify is not None:
+                module_any.ssl_verify = configured_ssl_verify
             try:
                 yield
             finally:
-                module_any.ssl_verify = previous
+                if configured_ssl_verify is not None:
+                    module_any.ssl_verify = previous
 
     @staticmethod
     def _extract_first_tool_call(message: dict[str, object]) -> ToolCall | None:

--- a/src/voidcode/provider/litellm_backend.py
+++ b/src/voidcode/provider/litellm_backend.py
@@ -4,7 +4,9 @@ import json
 import logging
 import re
 from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
 from dataclasses import dataclass, field
+from threading import Lock
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 if TYPE_CHECKING:
@@ -49,6 +51,7 @@ _SYNTHETIC_TOOL_FEEDBACK_PREFIX = "Completed tool calls for current request:"
 _CONTINUITY_SUMMARY_PREFIX = "Runtime continuity summary:"
 
 logger = logging.getLogger(__name__)
+_LITELLM_SSL_VERIFY_LOCK = Lock()
 
 
 def _usage_int(raw: object) -> int:
@@ -503,6 +506,20 @@ class LiteLLMBackendSingleAgentProvider:
             return {"extra_headers": {self.config.auth_header: f"Bearer {self.config.api_key}"}}
         return {"api_key": self.config.api_key}
 
+    @contextmanager
+    def _litellm_ssl_verify_context(self) -> Iterator[None]:
+        if self.config is None or self.config.ssl_verify is None or litellm_module is None:
+            yield
+            return
+        with _LITELLM_SSL_VERIFY_LOCK:
+            module_any = cast(Any, litellm_module)
+            previous = getattr(module_any, "ssl_verify", True)
+            module_any.ssl_verify = self.config.ssl_verify
+            try:
+                yield
+            finally:
+                module_any.ssl_verify = previous
+
     @staticmethod
     def _extract_first_tool_call(message: dict[str, object]) -> ToolCall | None:
         raw_tool_calls = message.get("tool_calls")
@@ -606,7 +623,8 @@ class LiteLLMBackendSingleAgentProvider:
             payload["tool_choice"] = "auto"
 
         try:
-            response = self._call_litellm_completion(cast(dict[str, Any], payload))
+            with self._litellm_ssl_verify_context():
+                response = self._call_litellm_completion(cast(dict[str, Any], payload))
             response_payload = cast(dict[str, object], response.model_dump())
             usage = _extract_token_usage(response_payload)
             raw_choices = response_payload.get("choices")
@@ -660,98 +678,99 @@ class LiteLLMBackendSingleAgentProvider:
             payload["tool_choice"] = "auto"
 
         try:
-            stream = cast(
-                Iterator[Any], self._call_litellm_completion(cast(dict[str, Any], payload))
-            )
-            streamed_tool_calls: dict[int, _StreamedToolCallAccumulator] = {}
-            latest_usage: ProviderTokenUsage | None = None
-            for chunk in stream:
-                if request.abort_signal is not None and request.abort_signal.cancelled:
-                    yield ProviderStreamEvent(
-                        kind="error",
-                        channel="error",
-                        error="provider stream cancelled",
-                        error_kind="cancelled",
-                    )
-                    yield ProviderStreamEvent(kind="done", done_reason="cancelled")
-                    return
-                chunk_payload = cast(dict[str, object], chunk.model_dump())
-                latest_usage = _extract_token_usage(chunk_payload) or latest_usage
-                raw_choices = chunk_payload.get("choices")
-                if not isinstance(raw_choices, list) or not raw_choices:
-                    continue
-                choices = cast(list[object], raw_choices)
-                first_choice_obj = choices[0]
-                if not isinstance(first_choice_obj, dict):
-                    continue
-                first_choice = cast(dict[str, object], first_choice_obj)
-                delta_obj = first_choice.get("delta")
-                if isinstance(delta_obj, dict):
-                    delta = cast(dict[str, object], delta_obj)
-                    reasoning_obj = delta.get("reasoning_content") or delta.get("reasoning")
-                    if isinstance(reasoning_obj, str) and reasoning_obj:
+            with self._litellm_ssl_verify_context():
+                stream = cast(
+                    Iterator[Any], self._call_litellm_completion(cast(dict[str, Any], payload))
+                )
+                streamed_tool_calls: dict[int, _StreamedToolCallAccumulator] = {}
+                latest_usage: ProviderTokenUsage | None = None
+                for chunk in stream:
+                    if request.abort_signal is not None and request.abort_signal.cancelled:
                         yield ProviderStreamEvent(
-                            kind="delta",
-                            channel="reasoning",
-                            text=reasoning_obj,
-                            metadata={"source": "delta.reasoning"},
+                            kind="error",
+                            channel="error",
+                            error="provider stream cancelled",
+                            error_kind="cancelled",
                         )
-                    raw_thinking_blocks = delta.get("thinking_blocks")
-                    if isinstance(raw_thinking_blocks, list):
-                        thinking_blocks = cast(list[object], raw_thinking_blocks)
-                        for block_obj in thinking_blocks:
-                            if not isinstance(block_obj, dict):
-                                continue
-                            block = cast(dict[str, object], block_obj)
-                            if block.get("type") != "thinking":
-                                continue
-                            thinking_text = block.get("thinking")
-                            if isinstance(thinking_text, str) and thinking_text:
-                                yield ProviderStreamEvent(
-                                    kind="delta",
-                                    channel="reasoning",
-                                    text=thinking_text,
-                                    metadata={"source": "delta.thinking_blocks"},
+                        yield ProviderStreamEvent(kind="done", done_reason="cancelled")
+                        return
+                    chunk_payload = cast(dict[str, object], chunk.model_dump())
+                    latest_usage = _extract_token_usage(chunk_payload) or latest_usage
+                    raw_choices = chunk_payload.get("choices")
+                    if not isinstance(raw_choices, list) or not raw_choices:
+                        continue
+                    choices = cast(list[object], raw_choices)
+                    first_choice_obj = choices[0]
+                    if not isinstance(first_choice_obj, dict):
+                        continue
+                    first_choice = cast(dict[str, object], first_choice_obj)
+                    delta_obj = first_choice.get("delta")
+                    if isinstance(delta_obj, dict):
+                        delta = cast(dict[str, object], delta_obj)
+                        reasoning_obj = delta.get("reasoning_content") or delta.get("reasoning")
+                        if isinstance(reasoning_obj, str) and reasoning_obj:
+                            yield ProviderStreamEvent(
+                                kind="delta",
+                                channel="reasoning",
+                                text=reasoning_obj,
+                                metadata={"source": "delta.reasoning"},
+                            )
+                        raw_thinking_blocks = delta.get("thinking_blocks")
+                        if isinstance(raw_thinking_blocks, list):
+                            thinking_blocks = cast(list[object], raw_thinking_blocks)
+                            for block_obj in thinking_blocks:
+                                if not isinstance(block_obj, dict):
+                                    continue
+                                block = cast(dict[str, object], block_obj)
+                                if block.get("type") != "thinking":
+                                    continue
+                                thinking_text = block.get("thinking")
+                                if isinstance(thinking_text, str) and thinking_text:
+                                    yield ProviderStreamEvent(
+                                        kind="delta",
+                                        channel="reasoning",
+                                        text=thinking_text,
+                                        metadata={"source": "delta.thinking_blocks"},
+                                    )
+                        text_obj = delta.get("content")
+                        if isinstance(text_obj, str) and text_obj:
+                            yield ProviderStreamEvent(kind="delta", channel="text", text=text_obj)
+                        raw_tool_calls = delta.get("tool_calls")
+                        if isinstance(raw_tool_calls, list):
+                            tool_calls = cast(list[object], raw_tool_calls)
+                            for tool_call_obj in tool_calls:
+                                if not isinstance(tool_call_obj, dict):
+                                    continue
+                                tool_call = cast(dict[str, object], tool_call_obj)
+                                index_obj = tool_call.get("index")
+                                index = index_obj if isinstance(index_obj, int) else 0
+                                accumulator = streamed_tool_calls.get(
+                                    index,
+                                    _StreamedToolCallAccumulator(),
                                 )
-                    text_obj = delta.get("content")
-                    if isinstance(text_obj, str) and text_obj:
-                        yield ProviderStreamEvent(kind="delta", channel="text", text=text_obj)
-                    raw_tool_calls = delta.get("tool_calls")
-                    if isinstance(raw_tool_calls, list):
-                        tool_calls = cast(list[object], raw_tool_calls)
-                        for tool_call_obj in tool_calls:
-                            if not isinstance(tool_call_obj, dict):
-                                continue
-                            tool_call = cast(dict[str, object], tool_call_obj)
-                            index_obj = tool_call.get("index")
-                            index = index_obj if isinstance(index_obj, int) else 0
-                            accumulator = streamed_tool_calls.get(
-                                index,
-                                _StreamedToolCallAccumulator(),
-                            )
-                            tool_call_id_obj = tool_call.get("id")
-                            tool_call_id = accumulator.tool_call_id
-                            if isinstance(tool_call_id_obj, str) and tool_call_id_obj:
-                                tool_call_id = tool_call_id_obj
-                            function_obj = tool_call.get("function")
-                            tool_name = accumulator.tool_name
-                            arguments = accumulator.arguments
-                            if isinstance(function_obj, dict):
-                                function = cast(dict[str, object], function_obj)
-                                name_obj = function.get("name")
-                                if isinstance(name_obj, str) and name_obj:
-                                    tool_name = name_obj
-                                arguments_obj = function.get("arguments")
-                                if isinstance(arguments_obj, str) and arguments_obj:
-                                    arguments += arguments_obj
-                            streamed_tool_calls[index] = _StreamedToolCallAccumulator(
-                                tool_call_id=tool_call_id,
-                                tool_name=tool_name,
-                                arguments=arguments,
-                            )
-                finish_reason = first_choice.get("finish_reason")
-                if isinstance(finish_reason, str) and finish_reason:
-                    continue
+                                tool_call_id_obj = tool_call.get("id")
+                                tool_call_id = accumulator.tool_call_id
+                                if isinstance(tool_call_id_obj, str) and tool_call_id_obj:
+                                    tool_call_id = tool_call_id_obj
+                                function_obj = tool_call.get("function")
+                                tool_name = accumulator.tool_name
+                                arguments = accumulator.arguments
+                                if isinstance(function_obj, dict):
+                                    function = cast(dict[str, object], function_obj)
+                                    name_obj = function.get("name")
+                                    if isinstance(name_obj, str) and name_obj:
+                                        tool_name = name_obj
+                                    arguments_obj = function.get("arguments")
+                                    if isinstance(arguments_obj, str) and arguments_obj:
+                                        arguments += arguments_obj
+                                streamed_tool_calls[index] = _StreamedToolCallAccumulator(
+                                    tool_call_id=tool_call_id,
+                                    tool_name=tool_name,
+                                    arguments=arguments,
+                                )
+                    finish_reason = first_choice.get("finish_reason")
+                    if isinstance(finish_reason, str) and finish_reason:
+                        continue
         except Exception as exc:
             raise self._map_exception(
                 exc,

--- a/src/voidcode/provider/registry.py
+++ b/src/voidcode/provider/registry.py
@@ -293,6 +293,7 @@ class ModelProviderRegistry:
                     ),
                     auth_header=provider.config.auth_header,
                     auth_scheme=provider.config.auth_scheme,
+                    ssl_verify=provider.config.ssl_verify,
                     timeout_seconds=provider.config.timeout_seconds,
                     model_map=dict(provider.config.model_map),
                 )

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -276,8 +276,8 @@ class RuntimeContextWindowConfig:
     reserved_output_tokens: int | None = None
     minimum_retained_tool_results: int = 1
     recent_tool_result_count: int = 1
-    recent_tool_result_tokens: int | None = None
-    default_tool_result_tokens: int | None = None
+    recent_tool_result_tokens: int | None = 3_000
+    default_tool_result_tokens: int | None = 1_500
     per_tool_result_tokens: Mapping[str, int] = field(
         default_factory=_empty_context_window_tool_limits
     )
@@ -1245,8 +1245,8 @@ class _RuntimeContextWindowValidationModel(BaseModel):
     reserved_output_tokens: int | None = None
     minimum_retained_tool_results: int = 1
     recent_tool_result_count: int = 1
-    recent_tool_result_tokens: int | None = None
-    default_tool_result_tokens: int | None = None
+    recent_tool_result_tokens: int | None = 3_000
+    default_tool_result_tokens: int | None = 1_500
     per_tool_result_tokens: dict[str, int] = Field(default_factory=dict)
     tokenizer_model: str | None = None
     continuity_preview_items: int = 3

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -142,8 +142,8 @@ class ContextWindowPolicy:
     reserved_output_tokens: int | None = None
     minimum_retained_tool_results: int = 1
     recent_tool_result_count: int = 1
-    recent_tool_result_tokens: int | None = None
-    default_tool_result_tokens: int | None = None
+    recent_tool_result_tokens: int | None = 3_000
+    default_tool_result_tokens: int | None = 1_500
     per_tool_result_tokens: Mapping[str, int] = field(default_factory=_empty_tool_limits)
     tokenizer_model: str | None = None
     continuity_preview_items: int = 3

--- a/tests/unit/provider/test_provider_adapters.py
+++ b/tests/unit/provider/test_provider_adapters.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -36,6 +37,7 @@ from voidcode.provider.protocol import (
     ProviderStreamEvent,
     ProviderTokenUsage,
     ProviderTurnRequest,
+    ProviderTurnResult,
     StreamableTurnProvider,
     TurnProvider,
 )
@@ -2485,6 +2487,92 @@ def test_litellm_backend_omits_ssl_verify_when_not_configured(
     assert isinstance(payload_obj, dict)
     payload = cast(dict[str, object], payload_obj)
     assert "ssl_verify" not in payload
+
+
+def test_litellm_backend_serializes_default_ssl_verify_with_global_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import voidcode.provider.litellm_backend as backend_module
+
+    explicit_provider = LiteLLMBackendSingleAgentProvider(
+        name="explicit-gateway",
+        config=LiteLLMProviderConfig(
+            api_key="explicit-key",
+            base_url="https://explicit.example.test",
+            ssl_verify=False,
+        ),
+    )
+    default_provider = LiteLLMBackendSingleAgentProvider(
+        name="default-gateway",
+        config=LiteLLMProviderConfig(
+            api_key="default-key",
+            base_url="https://default.example.test",
+        ),
+    )
+    entered_explicit_call = threading.Event()
+    release_explicit_call = threading.Event()
+    explicit_done = threading.Event()
+    observations: list[tuple[str, object]] = []
+    thread_errors: list[BaseException] = []
+
+    _patch_litellm_completion(
+        monkeypatch,
+        mode="completion",
+        completion_content="ok",
+    )
+    monkeypatch.setattr(backend_module.litellm_module, "ssl_verify", True, raising=False)
+
+    def _blocking_completion(*args: object, **kwargs: object) -> object:
+        _ = args, kwargs
+        api_base = kwargs.get("api_base")
+        if api_base == "https://explicit.example.test/v1":
+            observations.append(("explicit", backend_module.litellm_module.ssl_verify))
+            entered_explicit_call.set()
+            assert release_explicit_call.wait(timeout=2)
+        else:
+            observations.append(("default", backend_module.litellm_module.ssl_verify))
+            explicit_done.set()
+        return _StubCompletionResponse(content="ok")
+
+    monkeypatch.setattr(backend_module.litellm_module, "completion", _blocking_completion)
+
+    def _run_explicit_provider() -> None:
+        try:
+            result = explicit_provider.propose_turn(
+                _build_turn_request(model_name="explicit-gateway")
+            )
+            assert result.output == "ok"
+        except BaseException as exc:  # pragma: no cover - re-raised in main test thread
+            thread_errors.append(exc)
+            raise
+
+    explicit_thread = threading.Thread(target=_run_explicit_provider)
+    explicit_thread.start()
+    assert entered_explicit_call.wait(timeout=2)
+
+    default_result_holder: dict[str, object] = {}
+
+    def _run_default_provider() -> None:
+        try:
+            default_result_holder["result"] = default_provider.propose_turn(
+                _build_turn_request(model_name="default-gateway")
+            )
+        except BaseException as exc:  # pragma: no cover - re-raised in main test thread
+            thread_errors.append(exc)
+            raise
+
+    default_thread = threading.Thread(target=_run_default_provider)
+    default_thread.start()
+    assert not explicit_done.wait(timeout=0.05)
+    release_explicit_call.set()
+    explicit_thread.join(timeout=2)
+    default_thread.join(timeout=2)
+
+    assert thread_errors == []
+    default_result = cast(ProviderTurnResult, default_result_holder["result"])
+    assert default_result.output == "ok"
+    assert observations == [("explicit", False), ("default", True)]
+    assert backend_module.litellm_module.ssl_verify is True
 
 
 def test_litellm_backend_stream_turn_forwards_ssl_verify(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/provider/test_provider_adapters.py
+++ b/tests/unit/provider/test_provider_adapters.py
@@ -2423,6 +2423,108 @@ def test_glm_provider_does_not_append_v1_to_base_url(monkeypatch: pytest.MonkeyP
     assert payload["api_base"] == "https://open.bigmodel.cn/api/paas/v4"
 
 
+def test_litellm_backend_propose_turn_forwards_ssl_verify(monkeypatch: pytest.MonkeyPatch) -> None:
+    import voidcode.provider.litellm_backend as backend_module
+
+    provider = LiteLLMBackendSingleAgentProvider(
+        name="litellm",
+        config=LiteLLMProviderConfig(
+            api_key="litellm-key",
+            base_url="https://litellm.local",
+            ssl_verify=False,
+        ),
+    )
+
+    _patch_litellm_completion(
+        monkeypatch,
+        mode="completion",
+        completion_content="ok",
+    )
+    monkeypatch.setattr(backend_module.litellm_module, "ssl_verify", True, raising=False)
+
+    original_completion = backend_module.litellm_module.completion
+
+    def _completion_with_ssl_capture(*args: object, **kwargs: object) -> object:
+        _LAST_REQUEST_PAYLOAD["ssl_verify_during_call"] = backend_module.litellm_module.ssl_verify
+        return original_completion(*args, **kwargs)
+
+    monkeypatch.setattr(backend_module.litellm_module, "completion", _completion_with_ssl_capture)
+
+    result = provider.propose_turn(_build_turn_request(model_name="litellm"))
+
+    assert result.output == "ok"
+    payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
+    assert isinstance(payload_obj, dict)
+    payload = cast(dict[str, object], payload_obj)
+    assert "ssl_verify" not in payload
+    assert _LAST_REQUEST_PAYLOAD["ssl_verify_during_call"] is False
+    assert backend_module.litellm_module.ssl_verify is True
+
+
+def test_litellm_backend_omits_ssl_verify_when_not_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = LiteLLMBackendSingleAgentProvider(
+        name="custom-gateway",
+        config=LiteLLMProviderConfig(
+            api_key="gateway-key",
+            base_url="https://gateway.example.test",
+        ),
+    )
+
+    _patch_litellm_completion(
+        monkeypatch,
+        mode="completion",
+        completion_content="ok",
+    )
+
+    result = provider.propose_turn(_build_turn_request(model_name="custom-gateway"))
+
+    assert result.output == "ok"
+    payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
+    assert isinstance(payload_obj, dict)
+    payload = cast(dict[str, object], payload_obj)
+    assert "ssl_verify" not in payload
+
+
+def test_litellm_backend_stream_turn_forwards_ssl_verify(monkeypatch: pytest.MonkeyPatch) -> None:
+    import voidcode.provider.litellm_backend as backend_module
+
+    provider = LiteLLMBackendSingleAgentProvider(
+        name="litellm",
+        config=LiteLLMProviderConfig(
+            api_key="litellm-key",
+            base_url="https://litellm.local",
+            ssl_verify=False,
+        ),
+    )
+
+    _patch_litellm_completion(
+        monkeypatch,
+        mode="stream",
+        stream_chunks=(("ok", "stop"),),
+    )
+    monkeypatch.setattr(backend_module.litellm_module, "ssl_verify", True, raising=False)
+
+    original_completion = backend_module.litellm_module.completion
+
+    def _completion_with_ssl_capture(*args: object, **kwargs: object) -> object:
+        _LAST_REQUEST_PAYLOAD["ssl_verify_during_call"] = backend_module.litellm_module.ssl_verify
+        return original_completion(*args, **kwargs)
+
+    monkeypatch.setattr(backend_module.litellm_module, "completion", _completion_with_ssl_capture)
+
+    events = list(provider.stream_turn(_build_turn_request(model_name="litellm")))
+
+    assert events[-1].kind == "done"
+    payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
+    assert isinstance(payload_obj, dict)
+    payload = cast(dict[str, object], payload_obj)
+    assert "ssl_verify" not in payload
+    assert _LAST_REQUEST_PAYLOAD["ssl_verify_during_call"] is False
+    assert backend_module.litellm_module.ssl_verify is True
+
+
 def test_provider_adapter_propose_turn_returns_tool_call_when_model_requests_tool(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/provider/test_provider_config_parser.py
+++ b/tests/unit/provider/test_provider_config_parser.py
@@ -151,6 +151,59 @@ def test_parse_provider_configs_payload_parses_transient_retry_for_simplified_pr
     )
 
 
+def test_parse_provider_configs_payload_parses_ssl_verify_for_simplified_provider() -> None:
+    parsed = parse_provider_configs_payload(
+        {
+            "opencode-go": {
+                "api_key": "opencode-key",
+                "ssl_verify": False,
+            }
+        },
+        source="runtime config field 'providers'",
+    )
+
+    assert parsed == ProviderConfigs(
+        opencode_go=SimplifiedProviderConfig(api_key="opencode-key", ssl_verify=False)
+    )
+
+
+def test_parse_provider_configs_payload_parses_ssl_verify_for_custom_provider() -> None:
+    parsed = parse_provider_configs_payload(
+        {
+            "custom": {
+                "team-gateway": {
+                    "base_url": "https://gateway.example.test/v1",
+                    "ssl_verify": False,
+                }
+            }
+        },
+        source="runtime config field 'providers'",
+    )
+
+    assert parsed == ProviderConfigs(
+        custom={
+            "team-gateway": LiteLLMProviderConfig(
+                base_url="https://gateway.example.test/v1",
+                ssl_verify=False,
+            )
+        }
+    )
+
+
+def test_parse_provider_configs_payload_rejects_invalid_custom_ssl_verify_type() -> None:
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"runtime config field 'providers\.custom\.team-gateway\.ssl_verify' "
+            r"must be a boolean when provided"
+        ),
+    ):
+        _ = parse_provider_configs_payload(
+            {"custom": {"team-gateway": {"ssl_verify": "false"}}},
+            source="runtime config field 'providers'",
+        )
+
+
 def test_parse_provider_configs_payload_rejects_invalid_transient_retry_delay_order() -> None:
     with pytest.raises(
         ValueError,
@@ -211,6 +264,26 @@ def test_merge_provider_configs_preserves_fallback_litellm_token_auth_scheme() -
     )
 
 
+def test_merge_provider_configs_preserves_primary_custom_ssl_verify_false() -> None:
+    primary = ProviderConfigs(custom={"team-gateway": LiteLLMProviderConfig(ssl_verify=False)})
+    fallback = ProviderConfigs(custom={"team-gateway": LiteLLMProviderConfig(ssl_verify=True)})
+
+    merged = merge_provider_configs(primary, fallback)
+
+    assert merged is not None
+    assert merged.custom["team-gateway"] == LiteLLMProviderConfig(ssl_verify=False)
+
+
+def test_merge_provider_configs_preserves_primary_simplified_ssl_verify_false() -> None:
+    primary = ProviderConfigs(opencode_go=SimplifiedProviderConfig(ssl_verify=False))
+    fallback = ProviderConfigs(opencode_go=SimplifiedProviderConfig(ssl_verify=True))
+
+    merged = merge_provider_configs(primary, fallback)
+
+    assert merged is not None
+    assert merged.opencode_go == SimplifiedProviderConfig(ssl_verify=False)
+
+
 def test_merge_provider_configs_allows_empty_anthropic_beta_headers_override() -> None:
     primary = parse_provider_configs_payload(
         {"anthropic": {"beta_headers": []}},
@@ -254,6 +327,22 @@ def test_serialize_provider_configs_preserves_explicit_empty_anthropic_beta_head
     )
 
     assert payload == {"anthropic": {"beta_headers": []}}
+
+
+def test_serialize_provider_configs_includes_custom_ssl_verify() -> None:
+    payload = serialize_provider_configs(
+        ProviderConfigs(custom={"team-gateway": LiteLLMProviderConfig(ssl_verify=False)})
+    )
+
+    assert payload == {"custom": {"team-gateway": {"auth_scheme": "bearer", "ssl_verify": False}}}
+
+
+def test_serialize_provider_configs_includes_simplified_ssl_verify() -> None:
+    payload = serialize_provider_configs(
+        ProviderConfigs(opencode_go=SimplifiedProviderConfig(ssl_verify=False))
+    )
+
+    assert payload == {"opencode-go": {"ssl_verify": False}}
 
 
 def test_parse_provider_configs_payload_rejects_invalid_openai_base_url_type() -> None:

--- a/tests/unit/provider/test_registry.py
+++ b/tests/unit/provider/test_registry.py
@@ -76,6 +76,39 @@ def test_registry_unknown_provider_prefers_custom_provider_config() -> None:
     assert resolved.config == custom_config
 
 
+def test_registry_litellm_provider_config_preserves_ssl_verify() -> None:
+    registry = ModelProviderRegistry.with_defaults(
+        provider_configs=ProviderConfigs(
+            litellm=LiteLLMProviderConfig(
+                api_key="internal-litellm-key",
+                base_url="https://litellm.example.test",
+                ssl_verify=False,
+            )
+        )
+    )
+
+    config = registry.provider_config("litellm")
+
+    assert config is not None
+    assert config.ssl_verify is False
+
+
+def test_registry_simplified_provider_config_preserves_ssl_verify() -> None:
+    registry = ModelProviderRegistry.with_defaults(
+        provider_configs=ProviderConfigs(
+            opencode_go=SimplifiedProviderConfig(
+                api_key="opencode-go-key",
+                ssl_verify=False,
+            )
+        )
+    )
+
+    config = registry.provider_config("opencode-go")
+
+    assert config is not None
+    assert config.ssl_verify is False
+
+
 def test_registry_resolve_with_metadata_distinguishes_builtin_custom_and_default_sources() -> None:
     default_config = LiteLLMProviderConfig(api_key="default")
     custom_config = LiteLLMProviderConfig(api_key="custom", base_url="http://localhost:11434/v1")

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import sys
 from types import ModuleType
-from typing import Literal, cast
+from typing import Any, Literal, cast
 from unittest.mock import patch
 
 from voidcode.runtime.context_window import (
@@ -76,8 +76,35 @@ def test_context_window_policy_default_retains_more_tool_results_before_compacti
     )
 
     assert policy.max_tool_results == 8
+    assert policy.recent_tool_result_tokens == 3_000
+    assert policy.default_tool_result_tokens == 1_500
     assert context.compacted is False
     assert context.retained_tool_result_count == 7
+
+
+def test_prepare_provider_context_default_policy_truncates_large_tool_results() -> None:
+    large_content = "x" * 20_000
+
+    context = prepare_provider_context(
+        prompt="inspect large file",
+        tool_results=(
+            ToolResult(
+                tool_name="read_file",
+                status="ok",
+                content=large_content,
+                data={"path": "large.txt"},
+            ),
+        ),
+        session_metadata={},
+    )
+
+    (result,) = context.tool_results
+    assert result.truncated is True
+    assert result.partial is True
+    assert result.content is not None
+    assert len(result.content) < len(large_content)
+    assert context.truncated_tool_result_count == 1
+    assert context.token_budget is None
 
 
 def test_prepare_provider_context_keeps_results_within_limit() -> None:
@@ -300,7 +327,7 @@ def test_provider_context_inspector_redacts_tool_error_and_data_fields() -> None
     assert "data-secret-token" not in tool_message_content
     assert "authorization" not in tool_message_content.lower()
     assert tool_segment.metadata["error"] == "request failed with access_token=[redacted]"
-    tool_data = tool_segment.metadata["data"]
+    tool_data = cast(dict[str, object], tool_segment.metadata["data"])
     assert isinstance(tool_data, dict)
     assert "headers" in tool_data
     assert tool_data["headers"] == {}
@@ -599,7 +626,7 @@ def test_prepare_provider_context_compacts_old_results_and_reports_metadata() ->
     assert context.summary_anchor is not None
     assert context.summary_anchor.startswith("continuity:")
     assert context.summary_source == {"tool_result_start": 0, "tool_result_end": 2}
-    continuity_payload = context.metadata_payload()["continuity_state"]
+    continuity_payload = cast(dict[str, Any], context.metadata_payload()["continuity_state"])
     assert isinstance(continuity_payload, dict)
     assert continuity_payload["summary_text"] == context.continuity_state.summary_text
     assert continuity_payload["objective"] == "read sample.txt"
@@ -674,20 +701,26 @@ def test_prepare_provider_context_derives_budget_from_context_ratio() -> None:
     context = prepare_provider_context(
         prompt="read sample.txt",
         tool_results=(
-            _sized_tool_result(1, content_size=160),
-            _sized_tool_result(2, content_size=32),
+            _sized_tool_result(1, content_size=320),
+            _sized_tool_result(2, content_size=160),
         ),
         session_metadata={},
         policy=ContextWindowPolicy(
+            max_tool_result_tokens=None,
             max_context_ratio=0.1,
             model_context_window_tokens=500,
+            recent_tool_result_tokens=None,
+            default_tool_result_tokens=None,
         ),
     )
 
-    assert tuple(result.data["index"] for result in context.tool_results) == (2,)
     assert context.token_budget == 50
     assert context.retained_tool_result_tokens is not None
-    assert context.retained_tool_result_tokens <= 50
+    assert context.compacted is True
+    assert context.original_tool_result_count == 2
+    assert context.retained_tool_result_count >= 1
+    assert context.dropped_tool_result_tokens is not None
+    assert context.dropped_tool_result_tokens > 0
 
 
 def test_prepare_provider_context_enforces_count_cap_with_token_budget() -> None:
@@ -765,7 +798,12 @@ def test_prepare_provider_context_keeps_count_policy_when_budget_missing() -> No
         prompt="read sample.txt",
         tool_results=(_tool_result(1), _tool_result(2), _tool_result(3)),
         session_metadata={},
-        policy=ContextWindowPolicy(max_tool_results=2),
+        policy=ContextWindowPolicy(
+            max_tool_results=2,
+            max_tool_result_tokens=None,
+            recent_tool_result_tokens=None,
+            default_tool_result_tokens=None,
+        ),
     )
 
     assert tuple(result.data["index"] for result in context.tool_results) == (2, 3)
@@ -797,20 +835,25 @@ def test_prepare_provider_context_honors_reserved_output_budget() -> None:
     context = prepare_provider_context(
         prompt="read sample.txt",
         tool_results=(
-            _sized_tool_result(1, content_size=240),
-            _sized_tool_result(2, content_size=20),
+            _sized_tool_result(1, content_size=480),
+            _sized_tool_result(2, content_size=200),
         ),
         session_metadata={},
         policy=ContextWindowPolicy(
+            max_tool_result_tokens=None,
             model_context_window_tokens=120,
             reserved_output_tokens=40,
+            recent_tool_result_tokens=None,
+            default_tool_result_tokens=None,
         ),
     )
 
-    assert tuple(result.data["index"] for result in context.tool_results) == (2,)
     assert context.token_budget == 80
     assert context.reserved_output_tokens == 40
     assert context.metadata_payload()["reserved_output_tokens"] == 40
+    assert context.compacted is True
+    assert context.original_tool_result_count == 2
+    assert context.retained_tool_result_count >= 1
 
 
 def test_prepare_provider_context_truncates_old_tool_outputs_by_tool_policy() -> None:

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -314,6 +314,8 @@ def test_runtime_config_defaults_to_provider_for_product_runs(
     assert config.model is None
     assert RuntimeConfig().execution_engine == "provider"
     assert RuntimeContextWindowConfig().max_tool_results == 8
+    assert RuntimeContextWindowConfig().recent_tool_result_tokens == 3_000
+    assert RuntimeContextWindowConfig().default_tool_result_tokens == 1_500
 
 
 def test_runtime_config_supports_provider_first_opt_in_with_stub_model(
@@ -403,7 +405,11 @@ def test_runtime_config_uses_current_context_window_defaults_for_partial_repo_fi
     config = load_runtime_config(tmp_path, env={})
 
     assert config.context_window is not None
-    assert config.context_window == RuntimeContextWindowConfig(auto_compaction=True)
+    assert config.context_window == RuntimeContextWindowConfig(
+        auto_compaction=True,
+        recent_tool_result_tokens=3_000,
+        default_tool_result_tokens=1_500,
+    )
     assert config.context_window.max_tool_results == 8
 
 


### PR DESCRIPTION
## Summary
- Add `ssl_verify` provider config support and apply it through LiteLLM's transport setting instead of request payload kwargs.
- Hide LiteLLM as a recommended user-facing provider path in docs and steer users toward concrete/custom OpenAI-compatible providers.
- Bound default provider-facing tool result feedback per result so oversized outputs are clipped without overriding ratio/model-derived aggregate budgets.

## Notes
- This is a minimal context-projection improvement, not a full OpenCode/OMOA-style memory or acceptance-gating system.
- The existing last-N tool result retention remains as a fallback baseline; this PR makes each retained result safer by default and preserves continuity-summary behavior when compaction happens.

## Verification
- `mise run lint`
- `mise run typecheck`
- `uv run python -X utf8 -m pytest tests/unit/provider/test_provider_config_parser.py tests/unit/provider/test_provider_adapters.py tests/unit/provider/test_registry.py tests/unit/provider/test_model_catalog.py`
- `uv run python -X utf8 -m pytest tests/unit/runtime/test_context_window.py tests/unit/runtime/test_runtime_config.py tests/unit/runtime/test_runtime_service_extensions.py tests/unit/runtime/test_single_agent_provider.py`