### PR TITLE
Prioritize high-signal tool context

### DIFF
--- a/src/voidcode/provider/litellm_backend.py
+++ b/src/voidcode/provider/litellm_backend.py
@@ -511,17 +511,21 @@ class LiteLLMBackendSingleAgentProvider:
         if litellm_module is None:
             yield
             return
+        configured_ssl_verify = self.config.ssl_verify if self.config is not None else None
+        if configured_ssl_verify is None:
+            with _LITELLM_SSL_VERIFY_LOCK:
+                pass
+            yield
+            return
+
         with _LITELLM_SSL_VERIFY_LOCK:
             module_any = cast(Any, litellm_module)
             previous = getattr(module_any, "ssl_verify", True)
-            configured_ssl_verify = self.config.ssl_verify if self.config is not None else None
-            if configured_ssl_verify is not None:
-                module_any.ssl_verify = configured_ssl_verify
+            module_any.ssl_verify = configured_ssl_verify
             try:
                 yield
             finally:
-                if configured_ssl_verify is not None:
-                    module_any.ssl_verify = previous
+                module_any.ssl_verify = previous
 
     @staticmethod
     def _extract_first_tool_call(message: dict[str, object]) -> ToolCall | None:

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -153,6 +153,7 @@ class ContextWindowPolicy:
     continuity_distillation_enabled: bool = False
     continuity_distillation_max_input_items: int = 12
     continuity_distillation_max_input_chars: int = 4000
+    importance_retention: bool = True
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "per_tool_result_tokens", dict(self.per_tool_result_tokens))
@@ -229,6 +230,7 @@ class ContextWindowPolicy:
         payload["continuity_distillation_max_input_chars"] = (
             self.continuity_distillation_max_input_chars
         )
+        payload["importance_retention"] = self.importance_retention
         return payload
 
 
@@ -282,6 +284,21 @@ class RuntimeContextWindow:
         if self.summary_source is not None:
             payload["summary_source"] = dict(self.summary_source)
         return payload
+
+
+@dataclass(frozen=True, slots=True)
+class ToolResultProjection:
+    prepared_results: tuple[ToolResult, ...]
+    retained_indexes: tuple[int, ...]
+    dropped_indexes: tuple[int, ...]
+    retained_results: tuple[ToolResult, ...]
+    dropped_results: tuple[ToolResult, ...]
+    truncated_count: int
+    original_tokens: int | None = None
+    retained_tokens: int | None = None
+    dropped_tokens: int | None = None
+    token_budget: int | None = None
+    token_estimate_source: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -685,10 +702,14 @@ def _optional_tool_string(result: ToolResult, key: str) -> str | None:
 
 
 def _dropped_tool_diagnostics(
-    results: tuple[ToolResult, ...], *, tokenizer_model: str | None = None
+    results: tuple[ToolResult, ...],
+    *,
+    original_indexes: tuple[int, ...] | None = None,
+    tokenizer_model: str | None = None,
 ) -> tuple[DroppedToolResultDiagnostic, ...]:
     diagnostics: list[DroppedToolResultDiagnostic] = []
-    for index, result in enumerate(results, start=1):
+    for position, result in enumerate(results):
+        index = original_indexes[position] + 1 if original_indexes is not None else position + 1
         diagnostics.append(
             DroppedToolResultDiagnostic(
                 tool_name=result.tool_name,
@@ -708,6 +729,99 @@ def _dropped_tool_diagnostics(
             )
         )
     return tuple(diagnostics)
+
+
+def _tool_result_importance_score(result: ToolResult) -> int:
+    score = 0
+    if result.status == "error":
+        score += 100
+    if result.error_kind is not None:
+        score += 20
+    if result.truncated or result.partial:
+        score += 10
+    if result.tool_name in {"todo_write", "task", "background_output"}:
+        score += 80
+    if result.tool_name in {"write_file", "edit", "multi_edit", "apply_patch"}:
+        score += 70
+    if result.tool_name == "shell_exec":
+        score += 30
+    if any(isinstance(result.data.get(key), str) for key in ("path", "filePath")):
+        score += 10
+    return score
+
+
+def _select_tool_result_indexes_by_importance(
+    results: tuple[ToolResult, ...],
+    *,
+    max_tool_results: int,
+    protected_recent_count: int,
+) -> tuple[int, ...]:
+    if not results:
+        return ()
+    protected_recent_count = min(protected_recent_count, len(results))
+    protected_start = len(results) - protected_recent_count
+    protected_indexes = set(range(protected_start, len(results)))
+    if max_tool_results == 0:
+        return tuple(sorted(protected_indexes))
+
+    count_limit = max(max_tool_results, protected_recent_count)
+    remaining_slots = max(0, count_limit - len(protected_indexes))
+    ranked_candidates = sorted(
+        range(0, protected_start),
+        key=lambda index: (_tool_result_importance_score(results[index]), index),
+        reverse=True,
+    )
+    selected = set(ranked_candidates[:remaining_slots]) | protected_indexes
+    return tuple(sorted(selected))
+
+
+def _select_recent_tool_result_indexes(
+    results: tuple[ToolResult, ...],
+    *,
+    max_tool_results: int,
+    protected_recent_count: int,
+) -> tuple[int, ...]:
+    if not results:
+        return ()
+    count_limit = max(max_tool_results, min(protected_recent_count, len(results)))
+    if max_tool_results == 0:
+        count_limit = min(protected_recent_count, len(results))
+    start = max(0, len(results) - count_limit)
+    return tuple(range(start, len(results)))
+
+
+def _retain_indexes_within_token_budget(
+    results: tuple[ToolResult, ...],
+    candidate_indexes: tuple[int, ...],
+    *,
+    token_budget: int,
+    protected_recent_count: int,
+    tokenizer_model: str | None,
+) -> tuple[int, ...]:
+    if not candidate_indexes:
+        return ()
+    protected_recent_count = min(protected_recent_count, len(results))
+    protected_start = len(results) - protected_recent_count
+    protected_indexes = {index for index in candidate_indexes if index >= protected_start}
+    retained = set(protected_indexes)
+    retained_tokens = sum(
+        _tool_result_token_estimate(results[index], tokenizer_model=tokenizer_model).tokens
+        for index in protected_indexes
+    )
+    ranked_candidates = sorted(
+        (index for index in candidate_indexes if index not in protected_indexes),
+        key=lambda index: (_tool_result_importance_score(results[index]), index),
+        reverse=True,
+    )
+    for index in ranked_candidates:
+        estimate = _tool_result_token_estimate(
+            results[index], tokenizer_model=tokenizer_model
+        ).tokens
+        if retained_tokens + estimate > token_budget:
+            continue
+        retained.add(index)
+        retained_tokens += estimate
+    return tuple(sorted(retained))
 
 
 def _policy_token_budget(policy: ContextWindowPolicy) -> int | None:
@@ -871,6 +985,15 @@ def _coerce_float(payload: Mapping[str, object], key: str, *, default: float) ->
     return float(raw)
 
 
+def _coerce_bool(payload: Mapping[str, object], key: str, *, default: bool) -> bool:
+    raw = payload.get(key)
+    if raw is None:
+        return default
+    if not isinstance(raw, bool):
+        raise ValueError(f"context window policy field '{key}' must be a boolean")
+    return raw
+
+
 def context_window_policy_from_payload(raw_payload: object) -> ContextWindowPolicy:
     if not isinstance(raw_payload, dict):
         raise ValueError("context window policy payload must be an object")
@@ -961,6 +1084,11 @@ def context_window_policy_from_payload(raw_payload: object) -> ContextWindowPoli
             "continuity_distillation_max_input_chars",
             default=ContextWindowPolicy().continuity_distillation_max_input_chars,
         ),
+        importance_retention=_coerce_bool(
+            payload,
+            "importance_retention",
+            default=ContextWindowPolicy().importance_retention,
+        ),
     )
 
 
@@ -1004,6 +1132,7 @@ def _build_continuity_state(
     prompt: str,
     session_metadata: Mapping[str, object],
     dropped_results: tuple[ToolResult, ...],
+    dropped_result_indexes: tuple[int, ...],
     retained_results: tuple[ToolResult, ...],
     retained_count: int,
     preview_item_limit: int,
@@ -1097,6 +1226,7 @@ def _build_continuity_state(
         token_estimate_source=token_estimate_source,
         dropped_tool_results=_dropped_tool_diagnostics(
             dropped_results,
+            original_indexes=dropped_result_indexes,
             tokenizer_model=tokenizer_model,
         ),
         distillation_source="deterministic",
@@ -1324,15 +1454,113 @@ def continuity_summary_metadata(
         dropped_count=continuity_state.dropped_tool_result_count,
         retained_count=continuity_state.retained_tool_result_count,
     )
-    summary_source = (
-        {
-            "tool_result_start": 0,
-            "tool_result_end": continuity_state.dropped_tool_result_count,
-        }
-        if summary_anchor is not None and continuity_state.source == "tool_result_window"
-        else None
-    )
+    summary_source = None
+    if summary_anchor is not None and continuity_state.source == "tool_result_window":
+        dropped_indexes = tuple(item.index for item in continuity_state.dropped_tool_results)
+        if dropped_indexes == tuple(range(1, continuity_state.dropped_tool_result_count + 1)):
+            summary_source = {
+                "tool_result_start": 0,
+                "tool_result_end": continuity_state.dropped_tool_result_count,
+            }
     return summary_anchor, summary_source
+
+
+def project_tool_results_for_context_window(
+    *,
+    tool_results: tuple[ToolResult, ...],
+    policy: ContextWindowPolicy,
+) -> ToolResultProjection:
+    token_budget = _policy_token_budget(policy)
+    original_count = len(tool_results)
+    protected_recent_count = max(
+        policy.minimum_retained_tool_results,
+        policy.recent_tool_result_count,
+    )
+    protected_recent_count = min(protected_recent_count, original_count)
+    protected_start = original_count - protected_recent_count
+    truncated_results: list[ToolResult] = []
+    truncated_count = 0
+    for index, result in enumerate(tool_results):
+        if index >= protected_start:
+            content_limit = policy.recent_tool_result_tokens
+        else:
+            content_limit = _tool_limit_for_result(result, policy)
+        truncated_result, was_truncated = _truncate_tool_result_content(
+            result,
+            limit=content_limit,
+            tokenizer_model=policy.tokenizer_model,
+        )
+        truncated_results.append(truncated_result)
+        if was_truncated:
+            truncated_count += 1
+    prepared_results = tuple(truncated_results)
+
+    count_limited_indexes = (
+        _select_tool_result_indexes_by_importance(
+            prepared_results,
+            max_tool_results=policy.max_tool_results,
+            protected_recent_count=protected_recent_count,
+        )
+        if policy.importance_retention
+        else _select_recent_tool_result_indexes(
+            prepared_results,
+            max_tool_results=policy.max_tool_results,
+            protected_recent_count=protected_recent_count,
+        )
+    )
+    retained_indexes = (
+        _retain_indexes_within_token_budget(
+            prepared_results,
+            count_limited_indexes,
+            token_budget=token_budget,
+            protected_recent_count=protected_recent_count,
+            tokenizer_model=policy.tokenizer_model,
+        )
+        if token_budget is not None
+        else count_limited_indexes
+    )
+    retained_index_set = set(retained_indexes)
+    dropped_indexes = tuple(
+        index for index in range(len(prepared_results)) if index not in retained_index_set
+    )
+    retained_results = tuple(prepared_results[index] for index in retained_indexes)
+    dropped_results = tuple(prepared_results[index] for index in dropped_indexes)
+
+    original_tokens = None
+    retained_tokens = None
+    dropped_tokens = None
+    token_estimate_source = None
+    if token_budget is not None:
+        original_tokens = sum(
+            _tool_result_token_estimate(
+                result,
+                tokenizer_model=policy.tokenizer_model,
+            ).tokens
+            for result in prepared_results
+        )
+        retained_tokens = sum(
+            _tool_result_token_estimate(
+                result,
+                tokenizer_model=policy.tokenizer_model,
+            ).tokens
+            for result in retained_results
+        )
+        dropped_tokens = original_tokens - retained_tokens
+        token_estimate_source = _token_estimate_source(policy)
+
+    return ToolResultProjection(
+        prepared_results=prepared_results,
+        retained_indexes=retained_indexes,
+        dropped_indexes=dropped_indexes,
+        retained_results=retained_results,
+        dropped_results=dropped_results,
+        truncated_count=truncated_count,
+        original_tokens=original_tokens,
+        retained_tokens=retained_tokens,
+        dropped_tokens=dropped_tokens,
+        token_budget=token_budget,
+        token_estimate_source=token_estimate_source,
+    )
 
 
 def prepare_provider_context(
@@ -1385,77 +1613,26 @@ def prepare_provider_context(
             reserved_output_tokens=effective_policy.reserved_output_tokens,
         )
 
-    protected_recent_count = max(
-        effective_policy.minimum_retained_tool_results,
-        effective_policy.recent_tool_result_count,
+    projection = project_tool_results_for_context_window(
+        tool_results=tool_results,
+        policy=effective_policy,
     )
-    protected_recent_count = min(protected_recent_count, original_count)
-    protected_start = original_count - protected_recent_count
-    truncated_results: list[ToolResult] = []
-    truncated_count = 0
-    for index, result in enumerate(tool_results):
-        if index >= protected_start:
-            content_limit = effective_policy.recent_tool_result_tokens
-        else:
-            content_limit = _tool_limit_for_result(result, effective_policy)
-        truncated_result, was_truncated = _truncate_tool_result_content(
-            result,
-            limit=content_limit,
-            tokenizer_model=effective_policy.tokenizer_model,
-        )
-        truncated_results.append(truncated_result)
-        if was_truncated:
-            truncated_count += 1
-    prepared_results = tuple(truncated_results)
-
-    if effective_policy.max_tool_results == 0:
-        count_limited_results = (
-            prepared_results[-protected_recent_count:] if protected_recent_count else ()
-        )
-    else:
-        count_limit = max(effective_policy.max_tool_results, protected_recent_count)
-        count_limited_results = prepared_results[-count_limit:]
-
-    if token_budget is not None:
-        retained_results = _retain_results_within_token_budget(
-            count_limited_results,
-            token_budget=token_budget,
-            minimum_retained_results=protected_recent_count,
-            tokenizer_model=effective_policy.tokenizer_model,
-        )
-    else:
-        retained_results = count_limited_results
-
+    retained_results = projection.retained_results
     retained_count = len(retained_results)
     compacted = retained_count < original_count
-    dropped_results = prepared_results[: original_count - retained_count]
-    original_tokens = None
-    retained_tokens = None
-    dropped_tokens = None
-    token_estimate_source = None
-    if token_budget is not None:
-        original_tokens = sum(
-            _tool_result_token_estimate(
-                result,
-                tokenizer_model=effective_policy.tokenizer_model,
-            ).tokens
-            for result in prepared_results
-        )
-        retained_tokens = sum(
-            _tool_result_token_estimate(
-                result,
-                tokenizer_model=effective_policy.tokenizer_model,
-            ).tokens
-            for result in retained_results
-        )
-        dropped_tokens = original_tokens - retained_tokens
-        token_estimate_source = _token_estimate_source(effective_policy)
+    dropped_indexes = projection.dropped_indexes
+    dropped_results = projection.dropped_results
+    original_tokens = projection.original_tokens
+    retained_tokens = projection.retained_tokens
+    dropped_tokens = projection.dropped_tokens
+    token_estimate_source = projection.token_estimate_source
 
     continuity_state = (
         _build_continuity_state(
             prompt=prompt,
             session_metadata=session_metadata,
             dropped_results=dropped_results,
+            dropped_result_indexes=dropped_indexes,
             retained_results=retained_results,
             retained_count=retained_count,
             preview_item_limit=effective_policy.continuity_preview_items,
@@ -1498,7 +1675,7 @@ def prepare_provider_context(
         token_estimate_source=token_estimate_source,
         model_context_window_tokens=effective_policy.model_context_window_tokens,
         reserved_output_tokens=effective_policy.reserved_output_tokens,
-        truncated_tool_result_count=truncated_count,
+        truncated_tool_result_count=projection.truncated_count,
         continuity_state=continuity_state,
         summary_anchor=summary_anchor,
         summary_source=summary_source,

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -138,6 +138,7 @@ from .context_window import (
     assemble_provider_context,
     continuity_state_from_metadata_payload,
     prepare_provider_context,
+    project_tool_results_for_context_window,
 )
 from .continuity_distillation import build_distillation_input_envelope
 from .contracts import (
@@ -5958,18 +5959,10 @@ class VoidCodeRuntime:
     ) -> tuple[dict[str, object] | None, str | None]:
         if not tool_results:
             return None, "empty_tool_results"
-        protected_recent_count = max(
-            policy.minimum_retained_tool_results,
-            policy.recent_tool_result_count,
+        projection = project_tool_results_for_context_window(
+            tool_results=tool_results,
+            policy=policy,
         )
-        protected_recent_count = min(protected_recent_count, len(tool_results))
-        if policy.max_tool_results == 0:
-            retained_count = protected_recent_count
-        else:
-            retained_count = max(policy.max_tool_results, protected_recent_count)
-            retained_count = min(retained_count, len(tool_results))
-        dropped_guess = tool_results[: len(tool_results) - retained_count]
-        retained_guess = tool_results[len(tool_results) - retained_count :]
         previous_continuity: dict[str, object] | None = None
         runtime_state = session_metadata.get("runtime_state")
         if isinstance(runtime_state, dict):
@@ -5978,8 +5971,8 @@ class VoidCodeRuntime:
                 previous_continuity = cast(dict[str, object], raw_continuity)
         envelope = build_distillation_input_envelope(
             prompt=prompt,
-            dropped_results=dropped_guess,
-            retained_results=retained_guess,
+            dropped_results=projection.dropped_results,
+            retained_results=projection.retained_results,
             previous_continuity=previous_continuity,
             max_items=policy.continuity_distillation_max_input_items,
             max_chars=policy.continuity_distillation_max_input_chars,

--- a/tests/unit/provider/test_provider_adapters.py
+++ b/tests/unit/provider/test_provider_adapters.py
@@ -2489,7 +2489,7 @@ def test_litellm_backend_omits_ssl_verify_when_not_configured(
     assert "ssl_verify" not in payload
 
 
-def test_litellm_backend_serializes_default_ssl_verify_with_global_override(
+def test_litellm_backend_default_ssl_verify_waits_for_global_restore_without_serializing_call(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import voidcode.provider.litellm_backend as backend_module
@@ -2510,8 +2510,9 @@ def test_litellm_backend_serializes_default_ssl_verify_with_global_override(
         ),
     )
     entered_explicit_call = threading.Event()
+    entered_default_call = threading.Event()
+    release_default_call = threading.Event()
     release_explicit_call = threading.Event()
-    explicit_done = threading.Event()
     observations: list[tuple[str, object]] = []
     thread_errors: list[BaseException] = []
 
@@ -2531,7 +2532,8 @@ def test_litellm_backend_serializes_default_ssl_verify_with_global_override(
             assert release_explicit_call.wait(timeout=2)
         else:
             observations.append(("default", backend_module.litellm_module.ssl_verify))
-            explicit_done.set()
+            entered_default_call.set()
+            assert release_default_call.wait(timeout=2)
         return _StubCompletionResponse(content="ok")
 
     monkeypatch.setattr(backend_module.litellm_module, "completion", _blocking_completion)
@@ -2563,9 +2565,12 @@ def test_litellm_backend_serializes_default_ssl_verify_with_global_override(
 
     default_thread = threading.Thread(target=_run_default_provider)
     default_thread.start()
-    assert not explicit_done.wait(timeout=0.05)
+    assert not entered_default_call.wait(timeout=0.05)
     release_explicit_call.set()
+    assert entered_default_call.wait(timeout=2)
     explicit_thread.join(timeout=2)
+    assert explicit_thread.is_alive() is False
+    release_default_call.set()
     default_thread.join(timeout=2)
 
     assert thread_errors == []

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -12,6 +12,9 @@ from voidcode.runtime.context_window import (
     RuntimeAssembledContext,
     RuntimeContextSegment,
     RuntimeContinuityState,
+    _retain_indexes_within_token_budget,
+    _select_tool_result_indexes_by_importance,
+    _tool_result_importance_score,
     assemble_provider_context,
     context_window_policy_from_payload,
     continuity_state_from_metadata_payload,
@@ -63,6 +66,15 @@ def _sized_tool_result(index: int, *, content_size: int) -> ToolResult:
         content=f"content-{index}-" + ("x" * content_size),
         status="ok",
         data={"index": index, "path": f"sample-{index}.txt"},
+    )
+
+
+def _shell_tool_result(index: int, *, command: str, content: str = "ok") -> ToolResult:
+    return ToolResult(
+        tool_name="shell_exec",
+        content=content,
+        status="ok",
+        data={"index": index, "command": command},
     )
 
 
@@ -811,6 +823,379 @@ def test_prepare_provider_context_keeps_count_policy_when_budget_missing() -> No
     assert context.original_tool_result_tokens is None
 
 
+def test_prepare_provider_context_prioritizes_important_older_results() -> None:
+    context = prepare_provider_context(
+        prompt="fix failing tests",
+        tool_results=(
+            _tool_result(1),
+            ToolResult(
+                tool_name="read_file",
+                status="error",
+                error="missing file",
+                data={"index": 2, "path": "missing.py"},
+            ),
+            _shell_tool_result(3, command="run project verification"),
+            _tool_result(4),
+            _tool_result(5),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=3,
+            recent_tool_result_count=1,
+            max_tool_result_tokens=None,
+            recent_tool_result_tokens=None,
+            default_tool_result_tokens=None,
+        ),
+    )
+
+    assert tuple(result.data["index"] for result in context.tool_results) == (2, 3, 5)
+    assert context.compacted is True
+    assert context.continuity_state is not None
+    dropped_tool_names = [
+        item.metadata_payload()["tool_name"]
+        for item in context.continuity_state.dropped_tool_results
+    ]
+    assert dropped_tool_names == ["read_file", "read_file"]
+    dropped_index_positions = [
+        item.metadata_payload()["index"] for item in context.continuity_state.dropped_tool_results
+    ]
+    assert dropped_index_positions == [1, 4]
+
+
+def test_prepare_provider_context_token_budget_prefers_important_candidates() -> None:
+    context = prepare_provider_context(
+        prompt="verify fix",
+        tool_results=(
+            _sized_tool_result(1, content_size=160),
+            _shell_tool_result(2, command="run project verification", content="passed"),
+            _sized_tool_result(3, content_size=160),
+            _tool_result(4),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=3,
+            recent_tool_result_count=1,
+            max_tool_result_tokens=120,
+            recent_tool_result_tokens=None,
+            default_tool_result_tokens=None,
+        ),
+    )
+
+    retained_indexes = tuple(result.data["index"] for result in context.tool_results)
+    assert 2 in retained_indexes
+    assert 4 in retained_indexes
+    assert 1 not in retained_indexes or 3 not in retained_indexes
+    assert context.compacted is True
+    assert context.token_budget == 120
+
+
+def test_prepare_provider_context_can_disable_importance_retention() -> None:
+    context = prepare_provider_context(
+        prompt="debug",
+        tool_results=(
+            ToolResult(
+                tool_name="read_file",
+                status="error",
+                error="not found",
+                data={"index": 1, "path": "missing.py"},
+            ),
+            _shell_tool_result(2, command="run project verification", content="ok"),
+            _tool_result(3),
+            _tool_result(4),
+            _tool_result(5),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=3,
+            recent_tool_result_count=1,
+            importance_retention=False,
+            max_tool_result_tokens=None,
+            recent_tool_result_tokens=None,
+            default_tool_result_tokens=None,
+        ),
+    )
+
+    assert tuple(result.data["index"] for result in context.tool_results) == (3, 4, 5)
+
+
+def test_prepare_provider_context_older_todo_and_task_survive_over_newer_reads() -> None:
+    context = prepare_provider_context(
+        prompt="finish task",
+        tool_results=(
+            ToolResult(
+                tool_name="todo_write",
+                content="Updated todos",
+                status="ok",
+                data={"index": 1},
+            ),
+            ToolResult(
+                tool_name="task",
+                content="Background task launched.",
+                status="ok",
+                data={"index": 2, "task_id": "bg_1"},
+            ),
+            _tool_result(3),
+            _tool_result(4),
+            _tool_result(5),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=3,
+            recent_tool_result_count=1,
+            max_tool_result_tokens=None,
+            recent_tool_result_tokens=None,
+            default_tool_result_tokens=None,
+        ),
+    )
+
+    retained_indexes = tuple(result.data["index"] for result in context.tool_results)
+    assert retained_indexes == (1, 2, 5)
+
+
+def test_prepare_provider_context_older_write_edit_survive_over_newer_reads() -> None:
+    context = prepare_provider_context(
+        prompt="fix code",
+        tool_results=(
+            ToolResult(
+                tool_name="write_file",
+                content="written",
+                status="ok",
+                data={"index": 1, "path": "src/app.py"},
+            ),
+            ToolResult(
+                tool_name="edit",
+                content="edited",
+                status="ok",
+                data={"index": 2, "path": "src/utils.py"},
+            ),
+            _tool_result(3),
+            _tool_result(4),
+            _tool_result(5),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=3,
+            recent_tool_result_count=1,
+            max_tool_result_tokens=None,
+            recent_tool_result_tokens=None,
+            default_tool_result_tokens=None,
+        ),
+    )
+
+    retained_indexes = tuple(result.data["index"] for result in context.tool_results)
+    assert retained_indexes == (1, 2, 5)
+
+
+def test_prepare_provider_context_older_error_beats_newer_low_value() -> None:
+    context = prepare_provider_context(
+        prompt="debug",
+        tool_results=(
+            ToolResult(
+                tool_name="read_file",
+                status="error",
+                error="not found",
+                data={"index": 1, "path": "missing.py"},
+            ),
+            _tool_result(2),
+            _tool_result(3),
+            _tool_result(4),
+            _tool_result(5),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=3,
+            recent_tool_result_count=1,
+            max_tool_result_tokens=None,
+            recent_tool_result_tokens=None,
+            default_tool_result_tokens=None,
+        ),
+    )
+
+    retained_indexes = tuple(result.data["index"] for result in context.tool_results)
+    assert retained_indexes == (1, 4, 5)
+
+
+def test_prepare_provider_context_importance_tie_breaker_prefers_newer() -> None:
+    context = prepare_provider_context(
+        prompt="read files",
+        tool_results=(
+            _tool_result(1),
+            _tool_result(2),
+            _tool_result(3),
+            _tool_result(4),
+            _tool_result(5),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=3,
+            recent_tool_result_count=1,
+            max_tool_result_tokens=None,
+            recent_tool_result_tokens=None,
+            default_tool_result_tokens=None,
+        ),
+    )
+
+    retained_indexes = tuple(result.data["index"] for result in context.tool_results)
+    assert 5 in retained_indexes
+    assert retained_indexes == (3, 4, 5)
+
+
+def test_prepare_provider_context_protected_recent_always_kept() -> None:
+    context = prepare_provider_context(
+        prompt="continue",
+        tool_results=(
+            ToolResult(
+                tool_name="write_file",
+                content="important write",
+                status="ok",
+                data={"index": 1, "path": "src/app.py"},
+            ),
+            ToolResult(
+                tool_name="read_file",
+                status="error",
+                error="missing",
+                data={"index": 2, "path": "src/missing.py"},
+            ),
+            _tool_result(3),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=2,
+            recent_tool_result_count=1,
+            max_tool_result_tokens=None,
+            recent_tool_result_tokens=None,
+            default_tool_result_tokens=None,
+        ),
+    )
+
+    retained_indexes = tuple(result.data["index"] for result in context.tool_results)
+    assert 3 in retained_indexes
+
+
+def _error_result(index: int) -> ToolResult:
+    return ToolResult(
+        tool_name="read_file",
+        status="error",
+        error="error message",
+        data={"index": index},
+    )
+
+
+def test_tool_result_importance_score_errors_rank_high() -> None:
+    assert _tool_result_importance_score(_error_result(1)) >= 100
+
+
+def test_tool_result_importance_score_todo_beats_plain_read() -> None:
+    todo = ToolResult(tool_name="todo_write", content="todos", status="ok", data={"index": 1})
+    plain = _tool_result(2)
+    assert _tool_result_importance_score(todo) > _tool_result_importance_score(plain)
+
+
+def test_tool_result_importance_score_write_beats_plain_read() -> None:
+    write = ToolResult(
+        tool_name="write_file",
+        content="data",
+        status="ok",
+        data={"index": 1, "path": "out.txt"},
+    )
+    plain = _tool_result(2)
+    assert _tool_result_importance_score(write) > _tool_result_importance_score(plain)
+
+
+def test_tool_result_importance_score_shell_command_is_generic_signal() -> None:
+    project_shell = ToolResult(
+        tool_name="shell_exec",
+        content="completed",
+        status="ok",
+        data={"index": 1, "command": "run project verification"},
+    )
+    plain_shell = ToolResult(
+        tool_name="shell_exec",
+        content="ok",
+        status="ok",
+        data={"index": 2, "command": "run maintenance task"},
+    )
+    assert _tool_result_importance_score(project_shell) == _tool_result_importance_score(
+        plain_shell
+    )
+
+
+def test_tool_result_importance_score_delete_file_not_treated_as_write() -> None:
+    delete = ToolResult(
+        tool_name="delete_file",
+        content="deleted",
+        status="ok",
+        data={"index": 1, "path": "tmp.txt"},
+    )
+    write = ToolResult(
+        tool_name="write_file",
+        content="data",
+        status="ok",
+        data={"index": 2, "path": "out.txt"},
+    )
+    assert _tool_result_importance_score(delete) < _tool_result_importance_score(write)
+
+
+def test_select_tool_result_indexes_by_importance_max_zero() -> None:
+    results = (_tool_result(1), _tool_result(2), _tool_result(3))
+    selected = _select_tool_result_indexes_by_importance(
+        results, max_tool_results=0, protected_recent_count=1
+    )
+    assert len(selected) == 1
+    assert selected == (2,)
+
+
+def test_retain_indexes_within_token_budget_protects_recent() -> None:
+    results = (
+        _tool_result(1),
+        _tool_result(2),
+        _tool_result(3),
+    )
+    indexes = _retain_indexes_within_token_budget(
+        results,
+        candidate_indexes=(0, 1, 2),
+        token_budget=100,
+        protected_recent_count=1,
+        tokenizer_model=None,
+    )
+    assert len(indexes) >= 1
+
+
+def test_select_tool_result_indexes_by_importance_no_results() -> None:
+    selected = _select_tool_result_indexes_by_importance(
+        (), max_tool_results=3, protected_recent_count=1
+    )
+    assert selected == ()
+
+
+def test_select_tool_result_indexes_by_importance_return_order_is_sorted() -> None:
+    results = (
+        _tool_result(1),
+        ToolResult(
+            tool_name="read_file",
+            status="error",
+            error="fail",
+            data={"index": 2},
+        ),
+        _tool_result(3),
+        _tool_result(4),
+    )
+    selected = _select_tool_result_indexes_by_importance(
+        results, max_tool_results=2, protected_recent_count=1
+    )
+    assert selected == (1, 3)
+
+
+def test_context_window_policy_importance_retention_round_trips() -> None:
+    policy = ContextWindowPolicy(importance_retention=False)
+    parsed = context_window_policy_from_payload(policy.metadata_payload())
+    assert parsed.importance_retention is False
+
+    default_policy = ContextWindowPolicy()
+    default_parsed = context_window_policy_from_payload(default_policy.metadata_payload())
+    assert default_parsed.importance_retention is True
+
+
 def test_count_text_tokens_reports_estimated_fallback_metadata() -> None:
     counted = count_text_tokens("abcd你")
 
@@ -1002,11 +1387,18 @@ def test_continuity_summary_metadata_is_derived_from_state() -> None:
         summary_text="one",
         dropped_tool_result_count=1,
         retained_tool_result_count=3,
+        dropped_tool_results=(
+            DroppedToolResultDiagnostic(tool_name="read_file", status="ok", index=1),
+        ),
     )
     second = RuntimeContinuityState(
         summary_text="one",
         dropped_tool_result_count=2,
         retained_tool_result_count=3,
+        dropped_tool_results=(
+            DroppedToolResultDiagnostic(tool_name="read_file", status="ok", index=1),
+            DroppedToolResultDiagnostic(tool_name="read_file", status="ok", index=2),
+        ),
     )
 
     first_anchor, first_source = continuity_summary_metadata(first)

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -684,6 +684,7 @@ class _DistillAwareTurnProvider:
         self.distill_calls = 0
         self.main_calls = 0
         self.last_distill_abort_signal: object | None = None
+        self.last_distill_input: dict[str, object] | None = None
 
     def propose_turn(self, request: object) -> ProviderTurnResult:
         turn_request = cast(ProviderTurnRequest, request)
@@ -691,6 +692,13 @@ class _DistillAwareTurnProvider:
         if prompt.startswith("Return ONLY valid JSON matching these keys:"):
             self.distill_calls += 1
             self.last_distill_abort_signal = turn_request.abort_signal
+            marker = "INPUT="
+            marker_index = prompt.find(marker)
+            if marker_index != -1:
+                raw_input = prompt[marker_index + len(marker) :].strip()
+                parsed_input = json.loads(raw_input)
+                if isinstance(parsed_input, dict):
+                    self.last_distill_input = parsed_input
             if self.distill_error is not None:
                 raise self.distill_error
             if self.distill_output is None:
@@ -10736,6 +10744,72 @@ def test_runtime_distillation_receives_abort_signal_in_provider_request(tmp_path
 
     assert provider.distill_calls >= 1
     assert provider.last_distill_abort_signal is not None
+
+
+def test_runtime_distillation_uses_importance_aware_projection_split(tmp_path: Path) -> None:
+    provider = _DistillAwareTurnProvider(
+        name="opencode",
+        distill_output='{"objective_current_goal":"Goal"}',
+        distill_error=None,
+    )
+    registry = ModelProviderRegistry(
+        providers={"opencode": _DistillAwareModelProvider(name="opencode", provider=provider)}
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(model="opencode/gpt-5.4"),
+        model_provider_registry=registry,
+    )
+
+    metadata = runtime._session_metadata_with_distillation_candidate(  # pyright: ignore[reportPrivateUsage]
+        prompt="fix failing tests",
+        tool_results=(
+            ToolResult(tool_name="read_file", status="ok", content="content-1", data={"index": 1}),
+            ToolResult(
+                tool_name="read_file",
+                status="error",
+                error="missing file",
+                data={"index": 2, "path": "missing.py"},
+            ),
+            ToolResult(
+                tool_name="shell_exec",
+                status="ok",
+                content="passed",
+                data={"index": 3, "command": "pytest tests/unit/test_sample.py -q"},
+            ),
+            ToolResult(tool_name="read_file", status="ok", content="content-4", data={"index": 4}),
+            ToolResult(tool_name="read_file", status="ok", content="content-5", data={"index": 5}),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=3,
+            recent_tool_result_count=1,
+            continuity_distillation_enabled=True,
+            recent_tool_result_tokens=None,
+            default_tool_result_tokens=None,
+        ),
+        effective_config=runtime.effective_runtime_config(),
+        abort_signal=None,
+        provider_attempt=0,
+    )
+
+    runtime_state = cast(dict[str, object], metadata["runtime_state"])
+    assert "distillation_candidate" in runtime_state
+    assert provider.last_distill_input is not None
+    dropped_results = cast(
+        list[dict[str, object]],
+        provider.last_distill_input["dropped_tool_result_previews"],
+    )
+    retained_results = cast(
+        list[dict[str, object]],
+        provider.last_distill_input["recent_tail_previews"],
+    )
+    assert [cast(dict[str, object], item["data"])["index"] for item in dropped_results] == [1, 4]
+    assert [cast(dict[str, object], item["data"])["index"] for item in retained_results] == [
+        2,
+        3,
+        5,
+    ]
 
 
 def test_runtime_distillation_is_skipped_when_no_compaction_needed(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Avoid serializing default LiteLLM calls while preserving global ssl_verify isolation for explicit overrides.
- Add a shared runtime tool-result projection that keeps recent context plus generic high-signal evidence without command-name-specific verification scoring.
- Use the same projected retained/dropped split for provider context and model-assisted continuity distillation.

## Verification
- mise run lint
- mise run typecheck
- mise run test:fast
- uv run python -X utf8 -m pytest tests/unit/tools/test_tool_output_truncation.py -k 'artifact_retrieval_reports_missing'

Note: one `mise run test:fast` attempt hit a transient parallel artifact-missing test failure; the test passed in isolation and the full fast suite passed on re-run.