### PR TITLE
Improve runtime context management and isolate LiteLLM SSL verification

### DIFF
--- a/src/voidcode/provider/litellm_backend.py
+++ b/src/voidcode/provider/litellm_backend.py
@@ -4,9 +4,7 @@ import json
 import logging
 import re
 from collections.abc import Iterator, Mapping
-from contextlib import contextmanager
 from dataclasses import dataclass, field
-from threading import Lock
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 if TYPE_CHECKING:
@@ -51,7 +49,6 @@ _SYNTHETIC_TOOL_FEEDBACK_PREFIX = "Completed tool calls for current request:"
 _CONTINUITY_SUMMARY_PREFIX = "Runtime continuity summary:"
 
 logger = logging.getLogger(__name__)
-_LITELLM_SSL_VERIFY_LOCK = Lock()
 
 
 def _usage_int(raw: object) -> int:
@@ -261,6 +258,11 @@ class LiteLLMBackendSingleAgentProvider:
         self, request: ProviderTurnRequest
     ) -> dict[str, object]:
         return self._completion_kwargs_for_request(request)
+
+    def _apply_ssl_verify_payload(self, payload: dict[str, object]) -> None:
+        configured_ssl_verify = self.config.ssl_verify if self.config is not None else None
+        if configured_ssl_verify is not None:
+            payload["ssl_verify"] = configured_ssl_verify
 
     def _tool_feedback_mode_for_request(self, request: ProviderTurnRequest) -> ToolFeedbackMode:
         request_model_name = request.model_name
@@ -506,27 +508,6 @@ class LiteLLMBackendSingleAgentProvider:
             return {"extra_headers": {self.config.auth_header: f"Bearer {self.config.api_key}"}}
         return {"api_key": self.config.api_key}
 
-    @contextmanager
-    def _litellm_ssl_verify_context(self) -> Iterator[None]:
-        if litellm_module is None:
-            yield
-            return
-        configured_ssl_verify = self.config.ssl_verify if self.config is not None else None
-        if configured_ssl_verify is None:
-            with _LITELLM_SSL_VERIFY_LOCK:
-                pass
-            yield
-            return
-
-        with _LITELLM_SSL_VERIFY_LOCK:
-            module_any = cast(Any, litellm_module)
-            previous = getattr(module_any, "ssl_verify", True)
-            module_any.ssl_verify = configured_ssl_verify
-            try:
-                yield
-            finally:
-                module_any.ssl_verify = previous
-
     @staticmethod
     def _extract_first_tool_call(message: dict[str, object]) -> ToolCall | None:
         raw_tool_calls = message.get("tool_calls")
@@ -625,13 +606,13 @@ class LiteLLMBackendSingleAgentProvider:
             **self._auth_kwargs(),
         }
         payload.update(self._completion_kwargs_for_request(request))
+        self._apply_ssl_verify_payload(payload)
         if request.available_tools:
             payload["tools"] = [self._to_tool_schema(tool) for tool in request.available_tools]
             payload["tool_choice"] = "auto"
 
         try:
-            with self._litellm_ssl_verify_context():
-                response = self._call_litellm_completion(cast(dict[str, Any], payload))
+            response = self._call_litellm_completion(cast(dict[str, Any], payload))
             response_payload = cast(dict[str, object], response.model_dump())
             usage = _extract_token_usage(response_payload)
             raw_choices = response_payload.get("choices")
@@ -680,104 +661,104 @@ class LiteLLMBackendSingleAgentProvider:
             **self._auth_kwargs(),
         }
         payload.update(self._stream_completion_kwargs_for_request(request))
+        self._apply_ssl_verify_payload(payload)
         if request.available_tools:
             payload["tools"] = [self._to_tool_schema(tool) for tool in request.available_tools]
             payload["tool_choice"] = "auto"
 
         try:
-            with self._litellm_ssl_verify_context():
-                stream = cast(
-                    Iterator[Any], self._call_litellm_completion(cast(dict[str, Any], payload))
-                )
-                streamed_tool_calls: dict[int, _StreamedToolCallAccumulator] = {}
-                latest_usage: ProviderTokenUsage | None = None
-                for chunk in stream:
-                    if request.abort_signal is not None and request.abort_signal.cancelled:
+            stream = cast(
+                Iterator[Any], self._call_litellm_completion(cast(dict[str, Any], payload))
+            )
+            streamed_tool_calls: dict[int, _StreamedToolCallAccumulator] = {}
+            latest_usage: ProviderTokenUsage | None = None
+            for chunk in stream:
+                if request.abort_signal is not None and request.abort_signal.cancelled:
+                    yield ProviderStreamEvent(
+                        kind="error",
+                        channel="error",
+                        error="provider stream cancelled",
+                        error_kind="cancelled",
+                    )
+                    yield ProviderStreamEvent(kind="done", done_reason="cancelled")
+                    return
+                chunk_payload = cast(dict[str, object], chunk.model_dump())
+                latest_usage = _extract_token_usage(chunk_payload) or latest_usage
+                raw_choices = chunk_payload.get("choices")
+                if not isinstance(raw_choices, list) or not raw_choices:
+                    continue
+                choices = cast(list[object], raw_choices)
+                first_choice_obj = choices[0]
+                if not isinstance(first_choice_obj, dict):
+                    continue
+                first_choice = cast(dict[str, object], first_choice_obj)
+                delta_obj = first_choice.get("delta")
+                if isinstance(delta_obj, dict):
+                    delta = cast(dict[str, object], delta_obj)
+                    reasoning_obj = delta.get("reasoning_content") or delta.get("reasoning")
+                    if isinstance(reasoning_obj, str) and reasoning_obj:
                         yield ProviderStreamEvent(
-                            kind="error",
-                            channel="error",
-                            error="provider stream cancelled",
-                            error_kind="cancelled",
+                            kind="delta",
+                            channel="reasoning",
+                            text=reasoning_obj,
+                            metadata={"source": "delta.reasoning"},
                         )
-                        yield ProviderStreamEvent(kind="done", done_reason="cancelled")
-                        return
-                    chunk_payload = cast(dict[str, object], chunk.model_dump())
-                    latest_usage = _extract_token_usage(chunk_payload) or latest_usage
-                    raw_choices = chunk_payload.get("choices")
-                    if not isinstance(raw_choices, list) or not raw_choices:
-                        continue
-                    choices = cast(list[object], raw_choices)
-                    first_choice_obj = choices[0]
-                    if not isinstance(first_choice_obj, dict):
-                        continue
-                    first_choice = cast(dict[str, object], first_choice_obj)
-                    delta_obj = first_choice.get("delta")
-                    if isinstance(delta_obj, dict):
-                        delta = cast(dict[str, object], delta_obj)
-                        reasoning_obj = delta.get("reasoning_content") or delta.get("reasoning")
-                        if isinstance(reasoning_obj, str) and reasoning_obj:
-                            yield ProviderStreamEvent(
-                                kind="delta",
-                                channel="reasoning",
-                                text=reasoning_obj,
-                                metadata={"source": "delta.reasoning"},
+                    raw_thinking_blocks = delta.get("thinking_blocks")
+                    if isinstance(raw_thinking_blocks, list):
+                        thinking_blocks = cast(list[object], raw_thinking_blocks)
+                        for block_obj in thinking_blocks:
+                            if not isinstance(block_obj, dict):
+                                continue
+                            block = cast(dict[str, object], block_obj)
+                            if block.get("type") != "thinking":
+                                continue
+                            thinking_text = block.get("thinking")
+                            if isinstance(thinking_text, str) and thinking_text:
+                                yield ProviderStreamEvent(
+                                    kind="delta",
+                                    channel="reasoning",
+                                    text=thinking_text,
+                                    metadata={"source": "delta.thinking_blocks"},
+                                )
+                    text_obj = delta.get("content")
+                    if isinstance(text_obj, str) and text_obj:
+                        yield ProviderStreamEvent(kind="delta", channel="text", text=text_obj)
+                    raw_tool_calls = delta.get("tool_calls")
+                    if isinstance(raw_tool_calls, list):
+                        tool_calls = cast(list[object], raw_tool_calls)
+                        for tool_call_obj in tool_calls:
+                            if not isinstance(tool_call_obj, dict):
+                                continue
+                            tool_call = cast(dict[str, object], tool_call_obj)
+                            index_obj = tool_call.get("index")
+                            index = index_obj if isinstance(index_obj, int) else 0
+                            accumulator = streamed_tool_calls.get(
+                                index,
+                                _StreamedToolCallAccumulator(),
                             )
-                        raw_thinking_blocks = delta.get("thinking_blocks")
-                        if isinstance(raw_thinking_blocks, list):
-                            thinking_blocks = cast(list[object], raw_thinking_blocks)
-                            for block_obj in thinking_blocks:
-                                if not isinstance(block_obj, dict):
-                                    continue
-                                block = cast(dict[str, object], block_obj)
-                                if block.get("type") != "thinking":
-                                    continue
-                                thinking_text = block.get("thinking")
-                                if isinstance(thinking_text, str) and thinking_text:
-                                    yield ProviderStreamEvent(
-                                        kind="delta",
-                                        channel="reasoning",
-                                        text=thinking_text,
-                                        metadata={"source": "delta.thinking_blocks"},
-                                    )
-                        text_obj = delta.get("content")
-                        if isinstance(text_obj, str) and text_obj:
-                            yield ProviderStreamEvent(kind="delta", channel="text", text=text_obj)
-                        raw_tool_calls = delta.get("tool_calls")
-                        if isinstance(raw_tool_calls, list):
-                            tool_calls = cast(list[object], raw_tool_calls)
-                            for tool_call_obj in tool_calls:
-                                if not isinstance(tool_call_obj, dict):
-                                    continue
-                                tool_call = cast(dict[str, object], tool_call_obj)
-                                index_obj = tool_call.get("index")
-                                index = index_obj if isinstance(index_obj, int) else 0
-                                accumulator = streamed_tool_calls.get(
-                                    index,
-                                    _StreamedToolCallAccumulator(),
-                                )
-                                tool_call_id_obj = tool_call.get("id")
-                                tool_call_id = accumulator.tool_call_id
-                                if isinstance(tool_call_id_obj, str) and tool_call_id_obj:
-                                    tool_call_id = tool_call_id_obj
-                                function_obj = tool_call.get("function")
-                                tool_name = accumulator.tool_name
-                                arguments = accumulator.arguments
-                                if isinstance(function_obj, dict):
-                                    function = cast(dict[str, object], function_obj)
-                                    name_obj = function.get("name")
-                                    if isinstance(name_obj, str) and name_obj:
-                                        tool_name = name_obj
-                                    arguments_obj = function.get("arguments")
-                                    if isinstance(arguments_obj, str) and arguments_obj:
-                                        arguments += arguments_obj
-                                streamed_tool_calls[index] = _StreamedToolCallAccumulator(
-                                    tool_call_id=tool_call_id,
-                                    tool_name=tool_name,
-                                    arguments=arguments,
-                                )
-                    finish_reason = first_choice.get("finish_reason")
-                    if isinstance(finish_reason, str) and finish_reason:
-                        continue
+                            tool_call_id_obj = tool_call.get("id")
+                            tool_call_id = accumulator.tool_call_id
+                            if isinstance(tool_call_id_obj, str) and tool_call_id_obj:
+                                tool_call_id = tool_call_id_obj
+                            function_obj = tool_call.get("function")
+                            tool_name = accumulator.tool_name
+                            arguments = accumulator.arguments
+                            if isinstance(function_obj, dict):
+                                function = cast(dict[str, object], function_obj)
+                                name_obj = function.get("name")
+                                if isinstance(name_obj, str) and name_obj:
+                                    tool_name = name_obj
+                                arguments_obj = function.get("arguments")
+                                if isinstance(arguments_obj, str) and arguments_obj:
+                                    arguments += arguments_obj
+                            streamed_tool_calls[index] = _StreamedToolCallAccumulator(
+                                tool_call_id=tool_call_id,
+                                tool_name=tool_name,
+                                arguments=arguments,
+                            )
+                finish_reason = first_choice.get("finish_reason")
+                if isinstance(finish_reason, str) and finish_reason:
+                    continue
         except Exception as exc:
             raise self._map_exception(
                 exc,

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -27,6 +27,11 @@ class DroppedToolResultDiagnostic:
     status: str
     index: int
     tool_call_id: str | None = None
+    artifact_id: str | None = None
+    artifact_status: str | None = None
+    artifact_byte_count: int | None = None
+    artifact_line_count: int | None = None
+    reference: str | None = None
     path: str | None = None
     command: str | None = None
     pattern: str | None = None
@@ -43,6 +48,16 @@ class DroppedToolResultDiagnostic:
         }
         if self.tool_call_id is not None:
             payload["tool_call_id"] = self.tool_call_id
+        if self.artifact_id is not None:
+            payload["artifact_id"] = self.artifact_id
+        if self.artifact_status is not None:
+            payload["artifact_status"] = self.artifact_status
+        if self.artifact_byte_count is not None:
+            payload["artifact_byte_count"] = self.artifact_byte_count
+        if self.artifact_line_count is not None:
+            payload["artifact_line_count"] = self.artifact_line_count
+        if self.reference is not None:
+            payload["reference"] = self.reference
         if self.path is not None:
             payload["path"] = self.path
         if self.command is not None:
@@ -111,7 +126,7 @@ class RuntimeContinuityState:
             "distillation_source": self.distillation_source,
             "fact_reference_count": self.fact_reference_count,
             "source_references": list(self.source_references),
-            "version": 2,
+            "version": self.version,
         }
         if self.distillation_error is not None:
             payload["distillation_error"] = self.distillation_error
@@ -153,7 +168,7 @@ class ContextWindowPolicy:
     continuity_distillation_enabled: bool = False
     continuity_distillation_max_input_items: int = 12
     continuity_distillation_max_input_chars: int = 4000
-    importance_retention: bool = True
+    importance_retention: bool = False
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "per_tool_result_tokens", dict(self.per_tool_result_tokens))
@@ -323,6 +338,19 @@ class RuntimeContextSegment:
 
 def _tool_result_preview(result: ToolResult, *, max_preview_chars: int) -> str:
     parts = [result.tool_name, result.status]
+    artifact_id = _artifact_metadata_string(result, "artifact_id")
+    if artifact_id is not None:
+        parts.append(f"artifact_id={artifact_id}")
+        tool_call_id = _optional_tool_string(result, "tool_call_id")
+        if tool_call_id is not None:
+            parts.append(f"tool_call_id={tool_call_id}")
+        byte_count = _artifact_metadata_int(result, "byte_count")
+        if byte_count is not None:
+            parts.append(f"byte_count={byte_count}")
+        line_count = _artifact_metadata_int(result, "line_count")
+        if line_count is not None:
+            parts.append(f"line_count={line_count}")
+        return " ".join(parts)
     path = result.data.get("path")
     if isinstance(path, str) and path:
         parts.append(f"path={path}")
@@ -362,6 +390,11 @@ def _optional_entry_string(entry: Mapping[str, object], key: str) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
+def _optional_entry_int(entry: Mapping[str, object], key: str) -> int | None:
+    value = entry.get(key)
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
 def _dropped_tool_diagnostics_from_metadata_payload(
     payload: Mapping[str, object],
 ) -> tuple[DroppedToolResultDiagnostic, ...]:
@@ -390,6 +423,11 @@ def _dropped_tool_diagnostics_from_metadata_payload(
                 status=status,
                 index=index,
                 tool_call_id=_optional_entry_string(entry, "tool_call_id"),
+                artifact_id=_optional_entry_string(entry, "artifact_id"),
+                artifact_status=_optional_entry_string(entry, "artifact_status"),
+                artifact_byte_count=_optional_entry_int(entry, "artifact_byte_count"),
+                artifact_line_count=_optional_entry_int(entry, "artifact_line_count"),
+                reference=_optional_entry_string(entry, "reference"),
                 path=_optional_entry_string(entry, "path"),
                 command=_optional_entry_string(entry, "command"),
                 pattern=_optional_entry_string(entry, "pattern"),
@@ -409,6 +447,16 @@ def _dropped_tool_diagnostics_from_metadata_payload(
 def continuity_state_from_metadata_payload(
     payload: Mapping[str, object],
 ) -> RuntimeContinuityState | None:
+    version = payload.get("version")
+    if version is None:
+        resolved_version = 1
+    elif isinstance(version, int) and not isinstance(version, bool):
+        resolved_version = version
+    else:
+        return None
+    if resolved_version not in {1, 2}:
+        return None
+
     summary_text = payload.get("summary_text")
     if summary_text is not None and not isinstance(summary_text, str):
         return None
@@ -459,9 +507,6 @@ def continuity_state_from_metadata_payload(
     token_estimate_source = payload.get("token_estimate_source")
     if token_estimate_source is not None and not isinstance(token_estimate_source, str):
         return None
-    version = payload.get("version")
-    if version is not None and (not isinstance(version, int) or isinstance(version, bool)):
-        return None
     return RuntimeContinuityState(
         summary_text=summary_text,
         objective=objective,
@@ -490,7 +535,7 @@ def continuity_state_from_metadata_payload(
         token_budget=resolved_token_budget,
         token_estimate_source=token_estimate_source,
         dropped_tool_results=_dropped_tool_diagnostics_from_metadata_payload(payload),
-        version=version if version is not None else 1,
+        version=resolved_version,
     )
 
 
@@ -701,6 +746,30 @@ def _optional_tool_string(result: ToolResult, key: str) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
+def _optional_tool_int(result: ToolResult, key: str) -> int | None:
+    value = result.data.get(key)
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _artifact_metadata_value(result: ToolResult, key: str) -> object:
+    artifact = result.data.get("artifact")
+    if isinstance(artifact, Mapping):
+        value = cast(Mapping[str, object], artifact).get(key)
+        if value is not None:
+            return value
+    return result.data.get(key)
+
+
+def _artifact_metadata_string(result: ToolResult, key: str) -> str | None:
+    value = _artifact_metadata_value(result, key)
+    return value if isinstance(value, str) and value else None
+
+
+def _artifact_metadata_int(result: ToolResult, key: str) -> int | None:
+    value = _artifact_metadata_value(result, key)
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
 def _dropped_tool_diagnostics(
     results: tuple[ToolResult, ...],
     *,
@@ -716,6 +785,16 @@ def _dropped_tool_diagnostics(
                 status=result.status,
                 index=index,
                 tool_call_id=_optional_tool_string(result, "tool_call_id"),
+                artifact_id=_artifact_metadata_string(result, "artifact_id"),
+                artifact_status=_artifact_metadata_string(result, "status")
+                or _optional_tool_string(result, "artifact_status"),
+                artifact_byte_count=_artifact_metadata_int(result, "byte_count")
+                or _optional_tool_int(result, "original_byte_count")
+                or _optional_tool_int(result, "original_error_byte_count"),
+                artifact_line_count=_artifact_metadata_int(result, "line_count")
+                or _optional_tool_int(result, "original_line_count")
+                or _optional_tool_int(result, "original_error_line_count"),
+                reference=result.reference,
                 path=_optional_tool_string(result, "path"),
                 command=_optional_tool_string(result, "command"),
                 pattern=_optional_tool_string(result, "pattern"),
@@ -729,50 +808,6 @@ def _dropped_tool_diagnostics(
             )
         )
     return tuple(diagnostics)
-
-
-def _tool_result_importance_score(result: ToolResult) -> int:
-    score = 0
-    if result.status == "error":
-        score += 100
-    if result.error_kind is not None:
-        score += 20
-    if result.truncated or result.partial:
-        score += 10
-    if result.tool_name in {"todo_write", "task", "background_output"}:
-        score += 80
-    if result.tool_name in {"write_file", "edit", "multi_edit", "apply_patch"}:
-        score += 70
-    if result.tool_name == "shell_exec":
-        score += 30
-    if any(isinstance(result.data.get(key), str) for key in ("path", "filePath")):
-        score += 10
-    return score
-
-
-def _select_tool_result_indexes_by_importance(
-    results: tuple[ToolResult, ...],
-    *,
-    max_tool_results: int,
-    protected_recent_count: int,
-) -> tuple[int, ...]:
-    if not results:
-        return ()
-    protected_recent_count = min(protected_recent_count, len(results))
-    protected_start = len(results) - protected_recent_count
-    protected_indexes = set(range(protected_start, len(results)))
-    if max_tool_results == 0:
-        return tuple(sorted(protected_indexes))
-
-    count_limit = max(max_tool_results, protected_recent_count)
-    remaining_slots = max(0, count_limit - len(protected_indexes))
-    ranked_candidates = sorted(
-        range(0, protected_start),
-        key=lambda index: (_tool_result_importance_score(results[index]), index),
-        reverse=True,
-    )
-    selected = set(ranked_candidates[:remaining_slots]) | protected_indexes
-    return tuple(sorted(selected))
 
 
 def _select_recent_tool_result_indexes(
@@ -808,12 +843,10 @@ def _retain_indexes_within_token_budget(
         _tool_result_token_estimate(results[index], tokenizer_model=tokenizer_model).tokens
         for index in protected_indexes
     )
-    ranked_candidates = sorted(
+    for index in sorted(
         (index for index in candidate_indexes if index not in protected_indexes),
-        key=lambda index: (_tool_result_importance_score(results[index]), index),
         reverse=True,
-    )
-    for index in ranked_candidates:
+    ):
         estimate = _tool_result_token_estimate(
             results[index], tokenizer_model=tokenizer_model
         ).tokens
@@ -1465,6 +1498,66 @@ def continuity_summary_metadata(
     return summary_anchor, summary_source
 
 
+def _artifact_reference_segments(
+    continuity_state: RuntimeContinuityState | None,
+) -> tuple[RuntimeContextSegment, ...]:
+    if continuity_state is None:
+        return ()
+    segments: list[RuntimeContextSegment] = []
+    for diagnostic in continuity_state.dropped_tool_results:
+        if diagnostic.artifact_id is None:
+            continue
+        parts = [
+            "Runtime artifact reference for omitted tool output:",
+            f"artifact_id={diagnostic.artifact_id}",
+            f"tool_call_id={diagnostic.tool_call_id}" if diagnostic.tool_call_id else None,
+            f"tool_name={diagnostic.tool_name}",
+            f"status={diagnostic.status}",
+            (
+                f"artifact_status={diagnostic.artifact_status}"
+                if diagnostic.artifact_status
+                else None
+            ),
+            (
+                f"byte_count={diagnostic.artifact_byte_count}"
+                if diagnostic.artifact_byte_count is not None
+                else None
+            ),
+            (
+                f"line_count={diagnostic.artifact_line_count}"
+                if diagnostic.artifact_line_count is not None
+                else None
+            ),
+            f"reference={diagnostic.reference}" if diagnostic.reference else None,
+        ]
+        content = "\n".join(part for part in parts if part is not None)
+        metadata: dict[str, object] = {
+            "source": "runtime_context_artifact_reference",
+            "artifact_id": diagnostic.artifact_id,
+            "tool_name": diagnostic.tool_name,
+            "status": diagnostic.status,
+            "dropped_tool_result_index": diagnostic.index,
+        }
+        if diagnostic.tool_call_id is not None:
+            metadata["tool_call_id"] = diagnostic.tool_call_id
+        if diagnostic.artifact_status is not None:
+            metadata["artifact_status"] = diagnostic.artifact_status
+        if diagnostic.artifact_byte_count is not None:
+            metadata["byte_count"] = diagnostic.artifact_byte_count
+        if diagnostic.artifact_line_count is not None:
+            metadata["line_count"] = diagnostic.artifact_line_count
+        if diagnostic.reference is not None:
+            metadata["reference"] = diagnostic.reference
+        segments.append(
+            RuntimeContextSegment(
+                role="system",
+                content=content,
+                metadata=metadata,
+            )
+        )
+    return tuple(segments)
+
+
 def project_tool_results_for_context_window(
     *,
     tool_results: tuple[ToolResult, ...],
@@ -1495,18 +1588,10 @@ def project_tool_results_for_context_window(
             truncated_count += 1
     prepared_results = tuple(truncated_results)
 
-    count_limited_indexes = (
-        _select_tool_result_indexes_by_importance(
-            prepared_results,
-            max_tool_results=policy.max_tool_results,
-            protected_recent_count=protected_recent_count,
-        )
-        if policy.importance_retention
-        else _select_recent_tool_result_indexes(
-            prepared_results,
-            max_tool_results=policy.max_tool_results,
-            protected_recent_count=protected_recent_count,
-        )
+    count_limited_indexes = _select_recent_tool_result_indexes(
+        prepared_results,
+        max_tool_results=policy.max_tool_results,
+        protected_recent_count=protected_recent_count,
     )
     retained_indexes = (
         _retain_indexes_within_token_budget(
@@ -1725,10 +1810,20 @@ def assemble_provider_context(
     todo_prompt_context = render_provider_todo_state(session_metadata)
     if todo_prompt_context is not None:
         _append_system_segment(todo_prompt_context, source="runtime_todo_state")
-    continuity_state = preserved_continuity_state or context_window.continuity_state
+    continuity_state = (
+        preserved_continuity_state
+        or context_window.continuity_state
+        or _previous_continuity_state(session_metadata)
+    )
     metadata_payload = context_window.metadata_payload()
     if continuity_state is not None and "continuity_state" not in metadata_payload:
         metadata_payload["continuity_state"] = continuity_state.metadata_payload()
+    if continuity_state is not None and "summary_anchor" not in metadata_payload:
+        summary_anchor, summary_source = continuity_summary_metadata(continuity_state)
+        if summary_anchor is not None:
+            metadata_payload["summary_anchor"] = summary_anchor
+        if summary_source is not None:
+            metadata_payload["summary_source"] = summary_source
     if continuity_state is not None:
         summary_text = continuity_state.summary_text
         if isinstance(summary_text, str) and summary_text.strip():
@@ -1736,6 +1831,7 @@ def assemble_provider_context(
                 f"Runtime continuity summary:\n{summary_text.strip()}",
                 source="continuity_summary",
             )
+        segments.extend(_artifact_reference_segments(continuity_state))
     segments.append(
         RuntimeContextSegment(
             role="user",

--- a/src/voidcode/runtime/provider_context.py
+++ b/src/voidcode/runtime/provider_context.py
@@ -445,6 +445,7 @@ def _diagnostics(
 ) -> list[RuntimeProviderContextDiagnostic]:
     diagnostics: list[RuntimeProviderContextDiagnostic] = []
     diagnostics.extend(_duplicate_system_diagnostics(segments))
+    diagnostics.extend(_compact_projection_role_diagnostics(segments))
     diagnostics.extend(
         _tool_pair_diagnostics(
             segments,
@@ -495,6 +496,40 @@ def _duplicate_system_diagnostics(
         for indices in by_fingerprint.values()
         if len(indices) > 1
     ]
+
+
+def _compact_projection_role_diagnostics(
+    segments: tuple[RuntimeContextSegment, ...],
+) -> list[RuntimeProviderContextDiagnostic]:
+    compact_sources = {
+        "continuity_summary",
+        "runtime_context_artifact_reference",
+    }
+    diagnostics: list[RuntimeProviderContextDiagnostic] = []
+    for index, segment in enumerate(segments):
+        source = _source_from_metadata(segment)
+        if source not in compact_sources:
+            continue
+        if segment.role == "system" and segment.tool_call_id is None and segment.tool_name is None:
+            continue
+        diagnostics.append(
+            RuntimeProviderContextDiagnostic(
+                severity="error",
+                code="compact_projection_wrong_role",
+                message=(
+                    "Runtime compact projection segments must be system context, not "
+                    "provider tool-role messages or synthetic assistant tool calls."
+                ),
+                source=source,
+                segment_indices=(index,),
+                suggested_fix=(
+                    "Insert continuity summaries and artifact references as runtime-owned "
+                    "system segments without tool_call_id or tool_name."
+                ),
+                details={"role": segment.role},
+            )
+        )
+    return diagnostics
 
 
 def _tool_pair_diagnostics(
@@ -560,9 +595,14 @@ def _tool_pair_diagnostics(
                     details={"tool_call_id": tool_call_id},
                 )
             )
-    duplicate_ids = [
-        tool_call_id for tool_call_id, indices in assistant_ids.items() if len(indices) > 1
-    ]
+    duplicate_ids = sorted(
+        {
+            tool_call_id
+            for ids_by_role in (assistant_ids, tool_ids)
+            for tool_call_id, indices in ids_by_role.items()
+            if len(indices) > 1
+        }
+    )
     if duplicate_ids:
         diagnostics.append(
             RuntimeProviderContextDiagnostic(

--- a/tests/unit/provider/test_provider_adapters.py
+++ b/tests/unit/provider/test_provider_adapters.py
@@ -37,7 +37,6 @@ from voidcode.provider.protocol import (
     ProviderStreamEvent,
     ProviderTokenUsage,
     ProviderTurnRequest,
-    ProviderTurnResult,
     StreamableTurnProvider,
     TurnProvider,
 )
@@ -2426,8 +2425,6 @@ def test_glm_provider_does_not_append_v1_to_base_url(monkeypatch: pytest.MonkeyP
 
 
 def test_litellm_backend_propose_turn_forwards_ssl_verify(monkeypatch: pytest.MonkeyPatch) -> None:
-    import voidcode.provider.litellm_backend as backend_module
-
     provider = LiteLLMBackendSingleAgentProvider(
         name="litellm",
         config=LiteLLMProviderConfig(
@@ -2442,15 +2439,6 @@ def test_litellm_backend_propose_turn_forwards_ssl_verify(monkeypatch: pytest.Mo
         mode="completion",
         completion_content="ok",
     )
-    monkeypatch.setattr(backend_module.litellm_module, "ssl_verify", True, raising=False)
-
-    original_completion = backend_module.litellm_module.completion
-
-    def _completion_with_ssl_capture(*args: object, **kwargs: object) -> object:
-        _LAST_REQUEST_PAYLOAD["ssl_verify_during_call"] = backend_module.litellm_module.ssl_verify
-        return original_completion(*args, **kwargs)
-
-    monkeypatch.setattr(backend_module.litellm_module, "completion", _completion_with_ssl_capture)
 
     result = provider.propose_turn(_build_turn_request(model_name="litellm"))
 
@@ -2458,9 +2446,7 @@ def test_litellm_backend_propose_turn_forwards_ssl_verify(monkeypatch: pytest.Mo
     payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
     assert isinstance(payload_obj, dict)
     payload = cast(dict[str, object], payload_obj)
-    assert "ssl_verify" not in payload
-    assert _LAST_REQUEST_PAYLOAD["ssl_verify_during_call"] is False
-    assert backend_module.litellm_module.ssl_verify is True
+    assert payload["ssl_verify"] is False
 
 
 def test_litellm_backend_omits_ssl_verify_when_not_configured(
@@ -2489,8 +2475,19 @@ def test_litellm_backend_omits_ssl_verify_when_not_configured(
     assert "ssl_verify" not in payload
 
 
-def test_litellm_backend_default_ssl_verify_waits_for_global_restore_without_serializing_call(
+@pytest.mark.parametrize(
+    ("first_provider", "second_provider", "first_key", "second_key"),
+    [
+        ("default", "explicit", None, False),
+        ("explicit", "default", False, None),
+    ],
+)
+def test_litellm_backend_ssl_verify_is_request_scoped_under_concurrency(
     monkeypatch: pytest.MonkeyPatch,
+    first_provider: str,
+    second_provider: str,
+    first_key: bool | None,
+    second_key: bool | None,
 ) -> None:
     import voidcode.provider.litellm_backend as backend_module
 
@@ -2509,11 +2506,23 @@ def test_litellm_backend_default_ssl_verify_waits_for_global_restore_without_ser
             base_url="https://default.example.test",
         ),
     )
-    entered_explicit_call = threading.Event()
-    entered_default_call = threading.Event()
-    release_default_call = threading.Event()
-    release_explicit_call = threading.Event()
-    observations: list[tuple[str, object]] = []
+    providers = {
+        "explicit": explicit_provider,
+        "default": default_provider,
+    }
+    request_models = {
+        "explicit": "explicit-gateway",
+        "default": "default-gateway",
+    }
+    entered_calls: dict[str, threading.Event] = {
+        "explicit": threading.Event(),
+        "default": threading.Event(),
+    }
+    release_calls: dict[str, threading.Event] = {
+        "explicit": threading.Event(),
+        "default": threading.Event(),
+    }
+    observations: list[tuple[str, object, object]] = []
     thread_errors: list[BaseException] = []
 
     _patch_litellm_completion(
@@ -2521,68 +2530,77 @@ def test_litellm_backend_default_ssl_verify_waits_for_global_restore_without_ser
         mode="completion",
         completion_content="ok",
     )
-    monkeypatch.setattr(backend_module.litellm_module, "ssl_verify", True, raising=False)
+    monkeypatch.setattr(
+        backend_module.litellm_module,
+        "ssl_verify",
+        "module-sentinel",
+        raising=False,
+    )
 
     def _blocking_completion(*args: object, **kwargs: object) -> object:
         _ = args, kwargs
         api_base = kwargs.get("api_base")
         if api_base == "https://explicit.example.test/v1":
-            observations.append(("explicit", backend_module.litellm_module.ssl_verify))
-            entered_explicit_call.set()
-            assert release_explicit_call.wait(timeout=2)
+            observations.append(
+                ("explicit", backend_module.litellm_module.ssl_verify, kwargs.get("ssl_verify"))
+            )
+            entered_calls["explicit"].set()
+            assert release_calls["explicit"].wait(timeout=2)
         else:
-            observations.append(("default", backend_module.litellm_module.ssl_verify))
-            entered_default_call.set()
-            assert release_default_call.wait(timeout=2)
+            observations.append(
+                ("default", backend_module.litellm_module.ssl_verify, kwargs.get("ssl_verify"))
+            )
+            entered_calls["default"].set()
+            assert release_calls["default"].wait(timeout=2)
         return _StubCompletionResponse(content="ok")
 
     monkeypatch.setattr(backend_module.litellm_module, "completion", _blocking_completion)
 
-    def _run_explicit_provider() -> None:
+    first_entered = entered_calls[first_provider]
+    second_entered = entered_calls[second_provider]
+    first_release = release_calls[first_provider]
+    second_release = release_calls[second_provider]
+
+    def _run_provider(provider_name: str) -> None:
         try:
-            result = explicit_provider.propose_turn(
-                _build_turn_request(model_name="explicit-gateway")
+            result = providers[provider_name].propose_turn(
+                _build_turn_request(model_name=request_models[provider_name])
             )
             assert result.output == "ok"
         except BaseException as exc:  # pragma: no cover - re-raised in main test thread
             thread_errors.append(exc)
             raise
 
-    explicit_thread = threading.Thread(target=_run_explicit_provider)
-    explicit_thread.start()
-    assert entered_explicit_call.wait(timeout=2)
-
-    default_result_holder: dict[str, object] = {}
-
-    def _run_default_provider() -> None:
-        try:
-            default_result_holder["result"] = default_provider.propose_turn(
-                _build_turn_request(model_name="default-gateway")
-            )
-        except BaseException as exc:  # pragma: no cover - re-raised in main test thread
-            thread_errors.append(exc)
-            raise
-
-    default_thread = threading.Thread(target=_run_default_provider)
-    default_thread.start()
-    assert not entered_default_call.wait(timeout=0.05)
-    release_explicit_call.set()
-    assert entered_default_call.wait(timeout=2)
-    explicit_thread.join(timeout=2)
-    assert explicit_thread.is_alive() is False
-    release_default_call.set()
-    default_thread.join(timeout=2)
+    first_thread = threading.Thread(target=_run_provider, args=(first_provider,))
+    second_thread = threading.Thread(target=_run_provider, args=(second_provider,))
+    first_thread.start()
+    assert first_entered.wait(timeout=2)
+    second_thread.start()
+    assert second_entered.wait(timeout=2)
+    second_release.set()
+    first_release.set()
+    first_thread.join(timeout=2)
+    second_thread.join(timeout=2)
+    assert first_thread.is_alive() is False
+    assert second_thread.is_alive() is False
 
     assert thread_errors == []
-    default_result = cast(ProviderTurnResult, default_result_holder["result"])
-    assert default_result.output == "ok"
-    assert observations == [("explicit", False), ("default", True)]
-    assert backend_module.litellm_module.ssl_verify is True
+    assert observations == [
+        (
+            first_provider,
+            "module-sentinel",
+            first_key,
+        ),
+        (
+            second_provider,
+            "module-sentinel",
+            second_key,
+        ),
+    ]
+    assert backend_module.litellm_module.ssl_verify == "module-sentinel"
 
 
 def test_litellm_backend_stream_turn_forwards_ssl_verify(monkeypatch: pytest.MonkeyPatch) -> None:
-    import voidcode.provider.litellm_backend as backend_module
-
     provider = LiteLLMBackendSingleAgentProvider(
         name="litellm",
         config=LiteLLMProviderConfig(
@@ -2597,15 +2615,6 @@ def test_litellm_backend_stream_turn_forwards_ssl_verify(monkeypatch: pytest.Mon
         mode="stream",
         stream_chunks=(("ok", "stop"),),
     )
-    monkeypatch.setattr(backend_module.litellm_module, "ssl_verify", True, raising=False)
-
-    original_completion = backend_module.litellm_module.completion
-
-    def _completion_with_ssl_capture(*args: object, **kwargs: object) -> object:
-        _LAST_REQUEST_PAYLOAD["ssl_verify_during_call"] = backend_module.litellm_module.ssl_verify
-        return original_completion(*args, **kwargs)
-
-    monkeypatch.setattr(backend_module.litellm_module, "completion", _completion_with_ssl_capture)
 
     events = list(provider.stream_turn(_build_turn_request(model_name="litellm")))
 
@@ -2613,9 +2622,7 @@ def test_litellm_backend_stream_turn_forwards_ssl_verify(monkeypatch: pytest.Mon
     payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
     assert isinstance(payload_obj, dict)
     payload = cast(dict[str, object], payload_obj)
-    assert "ssl_verify" not in payload
-    assert _LAST_REQUEST_PAYLOAD["ssl_verify_during_call"] is False
-    assert backend_module.litellm_module.ssl_verify is True
+    assert payload["ssl_verify"] is False
 
 
 def test_provider_adapter_propose_turn_returns_tool_call_when_model_requests_tool(

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -13,8 +13,6 @@ from voidcode.runtime.context_window import (
     RuntimeContextSegment,
     RuntimeContinuityState,
     _retain_indexes_within_token_budget,
-    _select_tool_result_indexes_by_importance,
-    _tool_result_importance_score,
     assemble_provider_context,
     context_window_policy_from_payload,
     continuity_state_from_metadata_payload,
@@ -22,6 +20,7 @@ from voidcode.runtime.context_window import (
     count_text_tokens,
     normalize_read_file_output,
     prepare_provider_context,
+    project_tool_results_for_context_window,
 )
 from voidcode.runtime.provider_context import inspect_provider_context
 from voidcode.tools.contracts import ToolResult
@@ -382,6 +381,94 @@ def test_provider_context_inspector_reports_tool_pairing_problems() -> None:
     assert "missing_tool_result" in diagnostic_codes
     assert "orphan_tool_result" in diagnostic_codes
     assert "provider_requires_tools_schema" in diagnostic_codes
+
+
+def test_provider_context_inspector_reports_duplicate_tool_result_ids() -> None:
+    assembled = RuntimeAssembledContext(
+        prompt="continue",
+        tool_results=(),
+        continuity_state=None,
+        metadata={},
+        segments=(
+            RuntimeContextSegment(
+                role="assistant",
+                content=None,
+                tool_call_id="duplicate-result",
+                tool_name="read_file",
+            ),
+            RuntimeContextSegment(
+                role="tool",
+                content="first",
+                tool_call_id="duplicate-result",
+                tool_name="read_file",
+                metadata={"status": "ok", "data": {}},
+            ),
+            RuntimeContextSegment(
+                role="tool",
+                content="second",
+                tool_call_id="duplicate-result",
+                tool_name="read_file",
+                metadata={"status": "ok", "data": {}},
+            ),
+        ),
+    )
+
+    snapshot = inspect_provider_context(
+        assembled_context=assembled,
+        provider="openai",
+        model="gpt-4o",
+        execution_engine="provider",
+        available_tool_count=1,
+    )
+
+    duplicate = [
+        diagnostic
+        for diagnostic in snapshot.diagnostics
+        if diagnostic.code == "duplicate_tool_call_id"
+    ]
+    assert len(duplicate) == 1
+    assert duplicate[0].details == {"tool_call_ids": ["duplicate-result"]}
+
+
+def test_provider_context_inspector_reports_oversized_retained_tool_feedback() -> None:
+    assembled = RuntimeAssembledContext(
+        prompt="continue",
+        tool_results=(),
+        continuity_state=None,
+        metadata={},
+        segments=(
+            RuntimeContextSegment(
+                role="assistant",
+                content=None,
+                tool_call_id="large-result",
+                tool_name="read_file",
+            ),
+            RuntimeContextSegment(
+                role="tool",
+                content="x" * 32,
+                tool_call_id="large-result",
+                tool_name="read_file",
+                metadata={"status": "ok", "data": {}},
+            ),
+        ),
+    )
+
+    snapshot = inspect_provider_context(
+        assembled_context=assembled,
+        provider="openai",
+        model="gpt-4o",
+        execution_engine="provider",
+        available_tool_count=1,
+        oversized_tool_feedback_chars=8,
+    )
+
+    oversized = [
+        diagnostic
+        for diagnostic in snapshot.diagnostics
+        if diagnostic.code == "oversized_tool_feedback"
+    ]
+    assert len(oversized) == 1
+    assert oversized[0].details == {"content_chars": 32, "threshold_chars": 8}
 
 
 def test_provider_context_parity_matrix_preserves_tool_shapes_across_debug_messages() -> None:
@@ -823,7 +910,7 @@ def test_prepare_provider_context_keeps_count_policy_when_budget_missing() -> No
     assert context.original_tool_result_tokens is None
 
 
-def test_prepare_provider_context_prioritizes_important_older_results() -> None:
+def test_prepare_provider_context_retains_recent_tail_without_scoring() -> None:
     context = prepare_provider_context(
         prompt="fix failing tests",
         tool_results=(
@@ -848,7 +935,7 @@ def test_prepare_provider_context_prioritizes_important_older_results() -> None:
         ),
     )
 
-    assert tuple(result.data["index"] for result in context.tool_results) == (2, 3, 5)
+    assert tuple(result.data["index"] for result in context.tool_results) == (3, 4, 5)
     assert context.compacted is True
     assert context.continuity_state is not None
     dropped_tool_names = [
@@ -859,10 +946,10 @@ def test_prepare_provider_context_prioritizes_important_older_results() -> None:
     dropped_index_positions = [
         item.metadata_payload()["index"] for item in context.continuity_state.dropped_tool_results
     ]
-    assert dropped_index_positions == [1, 4]
+    assert dropped_index_positions == [1, 2]
 
 
-def test_prepare_provider_context_token_budget_prefers_important_candidates() -> None:
+def test_prepare_provider_context_token_budget_prefers_recent_candidates() -> None:
     context = prepare_provider_context(
         prompt="verify fix",
         tool_results=(
@@ -882,9 +969,9 @@ def test_prepare_provider_context_token_budget_prefers_important_candidates() ->
     )
 
     retained_indexes = tuple(result.data["index"] for result in context.tool_results)
-    assert 2 in retained_indexes
     assert 4 in retained_indexes
-    assert 1 not in retained_indexes or 3 not in retained_indexes
+    assert 3 in retained_indexes
+    assert 1 not in retained_indexes
     assert context.compacted is True
     assert context.token_budget == 120
 
@@ -918,7 +1005,7 @@ def test_prepare_provider_context_can_disable_importance_retention() -> None:
     assert tuple(result.data["index"] for result in context.tool_results) == (3, 4, 5)
 
 
-def test_prepare_provider_context_older_todo_and_task_survive_over_newer_reads() -> None:
+def test_prepare_provider_context_older_todo_and_task_do_not_displace_newer_reads() -> None:
     context = prepare_provider_context(
         prompt="finish task",
         tool_results=(
@@ -949,10 +1036,10 @@ def test_prepare_provider_context_older_todo_and_task_survive_over_newer_reads()
     )
 
     retained_indexes = tuple(result.data["index"] for result in context.tool_results)
-    assert retained_indexes == (1, 2, 5)
+    assert retained_indexes == (3, 4, 5)
 
 
-def test_prepare_provider_context_older_write_edit_survive_over_newer_reads() -> None:
+def test_prepare_provider_context_older_write_edit_do_not_displace_newer_reads() -> None:
     context = prepare_provider_context(
         prompt="fix code",
         tool_results=(
@@ -983,10 +1070,10 @@ def test_prepare_provider_context_older_write_edit_survive_over_newer_reads() ->
     )
 
     retained_indexes = tuple(result.data["index"] for result in context.tool_results)
-    assert retained_indexes == (1, 2, 5)
+    assert retained_indexes == (3, 4, 5)
 
 
-def test_prepare_provider_context_older_error_beats_newer_low_value() -> None:
+def test_prepare_provider_context_older_error_does_not_displace_newer_results() -> None:
     context = prepare_provider_context(
         prompt="debug",
         tool_results=(
@@ -1012,7 +1099,7 @@ def test_prepare_provider_context_older_error_beats_newer_low_value() -> None:
     )
 
     retained_indexes = tuple(result.data["index"] for result in context.tool_results)
-    assert retained_indexes == (1, 4, 5)
+    assert retained_indexes == (3, 4, 5)
 
 
 def test_prepare_provider_context_importance_tie_breaker_prefers_newer() -> None:
@@ -1072,79 +1159,6 @@ def test_prepare_provider_context_protected_recent_always_kept() -> None:
     assert 3 in retained_indexes
 
 
-def _error_result(index: int) -> ToolResult:
-    return ToolResult(
-        tool_name="read_file",
-        status="error",
-        error="error message",
-        data={"index": index},
-    )
-
-
-def test_tool_result_importance_score_errors_rank_high() -> None:
-    assert _tool_result_importance_score(_error_result(1)) >= 100
-
-
-def test_tool_result_importance_score_todo_beats_plain_read() -> None:
-    todo = ToolResult(tool_name="todo_write", content="todos", status="ok", data={"index": 1})
-    plain = _tool_result(2)
-    assert _tool_result_importance_score(todo) > _tool_result_importance_score(plain)
-
-
-def test_tool_result_importance_score_write_beats_plain_read() -> None:
-    write = ToolResult(
-        tool_name="write_file",
-        content="data",
-        status="ok",
-        data={"index": 1, "path": "out.txt"},
-    )
-    plain = _tool_result(2)
-    assert _tool_result_importance_score(write) > _tool_result_importance_score(plain)
-
-
-def test_tool_result_importance_score_shell_command_is_generic_signal() -> None:
-    project_shell = ToolResult(
-        tool_name="shell_exec",
-        content="completed",
-        status="ok",
-        data={"index": 1, "command": "run project verification"},
-    )
-    plain_shell = ToolResult(
-        tool_name="shell_exec",
-        content="ok",
-        status="ok",
-        data={"index": 2, "command": "run maintenance task"},
-    )
-    assert _tool_result_importance_score(project_shell) == _tool_result_importance_score(
-        plain_shell
-    )
-
-
-def test_tool_result_importance_score_delete_file_not_treated_as_write() -> None:
-    delete = ToolResult(
-        tool_name="delete_file",
-        content="deleted",
-        status="ok",
-        data={"index": 1, "path": "tmp.txt"},
-    )
-    write = ToolResult(
-        tool_name="write_file",
-        content="data",
-        status="ok",
-        data={"index": 2, "path": "out.txt"},
-    )
-    assert _tool_result_importance_score(delete) < _tool_result_importance_score(write)
-
-
-def test_select_tool_result_indexes_by_importance_max_zero() -> None:
-    results = (_tool_result(1), _tool_result(2), _tool_result(3))
-    selected = _select_tool_result_indexes_by_importance(
-        results, max_tool_results=0, protected_recent_count=1
-    )
-    assert len(selected) == 1
-    assert selected == (2,)
-
-
 def test_retain_indexes_within_token_budget_protects_recent() -> None:
     results = (
         _tool_result(1),
@@ -1161,39 +1175,19 @@ def test_retain_indexes_within_token_budget_protects_recent() -> None:
     assert len(indexes) >= 1
 
 
-def test_select_tool_result_indexes_by_importance_no_results() -> None:
-    selected = _select_tool_result_indexes_by_importance(
-        (), max_tool_results=3, protected_recent_count=1
-    )
-    assert selected == ()
-
-
-def test_select_tool_result_indexes_by_importance_return_order_is_sorted() -> None:
-    results = (
-        _tool_result(1),
-        ToolResult(
-            tool_name="read_file",
-            status="error",
-            error="fail",
-            data={"index": 2},
-        ),
-        _tool_result(3),
-        _tool_result(4),
-    )
-    selected = _select_tool_result_indexes_by_importance(
-        results, max_tool_results=2, protected_recent_count=1
-    )
-    assert selected == (1, 3)
-
-
-def test_context_window_policy_importance_retention_round_trips() -> None:
+def test_context_window_policy_importance_retention_is_compatibility_only() -> None:
     policy = ContextWindowPolicy(importance_retention=False)
     parsed = context_window_policy_from_payload(policy.metadata_payload())
     assert parsed.importance_retention is False
 
     default_policy = ContextWindowPolicy()
     default_parsed = context_window_policy_from_payload(default_policy.metadata_payload())
-    assert default_parsed.importance_retention is True
+    assert default_parsed.importance_retention is False
+
+    legacy_payload = default_policy.metadata_payload()
+    legacy_payload["importance_retention"] = True
+    legacy_parsed = context_window_policy_from_payload(legacy_payload)
+    assert legacy_parsed.importance_retention is True
 
 
 def test_count_text_tokens_reports_estimated_fallback_metadata() -> None:
@@ -1441,6 +1435,140 @@ def test_prepare_provider_context_continuity_metadata_includes_version() -> None
     assert payload.get("dropped_tool_result_count") == 1
     assert payload.get("retained_tool_result_count") == 1
     assert payload.get("objective") == "read sample.txt"
+
+
+def test_continuity_state_metadata_payload_uses_instance_version() -> None:
+    state = RuntimeContinuityState(
+        summary_text="legacy summary",
+        dropped_tool_result_count=1,
+        retained_tool_result_count=2,
+        source="tool_result_window",
+        version=1,
+    )
+
+    payload = state.metadata_payload()
+
+    assert payload["version"] == 1
+
+
+def test_continuity_state_from_metadata_payload_accepts_explicit_v1_fallback() -> None:
+    payload: dict[str, object] = {
+        "version": 1,
+        "summary_text": "v1 summary",
+        "dropped_tool_result_count": 1,
+        "retained_tool_result_count": 2,
+        "source": "tool_result_window",
+    }
+
+    state = continuity_state_from_metadata_payload(payload)
+
+    assert state is not None
+    assert state.version == 1
+    assert state.summary_text == "v1 summary"
+    assert state.distillation_source == "deterministic"
+
+
+def test_continuity_state_from_metadata_payload_defaults_missing_version_to_v1() -> None:
+    payload: dict[str, object] = {
+        "summary_text": "implicit legacy summary",
+        "dropped_tool_result_count": 1,
+        "retained_tool_result_count": 2,
+        "source": "tool_result_window",
+    }
+
+    state = continuity_state_from_metadata_payload(payload)
+
+    assert state is not None
+    assert state.version == 1
+    assert state.summary_text == "implicit legacy summary"
+
+
+def test_continuity_state_from_metadata_payload_rejects_unknown_version_safely() -> None:
+    payload: dict[str, object] = {
+        "version": 99,
+        "summary_text": "future summary",
+        "dropped_tool_result_count": 1,
+        "retained_tool_result_count": 2,
+        "source": "tool_result_window",
+    }
+
+    assert continuity_state_from_metadata_payload(payload) is None
+
+
+def test_continuity_state_from_metadata_payload_rejects_malformed_version_safely() -> None:
+    payload: dict[str, object] = {
+        "version": "2",
+        "summary_text": "malformed summary",
+        "dropped_tool_result_count": 1,
+        "retained_tool_result_count": 2,
+        "source": "tool_result_window",
+    }
+
+    assert continuity_state_from_metadata_payload(payload) is None
+
+
+def test_assemble_provider_context_ignores_malformed_prior_continuity_metadata() -> None:
+    assembled = assemble_provider_context(
+        prompt="continue",
+        tool_results=(_tool_result(1),),
+        session_metadata={
+            "runtime_state": {
+                "continuity": {
+                    "version": "bad",
+                    "summary_text": "must not be trusted as transcript truth",
+                    "dropped_tool_result_count": 1,
+                    "retained_tool_result_count": 1,
+                    "source": "tool_result_window",
+                }
+            }
+        },
+        policy=ContextWindowPolicy(max_tool_results=4),
+    )
+
+    assert assembled.continuity_state is None
+    assert "continuity_state" not in assembled.metadata
+    assert all(
+        segment.metadata is None or segment.metadata.get("source") != "continuity_summary"
+        for segment in assembled.segments
+    )
+
+
+def test_assemble_provider_context_reconstructs_projection_metadata_from_prior_continuity() -> None:
+    continuity = RuntimeContinuityState(
+        summary_text="Prior compact projection only",
+        objective="ship context continuity",
+        current_goal="resume safely",
+        dropped_tool_result_count=2,
+        retained_tool_result_count=1,
+        source="tool_result_window",
+        dropped_tool_results=(
+            DroppedToolResultDiagnostic(tool_name="read_file", status="ok", index=1),
+            DroppedToolResultDiagnostic(tool_name="grep", status="ok", index=2),
+        ),
+        version=2,
+    )
+
+    assembled = assemble_provider_context(
+        prompt="continue",
+        tool_results=(_tool_result(3),),
+        session_metadata={"runtime_state": {"continuity": continuity.metadata_payload()}},
+        policy=ContextWindowPolicy(max_tool_results=4),
+    )
+
+    assert assembled.continuity_state == continuity
+    assert assembled.metadata["continuity_state"] == continuity.metadata_payload()
+    assert isinstance(assembled.metadata["summary_anchor"], str)
+    assert assembled.metadata["summary_source"] == {"tool_result_start": 0, "tool_result_end": 2}
+    continuity_segments = [
+        segment
+        for segment in assembled.segments
+        if segment.metadata == {"source": "continuity_summary"}
+    ]
+    assert len(continuity_segments) == 1
+    assert "Prior compact projection only" in (continuity_segments[0].content or "")
+    retained_tool_segments = [segment for segment in assembled.segments if segment.role == "tool"]
+    assert len(retained_tool_segments) == 1
+    assert retained_tool_segments[0].content == "content-3"
 
 
 def test_prepare_provider_context_dropped_tool_diagnostics_omit_raw_content() -> None:
@@ -1811,3 +1939,665 @@ def test_context_window_token_estimate_counts_raw_read_file_content() -> None:
     assert raw_context.original_tool_result_tokens is not None
     assert stripped_context.original_tool_result_tokens is not None
     assert raw_context.original_tool_result_tokens > stripped_context.original_tool_result_tokens
+
+
+def test_artifact_placeholder_contract_projects_bounded_reference_for_omitted_output() -> None:
+    raw_output = "artifact payload line\n" * 1_000
+    artifact: dict[str, object] = {
+        "artifact_id": "artifact_111111111111111111111111",
+        "producer": "voidcode.tool_output.v1",
+        "tool_call_id": "call-artifact-1",
+        "tool_name": "shell_exec",
+        "kind": "content",
+        "byte_count": len(raw_output.encode("utf-8")),
+        "line_count": 1_000,
+        "status": "available",
+    }
+    assembled = assemble_provider_context(
+        prompt="summarize artifact output",
+        tool_results=(
+            ToolResult(
+                tool_name="shell_exec",
+                status="ok",
+                content=raw_output,
+                data={
+                    "index": 1,
+                    "tool_call_id": "call-artifact-1",
+                    "artifact": artifact,
+                    "artifact_id": artifact["artifact_id"],
+                    "artifact_status": "available",
+                    "original_byte_count": artifact["byte_count"],
+                    "original_line_count": artifact["line_count"],
+                },
+                truncated=True,
+                partial=True,
+                reference=f"artifact:{artifact['artifact_id']}",
+            ),
+            _tool_result(2),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=1,
+            recent_tool_result_count=1,
+            max_tool_result_tokens=None,
+            recent_tool_result_tokens=None,
+            default_tool_result_tokens=None,
+            importance_retention=False,
+        ),
+    )
+
+    placeholder_segments = [
+        segment
+        for segment in assembled.segments
+        if segment.metadata is not None
+        and segment.metadata.get("source") == "runtime_context_artifact_reference"
+    ]
+
+    assert len(placeholder_segments) == 1
+    placeholder = placeholder_segments[0]
+    assert placeholder.role == "system"
+    assert placeholder.tool_call_id is None
+    assert placeholder.tool_name is None
+    assert placeholder.content is not None
+    assert len(placeholder.content) < 1_000
+    assert "artifact_111111111111111111111111" in placeholder.content
+    assert "call-artifact-1" in placeholder.content
+    assert "byte_count=22000" in placeholder.content
+    assert raw_output[:200] not in placeholder.content
+    assert "artifact payload line\nartifact payload line" not in placeholder.content
+
+
+def test_artifact_placeholder_contract_is_not_projected_as_fake_tool_result() -> None:
+    assembled = assemble_provider_context(
+        prompt="continue",
+        tool_results=(
+            ToolResult(
+                tool_name="grep",
+                status="ok",
+                content="RAW OMITTED MATCH\n" * 500,
+                data={
+                    "index": 1,
+                    "tool_call_id": "grep-artifact-1",
+                    "artifact_id": "artifact_222222222222222222222222",
+                    "artifact": {
+                        "artifact_id": "artifact_222222222222222222222222",
+                        "producer": "voidcode.tool_output.v1",
+                        "tool_call_id": "grep-artifact-1",
+                        "tool_name": "grep",
+                        "kind": "content",
+                        "byte_count": 9_000,
+                        "line_count": 500,
+                        "status": "available",
+                    },
+                },
+                truncated=True,
+                partial=True,
+                reference="artifact:artifact_222222222222222222222222",
+            ),
+            _tool_result(2),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=1,
+            recent_tool_result_count=1,
+            max_tool_result_tokens=None,
+            recent_tool_result_tokens=None,
+            default_tool_result_tokens=None,
+            importance_retention=False,
+        ),
+    )
+
+    snapshot = inspect_provider_context(
+        assembled_context=assembled,
+        provider="openai",
+        model="gpt-4o",
+        execution_engine="provider",
+        available_tool_count=3,
+    )
+
+    assert [segment.role for segment in assembled.segments].count("assistant") == 1
+    assert [segment.role for segment in assembled.segments].count("tool") == 1
+    assert all(message.tool_call_id != "grep-artifact-1" for message in snapshot.provider_messages)
+    assert all(
+        message.source != "provider_native_tool_result" or message.tool_call_id != "grep-artifact-1"
+        for message in snapshot.provider_messages
+    )
+    assert any(
+        message.role == "system"
+        and message.source == "runtime_context_artifact_reference"
+        and message.content is not None
+        and "artifact_222222222222222222222222" in message.content
+        for message in snapshot.provider_messages
+    )
+
+
+def test_artifact_placeholder_contract_provider_context_omits_raw_unbounded_output() -> None:
+    raw_output = "unbounded artifact payload " * 2_000
+    assembled = assemble_provider_context(
+        prompt="continue",
+        tool_results=(
+            ToolResult(
+                tool_name="read_file",
+                status="ok",
+                content=raw_output,
+                data={
+                    "index": 1,
+                    "tool_call_id": "read-artifact-1",
+                    "artifact_id": "artifact_333333333333333333333333",
+                    "artifact": {
+                        "artifact_id": "artifact_333333333333333333333333",
+                        "producer": "voidcode.tool_output.v1",
+                        "tool_call_id": "read-artifact-1",
+                        "tool_name": "read_file",
+                        "kind": "content",
+                        "byte_count": len(raw_output.encode("utf-8")),
+                        "line_count": 1,
+                        "status": "available",
+                    },
+                },
+                truncated=True,
+                partial=True,
+                reference="artifact:artifact_333333333333333333333333",
+            ),
+            _tool_result(2),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=1,
+            recent_tool_result_count=1,
+            max_tool_result_tokens=None,
+            recent_tool_result_tokens=None,
+            default_tool_result_tokens=None,
+            importance_retention=False,
+        ),
+    )
+    snapshot = inspect_provider_context(
+        assembled_context=assembled,
+        provider="opencode-go",
+        model="glm-5",
+        execution_engine="provider",
+        available_tool_count=3,
+        tool_feedback_mode="synthetic_user_message",
+    )
+    provider_text = "\n".join(message.content or "" for message in snapshot.provider_messages)
+
+    assert "artifact_333333333333333333333333" in provider_text
+    assert "read-artifact-1" in provider_text
+    assert len(provider_text) < 4_000
+    assert raw_output[:1_000] not in provider_text
+    assert "unbounded artifact payload unbounded artifact payload" not in provider_text
+
+
+def test_compact_projection_provider_context_preserves_message_invariants() -> None:
+    raw_output = "omitted artifact payload " * 1_000
+    assembled = assemble_provider_context(
+        prompt="continue compact work",
+        tool_results=(
+            ToolResult(
+                tool_name="shell_exec",
+                status="ok",
+                content=raw_output,
+                data={
+                    "tool_call_id": "artifact-call-1",
+                    "artifact_id": "artifact_444444444444444444444444",
+                    "artifact": {
+                        "artifact_id": "artifact_444444444444444444444444",
+                        "producer": "voidcode.tool_output.v1",
+                        "tool_call_id": "artifact-call-1",
+                        "tool_name": "shell_exec",
+                        "kind": "content",
+                        "byte_count": len(raw_output.encode("utf-8")),
+                        "line_count": 1,
+                        "status": "available",
+                    },
+                },
+                truncated=True,
+                partial=True,
+                reference="artifact:artifact_444444444444444444444444",
+            ),
+            ToolResult(
+                tool_name="read_file",
+                status="ok",
+                content="retained content",
+                data={"tool_call_id": "retained-call-1", "arguments": {"path": "sample.txt"}},
+            ),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=1,
+            recent_tool_result_count=1,
+            max_tool_result_tokens=None,
+            recent_tool_result_tokens=None,
+            default_tool_result_tokens=None,
+        ),
+    )
+
+    snapshot = inspect_provider_context(
+        assembled_context=assembled,
+        provider="openai",
+        model="gpt-4o",
+        execution_engine="provider",
+        available_tool_count=2,
+    )
+    diagnostic_codes = {diagnostic.code for diagnostic in snapshot.diagnostics}
+
+    assert "missing_tool_result" not in diagnostic_codes
+    assert "orphan_tool_result" not in diagnostic_codes
+    assert "duplicate_tool_call_id" not in diagnostic_codes
+    assert "compact_projection_wrong_role" not in diagnostic_codes
+    compact_segments = [
+        segment
+        for segment in snapshot.segments
+        if segment.source in {"continuity_summary", "runtime_context_artifact_reference"}
+    ]
+    assert compact_segments
+    assert all(segment.role == "system" for segment in compact_segments)
+    assert all(segment.tool_call_id is None for segment in compact_segments)
+    assert all(segment.tool_name is None for segment in compact_segments)
+    assert "omitted artifact payload omitted artifact payload" not in "\n".join(
+        message.content or "" for message in snapshot.provider_messages
+    )
+
+
+def test_provider_context_inspector_reports_compact_projection_wrong_role() -> None:
+    assembled = RuntimeAssembledContext(
+        prompt="continue",
+        tool_results=(),
+        continuity_state=None,
+        metadata={},
+        segments=(
+            RuntimeContextSegment(
+                role="assistant",
+                content=None,
+                tool_call_id="fake-summary-call",
+                tool_name="continuity_summary",
+                metadata={"source": "continuity_summary"},
+            ),
+            RuntimeContextSegment(
+                role="tool",
+                content="Runtime artifact reference for omitted tool output",
+                tool_call_id="fake-summary-call",
+                tool_name="continuity_summary",
+                metadata={"source": "runtime_context_artifact_reference", "status": "ok"},
+            ),
+        ),
+    )
+
+    snapshot = inspect_provider_context(
+        assembled_context=assembled,
+        provider="openai",
+        model="gpt-4o",
+        execution_engine="provider",
+        available_tool_count=1,
+    )
+
+    wrong_role = [
+        diagnostic
+        for diagnostic in snapshot.diagnostics
+        if diagnostic.code == "compact_projection_wrong_role"
+    ]
+    assert len(wrong_role) == 2
+    assert {diagnostic.details["role"] for diagnostic in wrong_role} == {"assistant", "tool"}
+
+
+# ── Projection contract tests ───────────────────────────────────────────────
+# These encode the desired runtime context pipeline before production
+# implementation: persisted truth stays complete, provider context receives
+# bounded derived projection, score-driven retention is not the core policy,
+# and there are no command-name-specific verification heuristics.
+
+
+def test_projection_contract_continuity_state_preserves_full_dropped_record() -> None:
+    """Continuity state must record every dropped result with correct tool_name,
+    status, and index, preserving the complete session truth even when the
+    provider only sees a bounded projection."""
+    context = prepare_provider_context(
+        prompt="inspect failing tests",
+        tool_results=(
+            ToolResult(
+                tool_name="read_file",
+                status="ok",
+                content="content-1",
+                data={"index": 1, "path": "src/a.py"},
+            ),
+            ToolResult(
+                tool_name="shell_exec",
+                status="error",
+                error="exit code 1",
+                data={"index": 2, "command": "pytest tests/"},
+            ),
+            ToolResult(
+                tool_name="read_file",
+                status="ok",
+                content="content-3",
+                data={"index": 3, "path": "src/b.py"},
+            ),
+            ToolResult(
+                tool_name="edit",
+                status="ok",
+                content="patched",
+                data={"index": 4, "path": "src/b.py"},
+            ),
+            ToolResult(
+                tool_name="read_file",
+                status="ok",
+                content="content-5",
+                data={"index": 5, "path": "src/c.py"},
+            ),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=2,
+            recent_tool_result_count=1,
+            max_tool_result_tokens=None,
+            recent_tool_result_tokens=None,
+            default_tool_result_tokens=None,
+        ),
+    )
+
+    assert context.continuity_state is not None
+    assert context.continuity_state.dropped_tool_result_count == 3
+    assert context.continuity_state.retained_tool_result_count == 2
+    assert len(context.continuity_state.dropped_tool_results) == 3
+
+    # Every dropped result has a complete diagnostic entry
+    for diagnostic in context.continuity_state.dropped_tool_results:
+        payload = diagnostic.metadata_payload()
+        assert isinstance(payload["tool_name"], str) and payload["tool_name"]
+        assert isinstance(payload["status"], str) and payload["status"]
+        assert isinstance(payload["index"], int) and payload["index"] >= 1
+
+
+def test_projection_contract_structural_equivalence_across_shell_commands() -> None:
+    """Two shell_exec results with equivalent content and status but different
+    command names must receive the same retention treatment within a count-limited
+    policy. There is no command-name-specific verification taxonomy."""
+    # Identical structure: same content size, same status — only command differs
+    shell_a = ToolResult(
+        tool_name="shell_exec",
+        content="x" * 40,
+        status="ok",
+        data={"index": 1, "command": "pytest tests/unit/test_sample.py -q"},
+    )
+    shell_b = ToolResult(
+        tool_name="shell_exec",
+        content="x" * 40,
+        status="ok",
+        data={"index": 2, "command": "echo hello world"},
+    )
+
+    context_a = prepare_provider_context(
+        prompt="run tests",
+        tool_results=(
+            _tool_result(0),
+            _tool_result(0),
+            shell_a,
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=2,
+            recent_tool_result_count=2,
+            importance_retention=False,
+            max_tool_result_tokens=None,
+            recent_tool_result_tokens=None,
+            default_tool_result_tokens=None,
+        ),
+    )
+    context_b = prepare_provider_context(
+        prompt="run tests",
+        tool_results=(
+            _tool_result(0),
+            _tool_result(0),
+            shell_b,
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=2,
+            recent_tool_result_count=2,
+            importance_retention=False,
+            max_tool_result_tokens=None,
+            recent_tool_result_tokens=None,
+            default_tool_result_tokens=None,
+        ),
+    )
+
+    # Both shell results should be retained equally — no command-name bias
+    indices_a = [r.data["index"] for r in context_a.tool_results]
+    indices_b = [r.data["index"] for r in context_b.tool_results]
+    assert 1 in indices_a
+    assert 2 in indices_b
+    assert context_a.retained_tool_result_count == context_b.retained_tool_result_count
+
+
+def test_projection_contract_importance_retention_equals_recency() -> None:
+    """When importance_retention=True, retention behavior must match
+    importance_retention=False: both must select purely by recency, not by
+    tool-name or command-name scoring.
+
+    This encodes the architectural decision that score-driven retention is
+    NOT the core policy; importance_retention is compatibility-only recency
+    behavior."""
+    results: tuple[ToolResult, ...] = (
+        ToolResult(
+            tool_name="read_file",
+            status="error",
+            error="file not found",
+            data={"index": 1, "path": "missing.py"},
+        ),
+        _tool_result(2),
+        _tool_result(3),
+        _tool_result(4),
+        _tool_result(5),
+    )
+
+    policy_base = ContextWindowPolicy(
+        max_tool_results=3,
+        recent_tool_result_count=1,
+        max_tool_result_tokens=None,
+        recent_tool_result_tokens=None,
+        default_tool_result_tokens=None,
+    )
+
+    # With importance_retention=True — the compat field
+    context_importance = prepare_provider_context(
+        prompt="read sample.txt",
+        tool_results=results,
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=policy_base.max_tool_results,
+            recent_tool_result_count=policy_base.recent_tool_result_count,
+            max_tool_result_tokens=policy_base.max_tool_result_tokens,
+            recent_tool_result_tokens=policy_base.recent_tool_result_tokens,
+            default_tool_result_tokens=policy_base.default_tool_result_tokens,
+            importance_retention=True,
+        ),
+    )
+
+    # With importance_retention=False — explicit recency-only
+    context_recency = prepare_provider_context(
+        prompt="read sample.txt",
+        tool_results=results,
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=policy_base.max_tool_results,
+            recent_tool_result_count=policy_base.recent_tool_result_count,
+            max_tool_result_tokens=policy_base.max_tool_result_tokens,
+            recent_tool_result_tokens=policy_base.recent_tool_result_tokens,
+            default_tool_result_tokens=policy_base.default_tool_result_tokens,
+            importance_retention=False,
+        ),
+    )
+
+    # Contract: both policies must produce identical retained results.
+    importance_indices = tuple(result.data["index"] for result in context_importance.tool_results)
+    recency_indices = tuple(result.data["index"] for result in context_recency.tool_results)
+    assert importance_indices == recency_indices, (
+        "importance_retention=True must behave identically to "
+        "importance_retention=False (recency-only). "
+        f"Got importance={importance_indices}, recency={recency_indices}"
+    )
+
+
+def test_projection_contract_score_driven_tool_name_bias_not_acceptable() -> None:
+    """Tool name categories (write_file, todo_write, shell_exec, etc.) must
+    not influence retention priority. A write_file result at position 2 must
+    not displace a read_file result at position 3 just because write_file
+    had a higher score."""
+    results: tuple[ToolResult, ...] = (
+        _tool_result(1),
+        ToolResult(
+            tool_name="write_file",
+            content="written",
+            status="ok",
+            data={"index": 2, "path": "src/app.py"},
+        ),
+        _tool_result(3),
+        _tool_result(4),
+        _tool_result(5),
+    )
+
+    context = prepare_provider_context(
+        prompt="fix code",
+        tool_results=results,
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=3,
+            recent_tool_result_count=1,
+            max_tool_result_tokens=None,
+            recent_tool_result_tokens=None,
+            default_tool_result_tokens=None,
+            importance_retention=True,
+        ),
+    )
+
+    retained_indexes = tuple(result.data["index"] for result in context.tool_results)
+
+    # Contract: retention should follow the ordered tail, not tool-name scoring.
+    # The most recent three results (3, 4, 5) should be retained, with index 5
+    # always included as the protected recent. Index 2 (write_file) should NOT
+    # jump ahead of index 3 or 4 just because its tool name scores higher.
+    assert 5 in retained_indexes, "most recent result (protected) must always be retained"
+    assert retained_indexes == (3, 4, 5), (
+        "retention must be recency-based, not tool-name scored. "
+        f"Got {retained_indexes}, expected (3, 4, 5)"
+    )
+
+
+def test_projection_contract_token_budget_uses_recency_not_scoring() -> None:
+    """When a token budget constrains selection, the ranking must prefer recent
+    results over scoring by tool name. Older high-scoring results must not
+    displace newer results within budget."""
+    context = prepare_provider_context(
+        prompt="verify fix",
+        tool_results=(
+            _sized_tool_result(1, content_size=160),
+            ToolResult(
+                tool_name="shell_exec",
+                content="passed",
+                status="ok",
+                data={"index": 2, "command": "python -m pytest"},
+            ),
+            _sized_tool_result(3, content_size=160),
+            _tool_result(4),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(
+            max_tool_results=3,
+            recent_tool_result_count=1,
+            max_tool_result_tokens=120,
+            recent_tool_result_tokens=None,
+            default_tool_result_tokens=None,
+            importance_retention=True,
+        ),
+    )
+
+    retained_indexes = tuple(result.data["index"] for result in context.tool_results)
+
+    # Contract: index 4 (most recent) is always retained as protected.
+    # The remaining slots should be filled from newest to oldest within budget,
+    # not based on shell_exec scoring higher than read_file.
+    # Current scoring: shell_exec(index 2) gets +30, potentially displacing
+    # newer read_file results. This must not happen.
+    assert 4 in retained_indexes, "most recent result must always be retained"
+    # Newest results (3, 4) should be preferred. index 1 should not survive
+    # over index 3 just because it's more recent than 2 (which gets scored higher).
+    assert 3 in retained_indexes, (
+        f"newer results should be preferred over tool-name scoring. Got {retained_indexes}"
+    )
+    # Older index 1 should be dropped; it's not protected and not recent enough
+    assert 1 not in retained_indexes, (
+        f"oldest result (index 1) must be dropped in favor of newer results. Got {retained_indexes}"
+    )
+
+
+def test_projection_contract_default_policy_does_not_require_importance_retention() -> None:
+    """The default ContextWindowPolicy must NOT depend on importance_retention
+    for correct behavior. A policy with importance_retention defaults produces
+    the same projection result as a policy where importance_retention is
+    explicitly False, for identical input."""
+    default_policy = ContextWindowPolicy(
+        max_tool_results=3,
+        recent_tool_result_count=1,
+        max_tool_result_tokens=None,
+        recent_tool_result_tokens=None,
+        default_tool_result_tokens=None,
+    )
+    explicit_policy = ContextWindowPolicy(
+        max_tool_results=3,
+        recent_tool_result_count=1,
+        max_tool_result_tokens=None,
+        recent_tool_result_tokens=None,
+        default_tool_result_tokens=None,
+        importance_retention=False,
+    )
+
+    results: tuple[ToolResult, ...] = (
+        _tool_result(1),
+        ToolResult(
+            tool_name="read_file",
+            status="error",
+            error="missing",
+            data={"index": 2, "path": "missing.py"},
+        ),
+        _tool_result(3),
+        _tool_result(4),
+        _tool_result(5),
+    )
+
+    context_default = prepare_provider_context(
+        prompt="read sample.txt",
+        tool_results=results,
+        session_metadata={},
+        policy=default_policy,
+    )
+    context_explicit = prepare_provider_context(
+        prompt="read sample.txt",
+        tool_results=results,
+        session_metadata={},
+        policy=explicit_policy,
+    )
+
+    default_indices = tuple(r.data["index"] for r in context_default.tool_results)
+    explicit_indices = tuple(r.data["index"] for r in context_explicit.tool_results)
+    assert default_indices == explicit_indices, (
+        "default policy must produce same results as importance_retention=False. "
+        f"Got default={default_indices}, explicit={explicit_indices}"
+    )
+
+
+def test_projection_contract_projection_preserves_original_count_in_metadata() -> None:
+    """The RuntimeContextWindow metadata must record the original tool result
+    count and retained count, so consumers can distinguish the projection
+    from the full truth."""
+    projection = project_tool_results_for_context_window(
+        tool_results=(_tool_result(1), _tool_result(2), _tool_result(3), _tool_result(4)),
+        policy=ContextWindowPolicy(max_tool_results=2),
+    )
+
+    assert len(projection.prepared_results) == 4  # full set after truncation only
+    assert len(projection.retained_results) == 2  # bounded projection
+    assert len(projection.dropped_results) == 2  # what was excluded
+    assert len(projection.retained_indexes) == 2
+    assert len(projection.dropped_indexes) == 2
+    assert set(projection.retained_indexes) | set(projection.dropped_indexes) == {0, 1, 2, 3}
+    assert projection.truncated_count >= 0

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -10774,7 +10774,7 @@ def test_runtime_distillation_receives_abort_signal_in_provider_request(tmp_path
     assert provider.last_distill_abort_signal is not None
 
 
-def test_runtime_distillation_uses_importance_aware_projection_split(tmp_path: Path) -> None:
+def test_runtime_distillation_uses_recency_projection_split(tmp_path: Path) -> None:
     provider = _DistillAwareTurnProvider(
         name="opencode",
         distill_output='{"objective_current_goal":"Goal"}',
@@ -10832,10 +10832,10 @@ def test_runtime_distillation_uses_importance_aware_projection_split(tmp_path: P
         list[dict[str, object]],
         provider.last_distill_input["recent_tail_previews"],
     )
-    assert [cast(dict[str, object], item["data"])["index"] for item in dropped_results] == [1, 4]
+    assert [cast(dict[str, object], item["data"])["index"] for item in dropped_results] == [1, 2]
     assert [cast(dict[str, object], item["data"])["index"] for item in retained_results] == [
-        2,
         3,
+        4,
         5,
     ]
 
@@ -16303,3 +16303,223 @@ def test_runtime_executes_delegated_result_hook_for_completed_background_child(
         "delegated_result_available:leader-session:leader-session:"
         f"{delegated_session_id}::{started.task.id}:{delegated_session_id}"
     )
+
+
+# ── Context window projection contract tests ────────────────────────────────
+
+
+def test_runtime_context_window_projection_preserves_full_session_truth(
+    tmp_path: Path,
+) -> None:
+    """Session metadata must preserve complete context window information
+    (original counts, continuity state, compaction reason) even when the
+    provider only receives a bounded projection."""
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+
+    context_window = runtime._prepare_provider_context_window(  # pyright: ignore[reportPrivateUsage]
+        prompt="verify build",
+        tool_results=(
+            ToolResult(tool_name="read_file", status="ok", content="a", data={"index": 1}),
+            ToolResult(tool_name="read_file", status="ok", content="b", data={"index": 2}),
+            ToolResult(tool_name="read_file", status="ok", content="c", data={"index": 3}),
+        ),
+        session_metadata={
+            "runtime_config": runtime._runtime_config_metadata(),  # pyright: ignore[reportPrivateUsage]
+        },
+        policy=ContextWindowPolicy(max_tool_results=1),
+    )
+    session = SessionState(
+        session=SessionRef("proj-preserve-session"),
+        status="running",
+        turn=1,
+        metadata={
+            "runtime_config": runtime._runtime_config_metadata(),  # pyright: ignore[reportPrivateUsage]
+        },
+    )
+    enriched = VoidCodeRuntime._session_with_context_window_metadata(session, context_window)
+
+    persisted_cw = cast(dict[str, object], enriched.metadata["context_window"])
+    assert persisted_cw["original_tool_result_count"] == 3
+    assert persisted_cw["max_tool_result_count"] == 1
+    assert persisted_cw["compacted"] is True
+    runtime_state = cast(dict[str, object], enriched.metadata.get("runtime_state", {}))
+    continuity_summary = runtime_state.get("continuity_summary")
+    assert isinstance(continuity_summary, dict)
+    assert "anchor" in continuity_summary
+    assert "source" in continuity_summary
+
+
+def test_runtime_context_window_resume_continuity_metadata_is_projection_only(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+    prior_payload: dict[str, object] = {
+        "version": 2,
+        "summary_text": "Prior compact summary is projection metadata",
+        "objective": "ship resume-safe continuity",
+        "current_goal": "continue from raw events",
+        "dropped_tool_result_count": 2,
+        "retained_tool_result_count": 1,
+        "source": "tool_result_window",
+        "distillation_source": "deterministic",
+        "dropped_tool_results": [
+            {"tool_name": "read_file", "status": "ok", "index": 1},
+            {"tool_name": "grep", "status": "ok", "index": 2},
+        ],
+    }
+    session_metadata: dict[str, object] = {
+        "runtime_config": runtime._runtime_config_metadata(),  # pyright: ignore[reportPrivateUsage]
+        "runtime_state": {"continuity": prior_payload},
+    }
+
+    assembled = runtime._assemble_provider_context(  # pyright: ignore[reportPrivateUsage]
+        prompt="resume using raw events",
+        tool_results=(ToolResult(tool_name="read_file", status="ok", content="raw retained"),),
+        session_metadata=session_metadata,
+    )
+
+    assert assembled.continuity_state is not None
+    assert assembled.continuity_state.summary_text == "Prior compact summary is projection metadata"
+    continuity_metadata = cast(dict[str, object], assembled.metadata["continuity_state"])
+    assert continuity_metadata["version"] == 2
+    assert continuity_metadata["summary_text"] == "Prior compact summary is projection metadata"
+    assert continuity_metadata["dropped_tool_result_count"] == 2
+    assert assembled.metadata["summary_source"] == {"tool_result_start": 0, "tool_result_end": 2}
+    assert [segment.content for segment in assembled.segments if segment.role == "tool"] == [
+        "raw retained"
+    ]
+    assert any(
+        segment.metadata == {"source": "continuity_summary"}
+        and segment.content is not None
+        and "Prior compact summary is projection metadata" in segment.content
+        for segment in assembled.segments
+    )
+
+
+def test_runtime_context_window_malformed_resume_continuity_falls_back_safely(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+    session_metadata: dict[str, object] = {
+        "runtime_config": runtime._runtime_config_metadata(),  # pyright: ignore[reportPrivateUsage]
+        "runtime_state": {
+            "continuity": {
+                "version": [],
+                "summary_text": "malformed summary must not block resume",
+                "dropped_tool_result_count": 1,
+                "retained_tool_result_count": 1,
+                "source": "tool_result_window",
+            }
+        },
+    }
+
+    assembled = runtime._assemble_provider_context(  # pyright: ignore[reportPrivateUsage]
+        prompt="resume despite malformed metadata",
+        tool_results=(ToolResult(tool_name="read_file", status="ok", content="raw retained"),),
+        session_metadata=session_metadata,
+    )
+
+    assert assembled.continuity_state is None
+    assert "continuity_state" not in assembled.metadata
+    assert [segment.content for segment in assembled.segments if segment.role == "tool"] == [
+        "raw retained"
+    ]
+    assert all(
+        segment.metadata is None or segment.metadata.get("source") != "continuity_summary"
+        for segment in assembled.segments
+    )
+
+
+def test_runtime_context_window_projection_no_command_name_scoring(
+    tmp_path: Path,
+) -> None:
+    """At the runtime level, two equivalent shell_exec results with different
+    command names must receive the same projection treatment. The context
+    window policy must not use command-name-specific heuristics."""
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+
+    shell_a = ToolResult(
+        tool_name="shell_exec",
+        content="x" * 40,
+        status="ok",
+        data={"index": 1, "command": "pytest tests/ -q"},
+    )
+    shell_b = ToolResult(
+        tool_name="shell_exec",
+        content="x" * 40,
+        status="ok",
+        data={"index": 2, "command": "echo hello"},
+    )
+
+    meta: dict[str, object] = {
+        "runtime_config": runtime._runtime_config_metadata()  # pyright: ignore[reportPrivateUsage]
+    }
+    context_a = runtime._prepare_provider_context_window(  # pyright: ignore[reportPrivateUsage]
+        prompt="verify",
+        tool_results=(shell_a,),
+        session_metadata=meta,
+        policy=ContextWindowPolicy(max_tool_results=1),
+    )
+    context_b = runtime._prepare_provider_context_window(  # pyright: ignore[reportPrivateUsage]
+        prompt="verify",
+        tool_results=(shell_b,),
+        session_metadata=meta,
+        policy=ContextWindowPolicy(max_tool_results=1),
+    )
+
+    # Both are retained since there's only one result each
+    assert context_a.retained_tool_result_count == 1
+    assert context_b.retained_tool_result_count == 1
+    assert context_a.compacted == context_b.compacted
+
+
+def test_runtime_context_window_projection_bounded_output_within_limit(
+    tmp_path: Path,
+) -> None:
+    """The provider context is a bounded derived projection. With
+    max_tool_results=2 and 4 inputs, only 2 results should be retained."""
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+
+    context = runtime._prepare_provider_context_window(  # pyright: ignore[reportPrivateUsage]
+        prompt="continue coding",
+        tool_results=(
+            ToolResult(tool_name="read_file", status="ok", content="a", data={"index": 1}),
+            ToolResult(tool_name="read_file", status="ok", content="b", data={"index": 2}),
+            ToolResult(tool_name="read_file", status="ok", content="c", data={"index": 3}),
+            ToolResult(tool_name="read_file", status="ok", content="d", data={"index": 4}),
+        ),
+        session_metadata={
+            "runtime_config": runtime._runtime_config_metadata(),  # pyright: ignore[reportPrivateUsage]
+        },
+        policy=ContextWindowPolicy(max_tool_results=2),
+    )
+
+    assert context.original_tool_result_count == 4
+    assert context.retained_tool_result_count == 2
+    assert context.compacted is True
+    assert context.compaction_reason == "tool_result_window"
+
+
+def test_runtime_context_window_projection_auto_compaction_disabled_preserves_all(
+    tmp_path: Path,
+) -> None:
+    """When auto_compaction is false, all results are preserved in the
+    projection (derived output matches complete truth for this case)."""
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+
+    context = runtime._prepare_provider_context_window(  # pyright: ignore[reportPrivateUsage]
+        prompt="inspect",
+        tool_results=(
+            ToolResult(tool_name="read_file", status="ok", content="a", data={"index": 1}),
+            ToolResult(tool_name="read_file", status="ok", content="b", data={"index": 2}),
+            ToolResult(tool_name="read_file", status="ok", content="c", data={"index": 3}),
+        ),
+        session_metadata={
+            "runtime_config": runtime._runtime_config_metadata(),  # pyright: ignore[reportPrivateUsage]
+        },
+        policy=ContextWindowPolicy(auto_compaction=False, max_tool_results=1),
+    )
+
+    assert context.original_tool_result_count == 3
+    assert context.retained_tool_result_count == 3
+    assert context.compacted is False

--- a/tests/unit/runtime/test_single_agent_provider.py
+++ b/tests/unit/runtime/test_single_agent_provider.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 
 from voidcode.provider.registry import ModelProviderRegistry
 from voidcode.provider.resolution import resolve_provider_model
 from voidcode.runtime.context_window import (
+    ContextWindowPolicy,
     RuntimeAssembledContext,
     RuntimeContextSegment,
     RuntimeContextWindow,
+    assemble_provider_context,
 )
+from voidcode.runtime.provider_context import inspect_provider_context
 from voidcode.runtime.provider_protocol import (
     ProviderExecutionError,
     ProviderTurnRequest,
@@ -38,7 +43,9 @@ def _assembled_from_context_window(context_window: RuntimeContextWindow) -> Runt
             else f"voidcode_tool_{index}"
         )
         tool_arguments = result.data.get("arguments")
-        arguments_payload = tool_arguments if isinstance(tool_arguments, dict) else {}
+        arguments_payload = (
+            cast(dict[str, object], tool_arguments) if isinstance(tool_arguments, dict) else {}
+        )
         segments.append(
             RuntimeContextSegment(
                 role="assistant",
@@ -185,4 +192,56 @@ def test_stub_provider_protocol_uses_bounded_context_window_results_for_finalize
         )
     )
 
+    assert result.output == "new\n"
+
+
+def test_stub_provider_protocol_compact_projection_keeps_provider_invariants() -> None:
+    provider_model = resolve_provider_model(
+        "opencode/gpt-5.4",
+        registry=ModelProviderRegistry.with_defaults(),
+    )
+    assert provider_model.selection.provider is not None
+    assert provider_model.selection.model is not None
+    assembled = assemble_provider_context(
+        prompt="read sample.txt",
+        tool_results=(
+            ToolResult(
+                tool_name="read_file",
+                content="old\n",
+                status="ok",
+                data={"tool_call_id": "old-call", "path": "old.txt"},
+            ),
+            ToolResult(
+                tool_name="read_file",
+                content="new\n",
+                status="ok",
+                data={"tool_call_id": "new-call", "path": "sample.txt"},
+            ),
+        ),
+        session_metadata={},
+        policy=ContextWindowPolicy(max_tool_results=1),
+    )
+
+    snapshot = inspect_provider_context(
+        assembled_context=assembled,
+        provider=provider_model.selection.provider,
+        model=provider_model.selection.model,
+        execution_engine="provider",
+        available_tool_count=len(_tool_definitions()),
+    )
+    result = StubTurnProvider(name="opencode").propose_turn(
+        ProviderTurnRequest(
+            assembled_context=assembled,
+            available_tools=_tool_definitions(),
+            raw_model=provider_model.selection.raw_model,
+            provider_name=provider_model.selection.provider,
+            model_name=provider_model.selection.model,
+        )
+    )
+
+    diagnostic_codes = {diagnostic.code for diagnostic in snapshot.diagnostics}
+    assert "missing_tool_result" not in diagnostic_codes
+    assert "orphan_tool_result" not in diagnostic_codes
+    assert "duplicate_tool_call_id" not in diagnostic_codes
+    assert "compact_projection_wrong_role" not in diagnostic_codes
     assert result.output == "new\n"

--- a/tests/unit/tools/test_tool_output_truncation.py
+++ b/tests/unit/tools/test_tool_output_truncation.py
@@ -110,6 +110,40 @@ def test_tool_output_artifact_retrieval_supports_offsets_and_search(tmp_path: Pa
     assert matches[0] == {"line_number": 2, "line": "beta"}
 
 
+def test_tool_output_artifact_reference_metadata_is_bounded_and_safe(tmp_path: Path) -> None:
+    raw_content = "".join(f"artifact-line-{index}\n" for index in range(40))
+    result = ToolResult(tool_name="shell_exec", status="ok", content=raw_content)
+
+    capped = cap_tool_result_output(
+        result,
+        workspace=tmp_path,
+        session_id="session-1",
+        tool_call_id="call-1",
+        max_lines=2,
+        max_bytes=80,
+    )
+
+    assert capped.content is not None
+    assert "artifact-line-0" in capped.content
+    assert "artifact-line-10" not in capped.content
+    assert capped.reference == f"artifact:{capped.data['artifact_id']}"
+    assert "Use artifact retrieval by artifact_id or tool_call_id" in capped.content
+    raw_artifact = capped.data["artifact"]
+    assert isinstance(raw_artifact, dict)
+    artifact = cast(dict[str, object], raw_artifact)
+    assert artifact["artifact_id"] == capped.data["artifact_id"]
+    assert artifact["tool_call_id"] == "call-1"
+    assert artifact["byte_count"] == len(raw_content.encode("utf-8"))
+    assert artifact["line_count"] == 40
+    assert capped.data["output_path"] == artifact["path"]
+    assert str(tmp_path) not in cast(str, artifact["path"])
+
+    retrieved = read_tool_output_artifact(artifact, limit=10)
+    assert retrieved["artifact_missing"] is False
+    assert retrieved["content"] == "".join(f"artifact-line-{index}\n" for index in range(10))
+    assert retrieved["next_offset"] == 10
+
+
 def test_tool_output_artifact_resolves_from_events_by_id_or_tool_call(tmp_path: Path) -> None:
     result = ToolResult(tool_name="sample", status="ok", content="one\ntwo\nthree\n")
     capped = cap_tool_result_output(
@@ -217,6 +251,29 @@ def test_tool_output_artifact_rejects_untrusted_paths(tmp_path: Path) -> None:
     assert resolved is None
 
 
+def test_tool_output_artifact_rejects_traversal_reference(tmp_path: Path) -> None:
+    outside_file = tmp_path / "secret.txt"
+    outside_file.write_text("must not read", encoding="utf-8")
+    forged_artifact: dict[str, object] = {
+        "producer": "voidcode.tool_output.v1",
+        "artifact_id": "artifact_000000000000000000000000",
+        "path": str(outside_file.parent / ".." / outside_file.name),
+        "tool_call_id": "call-1",
+    }
+
+    read_result = read_tool_output_artifact(forged_artifact)
+    search_result = search_tool_output_artifact(forged_artifact, pattern="must")
+    resolved = resolve_tool_output_artifact(
+        [{"payload": {"artifact": forged_artifact}}],
+        tool_call_id="call-1",
+    )
+
+    assert read_result["status"] == "invalid"
+    assert "content" not in read_result
+    assert search_result["status"] == "invalid"
+    assert resolved is None
+
+
 def test_tool_output_artifact_rejects_short_id_for_another_artifact_path(
     tmp_path: Path,
 ) -> None:
@@ -278,6 +335,21 @@ def test_tool_output_artifact_retrieval_reports_missing(tmp_path: Path) -> None:
 
     assert missing["status"] == "missing"
     assert missing["artifact_missing"] is True
+
+
+def test_tool_output_artifact_search_reports_missing(tmp_path: Path) -> None:
+    result = ToolResult(tool_name="sample", status="ok", content="one\ntwo\nthree\n")
+    capped = cap_tool_result_output(result, workspace=tmp_path, max_lines=1, max_bytes=10_000)
+    raw_artifact = capped.data["artifact"]
+    assert isinstance(raw_artifact, dict)
+    artifact = cast(dict[str, object], raw_artifact)
+    Path(cast(str, artifact["path"])).unlink()
+
+    missing = search_tool_output_artifact(artifact, pattern="two")
+
+    assert missing["status"] == "missing"
+    assert missing["artifact_missing"] is True
+    assert "matches" not in missing
 
 
 def test_cap_tool_result_output_caps_by_utf8_byte_count_safely(tmp_path: Path) -> None:
@@ -346,11 +418,12 @@ def test_sanitize_tool_arguments_preserves_preview_for_oversized_benign_text() -
 
     query = sanitized["query"]
     assert isinstance(query, dict)
-    assert query["omitted"] is True
-    assert query["byte_count"] == len(large_query.encode("utf-8"))
-    assert query["line_count"] == 1
-    assert query["preview"] == large_query[:4000]
-    assert query["omitted_chars"] == len(large_query) - 4000
+    query_summary = cast(dict[str, object], query)
+    assert query_summary["omitted"] is True
+    assert query_summary["byte_count"] == len(large_query.encode("utf-8"))
+    assert query_summary["line_count"] == 1
+    assert query_summary["preview"] == large_query[:4000]
+    assert query_summary["omitted_chars"] == len(large_query) - 4000
 
 
 def test_sanitize_tool_result_data_strips_inline_blobs_and_nested_arguments() -> None:
@@ -369,8 +442,9 @@ def test_sanitize_tool_result_data_strips_inline_blobs_and_nested_arguments() ->
     }
     attachment = sanitized["attachment"]
     assert isinstance(attachment, dict)
-    assert attachment["mime"] == "image/png"
-    assert attachment["data_uri"] == {
+    attachment_payload = cast(dict[str, object], attachment)
+    assert attachment_payload["mime"] == "image/png"
+    assert attachment_payload["data_uri"] == {
         "omitted": True,
         "byte_count": len(data_uri.encode("utf-8")),
         "line_count": 1,


### PR DESCRIPTION
## Summary
- Keeps runtime-owned context management bounded and resume-safe while preserving durable session truth.
- Includes the request-scoped LiteLLM SSL fix so `ssl_verify` stays isolated per request instead of leaking across calls.
- Uses structural runtime context projection with bounded artifact placeholders and references, plus rolling continuity metadata for safe resume.

## Verification
- `uv run pytest tests/integration/test_read_only_slice.py tests/integration/test_http_transport.py` ✅ 155 passed
- Provider invariant coverage remains aligned with compact context rules, including orphan, missing, duplicate, oversized, and wrong-role diagnostics.

## Non-goals
- No structured verification tracker.
- No command memoization.
- No replay expansion.
- No cloud memory.
- No embeddings or vector memory.
- No full semantic memory.
- No provider-owned compaction policy.
- No arbitrary multi-agent topology.
- No command-name-specific verification heuristics or taxonomies, and no hardcoded command lists.

## SSL P1 fix
- Request-scoped LiteLLM `ssl_verify` is passed directly in each completion payload.
- The normal path avoids module-level global mutation and avoids cross-request leakage.

## Context pipeline
- Persisted truth stays in runtime storage, while provider input gets only a bounded projection.
- Dropped tool output is represented through bounded `runtime_context_artifact_reference` text, not fake tool messages.
- Rolling continuity metadata carries resume-safe projection state without replacing raw history.
- Provider diagnostics cover compact context invariant failures and keep valid compact projections clean.
- Command-name-specific verification heuristics were explicitly rejected because they are not general and cannot be exhaustively listed.
