### PR TITLE
feat(cli): add pending question answers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ voidcode/
 ## WHERE TO LOOK
 | Task | Location | Notes |
 |------|----------|-------|
-| CLI behavior | `src/voidcode/cli.py` | `voidcode run`, `sessions list`, `sessions resume` |
+| CLI behavior | `src/voidcode/cli/` | `voidcode run`, `sessions list`, `sessions resume`, `sessions answer` |
 | Python entrypoint | `src/voidcode/__main__.py` | `python -m voidcode` delegates to CLI |
 | Runtime orchestration boundary | `src/voidcode/runtime/service.py` | CLI calls runtime, not graph directly |
 | Runtime implementation work | `src/voidcode/runtime/AGENTS.md` | read before touching runtime control-plane code |
@@ -43,8 +43,8 @@ voidcode/
 ## CODE MAP
 | Symbol | Type | Location | Role |
 |--------|------|----------|------|
-| `main` | function | `src/voidcode/cli.py` | CLI process entry |
-| `build_parser` | function | `src/voidcode/cli.py` | command surface definition |
+| `main` | function | `src/voidcode/cli/app.py` | CLI process entry |
+| `build_parser` | function | `src/voidcode/cli/app.py` | command surface compatibility view |
 | `VoidCodeRuntime` | class | `src/voidcode/runtime/service.py` | runtime boundary for requests/sessions |
 | `ToolRegistry` | class | `src/voidcode/runtime/service.py` | current built-in tool registry |
 

--- a/docs/agent-tooling-adoption-plan.md
+++ b/docs/agent-tooling-adoption-plan.md
@@ -123,7 +123,7 @@ mise run lint
 **仓库中的实际落点：**
 
 - `src/voidcode/doctor/`
-- `src/voidcode/cli.py`
+- `src/voidcode/cli/`
 - 相关测试：`tests/unit/doctor/test_doctor.py`
 
 **当前实现说明：**

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -61,7 +61,7 @@
 - `src/voidcode/hook/presets.py`
 - `src/voidcode/graph/contracts.py`
 - `src/voidcode/tools/contracts.py`
-- `src/voidcode/cli.py`
+- `src/voidcode/cli/`
 
 ## 所有权规则
 

--- a/docs/contracts/client-api.md
+++ b/docs/contracts/client-api.md
@@ -113,6 +113,21 @@ StoredSessionSummary(
 - 运行时：`VoidCodeRuntime.resume(session_id)`
 - CLI：`voidcode sessions resume <session_id> [--workspace]`
 
+### 回答等待中的问题 (Answer pending question)
+
+输入：
+- `session_id`
+- `question_request_id`
+- `responses`: 一个或多个 `{header, answers}` 结构；CLI 简单文本模式会把 `--response` 归一化为 header 为 `response` 的单项回答
+
+输出：
+- 恢复后的 `RuntimeResponse`
+
+当前实现层面：
+- 运行时：`VoidCodeRuntime.answer_question(session_id, question_request_id=..., responses=...)`
+- CLI：`voidcode sessions answer <session_id> --question-request-id <id> --response <text> [--workspace]`
+- CLI 多问题/精确 header 形态：`--response-json '[{"header":"Confirm","answers":["yes"]}]'`
+
 ## 会话生命周期
 
 MVP 生命周期：

--- a/docs/contracts/web-opencode-alignment.md
+++ b/docs/contracts/web-opencode-alignment.md
@@ -15,7 +15,7 @@ This is not a parity checklist. Each concern is deliberately classified as one o
 ### 1. Launcher
 
 - **OpenCode reference**: `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/opencode/src/cli/cmd/web.ts`
-- **Local seams**: `src/voidcode/cli.py`, `src/voidcode/server.py`
+- **Local seams**: `src/voidcode/cli/`, `src/voidcode/server.py`
 - **Decision**: **Adopt**
 - **Why**: OpenCode's split between a headless server command and a user-friendly web launcher is production-grade, intuitive, and matches the user's requested end state.
 - **VoidCode target**:
@@ -30,9 +30,9 @@ This is not a parity checklist. Each concern is deliberately classified as one o
 - **OpenCode references**:
   - `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/opencode/src/index.ts`
   - `https://github.com/anomalyco/opencode/blob/4877eccc0d06c747624bf61aaa6f3e65cea9cc8d/packages/opencode/src/cli/cmd/cmd.ts`
-- **Local seams**: `src/voidcode/cli.py`, `src/voidcode/__main__.py`
+- **Local seams**: `src/voidcode/cli/`, `src/voidcode/__main__.py`
 - **Decision**: **Adapt**
-- **Why**: OpenCode's per-command module pattern is cleaner than the current monolithic argparse assembly, but VoidCode should keep Python-native command wiring rather than mimic the TypeScript/yargs structure directly.
+- **Why**: OpenCode's per-command module pattern is cleaner than a monolithic command assembly. VoidCode now keeps Python-native Click command wiring under `src/voidcode/cli/` rather than mimicking the TypeScript/yargs structure directly.
 - **VoidCode target**:
   - Extract `serve` / `web` command handling into clearer command-owned units if needed
   - Preserve shared startup primitives rather than duplicating server logic

--- a/docs/failure-diagnosis-runbook.md
+++ b/docs/failure-diagnosis-runbook.md
@@ -6,7 +6,7 @@
 
 本手册仅涉及当前 MVP 已实现的运行时表面：
 
-- CLI：`voidcode run`、`voidcode sessions list`、`voidcode sessions resume`、`voidcode serve`、`voidcode tasks` 子命令、`voidcode config show`、`voidcode doctor`
+- CLI：`voidcode run`、`voidcode sessions list`、`voidcode sessions resume`、`voidcode sessions answer`、`voidcode serve`、`voidcode tasks` 子命令、`voidcode config show`、`voidcode doctor`
 - HTTP 传输：`voidcode serve` 暴露的 `/api/sessions`、`/api/tasks`、`/api/runtime/run/stream` 等端点
 - SQLite 持久化：`.voidcode/sessions.sqlite3` 中面向操作员排障最重要的 `sessions`、`session_events`、`background_tasks`、`session_notifications` 表（另有用于事件投递去重的 `session_event_deliveries` 表）
 - 会话状态字面量：`idle`、`running`、`waiting`、`completed`、`failed`
@@ -72,7 +72,14 @@
       --approval-decision allow
     ```
     其中 `<request-id>` 可从 `runtime.approval_requested` 事件的 `request_id` payload 中获取，或从 SQLite 的 `pending_approval_json` 中解析。
-  - 如果等待原因是 `question_wait`，当前 CLI 没有与 `--approval-request-id` / `--approval-decision` 对等的“提交问题回答”子命令。CLI 能做的是先用 `uv run voidcode sessions resume <session-id> --workspace .` 重放上下文，然后改走 HTTP 端点提交回答，或在确认原因后重新发起新会话。
+  - 如果等待原因是 `question_wait`，使用 `sessions answer` 提交回答并恢复会话：
+    ```bash
+    uv run voidcode sessions answer <session-id> \
+      --workspace . \
+      --question-request-id <request-id> \
+      --response "answer text"
+    ```
+    单问题文本回答可重复传入 `--response` 形成同一问题的多个答案；多问题或精确 header 绑定场景使用 `--response-json '[{"header":"Confirm","answers":["yes"]}]'`。其中 `<request-id>` 可从 `runtime.question_requested` 事件的 `request_id` payload 中获取，或从 SQLite 的 `pending_question_json` 中解析。
 - **恢复（HTTP）**：
   - 提交审批决策：
     ```bash
@@ -81,11 +88,11 @@
       -d '{"request_id": "<request-id>", "decision": "allow"}'
     ```
   - 决策值为 `"allow"` 或 `"deny"`。响应为 `RuntimeResponse` JSON，包含恢复后的事件和当前输出；会话可能继续运行、再次进入 `waiting`，也可能到达 `completed` / `failed`。
-  - 如果是问题等待（question_wait），使用 `/api/sessions/{session-id}/question` 端点，payload 包含 `question_request_id` 和 `responses` 数组，例如：
+  - 如果是问题等待（question_wait），也可以使用 `/api/sessions/{session-id}/question` 端点，payload 包含 `question_request_id` 和 `responses` 数组，例如：
     ```bash
     curl -X POST http://127.0.0.1:8000/api/sessions/{session-id}/question \
       -H 'Content-Type: application/json' \
-      -d '{"question_request_id": "<request-id>", "responses": ["answer text"]}'
+      -d '{"question_request_id": "<request-id>", "responses": [{"header": "Confirm", "answers": ["answer text"]}]}'
     ```
 
 ### 2.4 `completed`

--- a/docs/mvp-todo-plan.md
+++ b/docs/mvp-todo-plan.md
@@ -253,5 +253,5 @@ VoidCode 已经拥有扎实的 pre-MVP 基础：
 - [x] Web 客户端接入 review tree / diff、question answer、workspace 切换、runtime status 和 backend-owned tool display/status 基线
 - [x] `voidcode doctor` 输出 first-task readiness summary 与 actionable next step
 - [ ] 完成 issue #390：定义最小用户可见 prompt command 集（`/review`、`/fix`、`/explain`、`/plan`、`/test`、`/commit`）
-- [ ] 为 CLI 补齐 pending question 的回答入口，使其与 HTTP/Web question answer 路径对等
+- [x] 为 CLI 补齐 pending question 的回答入口，使其与 HTTP/Web question answer 路径对等
 - [ ] 在 runtime 主线稳定之后，再重新评估 TUI 特定 epic 和剩余客户端 polish 工作

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "beautifulsoup4",
+  "click>=8.1.8",
   "langchain-core",
   "langgraph",
   "lsprotocol",

--- a/src/voidcode/cli/__init__.py
+++ b/src/voidcode/cli/__init__.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+from . import app as _app
+from .app import (
+    ProviderReadinessResult,
+    VoidCodeRuntime,
+    build_parser,
+    load_runtime_config,
+    main,
+    print,
+    root_cli,
+    serve,
+    web,
+)
+
+__all__ = [
+    "ProviderReadinessResult",
+    "VoidCodeRuntime",
+    "build_parser",
+    "load_runtime_config",
+    "main",
+    "print",
+    "root_cli",
+    "serve",
+    "web",
+]
+
+
+class _CliModule(ModuleType):
+    def __setattr__(self, name: str, value: object) -> None:
+        super().__setattr__(name, value)
+        if hasattr(_app, name):
+            setattr(_app, name, value)
+
+
+sys.modules[__name__].__class__ = _CliModule

--- a/src/voidcode/cli/__main__.py
+++ b/src/voidcode/cli/__main__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from .app import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/voidcode/cli/app.py
+++ b/src/voidcode/cli/app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import builtins as _builtins
 import json
 import shlex
 import sys
@@ -8,10 +9,12 @@ from collections.abc import Callable, Iterator, Sequence
 from pathlib import Path
 from typing import Protocol, cast
 
-from . import __version__
-from .acp.stdio import StdioAcpServer
-from .agent.builtin import list_top_level_selectable_agent_manifests
-from .cli_support import (
+import click
+
+from .. import __version__
+from ..acp.stdio import StdioAcpServer
+from ..agent.builtin import list_top_level_selectable_agent_manifests
+from ..cli_support import (
     EXIT_APPROVAL_DENIED,
     EXIT_CONFIG_ERROR,
     EXIT_GENERAL_ERROR,
@@ -29,9 +32,9 @@ from .cli_support import (
     serialize_session_state,
     serialize_stored_session_summary,
 )
-from .command.loader import load_command_registry
-from .command.registry import CommandRegistry
-from .doctor import (
+from ..command.loader import load_command_registry
+from ..command.registry import CommandRegistry
+from ..doctor import (
     CapabilityCheckResult,
     CapabilityCheckStatus,
     CapabilityDoctor,
@@ -41,29 +44,30 @@ from .doctor import (
     format_report,
     format_report_json,
 )
-from .provider.snapshot import resolved_provider_snapshot
-from .runtime.bundle import (
+from ..provider.snapshot import resolved_provider_snapshot
+from ..runtime.bundle import (
     SessionBundleError,
     SessionBundleFormat,
     SessionBundleOptions,
     write_session_bundle,
 )
-from .runtime.config import (
+from ..runtime.config import (
     RUNTIME_CONFIG_FILE_NAME,
     RuntimeConfig,
     load_runtime_config,
     serialize_provider_fallback_config,
     serialize_runtime_agent_config,
 )
-from .runtime.config_schema import (
+from ..runtime.config_schema import (
     format_starter_runtime_config_json,
     generate_starter_runtime_config,
     runtime_config_json_schema,
     write_runtime_config_payload,
 )
-from .runtime.contracts import (
+from ..runtime.contracts import (
     BackgroundTaskResult,
     CapabilityStatusSnapshot,
+    NoPendingQuestionError,
     ProviderInspectResult,
     ProviderModelMetadata,
     ProviderReadinessResult,
@@ -75,14 +79,107 @@ from .runtime.contracts import (
     RuntimeStreamChunk,
     validate_runtime_request_metadata,
 )
-from .runtime.events import EventEnvelope, redact_reasoning_payload
-from .runtime.permission import PermissionDecision, PermissionResolution
-from .runtime.service import VoidCodeRuntime
-from .runtime.session import SessionState, StoredSessionSummary
-from .runtime.task import BackgroundTaskState, StoredBackgroundTaskSummary
-from .server import serve, web
+from ..runtime.events import EventEnvelope, redact_reasoning_payload
+from ..runtime.permission import PermissionDecision, PermissionResolution
+from ..runtime.question import QuestionResponse
+from ..runtime.service import VoidCodeRuntime
+from ..runtime.session import SessionState, StoredSessionSummary
+from ..runtime.task import BackgroundTaskState, StoredBackgroundTaskSummary
+from ..server import serve, web
+
+print = _builtins.print
 
 Handler = Callable[[argparse.Namespace], int]
+
+
+class _CliUsageError(Exception):
+    def __init__(self, message: str, *, exit_code: int = 2) -> None:
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+def _namespace(**values: object) -> argparse.Namespace:
+    return argparse.Namespace(**values)
+
+
+def _click_path(value: str | Path) -> Path:
+    return value if isinstance(value, Path) else Path(value)
+
+
+def _click_optional_path(value: str | Path | None) -> Path | None:
+    if value is None or isinstance(value, Path):
+        return value
+    return Path(value)
+
+
+def _json_option_enabled(value: bool | None) -> bool:
+    return bool(value)
+
+
+def _build_click_command_context(
+    *,
+    command: str | None = None,
+    subcommand: str | None = None,
+    **values: object,
+) -> argparse.Namespace:
+    payload = dict(values)
+    if command is not None:
+        payload["command"] = command
+    if subcommand is not None and command is not None:
+        payload[f"{command}_command"] = subcommand
+    return _namespace(**payload)
+
+
+def _invoke_handler_from_click(handler: Handler, args: argparse.Namespace) -> int:
+    try:
+        return handler(args)
+    except _CliUsageError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return exc.exit_code
+    except SystemExit as exc:
+        return _handle_cli_system_exit(exc)
+    except RuntimeError as exc:
+        message = f"error: {exc}"
+        print(message, file=sys.stderr)
+        return _classify_cli_error(message)
+
+
+def _parse_question_responses(
+    *,
+    response: tuple[str, ...] = (),
+    response_json: str | None = None,
+) -> tuple[QuestionResponse, ...]:
+    if response_json is not None and response:
+        raise _CliUsageError("--response and --response-json cannot be used together")
+    if response_json is not None:
+        raw_payload = json.loads(response_json)
+        if not isinstance(raw_payload, list) or not raw_payload:
+            raise ValueError("--response-json must be a non-empty JSON array")
+        raw_items = cast(list[object], raw_payload)
+        parsed: list[QuestionResponse] = []
+        for index, raw_item in enumerate(raw_items):
+            if not isinstance(raw_item, dict):
+                raise ValueError(f"--response-json[{index}] must be an object")
+            item = cast(dict[str, object], raw_item)
+            raw_header = item.get("header")
+            if not isinstance(raw_header, str) or not raw_header.strip():
+                raise ValueError(f"--response-json[{index}].header must be a non-empty string")
+            raw_answers = item.get("answers")
+            if not isinstance(raw_answers, list) or not raw_answers:
+                raise ValueError(f"--response-json[{index}].answers must be a non-empty array")
+            answers: list[str] = []
+            for answer_index, raw_answer in enumerate(raw_answers):
+                if not isinstance(raw_answer, str) or not raw_answer.strip():
+                    raise ValueError(
+                        f"--response-json[{index}].answers[{answer_index}] "
+                        "must be a non-empty string"
+                    )
+                answers.append(raw_answer)
+            parsed.append(QuestionResponse(header=raw_header, answers=tuple(answers)))
+        return tuple(parsed)
+    if not response:
+        raise _CliUsageError("at least one --response or --response-json must be provided")
+    return (QuestionResponse(header="response", answers=tuple(response)),)
 
 
 class TuiAppProtocol(Protocol):
@@ -1083,6 +1180,51 @@ def _handle_sessions_resume_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def _handle_sessions_answer_command(args: argparse.Namespace) -> int:
+    workspace = cast(Path, args.workspace)
+    session_id = cast(str, args.session_id)
+    question_request_id = cast(str, args.question_request_id)
+    show_thinking = cast(bool, getattr(args, "show_thinking", False))
+    json_output = cast(bool, getattr(args, "json", False))
+    try:
+        responses = _parse_question_responses(
+            response=cast(tuple[str, ...], getattr(args, "response", ())),
+            response_json=cast(str | None, getattr(args, "response_json", None)),
+        )
+    except _CliUsageError:
+        raise
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise SystemExit(f"error: {exc}") from None
+
+    runtime = VoidCodeRuntime(workspace=workspace)
+    try:
+        try:
+            result = runtime.answer_question(
+                session_id,
+                question_request_id=question_request_id,
+                responses=responses,
+            )
+        except (ValueError, NoPendingQuestionError) as exc:
+            raise SystemExit(f"error: {exc}") from None
+    finally:
+        _close_runtime(runtime)
+
+    if json_output:
+        print_json(
+            {
+                "workspace": str(workspace),
+                "session": serialize_session_state(result.session),
+                "events": [
+                    serialize_event(event, show_thinking=show_thinking) for event in result.events
+                ],
+                "output": result.output,
+            }
+        )
+        return 0
+    _print_runtime_response(result, show_thinking=show_thinking)
+    return 0
+
+
 def _session_bundle_options_from_args(args: argparse.Namespace) -> SessionBundleOptions:
     if cast(bool, getattr(args, "support", False)):
         return SessionBundleOptions.support_artifact()
@@ -1806,7 +1948,7 @@ def _handle_tui_command(args: argparse.Namespace) -> int:
     workspace = cast(Path, args.workspace)
     approval_mode = cast(PermissionDecision | None, getattr(args, "approval_mode", None))
 
-    from .tui import VoidCodeTUI
+    from ..tui import VoidCodeTUI
 
     app = cast(TuiAppProtocol, VoidCodeTUI(workspace=workspace, approval_mode=approval_mode))
     app.run()
@@ -1872,6 +2014,7 @@ def _classify_cli_error(message: str) -> int:
     if (
         "unknown session" in normalized
         or "unknown task" in normalized
+        or "no pending question" in normalized
         or "workspace does not exist" in normalized
     ):
         return EXIT_INVALID_RESOURCE
@@ -1903,775 +2046,882 @@ def _handle_cli_system_exit(exc: SystemExit) -> int:
     return EXIT_GENERAL_ERROR
 
 
-def _add_command_discovery_arguments(parser: argparse.ArgumentParser) -> None:
-    _ = parser.add_argument(
+_SELECTABLE_AGENT_IDS = tuple(
+    manifest.id for manifest in list_top_level_selectable_agent_manifests()
+)
+_APPROVAL_MODES = ("allow", "deny", "ask")
+_APPROVAL_DECISIONS = ("allow", "deny")
+_EXECUTION_ENGINES = ("deterministic", "provider")
+_BUNDLE_FORMATS = ("zip", "json")
+_EXAMPLES = """
+Examples:
+  voidcode run 'read README.md' --workspace .
+  voidcode run 'read README.md' --json --workspace .
+  voidcode sessions list --json --workspace .
+  voidcode commands list --workspace .
+  voidcode commands show /review --json --workspace .
+""".strip()
+
+
+def _workspace_option(help_text: str) -> Callable[[Callable[..., object]], Callable[..., object]]:
+    return click.option(
         "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to discover project-local commands.",
+        type=click.Path(path_type=Path),
+        default=Path.cwd,
+        show_default=False,
+        help=help_text,
     )
-    _ = parser.add_argument(
+
+
+def _json_option(help_text: str) -> Callable[[Callable[..., object]], Callable[..., object]]:
+    return click.option("--json", "json_output", is_flag=True, help=help_text)
+
+
+def _show_thinking_option(
+    help_text: str,
+) -> Callable[[Callable[..., object]], Callable[..., object]]:
+    return click.option("--show-thinking", is_flag=True, help=help_text)
+
+
+def _command_discovery_options(function: Callable[..., object]) -> Callable[..., object]:
+    function = _workspace_option("Workspace root used to discover project-local commands.")(
+        function
+    )
+    return click.option(
         "--user-commands-dir",
-        type=Path,
+        type=click.Path(path_type=Path),
         help="Optional user command directory to merge before project commands.",
-    )
+    )(function)
 
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="voidcode",
-        description="Voidcode command-line interface.",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=(
-            "Examples:\n"
-            "  voidcode run 'read README.md' --workspace .\n"
-            "  voidcode run 'read README.md' --json --workspace .\n"
-            "  voidcode sessions list --json --workspace .\n"
-            "  voidcode commands list --workspace .\n"
-            "  voidcode commands show /review --json --workspace ."
-        ),
-    )
-    _ = parser.add_argument(
-        "--version",
-        action="version",
-        version=f"%(prog)s {__version__}",
-    )
-    subparsers = parser.add_subparsers(dest="command")
-
-    tui_parser = subparsers.add_parser(
-        "tui",
-        help="Run the VoidCode interactive Textual UI.",
-    )
-    _ = tui_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve relative read paths.",
-    )
-    _ = tui_parser.add_argument(
-        "--approval-mode",
-        choices=("allow", "deny", "ask"),
-        help="Override the runtime approval mode for this invocation.",
-    )
-    tui_parser.set_defaults(handler=_handle_tui_command)
-
-    run_parser = subparsers.add_parser(
-        "run",
-        help=(
-            "Run through the local runtime; provider-backed execution is the product path, "
-            "and deterministic is an explicit test/dev harness."
-        ),
-    )
-    _ = run_parser.add_argument(
-        "request",
-        help="Runtime request such as 'read README.md'.",
-    )
-    _ = run_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve relative read paths.",
-    )
-    _ = run_parser.add_argument(
-        "--session-id",
-        help="Optional session identifier used for persisted runs.",
-    )
-    _ = run_parser.add_argument(
-        "--approval-mode",
-        choices=("allow", "deny", "ask"),
-        help="Override the runtime approval mode for this invocation.",
-    )
-    _selectable_agent_ids = tuple(
-        manifest.id for manifest in list_top_level_selectable_agent_manifests()
-    )
-    _ = run_parser.add_argument(
-        "--agent",
-        choices=_selectable_agent_ids,
-        help="Select a top-level agent preset for this run.",
-    )
-    _ = run_parser.add_argument(
-        "--skills",
-        nargs="+",
-        help="Optional skill names applied for this run.",
-    )
-    _ = run_parser.add_argument(
-        "--max-steps",
-        type=int,
-        help="Optional max graph steps override for this run.",
-    )
-    _ = run_parser.add_argument(
-        "--reasoning-effort",
-        dest="reasoning_effort",
-        help=(
-            "Optional runtime-owned reasoning-effort hint forwarded to the active "
-            "provider when supported (for example, 'low', 'medium', 'high'). Overrides "
-            "any reasoning_effort configured in .voidcode.json or VOIDCODE_REASONING_EFFORT."
-        ),
-    )
-    _ = run_parser.add_argument(
-        "--show-thinking",
-        action="store_true",
-        help="Show persisted reasoning/thinking text; hidden by default.",
-    )
-    _ = run_parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Output a structured JSON payload with session, events, and final output.",
-    )
-    stream_group = run_parser.add_mutually_exclusive_group()
-    _ = stream_group.add_argument(
-        "--provider-stream",
-        dest="provider_stream",
-        action="store_true",
-        help="Enable provider-level streaming for this run.",
-    )
-    _ = stream_group.add_argument(
-        "--no-provider-stream",
-        dest="provider_stream",
-        action="store_false",
-        help="Disable provider-level streaming for this run.",
-    )
-    run_parser.set_defaults(provider_stream=None)
-    run_parser.set_defaults(handler=_handle_run_command)
-
-    acp_parser = subparsers.add_parser(
-        "acp",
-        help="Run the minimal external-facing ACP stdio JSON-RPC facade.",
-    )
-    _ = acp_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used by the ACP-backed runtime session database.",
-    )
-    _ = acp_parser.add_argument(
-        "--approval-mode",
-        choices=("allow", "deny", "ask"),
-        help="Override the runtime approval mode for this ACP process.",
-    )
-    acp_parser.set_defaults(handler=_handle_acp_command)
-
-    serve_parser = subparsers.add_parser(
-        "serve",
-        help="Serve the local HTTP runtime transport.",
-    )
-    _ = serve_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used by the local runtime and session database.",
-    )
-    _ = serve_parser.add_argument(
-        "--host",
-        default="127.0.0.1",
-        help="Host interface for the local transport server.",
-    )
-    _ = serve_parser.add_argument(
-        "--port",
-        type=int,
-        default=8000,
-        help="Port for the local transport server.",
-    )
-    _ = serve_parser.add_argument(
-        "--approval-mode",
-        choices=("allow", "deny", "ask"),
-        help="Override the runtime approval mode for this server process.",
-    )
-    serve_parser.set_defaults(handler=_handle_server_command, server_entry=serve)
-
-    web_parser = subparsers.add_parser(
-        "web",
-        help="Start the local web launcher entrypoint for the runtime transport.",
-    )
-    _ = web_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used by the local runtime and session database.",
-    )
-    _ = web_parser.add_argument(
-        "--host",
-        default="127.0.0.1",
-        help="Host interface for the local launcher server.",
-    )
-    _ = web_parser.add_argument(
-        "--port",
-        type=int,
-        default=8000,
-        help="Port for the local launcher server.",
-    )
-    _ = web_parser.add_argument(
-        "--approval-mode",
-        choices=("allow", "deny", "ask"),
-        help="Override the runtime approval mode for this launcher process.",
-    )
-    _ = web_parser.add_argument(
-        "--no-open",
-        dest="open_browser",
-        action="store_false",
-        help="Start the web launcher without opening a browser window.",
-    )
-    web_parser.set_defaults(open_browser=True)
-    web_parser.set_defaults(handler=_handle_server_command, server_entry=web)
-
-    sessions_parser = subparsers.add_parser("sessions", help="Inspect persisted local sessions.")
-    sessions_subparsers = sessions_parser.add_subparsers(dest="sessions_command")
-
-    tasks_parser = subparsers.add_parser("tasks", help="Inspect delegated background tasks.")
-    tasks_subparsers = tasks_parser.add_subparsers(dest="tasks_command")
-
-    storage_parser = subparsers.add_parser(
-        "storage",
-        help="Inspect and maintain the local runtime SQLite store.",
-    )
-    storage_subparsers = storage_parser.add_subparsers(dest="storage_command")
-
-    config_parser = subparsers.add_parser("config", help="Inspect effective runtime configuration.")
-    config_subparsers = config_parser.add_subparsers(dest="config_command")
-
-    provider_parser = subparsers.add_parser("provider", help="Inspect provider metadata.")
-    provider_subparsers = provider_parser.add_subparsers(dest="provider_command")
-
-    commands_parser = subparsers.add_parser(
-        "commands", help="Discover prompt commands available to runtime requests."
-    )
-    commands_subparsers = commands_parser.add_subparsers(dest="commands_command")
-
-    mcp_parser = subparsers.add_parser(
-        "mcp", help="Inspect runtime-managed MCP configuration and health."
-    )
-    mcp_subparsers = mcp_parser.add_subparsers(dest="mcp_command")
-
-    config_show_parser = config_subparsers.add_parser(
-        "show", help="Show effective runtime config for a workspace or session."
-    )
-    _ = config_show_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve runtime config and sessions.",
-    )
-    _ = config_show_parser.add_argument(
-        "--session",
-        dest="session_id",
-        help="Optional persisted session identifier used to show resumed effective config.",
-    )
-    _ = config_show_parser.add_argument(
-        "--json",
-        action="store_true",
-        default=True,
-        help="Output JSON effective config (default).",
-    )
-    config_show_parser.set_defaults(handler=_handle_config_show_command)
-
-    commands_list_parser = commands_subparsers.add_parser(
-        "list", help="List enabled prompt commands discovered for a workspace."
-    )
-    _add_command_discovery_arguments(commands_list_parser)
-    _ = commands_list_parser.add_argument(
-        "--include-hidden",
-        action="store_true",
-        help="Include commands marked hidden in discovery output.",
-    )
-    _ = commands_list_parser.add_argument(
-        "--include-disabled",
-        action="store_true",
-        help="Include disabled commands in discovery output.",
-    )
-    _ = commands_list_parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Output discovered commands as JSON.",
-    )
-    commands_list_parser.set_defaults(handler=_handle_commands_list_command)
-
-    commands_show_parser = commands_subparsers.add_parser(
-        "show", help="Show one prompt command definition and rendered template source."
-    )
-    _ = commands_show_parser.add_argument(
-        "name", help="Command name, with or without leading slash."
-    )
-    _add_command_discovery_arguments(commands_show_parser)
-    _ = commands_show_parser.add_argument(
-        "--include-hidden",
-        action="store_true",
-        help="Allow showing hidden commands explicitly by name.",
-    )
-    _ = commands_show_parser.add_argument(
-        "--include-disabled",
-        action="store_true",
-        help="Allow showing disabled commands explicitly by name.",
-    )
-    _ = commands_show_parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Output the command definition as JSON.",
-    )
-    commands_show_parser.set_defaults(handler=_handle_commands_show_command)
-
-    mcp_list_parser = mcp_subparsers.add_parser(
-        "list", help="List configured MCP servers and passive runtime status."
-    )
-    _ = mcp_list_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve runtime config and MCP state.",
-    )
-    _ = mcp_list_parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Output MCP status as JSON.",
-    )
-    mcp_list_parser.set_defaults(handler=_handle_mcp_list_command)
-
-    config_schema_parser = config_subparsers.add_parser(
-        "schema", help="Print the JSON Schema for .voidcode.json."
-    )
-    config_schema_parser.set_defaults(handler=_handle_config_schema_command)
-
-    config_init_parser = config_subparsers.add_parser(
-        "init", help="Generate a starter workspace .voidcode.json."
-    )
-    _ = config_init_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root where .voidcode.json should be generated.",
-    )
-    _ = config_init_parser.add_argument(
-        "--approval-mode",
-        choices=("allow", "deny", "ask"),
-        default="ask",
-        help="Starter approval mode to write.",
-    )
-    _ = config_init_parser.add_argument(
-        "--model",
-        help="Optional provider/model reference to include in the generated config.",
-    )
-    _ = config_init_parser.add_argument(
-        "--execution-engine",
-        choices=("deterministic", "provider"),
-        help="Optional execution engine to include in the generated config.",
-    )
-    _ = config_init_parser.add_argument(
-        "--max-steps",
-        type=int,
-        help="Optional max step budget to include in the generated config.",
-    )
-    _ = config_init_parser.add_argument(
-        "--with-examples",
-        action="store_true",
-        help="Include minimal tools and skills example blocks.",
-    )
-    _ = config_init_parser.add_argument(
-        "--print",
-        action="store_true",
-        help="Print the generated config instead of writing it.",
-    )
-    _ = config_init_parser.add_argument(
-        "--force",
-        action="store_true",
-        help="Overwrite an existing .voidcode.json.",
-    )
-    config_init_parser.set_defaults(handler=_handle_config_init_command)
-
-    provider_models_parser = provider_subparsers.add_parser(
-        "models", help="Show or refresh available models for one provider."
-    )
-    _ = provider_models_parser.add_argument(
-        "provider", help="Provider name, e.g. openai or litellm."
-    )
-    _ = provider_models_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve runtime config.",
-    )
-    _ = provider_models_parser.add_argument(
-        "--refresh",
-        action="store_true",
-        help="Refresh model list from provider endpoint before printing.",
-    )
-    provider_models_parser.set_defaults(handler=_handle_provider_models_command)
-
-    provider_inspect_parser = provider_subparsers.add_parser(
-        "inspect", help="Show configured status, model limits, and model capabilities."
-    )
-    _ = provider_inspect_parser.add_argument(
-        "provider", help="Provider name, e.g. openai or litellm."
-    )
-    _ = provider_inspect_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve runtime config.",
-    )
-    provider_inspect_parser.set_defaults(handler=_handle_provider_inspect_command)
-
-    list_parser = sessions_subparsers.add_parser("list", help="List persisted sessions.")
-    _ = list_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve the local session database.",
-    )
-    _ = list_parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Output persisted sessions as JSON.",
-    )
-    list_parser.set_defaults(handler=_handle_sessions_list_command)
-
-    resume_parser = sessions_subparsers.add_parser(
-        "resume", help="Replay a persisted session response."
-    )
-    _ = resume_parser.add_argument("session_id", help="Persisted session identifier to load.")
-    _ = resume_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve the local session database.",
-    )
-    _ = resume_parser.add_argument(
-        "--approval-request-id",
-        help="Optional pending approval request identifier to resolve during resume.",
-    )
-    _ = resume_parser.add_argument(
-        "--approval-decision",
-        choices=("allow", "deny"),
-        help="Optional approval decision applied to the pending request during resume.",
-    )
-    _ = resume_parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Inspect the persisted session without resuming execution.",
-    )
-    _ = resume_parser.add_argument(
-        "--show-thinking",
-        action="store_true",
-        help="Show persisted reasoning/thinking events during replay; hidden by default.",
-    )
-    resume_parser.set_defaults(handler=_handle_sessions_resume_command)
-
-    export_parser = sessions_subparsers.add_parser(
-        "export", help="Export a portable redacted session bundle."
-    )
-    _ = export_parser.add_argument("session_id", help="Persisted session identifier to export.")
-    _ = export_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve the local session database.",
-    )
-    _ = export_parser.add_argument(
-        "--output",
-        type=Path,
-        help="Bundle output path. Defaults to <session-id>.vcsession.zip for zip output.",
-    )
-    _ = export_parser.add_argument(
-        "--format",
-        choices=("zip", "json"),
-        default="zip",
-        help="Bundle output format. JSON without --output prints the artifact to stdout.",
-    )
-    redaction_group = export_parser.add_mutually_exclusive_group()
-    _ = redaction_group.add_argument(
-        "--redact",
-        dest="redact",
-        action="store_true",
-        help="Redact secrets and sensitive fields (default).",
-    )
-    _ = redaction_group.add_argument(
-        "--no-redact",
-        dest="redact",
-        action="store_false",
-        help="Do not redact bundle payloads. Use only for private artifacts.",
-    )
-    export_parser.set_defaults(redact=True)
-    _ = export_parser.add_argument(
-        "--include-tool-output",
-        action="store_true",
-        help="Include full raw tool output instead of bounded previews.",
-    )
-    _ = export_parser.add_argument(
-        "--include-raw-provider-messages",
-        action="store_true",
-        help="Include raw provider request/response payload events when present.",
-    )
-    _ = export_parser.add_argument(
-        "--include-reasoning-text",
-        action="store_true",
-        help="Include full reasoning/thinking text when present.",
-    )
-    _ = export_parser.add_argument(
-        "--support",
-        action="store_true",
-        help="Use support-artifact defaults: redacted, bounded, diagnostics-first.",
-    )
-    export_parser.set_defaults(handler=_handle_sessions_export_command)
-
-    import_parser = sessions_subparsers.add_parser(
-        "import", help="Import a portable session bundle for local inspection."
-    )
-    _ = import_parser.add_argument(
-        "bundle_path",
-        type=Path,
-        help="Session bundle zip or JSON file.",
-    )
-    _ = import_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve the local session database.",
-    )
-    _ = import_parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Validate and summarize the bundle without persisting imported sessions.",
-    )
-    import_parser.set_defaults(handler=_handle_sessions_import_command)
-
-    debug_parser = sessions_subparsers.add_parser(
-        "debug", help="Show a minimal runtime-owned debug snapshot for one session."
-    )
-    _ = debug_parser.add_argument("session_id", help="Persisted session identifier to inspect.")
-    _ = debug_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve the local session database.",
-    )
-    _ = debug_parser.add_argument(
-        "--json",
-        action="store_true",
-        default=True,
-        help="Output JSON debug snapshot (default).",
-    )
-    _ = debug_parser.add_argument(
-        "--show-thinking",
-        action="store_true",
-        help="Include reasoning/thinking text in debug event payloads; hidden by default.",
-    )
-    debug_parser.set_defaults(handler=_handle_sessions_debug_command)
-
-    undo_parser = sessions_subparsers.add_parser(
-        "undo", help="Revert the latest user turn out of provider-facing context."
-    )
-    _ = undo_parser.add_argument("session_id", help="Persisted session identifier to undo.")
-    _ = undo_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve the local session database.",
-    )
-    undo_parser.set_defaults(handler=_handle_sessions_undo_command)
-
-    revert_parser = sessions_subparsers.add_parser(
-        "revert", help="Revert provider-facing context to an event sequence."
-    )
-    _ = revert_parser.add_argument("session_id", help="Persisted session identifier to revert.")
-    _ = revert_parser.add_argument(
-        "--to",
-        dest="sequence",
-        type=int,
-        required=True,
-        help="Event sequence to use as the revert point.",
-    )
-    _ = revert_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve the local session database.",
-    )
-    revert_parser.set_defaults(handler=_handle_sessions_revert_command)
-
-    unrevert_parser = sessions_subparsers.add_parser(
-        "unrevert", help="Clear an active conversation revert marker."
-    )
-    _ = unrevert_parser.add_argument("session_id", help="Persisted session identifier to unrevert.")
-    _ = unrevert_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve the local session database.",
-    )
-    unrevert_parser.set_defaults(handler=_handle_sessions_unrevert_command)
-
-    tasks_status_parser = tasks_subparsers.add_parser(
-        "status", help="Show delegated task lifecycle state."
-    )
-    _ = tasks_status_parser.add_argument("task_id", help="Delegated background task identifier.")
-    _ = tasks_status_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve the local session database.",
-    )
-    _ = tasks_status_parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Output delegated task state as JSON.",
-    )
-    tasks_status_parser.set_defaults(handler=_handle_tasks_status_command)
-
-    tasks_output_parser = tasks_subparsers.add_parser(
-        "output", help="Show delegated task output and correlation details."
-    )
-    _ = tasks_output_parser.add_argument("task_id", help="Delegated background task identifier.")
-    _ = tasks_output_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve the local session database.",
-    )
-    _ = tasks_output_parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Output delegated task result and guidance as JSON.",
-    )
-    tasks_output_parser.set_defaults(handler=_handle_tasks_output_command)
-
-    tasks_cancel_parser = tasks_subparsers.add_parser(
-        "cancel", help="Cancel delegated background work."
-    )
-    _ = tasks_cancel_parser.add_argument("task_id", help="Delegated background task identifier.")
-    _ = tasks_cancel_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve the local session database.",
-    )
-    _ = tasks_cancel_parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Output cancelled delegated task state as JSON.",
-    )
-    tasks_cancel_parser.set_defaults(handler=_handle_tasks_cancel_command)
-
-    tasks_list_parser = tasks_subparsers.add_parser("list", help="List delegated background tasks.")
-    _ = tasks_list_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve the local session database.",
-    )
-    _ = tasks_list_parser.add_argument(
-        "--parent-session",
-        dest="parent_session_id",
-        help="Optional parent session identifier used to filter delegated tasks.",
-    )
-    _ = tasks_list_parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Output delegated task summaries as JSON.",
-    )
-    tasks_list_parser.set_defaults(handler=_handle_tasks_list_command)
-
-    storage_diagnostics_parser = storage_subparsers.add_parser(
-        "diagnostics",
-        help="Show SQLite runtime storage policy, checkpoint, size, and row counts.",
-    )
-    _ = storage_diagnostics_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve the local session database.",
-    )
-    _ = storage_diagnostics_parser.add_argument(
-        "--json",
-        action="store_true",
-        default=True,
-        help="Output storage diagnostics as JSON (default).",
-    )
-    storage_diagnostics_parser.set_defaults(handler=_handle_storage_diagnostics_command)
-
-    storage_prune_parser = storage_subparsers.add_parser(
-        "prune",
-        help="Prune terminal sessions and terminal background tasks from local storage.",
-    )
-    _ = storage_prune_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve the local session database.",
-    )
-    _ = storage_prune_parser.add_argument(
-        "--keep-sessions",
-        type=int,
-        help="Keep the newest N sessions and prune older terminal sessions.",
-    )
-    _ = storage_prune_parser.add_argument(
-        "--keep-background-tasks",
-        type=int,
-        help="Keep the newest N background tasks and prune older terminal tasks.",
-    )
-    _ = storage_prune_parser.add_argument(
-        "--older-than",
-        type=int,
-        help="Only prune records with updated_at lower than this runtime timestamp.",
-    )
-    storage_prune_parser.set_defaults(handler=_handle_storage_prune_command)
-
-    storage_reset_parser = storage_subparsers.add_parser(
-        "reset",
-        help="Delete the local pre-MVP runtime SQLite database and WAL/SHM files.",
-    )
-    _ = storage_reset_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve the local session database.",
-    )
-    storage_reset_parser.set_defaults(handler=_handle_storage_reset_command)
-
-    # Capability doctor command
-    doctor_parser = subparsers.add_parser(
-        "doctor",
-        help="Check runtime capability readiness (external tools, formatters, LSP, MCP).",
-    )
-    _ = doctor_parser.add_argument(
-        "--workspace",
-        type=Path,
-        default=Path.cwd(),
-        help="Workspace root used to resolve runtime config.",
-    )
-    _ = doctor_parser.add_argument(
-        "--verbose",
-        "-v",
-        action="store_true",
-        help="Show all capabilities including successful ones.",
-    )
-    _ = doctor_parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Output report in JSON format.",
-    )
-    doctor_parser.set_defaults(handler=_handle_doctor_command)
-
-    return parser
+def _normalize_click_argv(argv: Sequence[str] | None) -> list[str] | None:
+    if argv is None:
+        return None
+    normalized: list[str] = []
+    index = 0
+    while index < len(argv):
+        item = argv[index]
+        if item != "--skills":
+            normalized.append(item)
+            index += 1
+            continue
+        index += 1
+        while index < len(argv) and not argv[index].startswith("-"):
+            normalized.extend(("--skills", argv[index]))
+            index += 1
+    return normalized
 
 
-def main(argv: Sequence[str] | None = None) -> int:
-    parser = build_parser()
-    args = parser.parse_args(argv)
-    if (
-        getattr(args, "command", None) == "sessions"
-        and getattr(args, "sessions_command", None) == "resume"
-    ):
-        has_request_id = getattr(args, "approval_request_id", None) is not None
-        has_decision = getattr(args, "approval_decision", None) is not None
-        if has_request_id != has_decision:
-            parser.error("--approval-request-id and --approval-decision must be provided together")
-    handler = cast(Handler | None, getattr(args, "handler", None))
-    if handler is None:
-        parser.print_help()
-        return EXIT_SUCCESS
+def _run_click_command(command: click.Command, argv: Sequence[str] | None) -> int:
     try:
-        return handler(args)
+        result = command.main(
+            args=_normalize_click_argv(argv),
+            prog_name="voidcode",
+            standalone_mode=False,
+        )
+        return EXIT_SUCCESS if result is None else cast(int, result)
+    except click.exceptions.Exit as exc:
+        return exc.exit_code
+    except click.ClickException as exc:
+        exc.show(file=sys.stderr)
+        return exc.exit_code
+    except _CliUsageError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return exc.exit_code
     except SystemExit as exc:
         return _handle_cli_system_exit(exc)
     except RuntimeError as exc:
         message = f"error: {exc}"
         print(message, file=sys.stderr)
         return _classify_cli_error(message)
+
+
+@click.group(
+    invoke_without_command=True,
+    help="Voidcode command-line interface.\n\n" + _EXAMPLES,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+@click.version_option(__version__, "--version", prog_name="voidcode")
+@click.pass_context
+def root_cli(ctx: click.Context) -> None:
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@root_cli.command(help="Run the VoidCode interactive Textual UI.")
+@_workspace_option("Workspace root used to resolve relative read paths.")
+@click.option(
+    "--approval-mode",
+    type=click.Choice(_APPROVAL_MODES),
+    help="Override the runtime approval mode for this invocation.",
+)
+def tui(workspace: Path, approval_mode: str | None) -> int:
+    return _invoke_handler_from_click(
+        _handle_tui_command,
+        _build_click_command_context(
+            command="tui",
+            workspace=workspace,
+            approval_mode=approval_mode,
+        ),
+    )
+
+
+@root_cli.command(help="Run through the local runtime provider or deterministic harness.")
+@click.argument("request")
+@_workspace_option("Workspace root used to resolve relative read paths.")
+@click.option("--session-id", help="Optional session identifier used for persisted runs.")
+@click.option(
+    "--approval-mode",
+    type=click.Choice(_APPROVAL_MODES),
+    help="Override the runtime approval mode for this invocation.",
+)
+@click.option(
+    "--agent",
+    type=click.Choice(_SELECTABLE_AGENT_IDS),
+    help="Select a top-level agent preset for this run.",
+)
+@click.option("--skills", multiple=True, help="Optional skill names applied for this run.")
+@click.option("--max-steps", type=int, help="Optional max graph steps override for this run.")
+@click.option(
+    "--reasoning-effort",
+    help="Optional runtime-owned reasoning-effort hint forwarded to the active provider.",
+)
+@_show_thinking_option("Show persisted reasoning/thinking text; hidden by default.")
+@_json_option("Output a structured JSON payload with session, events, and final output.")
+@click.option(
+    "--provider-stream/--no-provider-stream",
+    default=None,
+    help="Enable or disable provider-level streaming for this run.",
+)
+def run(
+    request: str,
+    workspace: Path,
+    session_id: str | None,
+    approval_mode: str | None,
+    agent: str | None,
+    skills: tuple[str, ...],
+    max_steps: int | None,
+    reasoning_effort: str | None,
+    show_thinking: bool,
+    json_output: bool,
+    provider_stream: bool | None,
+) -> int:
+    return _invoke_handler_from_click(
+        _handle_run_command,
+        _build_click_command_context(
+            command="run",
+            request=request,
+            workspace=workspace,
+            session_id=session_id,
+            approval_mode=approval_mode,
+            agent=agent,
+            skills=list(skills),
+            max_steps=max_steps,
+            reasoning_effort=reasoning_effort,
+            show_thinking=show_thinking,
+            json=json_output,
+            provider_stream=provider_stream,
+        ),
+    )
+
+
+@root_cli.command(help="Run the minimal external-facing ACP stdio JSON-RPC facade.")
+@_workspace_option("Workspace root used by the ACP-backed runtime session database.")
+@click.option(
+    "--approval-mode",
+    type=click.Choice(_APPROVAL_MODES),
+    help="Override the runtime approval mode for this ACP process.",
+)
+def acp(workspace: Path, approval_mode: str | None) -> int:
+    return _invoke_handler_from_click(
+        _handle_acp_command,
+        _build_click_command_context(
+            command="acp",
+            workspace=workspace,
+            approval_mode=approval_mode,
+        ),
+    )
+
+
+def _server_command(
+    *,
+    command: str,
+    workspace: Path,
+    host: str,
+    port: int,
+    approval_mode: str | None,
+    server_entry: Callable[..., None],
+    open_browser: bool | None = None,
+) -> int:
+    return _invoke_handler_from_click(
+        _handle_server_command,
+        _build_click_command_context(
+            command=command,
+            workspace=workspace,
+            host=host,
+            port=port,
+            approval_mode=approval_mode,
+            server_entry=server_entry,
+        ),
+    )
+
+
+def _web_server_command(
+    *,
+    workspace: Path,
+    host: str,
+    port: int,
+    approval_mode: str | None,
+    open_browser: bool,
+) -> int:
+    return _invoke_handler_from_click(
+        _handle_server_command,
+        _build_click_command_context(
+            command="web",
+            workspace=workspace,
+            host=host,
+            port=port,
+            approval_mode=approval_mode,
+            server_entry=web,
+            open_browser=open_browser,
+        ),
+    )
+
+
+@root_cli.command(name="serve", help="Serve the local HTTP runtime transport.")
+@_workspace_option("Workspace root used by the local runtime and session database.")
+@click.option("--host", default="127.0.0.1", help="Host interface for the local transport server.")
+@click.option("--port", type=int, default=8000, help="Port for the local transport server.")
+@click.option(
+    "--approval-mode",
+    type=click.Choice(_APPROVAL_MODES),
+    help="Override the runtime approval mode for this server process.",
+)
+def serve_command(workspace: Path, host: str, port: int, approval_mode: str | None) -> int:
+    return _server_command(
+        command="serve",
+        workspace=workspace,
+        host=host,
+        port=port,
+        approval_mode=approval_mode,
+        server_entry=serve,
+    )
+
+
+@root_cli.command(
+    name="web",
+    help="Start the local web launcher entrypoint for the runtime transport.",
+)
+@_workspace_option("Workspace root used by the local runtime and session database.")
+@click.option("--host", default="127.0.0.1", help="Host interface for the local launcher server.")
+@click.option("--port", type=int, default=8000, help="Port for the local launcher server.")
+@click.option(
+    "--approval-mode",
+    type=click.Choice(_APPROVAL_MODES),
+    help="Override the runtime approval mode for this launcher process.",
+)
+@click.option(
+    "--no-open",
+    "open_browser",
+    flag_value=False,
+    default=True,
+    help="Start the web launcher without opening a browser window.",
+)
+def web_command(
+    workspace: Path,
+    host: str,
+    port: int,
+    approval_mode: str | None,
+    open_browser: bool,
+) -> int:
+    return _web_server_command(
+        workspace=workspace,
+        host=host,
+        port=port,
+        approval_mode=approval_mode,
+        open_browser=open_browser,
+    )
+
+
+@root_cli.group(help="Inspect persisted local sessions.")
+def sessions() -> None:
+    pass
+
+
+@sessions.command(name="list", help="List persisted sessions.")
+@_workspace_option("Workspace root used to resolve the local session database.")
+@_json_option("Output persisted sessions as JSON.")
+def sessions_list(workspace: Path, json_output: bool) -> int:
+    return _invoke_handler_from_click(
+        _handle_sessions_list_command,
+        _build_click_command_context(
+            command="sessions",
+            subcommand="list",
+            workspace=workspace,
+            json=json_output,
+        ),
+    )
+
+
+@sessions.command(help="Replay a persisted session response.")
+@click.argument("session_id")
+@_workspace_option("Workspace root used to resolve the local session database.")
+@click.option(
+    "--approval-request-id",
+    help="Optional pending approval request identifier to resolve during resume.",
+)
+@click.option(
+    "--approval-decision",
+    type=click.Choice(_APPROVAL_DECISIONS),
+    help="Optional approval decision applied to the pending request during resume.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Inspect the persisted session without resuming execution.",
+)
+@_show_thinking_option("Show persisted reasoning/thinking events during replay; hidden by default.")
+def resume(
+    session_id: str,
+    workspace: Path,
+    approval_request_id: str | None,
+    approval_decision: str | None,
+    dry_run: bool,
+    show_thinking: bool,
+) -> int:
+    if (approval_request_id is None) != (approval_decision is None):
+        raise _CliUsageError(
+            "--approval-request-id and --approval-decision must be provided together"
+        )
+    return _invoke_handler_from_click(
+        _handle_sessions_resume_command,
+        _build_click_command_context(
+            command="sessions",
+            subcommand="resume",
+            session_id=session_id,
+            workspace=workspace,
+            approval_request_id=approval_request_id,
+            approval_decision=approval_decision,
+            dry_run=dry_run,
+            show_thinking=show_thinking,
+        ),
+    )
+
+
+@sessions.command(help="Answer a pending runtime.question_requested session.")
+@click.argument("session_id")
+@_workspace_option("Workspace root used to resolve the local session database.")
+@click.option(
+    "--question-request-id",
+    required=True,
+    help="Pending question request identifier to answer.",
+)
+@click.option(
+    "--response",
+    multiple=True,
+    help="Text answer. Repeat for multi-answer simple responses.",
+)
+@click.option(
+    "--response-json",
+    help="JSON array of {header, answers} objects for multi-question answers.",
+)
+@_json_option("Output the resumed runtime response as JSON.")
+@_show_thinking_option("Show persisted reasoning/thinking events during replay; hidden by default.")
+def answer(
+    session_id: str,
+    workspace: Path,
+    question_request_id: str,
+    response: tuple[str, ...],
+    response_json: str | None,
+    json_output: bool,
+    show_thinking: bool,
+) -> int:
+    return _invoke_handler_from_click(
+        _handle_sessions_answer_command,
+        _build_click_command_context(
+            command="sessions",
+            subcommand="answer",
+            session_id=session_id,
+            workspace=workspace,
+            question_request_id=question_request_id,
+            response=response,
+            response_json=response_json,
+            json=json_output,
+            show_thinking=show_thinking,
+        ),
+    )
+
+
+@sessions.command(name="export", help="Export a portable redacted session bundle.")
+@click.argument("session_id")
+@_workspace_option("Workspace root used to resolve the local session database.")
+@click.option("--output", type=click.Path(path_type=Path), help="Bundle output path.")
+@click.option("--format", "fmt", type=click.Choice(_BUNDLE_FORMATS), default="zip")
+@click.option("--redact/--no-redact", default=True)
+@click.option("--include-tool-output", is_flag=True)
+@click.option("--include-raw-provider-messages", is_flag=True)
+@click.option("--include-reasoning-text", is_flag=True)
+@click.option("--support", is_flag=True)
+def sessions_export(
+    session_id: str,
+    workspace: Path,
+    output: Path | None,
+    fmt: str,
+    redact: bool,
+    include_tool_output: bool,
+    include_raw_provider_messages: bool,
+    include_reasoning_text: bool,
+    support: bool,
+) -> int:
+    return _invoke_handler_from_click(
+        _handle_sessions_export_command,
+        _build_click_command_context(
+            command="sessions",
+            subcommand="export",
+            session_id=session_id,
+            workspace=workspace,
+            output=output,
+            format=fmt,
+            redact=redact,
+            include_tool_output=include_tool_output,
+            include_raw_provider_messages=include_raw_provider_messages,
+            include_reasoning_text=include_reasoning_text,
+            support=support,
+        ),
+    )
+
+
+@sessions.command(name="import", help="Import a portable session bundle for local inspection.")
+@click.argument("bundle_path", type=click.Path(path_type=Path))
+@_workspace_option("Workspace root used to resolve the local session database.")
+@click.option("--dry-run", is_flag=True)
+def sessions_import(bundle_path: Path, workspace: Path, dry_run: bool) -> int:
+    return _invoke_handler_from_click(
+        _handle_sessions_import_command,
+        _build_click_command_context(
+            command="sessions",
+            subcommand="import",
+            bundle_path=bundle_path,
+            workspace=workspace,
+            dry_run=dry_run,
+        ),
+    )
+
+
+@sessions.command(help="Show a minimal runtime-owned debug snapshot for one session.")
+@click.argument("session_id")
+@_workspace_option("Workspace root used to resolve the local session database.")
+@_json_option("Output JSON debug snapshot (default).")
+@_show_thinking_option(
+    "Include reasoning/thinking text in debug event payloads; hidden by default."
+)
+def debug(session_id: str, workspace: Path, json_output: bool, show_thinking: bool) -> int:
+    _ = json_output
+    return _invoke_handler_from_click(
+        _handle_sessions_debug_command,
+        _build_click_command_context(
+            command="sessions",
+            subcommand="debug",
+            session_id=session_id,
+            workspace=workspace,
+            json=True,
+            show_thinking=show_thinking,
+        ),
+    )
+
+
+@sessions.command(help="Revert the latest user turn out of provider-facing context.")
+@click.argument("session_id")
+@_workspace_option("Workspace root used to resolve the local session database.")
+def undo(session_id: str, workspace: Path) -> int:
+    return _invoke_handler_from_click(
+        _handle_sessions_undo_command,
+        _build_click_command_context(
+            command="sessions", subcommand="undo", session_id=session_id, workspace=workspace
+        ),
+    )
+
+
+@sessions.command(help="Revert provider-facing context to an event sequence.")
+@click.argument("session_id")
+@click.option("--to", "sequence", type=int, required=True)
+@_workspace_option("Workspace root used to resolve the local session database.")
+def revert(session_id: str, sequence: int, workspace: Path) -> int:
+    return _invoke_handler_from_click(
+        _handle_sessions_revert_command,
+        _build_click_command_context(
+            command="sessions",
+            subcommand="revert",
+            session_id=session_id,
+            sequence=sequence,
+            workspace=workspace,
+        ),
+    )
+
+
+@sessions.command(help="Clear an active conversation revert marker.")
+@click.argument("session_id")
+@_workspace_option("Workspace root used to resolve the local session database.")
+def unrevert(session_id: str, workspace: Path) -> int:
+    return _invoke_handler_from_click(
+        _handle_sessions_unrevert_command,
+        _build_click_command_context(
+            command="sessions",
+            subcommand="unrevert",
+            session_id=session_id,
+            workspace=workspace,
+        ),
+    )
+
+
+@root_cli.group(help="Inspect delegated background tasks.")
+def tasks() -> None:
+    pass
+
+
+@tasks.command(help="Show delegated task lifecycle state.")
+@click.argument("task_id")
+@_workspace_option("Workspace root used to resolve the local session database.")
+@_json_option("Output delegated task state as JSON.")
+def status(task_id: str, workspace: Path, json_output: bool) -> int:
+    return _invoke_handler_from_click(
+        _handle_tasks_status_command,
+        _build_click_command_context(
+            command="tasks",
+            subcommand="status",
+            task_id=task_id,
+            workspace=workspace,
+            json=json_output,
+        ),
+    )
+
+
+@tasks.command(help="Show delegated task output and correlation details.")
+@click.argument("task_id")
+@_workspace_option("Workspace root used to resolve the local session database.")
+@_json_option("Output delegated task result and guidance as JSON.")
+def output(task_id: str, workspace: Path, json_output: bool) -> int:
+    return _invoke_handler_from_click(
+        _handle_tasks_output_command,
+        _build_click_command_context(
+            command="tasks",
+            subcommand="output",
+            task_id=task_id,
+            workspace=workspace,
+            json=json_output,
+        ),
+    )
+
+
+@tasks.command(help="Cancel delegated background work.")
+@click.argument("task_id")
+@_workspace_option("Workspace root used to resolve the local session database.")
+@_json_option("Output cancelled delegated task state as JSON.")
+def cancel(task_id: str, workspace: Path, json_output: bool) -> int:
+    return _invoke_handler_from_click(
+        _handle_tasks_cancel_command,
+        _build_click_command_context(
+            command="tasks",
+            subcommand="cancel",
+            task_id=task_id,
+            workspace=workspace,
+            json=json_output,
+        ),
+    )
+
+
+@tasks.command(name="list", help="List delegated background tasks.")
+@_workspace_option("Workspace root used to resolve the local session database.")
+@click.option("--parent-session", "parent_session_id")
+@_json_option("Output delegated task summaries as JSON.")
+def tasks_list(workspace: Path, parent_session_id: str | None, json_output: bool) -> int:
+    return _invoke_handler_from_click(
+        _handle_tasks_list_command,
+        _build_click_command_context(
+            command="tasks",
+            subcommand="list",
+            workspace=workspace,
+            parent_session_id=parent_session_id,
+            json=json_output,
+        ),
+    )
+
+
+@root_cli.group(help="Inspect and maintain the local runtime SQLite store.")
+def storage() -> None:
+    pass
+
+
+@storage.command(help="Show SQLite runtime storage policy, checkpoint, size, and row counts.")
+@_workspace_option("Workspace root used to resolve the local session database.")
+@_json_option("Output storage diagnostics as JSON (default).")
+def diagnostics(workspace: Path, json_output: bool) -> int:
+    _ = json_output
+    return _invoke_handler_from_click(
+        _handle_storage_diagnostics_command,
+        _build_click_command_context(
+            command="storage", subcommand="diagnostics", workspace=workspace, json=True
+        ),
+    )
+
+
+@storage.command(help="Prune terminal sessions and terminal background tasks from local storage.")
+@_workspace_option("Workspace root used to resolve the local session database.")
+@click.option("--keep-sessions", type=int)
+@click.option("--keep-background-tasks", type=int)
+@click.option("--older-than", type=int)
+def prune(
+    workspace: Path,
+    keep_sessions: int | None,
+    keep_background_tasks: int | None,
+    older_than: int | None,
+) -> int:
+    return _invoke_handler_from_click(
+        _handle_storage_prune_command,
+        _build_click_command_context(
+            command="storage",
+            subcommand="prune",
+            workspace=workspace,
+            keep_sessions=keep_sessions,
+            keep_background_tasks=keep_background_tasks,
+            older_than=older_than,
+        ),
+    )
+
+
+@storage.command(help="Delete the local pre-MVP runtime SQLite database and WAL/SHM files.")
+@_workspace_option("Workspace root used to resolve the local session database.")
+def reset(workspace: Path) -> int:
+    return _invoke_handler_from_click(
+        _handle_storage_reset_command,
+        _build_click_command_context(command="storage", subcommand="reset", workspace=workspace),
+    )
+
+
+@root_cli.group(help="Inspect effective runtime configuration.")
+def config() -> None:
+    pass
+
+
+@config.command(name="show", help="Show effective runtime config for a workspace or session.")
+@_workspace_option("Workspace root used to resolve runtime config and sessions.")
+@click.option("--session", "session_id")
+@_json_option("Output JSON effective config (default).")
+def config_show(workspace: Path, session_id: str | None, json_output: bool) -> int:
+    _ = json_output
+    return _invoke_handler_from_click(
+        _handle_config_show_command,
+        _build_click_command_context(
+            command="config",
+            subcommand="show",
+            workspace=workspace,
+            session_id=session_id,
+            json=True,
+        ),
+    )
+
+
+@config.command(name="schema", help="Print the JSON Schema for .voidcode.json.")
+def config_schema() -> int:
+    return _invoke_handler_from_click(
+        _handle_config_schema_command,
+        _build_click_command_context(command="config", subcommand="schema"),
+    )
+
+
+@config.command(name="init", help="Generate a starter workspace .voidcode.json.")
+@_workspace_option("Workspace root where .voidcode.json should be generated.")
+@click.option("--approval-mode", type=click.Choice(_APPROVAL_MODES), default="ask")
+@click.option("--model")
+@click.option("--execution-engine", type=click.Choice(_EXECUTION_ENGINES))
+@click.option("--max-steps", type=int)
+@click.option("--with-examples", is_flag=True)
+@click.option("--print", "print_config", is_flag=True)
+@click.option("--force", is_flag=True)
+def config_init(
+    workspace: Path,
+    approval_mode: str,
+    model: str | None,
+    execution_engine: str | None,
+    max_steps: int | None,
+    with_examples: bool,
+    print_config: bool,
+    force: bool,
+) -> int:
+    return _invoke_handler_from_click(
+        _handle_config_init_command,
+        _build_click_command_context(
+            command="config",
+            subcommand="init",
+            workspace=workspace,
+            approval_mode=approval_mode,
+            model=model,
+            execution_engine=execution_engine,
+            max_steps=max_steps,
+            with_examples=with_examples,
+            print=print_config,
+            force=force,
+        ),
+    )
+
+
+@root_cli.group(help="Inspect provider metadata.")
+def provider() -> None:
+    pass
+
+
+@provider.command(help="Show or refresh available models for one provider.")
+@click.argument("provider_name")
+@_workspace_option("Workspace root used to resolve runtime config.")
+@click.option("--refresh", is_flag=True)
+def models(provider_name: str, workspace: Path, refresh: bool) -> int:
+    return _invoke_handler_from_click(
+        _handle_provider_models_command,
+        _build_click_command_context(
+            command="provider",
+            subcommand="models",
+            provider=provider_name,
+            workspace=workspace,
+            refresh=refresh,
+        ),
+    )
+
+
+@provider.command(help="Show configured status, model limits, and model capabilities.")
+@click.argument("provider_name")
+@_workspace_option("Workspace root used to resolve runtime config.")
+def inspect(provider_name: str, workspace: Path) -> int:
+    return _invoke_handler_from_click(
+        _handle_provider_inspect_command,
+        _build_click_command_context(
+            command="provider",
+            subcommand="inspect",
+            provider=provider_name,
+            workspace=workspace,
+        ),
+    )
+
+
+@root_cli.group(help="Discover prompt commands available to runtime requests.")
+def commands() -> None:
+    pass
+
+
+@commands.command(name="list", help="List enabled prompt commands discovered for a workspace.")
+@_command_discovery_options
+@click.option("--include-hidden", is_flag=True)
+@click.option("--include-disabled", is_flag=True)
+@_json_option("Output discovered commands as JSON.")
+def commands_list(
+    workspace: Path,
+    user_commands_dir: Path | None,
+    include_hidden: bool,
+    include_disabled: bool,
+    json_output: bool,
+) -> int:
+    return _invoke_handler_from_click(
+        _handle_commands_list_command,
+        _build_click_command_context(
+            command="commands",
+            subcommand="list",
+            workspace=workspace,
+            user_commands_dir=user_commands_dir,
+            include_hidden=include_hidden,
+            include_disabled=include_disabled,
+            json=json_output,
+        ),
+    )
+
+
+@commands.command(
+    name="show",
+    help="Show one prompt command definition and rendered template source.",
+)
+@click.argument("name")
+@_command_discovery_options
+@click.option("--include-hidden", is_flag=True)
+@click.option("--include-disabled", is_flag=True)
+@_json_option("Output the command definition as JSON.")
+def commands_show(
+    name: str,
+    workspace: Path,
+    user_commands_dir: Path | None,
+    include_hidden: bool,
+    include_disabled: bool,
+    json_output: bool,
+) -> int:
+    return _invoke_handler_from_click(
+        _handle_commands_show_command,
+        _build_click_command_context(
+            command="commands",
+            subcommand="show",
+            name=name,
+            workspace=workspace,
+            user_commands_dir=user_commands_dir,
+            include_hidden=include_hidden,
+            include_disabled=include_disabled,
+            json=json_output,
+        ),
+    )
+
+
+@root_cli.group(help="Inspect runtime-managed MCP configuration and health.")
+def mcp() -> None:
+    pass
+
+
+@mcp.command(name="list", help="List configured MCP servers and passive runtime status.")
+@_workspace_option("Workspace root used to resolve runtime config and MCP state.")
+@_json_option("Output MCP status as JSON.")
+def mcp_list(workspace: Path, json_output: bool) -> int:
+    return _invoke_handler_from_click(
+        _handle_mcp_list_command,
+        _build_click_command_context(
+            command="mcp", subcommand="list", workspace=workspace, json=json_output
+        ),
+    )
+
+
+@root_cli.command(help="Check runtime capability readiness (external tools, formatters, LSP, MCP).")
+@_workspace_option("Workspace root used to resolve runtime config.")
+@click.option("--verbose", "verbose", "-v", is_flag=True)
+@_json_option("Output report in JSON format.")
+def doctor(workspace: Path, verbose: bool, json_output: bool) -> int:
+    return _invoke_handler_from_click(
+        _handle_doctor_command,
+        _build_click_command_context(
+            command="doctor", workspace=workspace, verbose=verbose, json=json_output
+        ),
+    )
+
+
+class _CompatChoiceAction:
+    def __init__(self, dest: str) -> None:
+        self.dest = dest
+
+
+class _CompatSubparsers:
+    def __init__(self, command: click.Command) -> None:
+        commands = command.commands if isinstance(command, click.Group) else {}
+        self.choices = {name: _CompatParser(child) for name, child in commands.items()}
+        self._choices_actions = [_CompatChoiceAction(name) for name in commands]
+        self._parser_class = _CompatParser
+
+
+class _CompatSubparserContainer:
+    def __init__(self, command: click.Command) -> None:
+        self._group_actions = [_CompatSubparsers(command)]
+
+
+class _CompatParser:
+    def __init__(self, command: click.Command) -> None:
+        self._command = command
+        self._subparsers = _CompatSubparserContainer(command)
+
+
+def build_parser() -> _CompatParser:
+    return _CompatParser(root_cli)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    return _run_click_command(root_cli, argv)

--- a/tests/unit/interface/test_cli_delegated_parity.py
+++ b/tests/unit/interface/test_cli_delegated_parity.py
@@ -25,12 +25,13 @@ import sys
 import time
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
 
-from voidcode.runtime.task import is_background_task_terminal
+from voidcode.runtime.task import BackgroundTaskStatus, is_background_task_terminal
+from voidcode.tools import ToolCall
 
 from .._paths import with_src_pythonpath
 
@@ -75,11 +76,36 @@ def _wait_for_background_task(
 
 
 def _is_terminal_background_task(task: Any) -> bool:
-    return is_background_task_terminal(getattr(task, "status", None))
+    return is_background_task_terminal(cast(BackgroundTaskStatus, task.status))
 
 
 def _is_waiting_approval_background_task(task: Any) -> bool:
     return getattr(task, "approval_request_id", None) is not None
+
+
+class _QuestionThenDoneGraph:
+    def step(self, request: Any, tool_results: tuple[object, ...], *, session: Any) -> Any:
+        _ = request, session
+        if not tool_results:
+            return SimpleNamespace(
+                tool_call=ToolCall(
+                    tool_name="question",
+                    arguments={
+                        "questions": [
+                            {
+                                "question": "Which runtime path should we use?",
+                                "header": "Runtime path",
+                                "options": [{"label": "Reuse existing", "description": ""}],
+                                "multiple": False,
+                            }
+                        ]
+                    },
+                ),
+                output=None,
+                events=(),
+                is_finished=False,
+            )
+        return SimpleNamespace(tool_call=None, output="done", events=(), is_finished=True)
 
 
 # ---------------------------------------------------------------------------
@@ -107,6 +133,20 @@ def test_cli_parser_has_sessions_resume_subcommand() -> None:
     assert sessions_parser is not None
     sub_actions = {a.dest for a in sessions_parser._subparsers._group_actions[0]._choices_actions}
     assert "resume" in sub_actions
+
+
+def test_cli_parser_has_sessions_answer_subcommand() -> None:
+    """``voidcode sessions answer`` must exist for pending-question waits."""
+    cli = importlib.import_module("voidcode.cli")
+    parser = cli.build_parser()
+    sessions_parser = None
+    for action in parser._subparsers._group_actions:
+        if hasattr(action, "_parser_class") and "sessions" in (action.choices or {}):
+            sessions_parser = action.choices["sessions"]
+            break
+    assert sessions_parser is not None
+    sub_actions = {a.dest for a in sessions_parser._subparsers._group_actions[0]._choices_actions}
+    assert "answer" in sub_actions
 
 
 def test_cli_parser_has_run_subcommand() -> None:
@@ -295,6 +335,136 @@ def test_cli_sessions_resume_resolves_approval_deny() -> None:
 
     assert result == 0
     assert runtime_class.return_value.resume.call_args.kwargs["approval_decision"] == "deny"
+
+
+def test_cli_sessions_answer_resolves_pending_question() -> None:
+    """``voidcode sessions answer`` must call the runtime-owned question path."""
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/demo-workspace")
+    response = SimpleNamespace(
+        session=SimpleNamespace(
+            session=SimpleNamespace(id="question-session"),
+            status="completed",
+            turn=1,
+            metadata={"workspace": str(workspace)},
+        ),
+        events=(
+            SimpleNamespace(
+                session_id="question-session",
+                sequence=3,
+                event_type="runtime.question_answered",
+                source="runtime",
+                payload={"request_id": "question-1"},
+            ),
+        ),
+        output="answered\n",
+    )
+
+    with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
+        runtime_class.return_value.answer_question.return_value = response
+        result = cli.main(
+            [
+                "sessions",
+                "answer",
+                "question-session",
+                "--workspace",
+                str(workspace),
+                "--question-request-id",
+                "question-1",
+                "--response",
+                "yes",
+            ]
+        )
+
+    assert result == 0
+    runtime_class.return_value.answer_question.assert_called_once()
+    call = runtime_class.return_value.answer_question.call_args
+    assert call.args == ("question-session",)
+    assert call.kwargs["question_request_id"] == "question-1"
+    responses = call.kwargs["responses"]
+    assert len(responses) == 1
+    assert responses[0].header == "response"
+    assert responses[0].answers == ("yes",)
+
+
+def test_cli_sessions_answer_accepts_json_responses() -> None:
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/demo-workspace")
+    response = SimpleNamespace(
+        session=SimpleNamespace(
+            session=SimpleNamespace(id="question-session"),
+            status="completed",
+            turn=1,
+            metadata={"workspace": str(workspace)},
+        ),
+        events=(),
+        output=None,
+    )
+
+    with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
+        runtime_class.return_value.answer_question.return_value = response
+        result = cli.main(
+            [
+                "sessions",
+                "answer",
+                "question-session",
+                "--workspace",
+                str(workspace),
+                "--question-request-id",
+                "question-1",
+                "--response-json",
+                '[{"header":"Confirm","answers":["yes","ship it"]}]',
+            ]
+        )
+
+    assert result == 0
+    responses = runtime_class.return_value.answer_question.call_args.kwargs["responses"]
+    assert responses[0].header == "Confirm"
+    assert responses[0].answers == ("yes", "ship it")
+
+
+def test_cli_sessions_answer_completes_real_question_wait(tmp_path: Path) -> None:
+    cli = importlib.import_module("voidcode.cli")
+    runtime_module = importlib.import_module("voidcode.runtime")
+    config_module = importlib.import_module("voidcode.runtime.config")
+
+    runtime = runtime_module.VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_QuestionThenDoneGraph(),
+        config=config_module.RuntimeConfig(approval_mode="ask"),
+    )
+    waiting = runtime.run(
+        runtime_module.RuntimeRequest(prompt="ask", session_id="question-session")
+    )
+    question_request_id = waiting.events[-1].payload["request_id"]
+    runtime.__exit__(None, None, None)
+
+    def _runtime_factory(*, workspace: Path) -> Any:
+        return runtime_module.VoidCodeRuntime(
+            workspace=workspace,
+            graph=_QuestionThenDoneGraph(),
+            config=config_module.RuntimeConfig(approval_mode="ask"),
+        )
+
+    with patch.object(cli, "VoidCodeRuntime", side_effect=_runtime_factory):
+        result = cli.main(
+            [
+                "sessions",
+                "answer",
+                "question-session",
+                "--workspace",
+                str(tmp_path),
+                "--question-request-id",
+                str(question_request_id),
+                "--response-json",
+                '[{"header":"Runtime path","answers":["Reuse existing"]}]',
+            ]
+        )
+
+    resumed = runtime_module.VoidCodeRuntime(workspace=tmp_path).resume("question-session")
+    assert result == 0
+    assert resumed.session.status == "completed"
+    assert resumed.output == "done"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -468,6 +468,52 @@ def test_sessions_resume_surfaces_approval_resolution_errors_cleanly() -> None:
     assert "Traceback" not in resume_result.stderr
 
 
+def test_sessions_answer_requires_response_text() -> None:
+    result = _run_module_cli(
+        "sessions",
+        "answer",
+        "question-session",
+        "--question-request-id",
+        "question-1",
+    )
+
+    assert result.returncode == 2
+    assert "at least one --response or --response-json must be provided" in result.stderr
+
+
+def test_sessions_answer_surfaces_missing_pending_question_cleanly() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        _ = (workspace / "sample.txt").write_text("sample\n", encoding="utf-8")
+        env = with_src_pythonpath(os.environ.copy())
+        setup_result = _run_module_cli(
+            "run",
+            "read sample.txt",
+            "--workspace",
+            str(workspace),
+            "--session-id",
+            "question-session",
+            env=env,
+        )
+        answer_result = _run_module_cli(
+            "sessions",
+            "answer",
+            "question-session",
+            "--workspace",
+            str(workspace),
+            "--question-request-id",
+            "question-1",
+            "--response",
+            "yes",
+            env=env,
+        )
+
+    assert setup_result.returncode == 0
+    assert answer_result.returncode == 16
+    assert "no pending question" in answer_result.stderr
+    assert "Traceback" not in answer_result.stderr
+
+
 def test_sessions_debug_outputs_json_snapshot() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         workspace = Path(tmp)

--- a/uv.lock
+++ b/uv.lock
@@ -1718,6 +1718,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
+    { name = "click" },
     { name = "httpx" },
     { name = "langchain-core" },
     { name = "langgraph" },
@@ -1747,6 +1748,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4" },
+    { name = "click", specifier = ">=8.1.8" },
     { name = "httpx" },
     { name = "hypothesis", marker = "extra == 'dev'" },
     { name = "langchain-core" },


### PR DESCRIPTION
## Summary
- Migrate the CLI command surface into a Click-backed `src/voidcode/cli/` package while preserving `voidcode.cli:main`, `python -m voidcode`, and compatibility seams.
- Add `voidcode sessions answer <session-id>` for pending `runtime.question_requested` waits via `VoidCodeRuntime.answer_question(...)`, with `--response` and `--response-json` shapes.
- Update CLI parity/smoke coverage and recovery/client docs for question answer workflows.

## Verification
- `uv run --extra dev ruff check .`
- `uv run --extra dev ty check src`
- `uv run --extra dev python -X utf8 -m pytest tests/unit/interface/test_cli_delegated_parity.py tests/unit/interface/test_cli_smoke.py -q` (107 passed)
- `uv run --extra dev python -X utf8 -m pytest tests/unit/runtime/test_runtime_service_extensions.py -q` (398 passed)
- `uv run --extra dev python -X utf8 -m pytest -n auto` (2046 passed)
- `uv build` (passed before rebase)

## Review
- 5-agent post-implementation review completed.
- Security, goal verification, code quality, and QA passed.
- Context mining found stale `src/voidcode/cli.py` references; fixed in `docs(cli): update package references`.

Closes #398