### PR TITLE
fix(tools): clarify tool argument validation feedback

### DIFF
--- a/src/voidcode/acp/stdio.py
+++ b/src/voidcode/acp/stdio.py
@@ -230,6 +230,7 @@ class StdioAcpServer:
     ) -> None:
         stop_reason = "end_turn"
         failed_execution = False
+        failure_message: str | None = None
         final_session_status: object = None
         try:
             request = RuntimeRequest(
@@ -259,6 +260,9 @@ class StdioAcpServer:
                 if chunk.event is not None:
                     if _optional_attr(chunk.event, "event_type") == "runtime.failed":
                         failed_execution = True
+                        failure_message = _runtime_failure_summary(
+                            _mapping_attr(chunk.event, "payload")
+                        )
                     self._write_runtime_event_update(
                         acp_session_id=acp_session_id,
                         runtime_session_id=chunk.session.session.id,
@@ -278,7 +282,11 @@ class StdioAcpServer:
             if binding.cancel_requested:
                 stop_reason = "cancelled"
             if failed_execution or final_session_status == "failed":
-                self._write_error(request_id, _ERROR_INTERNAL, "runtime execution failed")
+                self._write_error(
+                    request_id,
+                    _ERROR_INTERNAL,
+                    failure_message or "runtime execution failed",
+                )
                 return
             self._write_result(
                 request_id,
@@ -286,14 +294,15 @@ class StdioAcpServer:
             )
         except Exception as exc:
             self._log_exception("ACP prompt failed", exc)
+            summary = _runtime_failure_summary({"error": str(exc)})
             self._write_session_update(
                 acp_session_id,
                 {
                     "sessionUpdate": "agent_message_chunk",
-                    "content": {"type": "text", "text": "Runtime failed."},
+                    "content": {"type": "text", "text": summary},
                 },
             )
-            self._write_error(request_id, _ERROR_INTERNAL, "runtime execution failed")
+            self._write_error(request_id, _ERROR_INTERNAL, summary)
         finally:
             binding.active = False
             binding.active_run_id = None
@@ -378,13 +387,14 @@ class StdioAcpServer:
             )
             return
         if event_type == "runtime.failed":
+            summary = _runtime_failure_summary(payload)
             self._write_session_update(
                 acp_session_id,
                 {
                     "sessionUpdate": "agent_message_chunk",
                     "content": {
                         "type": "text",
-                        "text": "Runtime failed.",
+                        "text": summary,
                     },
                 },
             )
@@ -531,3 +541,13 @@ def _tool_call_id(payload: Mapping[str, object], runtime_session_id: str) -> str
             return value
     tool_name = _string_payload(payload, "tool", default="tool")
     return f"{runtime_session_id}:{tool_name}"
+
+
+def _runtime_failure_summary(payload: Mapping[str, object]) -> str:
+    summary = payload.get("error_summary")
+    if isinstance(summary, str) and summary.strip():
+        return summary.strip()
+    error = payload.get("error")
+    if isinstance(error, str) and error.strip():
+        return error.strip()
+    return "Runtime failed."

--- a/src/voidcode/cli/app.py
+++ b/src/voidcode/cli/app.py
@@ -773,7 +773,20 @@ def _runtime_failed_error(result: RuntimeStreamResult) -> str | None:
     if failed_event is None:
         return None
     error = failed_event.payload.get("error")
-    return error if isinstance(error, str) and error else None
+    if not isinstance(error, str) or not error:
+        return None
+    return _format_runtime_error_summary(error)
+
+
+def _format_runtime_error_summary(error: str) -> str:
+    cleaned = error.removeprefix("Error: ").strip()
+    if not cleaned:
+        return error
+    for prefix in ("Runtime failed:", "runtime failed:"):
+        if cleaned.startswith(prefix):
+            cleaned = cleaned[len(prefix) :].strip()
+            break
+    return cleaned or error
 
 
 def _blocked_payload(result: RuntimeStreamResult, event: EventEnvelope) -> dict[str, object]:

--- a/src/voidcode/cli/app.py
+++ b/src/voidcode/cli/app.py
@@ -772,6 +772,9 @@ def _runtime_failed_error(result: RuntimeStreamResult) -> str | None:
     )
     if failed_event is None:
         return None
+    summary = failed_event.payload.get("error_summary")
+    if isinstance(summary, str) and summary:
+        return _format_runtime_error_summary(summary)
     error = failed_event.payload.get("error")
     if not isinstance(error, str) or not error:
         return None

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -959,6 +959,9 @@ def _truncate_tool_result_content(
             fallback_reason=result.fallback_reason,
             reference=result.reference,
             error_kind=result.error_kind,
+            error_summary=result.error_summary,
+            error_details=result.error_details,
+            retry_guidance=result.retry_guidance,
         ),
         True,
     )

--- a/src/voidcode/runtime/resume.py
+++ b/src/voidcode/runtime/resume.py
@@ -1353,6 +1353,10 @@ class RuntimeResumeCoordinator:
             data = payload.get("data")
             content = payload.get("content")
             error = payload.get("error")
+            error_kind = payload.get("error_kind")
+            error_summary = payload.get("error_summary")
+            error_details = payload.get("error_details")
+            retry_guidance = payload.get("retry_guidance")
             if not isinstance(tool_name, str) or status is None or not isinstance(data, dict):
                 raise ValueError("persisted resume checkpoint tool_results are malformed")
             if content is not None and not isinstance(content, str):
@@ -1363,6 +1367,24 @@ class RuntimeResumeCoordinator:
                 raise ValueError(
                     "persisted resume checkpoint tool result error must be a string or null"
                 )
+            if error_kind is not None and not isinstance(error_kind, str):
+                raise ValueError(
+                    "persisted resume checkpoint tool result error_kind must be a string or null"
+                )
+            if error_summary is not None and not isinstance(error_summary, str):
+                raise ValueError(
+                    "persisted resume checkpoint tool result error_summary must be a string or null"
+                )
+            if error_details is not None and not isinstance(error_details, dict):
+                raise ValueError(
+                    "persisted resume checkpoint tool result error_details "
+                    "must be an object or null"
+                )
+            if retry_guidance is not None and not isinstance(retry_guidance, str):
+                raise ValueError(
+                    "persisted resume checkpoint tool result retry_guidance "
+                    "must be a string or null"
+                )
             parsed.append(
                 ToolResult(
                     tool_name=tool_name,
@@ -1370,6 +1392,14 @@ class RuntimeResumeCoordinator:
                     status=status,
                     data=sanitize_tool_result_data(cast(dict[str, object], data)),
                     error=error,
+                    error_kind=error_kind,
+                    error_summary=error_summary,
+                    error_details=(
+                        cast(dict[str, object], error_details)
+                        if isinstance(error_details, dict)
+                        else None
+                    ),
+                    retry_guidance=retry_guidance,
                 )
             )
         return tuple(parsed)
@@ -1451,6 +1481,26 @@ class RuntimeResumeCoordinator:
                     status="error" if is_err else "ok",
                     data=sanitize_tool_result_data(event.payload),
                     error=str(error_value) if is_err else None,
+                    error_kind=(
+                        cast(str, event.payload.get("error_kind"))
+                        if isinstance(event.payload.get("error_kind"), str) and is_err
+                        else None
+                    ),
+                    error_summary=(
+                        cast(str, event.payload.get("error_summary"))
+                        if isinstance(event.payload.get("error_summary"), str) and is_err
+                        else None
+                    ),
+                    error_details=(
+                        cast(dict[str, object], event.payload.get("error_details"))
+                        if isinstance(event.payload.get("error_details"), dict) and is_err
+                        else None
+                    ),
+                    retry_guidance=(
+                        cast(str, event.payload.get("retry_guidance"))
+                        if isinstance(event.payload.get("retry_guidance"), str) and is_err
+                        else None
+                    ),
                 )
             )
         return prompt, tool_results

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -29,6 +29,7 @@ from ..tools.contracts import (
     RuntimeToolTimeoutError,
     ToolCall,
     ToolDefinition,
+    ToolErrorDetails,
     ToolResult,
 )
 from ..tools.output import (
@@ -87,6 +88,66 @@ def _provider_transient_retry_delay_ms(
 
 def _tool_error_content(tool_name: str, error: str) -> str:
     return f"{tool_name} failed: {error}. Please correct the tool arguments and retry."
+
+
+def _tool_error_summary(error: str) -> str:
+    cleaned = error.removeprefix("Error: ").strip()
+    return cleaned or error
+
+
+def _tool_error_retry_guidance(error: str) -> str | None:
+    lowered = error.lower()
+    if "validation error:" in lowered:
+        return "Retry with corrected arguments that satisfy the tool schema."
+    if "permission denied" in lowered:
+        return "Adjust the request or approval settings, then retry."
+    if "timed out" in lowered or "timeout" in lowered:
+        return "Reduce the command scope, increase the timeout, or retry."
+    return None
+
+
+def _tool_error_details(
+    *,
+    tool_name: str,
+    error: str,
+    error_kind: str | None = None,
+    extra: dict[str, object] | None = None,
+) -> ToolErrorDetails:
+    details: ToolErrorDetails = {
+        "tool_name": tool_name,
+        "message": error,
+        "summary": _tool_error_summary(error),
+    }
+    if error_kind is not None:
+        details["error_kind"] = error_kind
+    if extra:
+        details.update(extra)
+    return details
+
+
+def _tool_error_payload(
+    *,
+    tool_name: str,
+    error: str,
+    error_kind: str | None = None,
+    extra_details: dict[str, object] | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "error": error,
+        "error_summary": _tool_error_summary(error),
+        "error_details": _tool_error_details(
+            tool_name=tool_name,
+            error=error,
+            error_kind=error_kind,
+            extra=extra_details,
+        ),
+    }
+    if error_kind is not None:
+        payload["error_kind"] = error_kind
+    retry_guidance = _tool_error_retry_guidance(error)
+    if retry_guidance is not None:
+        payload["retry_guidance"] = retry_guidance
+    return payload
 
 
 def _metadata_without_provider_attempt(metadata: Mapping[str, object]) -> dict[str, object]:
@@ -595,7 +656,15 @@ class RuntimeRunLoopCoordinator:
                             "arguments": timeout_sanitized_args,
                             "status": "error",
                             "content": partial_timeout_content,
-                            "error": partial_timeout_error or str(exc),
+                            **_tool_error_payload(
+                                tool_name=tool_call.tool_name,
+                                error=partial_timeout_error or str(exc),
+                                error_kind="tool_timeout",
+                                extra_details={
+                                    "timed_out": True,
+                                    "timeout_seconds": tool_timeout,
+                                },
+                            ),
                             "display": failed_display,
                             "tool_status": failed_status,
                         },
@@ -628,7 +697,10 @@ class RuntimeRunLoopCoordinator:
                             "arguments": error_sanitized_args,
                             "status": "error",
                             "content": _tool_error_content(tool_call.tool_name, str(exc)),
-                            "error": str(exc),
+                            **_tool_error_payload(
+                                tool_name=tool_call.tool_name,
+                                error=str(exc),
+                            ),
                             "display": failed_display,
                             "tool_status": failed_status,
                         },
@@ -645,6 +717,9 @@ class RuntimeRunLoopCoordinator:
                     "tool_call_id": tool_call_id,
                     "arguments": dict(tool_call.arguments),
                 },
+                error_summary=_tool_error_summary(str(exc)),
+                error_details=_tool_error_details(tool_name=tool_call.tool_name, error=str(exc)),
+                retry_guidance=_tool_error_retry_guidance(str(exc)),
             )
 
         sanitized_arguments = sanitize_tool_arguments(dict(tool_call.arguments))
@@ -673,6 +748,14 @@ class RuntimeRunLoopCoordinator:
             "content": tool_result.content,
             "error": tool_result.error,
         }
+        if tool_result.error_kind is not None:
+            completed_payload["error_kind"] = tool_result.error_kind
+        if tool_result.error_summary is not None:
+            completed_payload["error_summary"] = tool_result.error_summary
+        if tool_result.error_details is not None:
+            completed_payload["error_details"] = tool_result.error_details
+        if tool_result.retry_guidance is not None:
+            completed_payload["retry_guidance"] = tool_result.retry_guidance
         completed_payload.setdefault("tool", tool_result.tool_name)
 
         completed_display = build_tool_display(
@@ -1782,7 +1865,15 @@ class RuntimeRunLoopCoordinator:
                                 "arguments": timeout_sanitized_args,
                                 "status": "error",
                                 "content": partial_timeout_content,
-                                "error": partial_timeout_error or str(exc),
+                                **_tool_error_payload(
+                                    tool_name=plan_tool_call.tool_name,
+                                    error=partial_timeout_error or str(exc),
+                                    error_kind="tool_timeout",
+                                    extra_details={
+                                        "timed_out": True,
+                                        "timeout_seconds": tool_timeout,
+                                    },
+                                ),
                                 "display": failed_display,
                                 "tool_status": failed_status,
                             },
@@ -1819,7 +1910,10 @@ class RuntimeRunLoopCoordinator:
                                 "arguments": error_sanitized_args,
                                 "status": "error",
                                 "content": _tool_error_content(plan_tool_call.tool_name, str(exc)),
-                                "error": str(exc),
+                                **_tool_error_payload(
+                                    tool_name=plan_tool_call.tool_name,
+                                    error=str(exc),
+                                ),
                                 "display": failed_display,
                                 "tool_status": failed_status,
                             },
@@ -1838,6 +1932,12 @@ class RuntimeRunLoopCoordinator:
                         "tool_call_id": tool_call_id,
                         "arguments": dict(plan_tool_call.arguments),
                     },
+                    error_summary=_tool_error_summary(str(exc)),
+                    error_details=_tool_error_details(
+                        tool_name=plan_tool_call.tool_name,
+                        error=str(exc),
+                    ),
+                    retry_guidance=_tool_error_retry_guidance(str(exc)),
                 )
 
             runtime_tool_result_data = dict(tool_result.data)
@@ -1921,6 +2021,14 @@ class RuntimeRunLoopCoordinator:
                 "content": tool_result.content,
                 "error": tool_result.error,
             }
+            if tool_result.error_kind is not None:
+                completed_payload["error_kind"] = tool_result.error_kind
+            if tool_result.error_summary is not None:
+                completed_payload["error_summary"] = tool_result.error_summary
+            if tool_result.error_details is not None:
+                completed_payload["error_details"] = tool_result.error_details
+            if tool_result.retry_guidance is not None:
+                completed_payload["retry_guidance"] = tool_result.retry_guidance
             completed_payload.setdefault("tool", tool_result.tool_name)
 
             completed_display = build_tool_display(
@@ -2088,6 +2196,15 @@ class RuntimeRunLoopCoordinator:
             content=_tool_error_content(tool_call.tool_name, error),
             error=error,
             data=sanitize_tool_result_data(result_data),
+            error_kind="permission_denied",
+            error_summary=_tool_error_summary(error),
+            error_details=_tool_error_details(
+                tool_name=tool_call.tool_name,
+                error=error,
+                error_kind="permission_denied",
+                extra={"permission_denied": True},
+            ),
+            retry_guidance="Adjust the request or approval settings, then retry.",
         )
         completed_display = build_tool_display(
             tool_call.tool_name,
@@ -2117,6 +2234,10 @@ class RuntimeRunLoopCoordinator:
                     "status": tool_result.status,
                     "content": tool_result.content,
                     "error": tool_result.error,
+                    "error_kind": tool_result.error_kind,
+                    "error_summary": tool_result.error_summary,
+                    "error_details": tool_result.error_details,
+                    "retry_guidance": tool_result.retry_guidance,
                     "display": completed_display,
                     "tool_status": completed_status,
                 },

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -61,7 +61,12 @@ from ..provider.models import (
     ResolvedProviderConfig,
     ResolvedProviderModel,
 )
-from ..provider.protocol import ProviderAbortSignal, ProviderTokenUsage, ProviderTurnRequest
+from ..provider.protocol import (
+    ProviderAbortSignal,
+    ProviderErrorKind,
+    ProviderTokenUsage,
+    ProviderTurnRequest,
+)
 from ..provider.registry import ModelProviderRegistry
 from ..provider.resolution import resolve_provider_config
 from ..provider.snapshot import (
@@ -2600,6 +2605,7 @@ class VoidCodeRuntime:
             error=error,
         )
         failure_payload = {"error": error, **(payload or {})}
+        failure_payload = self._with_runtime_failure_details(failure_payload)
         return RuntimeStreamChunk(
             kind="event",
             session=failed_session,
@@ -2611,6 +2617,58 @@ class VoidCodeRuntime:
                 payload=failure_payload,
             ),
         )
+
+    @staticmethod
+    def _with_runtime_failure_details(payload: dict[str, object]) -> dict[str, object]:
+        normalized = dict(payload)
+        error = normalized.get("error")
+        if not isinstance(error, str) or not error:
+            return normalized
+        summary = normalized.get("error_summary")
+        if not isinstance(summary, str) or not summary:
+            summary = VoidCodeRuntime._format_runtime_error_summary(error)
+            normalized["error_summary"] = summary
+        guidance = normalized.get("retry_guidance")
+        if not isinstance(guidance, str) or not guidance:
+            retry_guidance = VoidCodeRuntime._retry_guidance_for_runtime_failure(normalized)
+            if retry_guidance is not None:
+                normalized["retry_guidance"] = retry_guidance
+        if "error_details" not in normalized:
+            details: dict[str, object] = {"message": error, "summary": summary}
+            if isinstance(normalized.get("provider_error_kind"), str):
+                details["provider_error_kind"] = normalized["provider_error_kind"]
+            if isinstance(normalized.get("provider_error_details"), dict):
+                details["provider_error_details"] = normalized["provider_error_details"]
+            if normalized.get("cancelled") is True:
+                details["cancelled"] = True
+            normalized["error_details"] = details
+        return normalized
+
+    @staticmethod
+    def _retry_guidance_for_runtime_failure(payload: dict[str, object]) -> str | None:
+        provider_error_kind = payload.get("provider_error_kind")
+        if isinstance(provider_error_kind, str) and provider_error_kind:
+            guidance = guidance_for_provider_error_kind(
+                cast(ProviderErrorKind, provider_error_kind)
+            )
+            if guidance:
+                return guidance
+        if payload.get("cancelled") is True:
+            return "Retry the request if you still want to continue this run."
+        if payload.get("kind") == "interrupted":
+            return "Retry the request if you want to resume execution after the interruption."
+        return None
+
+    @staticmethod
+    def _format_runtime_error_summary(error: str) -> str:
+        cleaned = error.removeprefix("Error: ").strip()
+        if not cleaned:
+            return error
+        for prefix in ("Runtime failed:", "runtime failed:"):
+            if cleaned.startswith(prefix):
+                cleaned = cleaned[len(prefix) :].strip()
+                break
+        return cleaned or error
 
     def _persist_response(self, *, request: RuntimeRequest, response: RuntimeResponse) -> None:
         if response.session.status == "waiting":
@@ -4911,7 +4969,10 @@ class VoidCodeRuntime:
             status = raw_status if isinstance(raw_status, str) and raw_status else "ok"
             if status not in {"ok", "error"}:
                 status = "error" if payload.get("error") is not None else "ok"
-            summary_source = payload.get("error") if status == "error" else payload.get("content")
+            if status == "error":
+                summary_source = payload.get("error_summary") or payload.get("error")
+            else:
+                summary_source = payload.get("content")
             summary = str(summary_source).strip() if summary_source is not None else tool_name
             if len(summary) > 160:
                 summary = summary[:157] + "..."
@@ -5062,6 +5123,26 @@ class VoidCodeRuntime:
                         if isinstance(event.payload.get("reference"), str)
                         else None
                     ),
+                    error_kind=(
+                        cast(str, event.payload.get("error_kind"))
+                        if isinstance(event.payload.get("error_kind"), str) and is_error
+                        else None
+                    ),
+                    error_summary=(
+                        cast(str, event.payload.get("error_summary"))
+                        if isinstance(event.payload.get("error_summary"), str) and is_error
+                        else None
+                    ),
+                    error_details=(
+                        cast(dict[str, object], event.payload.get("error_details"))
+                        if isinstance(event.payload.get("error_details"), dict) and is_error
+                        else None
+                    ),
+                    retry_guidance=(
+                        cast(str, event.payload.get("retry_guidance"))
+                        if isinstance(event.payload.get("retry_guidance"), str) and is_error
+                        else None
+                    ),
                 )
             )
         return prompt, tool_results
@@ -5072,6 +5153,9 @@ class VoidCodeRuntime:
             "content",
             "display",
             "error",
+            "error_details",
+            "error_summary",
+            "retry_guidance",
             "status",
             "tool",
             "tool_status",

--- a/src/voidcode/runtime/storage.py
+++ b/src/voidcode/runtime/storage.py
@@ -1737,17 +1737,25 @@ class SqliteSessionStore:
                 is_err = payload.get("error") is not None
             raw_content = payload.get("content")
             raw_error = payload.get("error")
-            tool_results.append(
-                {
-                    "tool_name": str(payload.get("tool", "unknown")),
-                    "content": (
-                        str(raw_content) if raw_content is not None and not is_err else None
-                    ),
-                    "status": "error" if is_err else "ok",
-                    "data": payload,
-                    "error": str(raw_error) if raw_error is not None and is_err else None,
-                }
-            )
+            tool_result: dict[str, object] = {
+                "tool_name": str(payload.get("tool", "unknown")),
+                "content": str(raw_content) if raw_content is not None and not is_err else None,
+                "status": "error" if is_err else "ok",
+                "data": payload,
+                "error": str(raw_error) if raw_error is not None and is_err else None,
+            }
+            if is_err:
+                if payload.get("error_kind") is not None:
+                    tool_result["error_kind"] = str(payload.get("error_kind"))
+                if payload.get("error_summary") is not None:
+                    tool_result["error_summary"] = str(payload.get("error_summary"))
+                if isinstance(payload.get("error_details"), dict):
+                    tool_result["error_details"] = cast(
+                        dict[str, object], payload.get("error_details")
+                    )
+                if payload.get("retry_guidance") is not None:
+                    tool_result["retry_guidance"] = str(payload.get("retry_guidance"))
+            tool_results.append(tool_result)
         return tool_results
 
     def has_session(self, *, workspace: Path, session_id: str) -> bool:

--- a/src/voidcode/server.py
+++ b/src/voidcode/server.py
@@ -36,11 +36,13 @@ def serve(
     _run_runtime_server(workspace=workspace, host=host, port=port, config=config)
 
 
-_BANNER = """\
-  ╭─────────────────────────────────╮
-  │          VoidCode Web           │
-  │    Local-first Coding Agent     │
-  ╰─────────────────────────────────╯
+_BANNER = r"""\
+            _     _               _
+__   _____ (_) __| | ___ ___   __| | ___
+\ \ / / _ \| |/ _` |/ __/ _ \ / _` |/ _ \
+ \ V / (_) | | (_| | (_| (_) | (_| |  __/
+  \_/ \___/|_|\__,_|\___\___/ \__,_|\___|
+
 """
 
 # Locate the built frontend dist relative to this package.

--- a/src/voidcode/server.py
+++ b/src/voidcode/server.py
@@ -71,6 +71,7 @@ def web(
     url = f"http://{host}:{port}"
     frontend_dist = _resolve_frontend_dist()
 
+    print("VoidCode")
     print(_BANNER)
     print(f"  Local server running at: {url}")
     print()

--- a/src/voidcode/tools/_pydantic_args.py
+++ b/src/voidcode/tools/_pydantic_args.py
@@ -1,6 +1,32 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, field_validator
+from collections.abc import Iterable, Mapping
+
+from pydantic import BaseModel, ValidationError, field_validator
+
+
+def format_validation_error(tool_name: str, exc: ValidationError) -> str:
+    details = "; ".join(_format_validation_error_item(error) for error in exc.errors())
+    return f"{tool_name} invalid arguments: {details}"
+
+
+def _format_validation_error_item(error: Mapping[str, object]) -> str:
+    loc = error.get("loc", ())
+    field_path = _format_error_location(loc)
+    message = str(error.get("msg") or "invalid value")
+    input_value = error.get("input")
+    input_type = type(input_value).__name__
+    return f"{field_path}: {message} (received {input_type})"
+
+
+def _format_error_location(loc: object) -> str:
+    if isinstance(loc, str):
+        return loc
+    if isinstance(loc, Iterable):
+        parts = [str(part) for part in loc]
+        if parts:
+            return ".".join(parts)
+    return "arguments"
 
 
 class ReadFileArgs(BaseModel):
@@ -87,12 +113,20 @@ class GrepArgs(BaseModel):
 
 class WebSearchArgs(BaseModel):
     query: str
+    numResults: int = 8
 
     @field_validator("query", mode="after")
     @classmethod
     def _validate_query(cls, value: str) -> str:
         if not value.strip():
             raise ValueError("query must not be empty")
+        return value
+
+    @field_validator("numResults", mode="after")
+    @classmethod
+    def _validate_num_results(cls, value: int) -> int:
+        if value < 1:
+            raise ValueError("numResults must be greater than or equal to 1")
         return value
 
 

--- a/src/voidcode/tools/_pydantic_args.py
+++ b/src/voidcode/tools/_pydantic_args.py
@@ -7,7 +7,10 @@ from pydantic import BaseModel, ValidationError, field_validator
 
 def format_validation_error(tool_name: str, exc: ValidationError) -> str:
     details = "; ".join(_format_validation_error_item(error) for error in exc.errors())
-    return f"{tool_name} invalid arguments: {details}"
+    return (
+        f"{tool_name} Validation error: {details}. "
+        "Please retry with corrected arguments that satisfy the tool schema."
+    )
 
 
 def _format_validation_error_item(error: Mapping[str, object]) -> str:

--- a/src/voidcode/tools/background_cancel.py
+++ b/src/voidcode/tools/background_cancel.py
@@ -51,13 +51,15 @@ class BackgroundCancelTool:
             raise ValueError(format_validation_error(self.definition.name, exc)) from exc
         if args.all:
             raise ValueError(
-                "background_cancel invalid arguments: all: Value error, "
-                "all=true is not supported in VoidCode yet (received bool)"
+                "background_cancel Validation error: all: Value error, "
+                "all=true is not supported in VoidCode yet (received bool). "
+                "Please retry with corrected arguments that satisfy the tool schema."
             )
         if args.taskId is None:
             raise ValueError(
-                "background_cancel invalid arguments: taskId: Value error, "
-                "taskId is required when all is false (received NoneType)"
+                "background_cancel Validation error: taskId: Value error, "
+                "taskId is required when all is false (received NoneType). "
+                "Please retry with corrected arguments that satisfy the tool schema."
             )
         try:
             task = self._runtime.cancel_background_task(args.taskId)

--- a/src/voidcode/tools/background_cancel.py
+++ b/src/voidcode/tools/background_cancel.py
@@ -45,22 +45,20 @@ class BackgroundCancelTool:
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
         _ = workspace
-        all_value = call.arguments.get("all", False)
-        if all_value is True:
-            raise ValueError(
-                "background_cancel invalid arguments: all: Value error, "
-                "all=true is not supported in VoidCode yet (received bool)"
-            )
-        if all_value is False and call.arguments.get("taskId") is None:
-            raise ValueError(
-                "background_cancel invalid arguments: taskId: Value error, "
-                "taskId is required when all is false (received NoneType)"
-            )
         try:
             args = _BackgroundCancelArgs.model_validate(call.arguments)
         except ValidationError as exc:
             raise ValueError(format_validation_error(self.definition.name, exc)) from exc
-        assert args.taskId is not None
+        if args.all:
+            raise ValueError(
+                "background_cancel invalid arguments: all: Value error, "
+                "all=true is not supported in VoidCode yet (received bool)"
+            )
+        if args.taskId is None:
+            raise ValueError(
+                "background_cancel invalid arguments: taskId: Value error, "
+                "taskId is required when all is false (received NoneType)"
+            )
         try:
             task = self._runtime.cancel_background_task(args.taskId)
         except ValueError as exc:

--- a/src/voidcode/tools/background_cancel.py
+++ b/src/voidcode/tools/background_cancel.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Protocol
 
-from pydantic import BaseModel, ValidationError, model_validator
+from pydantic import BaseModel, ValidationError, field_validator
 
 from ..runtime.task import BackgroundTaskState, is_background_task_terminal
+from ._pydantic_args import format_validation_error
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 
@@ -17,14 +18,15 @@ class _BackgroundCancelArgs(BaseModel):
     taskId: str | None = None
     all: bool = False
 
-    @model_validator(mode="after")
-    def _validate_args(self) -> _BackgroundCancelArgs:
-        if self.all:
-            raise ValueError("background_cancel(all=true) is not supported in VoidCode yet")
-        if self.taskId is None or not self.taskId.strip():
-            raise ValueError("background_cancel requires taskId when all is false")
-        self.taskId = self.taskId.strip()
-        return self
+    @field_validator("taskId", mode="after")
+    @classmethod
+    def _validate_task_id(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("taskId must be a non-empty string when provided")
+        return stripped
 
 
 class BackgroundCancelTool:
@@ -43,10 +45,21 @@ class BackgroundCancelTool:
 
     def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
         _ = workspace
+        all_value = call.arguments.get("all", False)
+        if all_value is True:
+            raise ValueError(
+                "background_cancel invalid arguments: all: Value error, "
+                "all=true is not supported in VoidCode yet (received bool)"
+            )
+        if all_value is False and call.arguments.get("taskId") is None:
+            raise ValueError(
+                "background_cancel invalid arguments: taskId: Value error, "
+                "taskId is required when all is false (received NoneType)"
+            )
         try:
             args = _BackgroundCancelArgs.model_validate(call.arguments)
         except ValidationError as exc:
-            raise ValueError(str(exc.errors()[0]["msg"])) from exc
+            raise ValueError(format_validation_error(self.definition.name, exc)) from exc
         assert args.taskId is not None
         try:
             task = self._runtime.cancel_background_task(args.taskId)

--- a/src/voidcode/tools/background_output.py
+++ b/src/voidcode/tools/background_output.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ValidationError, field_validator
 
 from ..runtime.contracts import BackgroundTaskResult, RuntimeSessionResult
 from ..runtime.task import is_background_task_terminal
+from ._pydantic_args import format_validation_error
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 
@@ -65,7 +66,7 @@ class BackgroundOutputTool:
         try:
             args = _BackgroundOutputArgs.model_validate(call.arguments)
         except ValidationError as exc:
-            raise ValueError("background_output requires a non-empty task_id") from exc
+            raise ValueError(format_validation_error(self.definition.name, exc)) from exc
 
         deadline = time.monotonic() + max(args.timeout, 1) / 1000
         result = self._runtime.load_background_task_result(

--- a/src/voidcode/tools/contracts.py
+++ b/src/voidcode/tools/contracts.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import ClassVar, Literal, Protocol, runtime_checkable
 
 type ToolResultStatus = Literal["ok", "error"]
+type ToolErrorDetails = dict[str, object]
 
 
 class RuntimeToolTimeoutError(TimeoutError):
@@ -45,12 +46,17 @@ class ToolResult:
     fallback_reason: str | None = None
     reference: str | None = None
     error_kind: str | None = None
+    error_summary: str | None = None
+    error_details: ToolErrorDetails | None = None
+    retry_guidance: str | None = None
 
     def __post_init__(self) -> None:
         if self.status == "error" and self.error is None:
             raise ValueError("error results must include an error message")
         if self.status == "ok" and self.error is not None:
             raise ValueError("successful results cannot include an error message")
+        if self.status == "ok" and self.error_summary is not None:
+            raise ValueError("successful results cannot include an error summary")
 
 
 @runtime_checkable

--- a/src/voidcode/tools/grep.py
+++ b/src/voidcode/tools/grep.py
@@ -152,7 +152,9 @@ class GrepTool:
             pattern = re.compile(args.pattern if args.regex else re.escape(args.pattern))
         except re.error as exc:
             raise ValueError(
-                f"grep invalid arguments: pattern: invalid regex pattern ({exc.msg}) (received str)"
+                "grep Validation error: pattern: invalid regex pattern "
+                f"({exc.msg}) (received str). "
+                "Please retry with corrected arguments that satisfy the tool schema."
             ) from exc
         targets = self._collect_targets(
             candidate,

--- a/src/voidcode/tools/grep.py
+++ b/src/voidcode/tools/grep.py
@@ -9,7 +9,7 @@ from typing import ClassVar, cast, final
 from pydantic import ValidationError
 
 from ..security.path_policy import resolve_workspace_path as resolve_workspace_path_policy
-from ._pydantic_args import GrepArgs
+from ._pydantic_args import GrepArgs, format_validation_error
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 MAX_MATCHES = 200
@@ -129,13 +129,7 @@ class GrepTool:
                 }
             )
         except ValidationError as exc:
-            first_error = exc.errors()[0]
-            field_name = first_error.get("loc", (None,))[0]
-            if field_name == "path":
-                raise ValueError("grep requires a string path argument") from exc
-            if first_error.get("type") == "value_error":
-                raise ValueError("grep pattern must not be empty") from exc
-            raise ValueError("grep requires a string pattern argument") from exc
+            raise ValueError(format_validation_error(self.definition.name, exc)) from exc
 
         resolution = resolve_workspace_path_policy(
             workspace=workspace,
@@ -154,7 +148,12 @@ class GrepTool:
             candidate if resolution.is_external and candidate.is_dir() else workspace_root
         )
 
-        pattern = re.compile(args.pattern if args.regex else re.escape(args.pattern))
+        try:
+            pattern = re.compile(args.pattern if args.regex else re.escape(args.pattern))
+        except re.error as exc:
+            raise ValueError(
+                f"grep invalid arguments: pattern: invalid regex pattern ({exc.msg}) (received str)"
+            ) from exc
         targets = self._collect_targets(
             candidate,
             project_root=effective_root,

--- a/src/voidcode/tools/question.py
+++ b/src/voidcode/tools/question.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 from pydantic import BaseModel, ValidationError, field_validator
 
 from ..runtime.question import PendingQuestionOption, PendingQuestionPrompt, QuestionResponse
+from ._pydantic_args import format_validation_error
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 
@@ -73,7 +74,7 @@ class QuestionTool:
         try:
             parsed = _QuestionArgsModel.model_validate(arguments)
         except ValidationError as exc:
-            raise ValueError("question requires a non-empty questions array") from exc
+            raise ValueError(format_validation_error("question", exc)) from exc
         return tuple(
             PendingQuestionPrompt(
                 question=item.question,

--- a/src/voidcode/tools/read_file.py
+++ b/src/voidcode/tools/read_file.py
@@ -11,7 +11,7 @@ from typing import ClassVar, cast, final
 from pydantic import ValidationError
 
 from ..security.path_policy import resolve_workspace_path as resolve_workspace_path_policy
-from ._pydantic_args import ReadFileArgs
+from ._pydantic_args import ReadFileArgs, format_validation_error
 from ._workspace import suggest_workspace_paths
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
@@ -218,12 +218,7 @@ class ReadFileTool:
                 }
             )
         except ValidationError as exc:
-            first_error = exc.errors()[0]
-            if first_error.get("loc", (None,))[0] == "offset":
-                raise ValueError("read_file offset must be greater than or equal to 1") from exc
-            if first_error.get("loc", (None,))[0] == "limit":
-                raise ValueError("read_file limit must be greater than or equal to 1") from exc
-            raise ValueError("read_file requires a string filePath argument") from exc
+            raise ValueError(format_validation_error(self.definition.name, exc)) from exc
 
         resolution = resolve_workspace_path_policy(
             workspace=workspace,

--- a/src/voidcode/tools/shell_exec.py
+++ b/src/voidcode/tools/shell_exec.py
@@ -15,7 +15,7 @@ from ..security.shell_policy import (
     DEFAULT_TIMEOUT_SECONDS,
     resolve_shell_execution_policy,
 )
-from ._pydantic_args import ShellExecArgs
+from ._pydantic_args import ShellExecArgs, format_validation_error
 from .contracts import RuntimeToolTimeoutError, ToolCall, ToolDefinition, ToolResult
 from .runtime_context import current_runtime_tool_context
 
@@ -156,12 +156,14 @@ class ShellExecTool:
         runtime_timeout_seconds: int | None,
     ) -> ToolResult:
         try:
-            args = ShellExecArgs.model_validate({"command": call.arguments.get("command")})
+            args = ShellExecArgs.model_validate(
+                {
+                    "command": call.arguments.get("command"),
+                    "description": call.arguments.get("description"),
+                }
+            )
         except ValidationError as exc:
-            first_error = exc.errors()[0]
-            if first_error.get("type") == "value_error":
-                raise ValueError("shell_exec command must not be empty") from exc
-            raise ValueError("shell_exec requires a string command argument") from exc
+            raise ValueError(format_validation_error(self.definition.name, exc)) from exc
 
         command_text = args.command.strip()
 

--- a/src/voidcode/tools/skill.py
+++ b/src/voidcode/tools/skill.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from pydantic import BaseModel, ValidationError, field_validator
 
 from ..skills.models import SkillMetadata
+from ._pydantic_args import format_validation_error
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 
@@ -79,7 +80,7 @@ class SkillTool:
         try:
             args = _SkillArgs.model_validate(call.arguments)
         except ValidationError as exc:
-            raise ValueError("skill requires a non-empty string name") from exc
+            raise ValueError(format_validation_error("skill", exc)) from exc
 
         skill = self._resolve_skill(args.name)
         content_lines = [

--- a/src/voidcode/tools/task.py
+++ b/src/voidcode/tools/task.py
@@ -131,16 +131,89 @@ def _delegated_prompt(args: _TaskArgs) -> str:
 class TaskTool:
     definition = ToolDefinition(
         name="task",
-        description="Delegate work to a child runtime session or background task.",
+        description=(
+            "Delegate work to a child runtime session. Always include prompt, "
+            "run_in_background, and load_skills. Provide exactly one of category or "
+            "subagent_type. Prefer run_in_background=true for delegated work that can "
+            "run independently."
+        ),
         input_schema={
-            "prompt": {"type": "string"},
-            "run_in_background": {"type": "boolean"},
-            "load_skills": {"type": "array", "items": {"type": "string"}},
-            "category": {"type": "string"},
-            "subagent_type": {"type": "string"},
-            "description": {"type": "string"},
-            "session_id": {"type": "string"},
-            "command": {"type": "string"},
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "description": "Full delegated task prompt for the child session.",
+                    "minLength": 1,
+                },
+                "run_in_background": {
+                    "type": "boolean",
+                    "description": (
+                        "Required. true starts delegated work in the background and returns "
+                        "a task_id. false runs the child session synchronously. Prefer true "
+                        "for independent delegated work."
+                    ),
+                },
+                "load_skills": {
+                    "type": "array",
+                    "description": (
+                        "Required. Array of skill names to force-load in the child session. "
+                        "Pass [] when no extra skills are needed."
+                    ),
+                    "items": {
+                        "type": "string",
+                        "minLength": 1,
+                    },
+                },
+                "category": {
+                    "type": "string",
+                    "description": (
+                        "Runtime-selected child route. Provide this or subagent_type, but not both."
+                    ),
+                    "minLength": 1,
+                },
+                "subagent_type": {
+                    "type": "string",
+                    "description": (
+                        "Explicit child preset. Provide this or category, but not both."
+                    ),
+                    "minLength": 1,
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Optional short delegation description.",
+                    "minLength": 1,
+                },
+                "session_id": {
+                    "type": "string",
+                    "description": "Optional existing child session id to continue.",
+                    "minLength": 1,
+                },
+                "command": {
+                    "type": "string",
+                    "description": "Optional originating command label for delegated work.",
+                    "minLength": 1,
+                },
+            },
+            "required": ["prompt", "run_in_background", "load_skills"],
+            "oneOf": [
+                {"required": ["category"], "not": {"required": ["subagent_type"]}},
+                {"required": ["subagent_type"], "not": {"required": ["category"]}},
+            ],
+            "examples": [
+                {
+                    "prompt": "Find where background task cancellation is implemented.",
+                    "run_in_background": True,
+                    "load_skills": [],
+                    "subagent_type": "explore",
+                },
+                {
+                    "prompt": "Review the architecture tradeoffs and summarize them.",
+                    "run_in_background": False,
+                    "load_skills": [],
+                    "category": "writing",
+                },
+            ],
         },
         read_only=True,
     )

--- a/src/voidcode/tools/task.py
+++ b/src/voidcode/tools/task.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Protocol
 
@@ -14,6 +15,7 @@ from ..runtime.contracts import (
     validate_runtime_request_metadata,
 )
 from ..runtime.task import BackgroundTaskState, StoredBackgroundTaskSummary
+from ._pydantic_args import format_validation_error
 from .contracts import ToolCall, ToolDefinition, ToolResult
 from .runtime_context import require_runtime_tool_context
 
@@ -49,6 +51,20 @@ class _TaskArgs(BaseModel):
         if not stripped:
             raise ValueError("prompt must be a non-empty string")
         return stripped
+
+    @field_validator("load_skills", mode="before")
+    @classmethod
+    def _parse_load_skills(cls, value: object) -> object:
+        if not isinstance(value, str):
+            return value
+        stripped = value.strip()
+        if not stripped:
+            return []
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            return value
+        return parsed
 
     @field_validator("load_skills", mode="after")
     @classmethod
@@ -137,9 +153,7 @@ class TaskTool:
         try:
             args = _TaskArgs.model_validate(call.arguments)
         except ValidationError as exc:
-            raise ValueError(
-                "task requires prompt, run_in_background, load_skills, and exactly one of category or subagent_type"  # noqa: E501
-            ) from exc
+            raise ValueError(format_validation_error(self.definition.name, exc)) from exc
 
         context = require_runtime_tool_context(self.definition.name)
         delegation_metadata: dict[str, object] = dict(_delegation_metadata(args).items())

--- a/src/voidcode/tools/task.txt
+++ b/src/voidcode/tools/task.txt
@@ -1,10 +1,13 @@
 Delegate work to a child runtime session or background task.
 
 Usage:
+- Always include `prompt`, `run_in_background`, and `load_skills` on every `task` call.
+- `load_skills` must be an array of strings. Pass `[]` when no extra skills are needed.
+- Provide exactly one of `category` or `subagent_type`. Never send both.
+- Prefer `run_in_background=true` for delegated work unless you intentionally need a synchronous child session result in the same turn.
 - Use this tool when the work should be split into a delegated child run rather than handled inline.
-- Provide exactly one of `category` or `subagent_type` so the request has a declared routing intent within the runtime-owned delegated execution model.
-- `prompt` is required and should contain the full delegated task.
-- `load_skills` is required. Pass an empty list when no extra skills are needed.
 - When `run_in_background` is true, this tool starts a real background task and returns a `task_id`.
 - After starting a background task, use `background_output` to read status/results and `background_cancel` to cancel a task by id.
+- Example background call: `task(prompt="Inspect the auth flow", run_in_background=true, load_skills=[], subagent_type="explore")`
+- Example sync call: `task(prompt="Summarize these findings", run_in_background=false, load_skills=[], category="writing")`
 - The current runtime preserves parent/child lineage, requested skills, and delegated task correlation. Top-level active runs still execute as `leader`, while delegated child runs can execute routed `advisor`, `explore`, `product`, `researcher`, or `worker` presets through the runtime-owned delegation path.

--- a/src/voidcode/tools/web_search.py
+++ b/src/voidcode/tools/web_search.py
@@ -8,7 +8,7 @@ from typing import ClassVar
 import httpx
 from pydantic import ValidationError
 
-from ._pydantic_args import WebSearchArgs
+from ._pydantic_args import WebSearchArgs, format_validation_error
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 DEFAULT_NUM_RESULTS = 8
@@ -150,18 +150,16 @@ class WebSearchTool:
         runtime_timeout_seconds: int | None,
     ) -> ToolResult:
         try:
-            args = WebSearchArgs.model_validate({"query": call.arguments.get("query")})
+            args = WebSearchArgs.model_validate(
+                {
+                    "query": call.arguments.get("query"),
+                    "numResults": call.arguments.get("numResults", DEFAULT_NUM_RESULTS),
+                }
+            )
         except ValidationError as exc:
-            first_error = exc.errors()[0]
-            if first_error.get("type") == "value_error":
-                raise ValueError("web_search query must not be empty") from exc
-            raise ValueError("web_search requires a string query argument") from exc
+            raise ValueError(format_validation_error(self.definition.name, exc)) from exc
 
-        num_results = call.arguments.get("numResults", DEFAULT_NUM_RESULTS)
-        if isinstance(num_results, (int, float)) and num_results > 0:
-            num_results = min(int(num_results), 20)
-        else:
-            num_results = DEFAULT_NUM_RESULTS
+        num_results = min(args.numResults, 20)
 
         timeout = (
             DEFAULT_TIMEOUT

--- a/src/voidcode/tools/write_file.py
+++ b/src/voidcode/tools/write_file.py
@@ -9,7 +9,7 @@ from pydantic import ValidationError
 from ..hook.config import RuntimeHooksConfig
 from ..security.path_policy import resolve_workspace_path
 from ._formatter import FormatterExecutor, formatter_diagnostics, formatter_payload
-from ._pydantic_args import WriteFileArgs
+from ._pydantic_args import WriteFileArgs, format_validation_error
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 
@@ -34,11 +34,7 @@ class WriteFileTool:
                 }
             )
         except ValidationError as exc:
-            first_error = exc.errors()[0]
-            field_name = first_error.get("loc", (None,))[0]
-            if field_name == "content":
-                raise ValueError("write_file requires a non-empty string content argument") from exc
-            raise ValueError("write_file requires a string path argument") from exc
+            raise ValueError(format_validation_error(self.definition.name, exc)) from exc
 
         resolution = resolve_workspace_path(
             workspace=workspace,

--- a/src/voidcode/tui/app.py
+++ b/src/voidcode/tui/app.py
@@ -355,7 +355,7 @@ class VoidCodeTUI(App[int]):
             decision = payload.get("decision", "unknown")
             text = Text(f"ℹ Approval {decision} for tool: {tool_name}", style="bold cyan")
         elif event.event_type == "runtime.failed":
-            error_msg = payload.get("error", "Unknown error")
+            error_msg = payload.get("error_summary", payload.get("error", "Unknown error"))
             formatted_error = self._format_runtime_error(error_msg)
             text = Text(f"✖ Failed: {formatted_error}", style="bold red")
         else:

--- a/src/voidcode/tui/app.py
+++ b/src/voidcode/tui/app.py
@@ -356,7 +356,8 @@ class VoidCodeTUI(App[int]):
             text = Text(f"ℹ Approval {decision} for tool: {tool_name}", style="bold cyan")
         elif event.event_type == "runtime.failed":
             error_msg = payload.get("error", "Unknown error")
-            text = Text(f"✖ Failed: {error_msg}", style="bold red")
+            formatted_error = self._format_runtime_error(error_msg)
+            text = Text(f"✖ Failed: {formatted_error}", style="bold red")
         else:
             text = Text(f"EVENT {event.event_type} source={event.source}", style="dim")
 
@@ -364,6 +365,17 @@ class VoidCodeTUI(App[int]):
 
     def _write_output_line(self, output: str) -> None:
         self.query_one("#transcript-log", RichLog).write(Markdown(output))
+
+    @staticmethod
+    def _format_runtime_error(error: object) -> str:
+        if not isinstance(error, str):
+            return "Unknown error"
+        cleaned = error.removeprefix("Error: ").strip()
+        for prefix in ("Runtime failed:", "runtime failed:"):
+            if cleaned.startswith(prefix):
+                cleaned = cleaned[len(prefix) :].strip()
+                break
+        return cleaned or error
 
     @staticmethod
     def _context_int_value(context_window: dict[str, object], key: str, default: int = 0) -> int:
@@ -546,7 +558,7 @@ class VoidCodeTUI(App[int]):
 
     def on_stream_failed(self, message: StreamFailed) -> None:
         self.query_one("#transcript-log", RichLog).write(
-            Text(f"Error: {message.error}", style="bold red")
+            Text(f"Error: {self._format_runtime_error(message.error)}", style="bold red")
         )
         self.pending_request_id = None
         self._set_state("Failed")

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -2784,7 +2784,14 @@ def test_transport_persists_failed_stream_for_replay(tmp_path: Path) -> None:
         "sequence": 10,
         "event_type": "runtime.failed",
         "source": "runtime",
-        "payload": {"error": "boom from transport stream"},
+        "payload": {
+            "error": "boom from transport stream",
+            "error_summary": "boom from transport stream",
+            "error_details": {
+                "message": "boom from transport stream",
+                "summary": "boom from transport stream",
+            },
+        },
     }
     assert list_response.json() == [
         {

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -459,6 +459,11 @@ def test_provider_runtime_surfaces_provider_context_limit_failure_kind(tmp_path:
     assert failed.events[-1].payload == {
         "error": "provider context window exceeded",
         "kind": "provider_context_limit",
+        "error_summary": "provider context window exceeded",
+        "error_details": {
+            "message": "provider context window exceeded",
+            "summary": "provider context window exceeded",
+        },
     }
 
 
@@ -1961,13 +1966,19 @@ def test_runtime_rejects_denied_raw_provider_tool_calls_for_delegated_agents(
                 events.append(chunk.event)
 
     assert events[-1].event_type == "runtime.failed"
+    expected_error = (
+        f"delegation policy denied tool '{tool_name}' for child preset '{subagent_type}'; "
+        "this preset may only call tools allowed by its manifest tool_allowlist"
+    )
     assert events[-1].payload == {
-        "error": (
-            f"delegation policy denied tool '{tool_name}' for child preset '{subagent_type}'; "
-            "this preset may only call tools allowed by its manifest tool_allowlist"
-        ),
+        "error": expected_error,
         "kind": "delegation_tool_policy_denied",
         "tool": tool_name,
+        "error_summary": expected_error,
+        "error_details": {
+            "message": expected_error,
+            "summary": expected_error,
+        },
     }
     assert target.exists() is False
 
@@ -2797,7 +2808,14 @@ def test_runtime_persists_initial_allow_finalize_failure_for_resume(tmp_path: Pa
     assert resumed.session.status == "failed"
     assert resumed.events[-2].event_type == "runtime.tool_completed"
     assert resumed.events[-1].event_type == "runtime.failed"
-    assert resumed.events[-1].payload == {"error": "finalize boom"}
+    assert resumed.events[-1].payload == {
+        "error": "finalize boom",
+        "error_summary": "finalize boom",
+        "error_details": {
+            "message": "finalize boom",
+            "summary": "finalize boom",
+        },
+    }
 
 
 def test_runtime_persists_initial_plan_failure_for_resume(tmp_path: Path) -> None:
@@ -2845,7 +2863,14 @@ def test_runtime_persists_initial_plan_failure_for_resume(tmp_path: Path) -> Non
 
     assert resumed.session.status == "failed"
     assert resumed.events[-1].event_type == "runtime.failed"
-    assert resumed.events[-1].payload == {"error": "plan boom"}
+    assert resumed.events[-1].payload == {
+        "error": "plan boom",
+        "error_summary": "plan boom",
+        "error_details": {
+            "message": "plan boom",
+            "summary": "plan boom",
+        },
+    }
 
 
 def test_runtime_denies_non_read_only_tool_when_policy_is_deny(tmp_path: Path) -> None:
@@ -4047,7 +4072,14 @@ def test_runtime_approved_resume_persists_failure_when_pending_tool_is_missing(
         "runtime.failed",
     ]
     assert [event.sequence for event in resumed.events] == list(range(1, 10))
-    assert resumed.events[-1].payload == {"error": "unknown tool: write_file"}
+    assert resumed.events[-1].payload == {
+        "error": "unknown tool: write_file",
+        "error_summary": "unknown tool: write_file",
+        "error_details": {
+            "message": "unknown tool: write_file",
+            "summary": "unknown tool: write_file",
+        },
+    }
     assert replay.session.status == "failed"
     assert [(event.sequence, event.event_type, event.payload) for event in replay.events] == [
         (event.sequence, event.event_type, event.payload) for event in resumed.events

--- a/tests/unit/acp/test_stdio.py
+++ b/tests/unit/acp/test_stdio.py
@@ -251,9 +251,9 @@ def test_prompt_failure_emits_failure_notification_and_json_rpc_error() -> None:
     assert messages[1]["method"] == "session/update"
     assert messages[1]["params"]["update"] == {
         "sessionUpdate": "agent_message_chunk",
-        "content": {"type": "text", "text": "Runtime failed."},
+        "content": {"type": "text", "text": "runtime exploded"},
     }
-    assert messages[2]["error"] == {"code": -32603, "message": "runtime execution failed"}
+    assert messages[2]["error"] == {"code": -32603, "message": "runtime exploded"}
 
 
 def test_prompt_runtime_failed_event_returns_json_rpc_error() -> None:
@@ -293,9 +293,65 @@ def test_prompt_runtime_failed_event_returns_json_rpc_error() -> None:
     assert messages[-1] == {
         "jsonrpc": "2.0",
         "id": 2,
-        "error": {"code": -32603, "message": "runtime execution failed"},
+        "error": {"code": -32603, "message": "permission denied for tool: write_file"},
     }
     assert not any(message.get("result") == {"stopReason": "end_turn"} for message in messages)
+
+
+def test_prompt_runtime_failed_event_uses_error_summary_for_message_chunk() -> None:
+    runtime = _StubRuntime(
+        [
+            _StubChunk(
+                kind="event",
+                session=_StubSession(_StubSessionRef("runtime-1")),
+                event=_StubEvent(
+                    session_id="runtime-1",
+                    sequence=1,
+                    event_type="runtime.request_received",
+                    source="runtime",
+                    payload={"prompt": "hello"},
+                ),
+            ),
+            _StubChunk(
+                kind="event",
+                session=_StubSession(_StubSessionRef("runtime-1"), status="failed"),
+                event=_StubEvent(
+                    session_id="runtime-1",
+                    sequence=2,
+                    event_type="runtime.failed",
+                    source="runtime",
+                    payload={
+                        "error": "Runtime failed: provider fallback exhausted",
+                        "error_summary": "provider fallback exhausted",
+                    },
+                ),
+            ),
+        ]
+    )
+    with patch("voidcode.acp.stdio.uuid4", return_value=SimpleNamespace(hex="abc")):
+        messages, _ = _run_server(
+            runtime,
+            _request("session/new", 1),
+            _request("session/prompt", 2, {"sessionId": "acp-session-abc", "prompt": "hello"}),
+        )
+
+    assert messages[1]["method"] == "session/update"
+    assert messages[1]["params"]["update"] == {
+        "sessionUpdate": "agent_thought_chunk",
+        "content": {
+            "type": "text",
+            "text": (
+                '{"sessionId":"runtime-1","sequence":1,'
+                '"type":"runtime.request_received","source":"runtime",'
+                '"payload":{"prompt":"hello"}}'
+            ),
+        },
+    }
+    assert messages[2]["method"] == "session/update"
+    assert messages[2]["params"]["update"] == {
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "provider fallback exhausted"},
+    }
 
 
 def test_cancel_returns_limited_success_without_crashing() -> None:

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -1213,6 +1213,33 @@ def test_run_trace_conflicts_with_json(capsys: Any) -> None:
     assert "--json and --trace cannot be used together" in captured.err
 
 
+def test_run_json_strips_runtime_failed_prefix_from_error_summary(capsys: Any) -> None:
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/demo-workspace")
+    config = SimpleNamespace(approval_mode="allow")
+    chunks = (
+        _make_chunk(
+            session_id="json-summary-session",
+            status="failed",
+            event=_runtime_event(
+                "runtime.failed",
+                sequence=1,
+                error="Runtime failed: provider fallback exhausted",
+            ),
+        ),
+    )
+
+    with patch.object(cli, "load_runtime_config", autospec=True, return_value=config):
+        with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
+            runtime_class.return_value.run_stream.return_value = iter(chunks)
+            result = cli.main(["run", "go", "--workspace", str(workspace), "--json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert result == 12
+    assert payload["error"] == "provider fallback exhausted"
+
+
 def test_run_command_forwards_reasoning_effort_flag_to_metadata_and_config() -> None:
     cli = importlib.import_module("voidcode.cli")
     workspace = Path("/tmp/demo-workspace")

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -1240,6 +1240,34 @@ def test_run_json_strips_runtime_failed_prefix_from_error_summary(capsys: Any) -
     assert payload["error"] == "provider fallback exhausted"
 
 
+def test_run_json_prefers_runtime_error_summary_field(capsys: Any) -> None:
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/demo-workspace")
+    config = SimpleNamespace(approval_mode="allow")
+    chunks = (
+        _make_chunk(
+            session_id="json-summary-field-session",
+            status="failed",
+            event=_runtime_event(
+                "runtime.failed",
+                sequence=1,
+                error="Runtime failed: provider fallback exhausted",
+                error_summary="provider fallback exhausted",
+            ),
+        ),
+    )
+
+    with patch.object(cli, "load_runtime_config", autospec=True, return_value=config):
+        with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
+            runtime_class.return_value.run_stream.return_value = iter(chunks)
+            result = cli.main(["run", "go", "--workspace", str(workspace), "--json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert result == 12
+    assert payload["error"] == "provider fallback exhausted"
+
+
 def test_run_command_forwards_reasoning_effort_flag_to_metadata_and_config() -> None:
     cli = importlib.import_module("voidcode.cli")
     workspace = Path("/tmp/demo-workspace")

--- a/tests/unit/interface/test_tui.py
+++ b/tests/unit/interface/test_tui.py
@@ -239,6 +239,39 @@ async def test_tui_strips_runtime_failed_prefix_from_error_lines(app_class: Any)
 
 
 @pytest.mark.anyio
+async def test_tui_prefers_runtime_error_summary_when_present(app_class: Any) -> None:
+    VoidCodeTUI, StreamChunkReceived, StreamCompleted = app_class
+
+    with patch(
+        "voidcode.tui.app.load_runtime_config",
+        autospec=True,
+        return_value=_mock_runtime_config(),
+    ):
+        with patch("voidcode.tui.app.VoidCodeRuntime", autospec=True):
+            app = VoidCodeTUI(workspace=Path("."))
+
+            async with app.run_test() as pilot:
+                app.on_stream_chunk_received(
+                    StreamChunkReceived(
+                        _make_chunk(
+                            status="failed",
+                            event=_runtime_event(
+                                "runtime.failed",
+                                error="Runtime failed: provider fallback exhausted",
+                                error_summary="provider fallback exhausted",
+                            ),
+                        )
+                    )
+                )
+                app.on_stream_completed(StreamCompleted("failed"))
+                await pilot.pause()
+
+                log = app.query_one("#transcript-log")
+                plain_lines = ["".join(segment.text for segment in line) for line in log.lines]
+                assert any("✖ Failed: provider fallback exhausted" in line for line in plain_lines)
+
+
+@pytest.mark.anyio
 async def test_tui_sidebar_updates_on_mount(app_class: Any) -> None:
     VoidCodeTUI, _, _ = app_class
 

--- a/tests/unit/interface/test_tui.py
+++ b/tests/unit/interface/test_tui.py
@@ -207,6 +207,38 @@ async def test_tui_failed_stream_stays_failed(app_class: Any) -> None:
 
 
 @pytest.mark.anyio
+async def test_tui_strips_runtime_failed_prefix_from_error_lines(app_class: Any) -> None:
+    VoidCodeTUI, StreamChunkReceived, StreamCompleted = app_class
+
+    with patch(
+        "voidcode.tui.app.load_runtime_config",
+        autospec=True,
+        return_value=_mock_runtime_config(),
+    ):
+        with patch("voidcode.tui.app.VoidCodeRuntime", autospec=True):
+            app = VoidCodeTUI(workspace=Path("."))
+
+            async with app.run_test() as pilot:
+                app.on_stream_chunk_received(
+                    StreamChunkReceived(
+                        _make_chunk(
+                            status="failed",
+                            event=_runtime_event(
+                                "runtime.failed",
+                                error="Runtime failed: provider fallback exhausted",
+                            ),
+                        )
+                    )
+                )
+                app.on_stream_completed(StreamCompleted("failed"))
+                await pilot.pause()
+
+                log = app.query_one("#transcript-log")
+                plain_lines = ["".join(segment.text for segment in line) for line in log.lines]
+                assert any("✖ Failed: provider fallback exhausted" in line for line in plain_lines)
+
+
+@pytest.mark.anyio
 async def test_tui_sidebar_updates_on_mount(app_class: Any) -> None:
     VoidCodeTUI, _, _ = app_class
 

--- a/tests/unit/provider/test_provider_adapters.py
+++ b/tests/unit/provider/test_provider_adapters.py
@@ -568,9 +568,18 @@ def test_provider_adapter_wraps_task_tool_description_argument(
     properties = cast(dict[str, object], properties_obj)
 
     assert parameters["type"] == "object"
-    assert "description" not in parameters
-    assert properties["description"] == {"type": "string"}
-    assert properties["prompt"] == {"type": "string"}
+    assert parameters["additionalProperties"] is False
+    assert parameters["required"] == ["prompt", "run_in_background", "load_skills"]
+    one_of = cast(list[object], parameters["oneOf"])
+    assert len(one_of) == 2
+    examples = cast(list[object], parameters["examples"])
+    assert cast(dict[str, object], examples[0])["run_in_background"] is True
+    assert cast(dict[str, object], examples[1])["run_in_background"] is False
+    description_property = cast(dict[str, object], properties["description"])
+    prompt_property = cast(dict[str, object], properties["prompt"])
+    assert description_property["type"] == "string"
+    assert prompt_property["type"] == "string"
+    assert "Full delegated task prompt" in cast(str, prompt_property["description"])
 
 
 def test_provider_adapter_preserves_object_schema_without_explicit_type(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -2845,6 +2845,24 @@ def test_runtime_tool_validation_error_includes_actionable_content(tmp_path: Pat
         "write_file Validation error: content: Value error, content must not be empty "
         "(received str). Please retry with corrected arguments that satisfy the tool schema."
     )
+    assert tool_completed.payload["error_summary"] == (
+        "write_file Validation error: content: Value error, content must not be empty "
+        "(received str). Please retry with corrected arguments that satisfy the tool schema."
+    )
+    assert tool_completed.payload["error_details"] == {
+        "tool_name": "write_file",
+        "message": (
+            "write_file Validation error: content: Value error, content must not be empty "
+            "(received str). Please retry with corrected arguments that satisfy the tool schema."
+        ),
+        "summary": (
+            "write_file Validation error: content: Value error, content must not be empty "
+            "(received str). Please retry with corrected arguments that satisfy the tool schema."
+        ),
+    }
+    assert tool_completed.payload["retry_guidance"] == (
+        "Retry with corrected arguments that satisfy the tool schema."
+    )
     assert tool_completed.payload["content"] == (
         "write_file failed: write_file Validation error: content: Value error, content must not "
         "be empty (received str). Please retry with corrected arguments that satisfy the tool "
@@ -2852,6 +2870,9 @@ def test_runtime_tool_validation_error_includes_actionable_content(tmp_path: Pat
     )
     failed_tool_result = created_providers[-1].requests[-1].tool_results[-1]
     assert failed_tool_result.content == tool_completed.payload["content"]
+    assert failed_tool_result.error_summary == tool_completed.payload["error_summary"]
+    assert failed_tool_result.error_details == tool_completed.payload["error_details"]
+    assert failed_tool_result.retry_guidance == tool_completed.payload["retry_guidance"]
 
 
 def test_runtime_session_debug_snapshot_reports_failure_classification_and_last_tool(
@@ -8429,9 +8450,14 @@ def test_runtime_run_fails_when_acp_handshake_fails(tmp_path: Path) -> None:
     assert event_types[0] == "runtime.request_received"
     assert "runtime.acp_failed" in event_types
     assert event_types[-1] == "runtime.failed"
-    assert response.events[-1].payload == {
-        "error": "ACP handshake rejected by memory transport",
-        "kind": "acp_startup_failed",
+    assert response.events[-1].payload["error"] == "ACP handshake rejected by memory transport"
+    assert response.events[-1].payload["kind"] == "acp_startup_failed"
+    assert response.events[-1].payload["error_summary"] == (
+        "ACP handshake rejected by memory transport"
+    )
+    assert response.events[-1].payload["error_details"] == {
+        "message": "ACP handshake rejected by memory transport",
+        "summary": "ACP handshake rejected by memory transport",
     }
     runtime_state_metadata = cast(dict[str, object], response.session.metadata["runtime_state"])
     assert runtime_state_metadata["acp"] == {
@@ -8606,9 +8632,14 @@ def test_runtime_resume_fails_when_acp_handshake_fails_after_restart(
     ]
     assert resumed_suffix[-1] == "runtime.failed"
     assert resumed_suffix.count("runtime.acp_failed") >= 1
-    assert resumed.events[-1].payload == {
-        "error": "ACP handshake rejected by memory transport",
-        "kind": "acp_startup_failed",
+    assert resumed.events[-1].payload["error"] == "ACP handshake rejected by memory transport"
+    assert resumed.events[-1].payload["kind"] == "acp_startup_failed"
+    assert resumed.events[-1].payload["error_summary"] == (
+        "ACP handshake rejected by memory transport"
+    )
+    assert resumed.events[-1].payload["error_details"] == {
+        "message": "ACP handshake rejected by memory transport",
+        "summary": "ACP handshake rejected by memory transport",
     }
 
 
@@ -8649,9 +8680,12 @@ def test_runtime_resume_stream_emits_terminal_failure_when_acp_handshake_fails(
     assert event_types.count("runtime.acp_failed") >= 1
     assert chunks[-1].session.status == "failed"
     assert chunks[-1].event is not None
-    assert chunks[-1].event.payload == {
-        "error": "ACP handshake rejected by memory transport",
-        "kind": "acp_startup_failed",
+    assert chunks[-1].event.payload["error"] == "ACP handshake rejected by memory transport"
+    assert chunks[-1].event.payload["kind"] == "acp_startup_failed"
+    assert chunks[-1].event.payload["error_summary"] == "ACP handshake rejected by memory transport"
+    assert chunks[-1].event.payload["error_details"] == {
+        "message": "ACP handshake rejected by memory transport",
+        "summary": "ACP handshake rejected by memory transport",
     }
 
 
@@ -11611,9 +11645,12 @@ def test_runtime_classifies_provider_context_limit_failures(tmp_path: Path) -> N
 
     assert response.session.status == "failed"
     assert response.events[-1].event_type == "runtime.failed"
-    assert response.events[-1].payload == {
-        "error": "provider context window exceeded",
-        "kind": "provider_context_limit",
+    assert response.events[-1].payload["error"] == "provider context window exceeded"
+    assert response.events[-1].payload["kind"] == "provider_context_limit"
+    assert response.events[-1].payload["error_summary"] == "provider context window exceeded"
+    assert response.events[-1].payload["error_details"] == {
+        "message": "provider context window exceeded",
+        "summary": "provider context window exceeded",
     }
 
 
@@ -17160,13 +17197,21 @@ def test_runtime_provider_stream_cancelled_maps_to_failed_without_fallback(
 
     assert response.session.status == "failed"
     assert response.events[-1].event_type == "runtime.failed"
-    assert response.events[-1].payload == {
-        "error": "cancelled by runtime",
+    assert response.events[-1].payload["error"] == "cancelled by runtime"
+    assert response.events[-1].payload["provider_error_kind"] == "cancelled"
+    assert response.events[-1].payload["provider"] == "opencode"
+    assert response.events[-1].payload["model"] == "gpt-5.4"
+    assert response.events[-1].payload["cancelled"] is True
+    assert response.events[-1].payload["error_summary"] == "cancelled by runtime"
+    assert response.events[-1].payload["error_details"] == {
+        "message": "cancelled by runtime",
+        "summary": "cancelled by runtime",
         "provider_error_kind": "cancelled",
-        "provider": "opencode",
-        "model": "gpt-5.4",
         "cancelled": True,
     }
+    assert response.events[-1].payload["retry_guidance"] == (
+        "The request was cancelled; rerun when ready."
+    )
 
 
 def test_runtime_fails_without_downgrade_on_context_limit(tmp_path: Path) -> None:
@@ -17202,12 +17247,19 @@ def test_runtime_fails_without_downgrade_on_context_limit(tmp_path: Path) -> Non
 
     assert response.session.status == "failed"
     assert response.events[-1].event_type == "runtime.failed"
-    assert response.events[-1].payload == {
-        "error": "context exceeded",
+    assert response.events[-1].payload["error"] == "context exceeded"
+    assert response.events[-1].payload["provider_error_kind"] == "context_limit"
+    assert response.events[-1].payload["provider"] == "opencode"
+    assert response.events[-1].payload["model"] == "gpt-5.4"
+    assert response.events[-1].payload["error_summary"] == "context exceeded"
+    assert response.events[-1].payload["error_details"] == {
+        "message": "context exceeded",
+        "summary": "context exceeded",
         "provider_error_kind": "context_limit",
-        "provider": "opencode",
-        "model": "gpt-5.4",
     }
+    assert response.events[-1].payload["retry_guidance"] == (
+        "Reduce prompt/tool-result context or switch to a model with a larger context window."
+    )
 
 
 def test_runtime_refresh_provider_models_returns_catalog_with_model_map_fallback(
@@ -17512,15 +17564,28 @@ def test_runtime_provider_fallback_exhaustion_after_three_targets_reports_termin
         "attempt": 2,
     }
     assert response.events[-1].event_type == "runtime.failed"
-    assert response.events[-1].payload == {
-        "error": (
+    assert response.events[-1].payload["error"] == (
+        "provider fallback exhausted after anthropic/claude-3-7-sonnet failed at attempt 3"
+    )
+    assert response.events[-1].payload["provider_error_kind"] == "invalid_model"
+    assert response.events[-1].payload["provider"] == "anthropic"
+    assert response.events[-1].payload["model"] == "claude-3-7-sonnet"
+    assert response.events[-1].payload["fallback_exhausted"] is True
+    assert response.events[-1].payload["error_summary"] == (
+        "provider fallback exhausted after anthropic/claude-3-7-sonnet failed at attempt 3"
+    )
+    assert response.events[-1].payload["error_details"] == {
+        "message": (
+            "provider fallback exhausted after anthropic/claude-3-7-sonnet failed at attempt 3"
+        ),
+        "summary": (
             "provider fallback exhausted after anthropic/claude-3-7-sonnet failed at attempt 3"
         ),
         "provider_error_kind": "invalid_model",
-        "provider": "anthropic",
-        "model": "claude-3-7-sonnet",
-        "fallback_exhausted": True,
     }
+    assert response.events[-1].payload["retry_guidance"] == (
+        "Check the configured provider/model name and model access permissions."
+    )
 
 
 def test_runtime_executes_session_start_and_end_hooks(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -2842,11 +2842,13 @@ def test_runtime_tool_validation_error_includes_actionable_content(tmp_path: Pat
     )
     assert tool_completed.payload["status"] == "error"
     assert tool_completed.payload["error"] == (
-        "write_file requires a non-empty string content argument"
+        "write_file Validation error: content: Value error, content must not be empty "
+        "(received str). Please retry with corrected arguments that satisfy the tool schema."
     )
     assert tool_completed.payload["content"] == (
-        "write_file failed: write_file requires a non-empty string content argument. "
-        "Please correct the tool arguments and retry."
+        "write_file failed: write_file Validation error: content: Value error, content must not "
+        "be empty (received str). Please retry with corrected arguments that satisfy the tool "
+        "schema.. Please correct the tool arguments and retry."
     )
     failed_tool_result = created_providers[-1].requests[-1].tool_results[-1]
     assert failed_tool_result.content == tool_completed.payload["content"]

--- a/tests/unit/runtime/test_tool_execution_timeout.py
+++ b/tests/unit/runtime/test_tool_execution_timeout.py
@@ -991,6 +991,17 @@ def test_timeout_exit_emits_terminal_tool_status_with_error(
 
     assert payload["status"] == "error", "terminal tool status must be error"
     assert payload["tool"] == "shell_exec"
+    assert payload["error_kind"] == "tool_timeout"
+    assert payload["error_summary"] == "tool 'shell_exec' exceeded runtime timeout of 1s"
+    assert payload["error_details"] == {
+        "tool_name": "shell_exec",
+        "message": "tool 'shell_exec' exceeded runtime timeout of 1s",
+        "summary": "tool 'shell_exec' exceeded runtime timeout of 1s",
+        "error_kind": "tool_timeout",
+        "timed_out": True,
+        "timeout_seconds": 1,
+    }
+    assert payload["retry_guidance"] == "Reduce the command scope, increase the timeout, or retry."
 
     assert "tool_call_id" in payload
     assert isinstance(payload["tool_call_id"], str)
@@ -1132,6 +1143,8 @@ def test_timeout_replay_preserves_terminal_tool_status_with_matching_call_id(
     completed_payload = completed_events[0].payload
     assert completed_payload["status"] == "error"
     assert completed_payload["tool"] == "shell_exec"
+    assert completed_payload["error_kind"] == "tool_timeout"
+    assert completed_payload["error_summary"] == "tool 'shell_exec' exceeded runtime timeout of 1s"
 
     started_call_id = started_events[0].payload["tool_call_id"]
     assert isinstance(started_call_id, str)

--- a/tests/unit/tools/fuzz/test_runtime_agent_tools_fuzz.py
+++ b/tests/unit/tools/fuzz/test_runtime_agent_tools_fuzz.py
@@ -163,7 +163,13 @@ def test_question_tool_parse_prompts_trims_valid_payloads(
 def test_question_tool_parse_prompts_rejects_malformed_questions_payload(
     bad_questions: object,
 ) -> None:
-    with pytest.raises(ValueError, match="question requires a non-empty questions array"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"question Validation error: questions(?:\.0)?: .* "
+            r"Please retry with corrected arguments that satisfy the tool schema\."
+        ),
+    ):
         QuestionTool.parse_prompts({"questions": bad_questions})
 
 
@@ -190,7 +196,13 @@ def test_background_output_tool_rejects_invalid_task_id_values(task_id: object) 
     tool = BackgroundOutputTool(runtime=_RecordingBackgroundOutputRuntime())
 
     with TemporaryDirectory() as temp_dir:
-        with pytest.raises(ValueError, match="background_output requires a non-empty task_id"):
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"background_output Validation error: task_id: .* "
+                r"Please retry with corrected arguments that satisfy the tool schema\."
+            ),
+        ):
             tool.invoke(
                 ToolCall(tool_name="background_output", arguments={"task_id": task_id}),
                 workspace=Path(temp_dir),
@@ -242,7 +254,13 @@ def test_skill_tool_rejects_invalid_name_values(name: object) -> None:
     )
 
     with TemporaryDirectory() as temp_dir:
-        with pytest.raises(ValueError, match="skill requires a non-empty string name"):
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"skill Validation error: name: .* "
+                r"Please retry with corrected arguments that satisfy the tool schema\."
+            ),
+        ):
             tool.invoke(
                 ToolCall(tool_name="skill", arguments={"name": name}),
                 workspace=Path(temp_dir),
@@ -261,8 +279,8 @@ def test_task_tool_rejects_invalid_prompt_values(
         with pytest.raises(
             ValueError,
             match=(
-                "task requires prompt, run_in_background, load_skills, and exactly one "
-                "of category or subagent_type"
+                r"task Validation error: prompt: .* "
+                r"Please retry with corrected arguments that satisfy the tool schema\."
             ),
         ):
             tool.invoke(
@@ -291,8 +309,8 @@ def test_task_tool_rejects_invalid_load_skills_entries(
         with pytest.raises(
             ValueError,
             match=(
-                "task requires prompt, run_in_background, load_skills, and exactly one "
-                "of category or subagent_type"
+                r"task Validation error: load_skills(?:\.0)?: .* "
+                r"Please retry with corrected arguments that satisfy the tool schema\."
             ),
         ):
             tool.invoke(
@@ -311,10 +329,15 @@ def test_task_tool_rejects_invalid_load_skills_entries(
 
 def test_task_tool_rejects_ambiguous_or_missing_routing_arguments() -> None:
     tool = TaskTool(runtime=_UnusedTaskRuntime())
+    routing_error = (
+        r"task Validation error: arguments: Value error, "
+        r"provide exactly one of category or subagent_type \(received dict\)\. "
+        r"Please retry with corrected arguments that satisfy the tool schema\."
+    )
 
     with TemporaryDirectory() as temp_dir:
         workspace = Path(temp_dir)
-        with pytest.raises(ValueError, match="task requires prompt"):
+        with pytest.raises(ValueError, match=routing_error):
             tool.invoke(
                 ToolCall(
                     tool_name="task",
@@ -326,7 +349,7 @@ def test_task_tool_rejects_ambiguous_or_missing_routing_arguments() -> None:
                 ),
                 workspace=workspace,
             )
-        with pytest.raises(ValueError, match="task requires prompt"):
+        with pytest.raises(ValueError, match=routing_error):
             tool.invoke(
                 ToolCall(
                     tool_name="task",

--- a/tests/unit/tools/test_background_task_tools.py
+++ b/tests/unit/tools/test_background_task_tools.py
@@ -567,7 +567,7 @@ def test_background_cancel_tool_reports_unknown_task_deterministically(tmp_path:
 def test_background_cancel_tool_rejects_all_true(tmp_path: Path) -> None:
     tool = BackgroundCancelTool(runtime=_StubBackgroundRuntime())
     all_true_error = (
-        r"background_cancel invalid arguments: all: Value error, "
+        r"background_cancel Validation error: all: Value error, "
         r"all=true is not supported in VoidCode yet \(received bool\)"
     )
 
@@ -581,8 +581,9 @@ def test_background_cancel_tool_rejects_all_true(tmp_path: Path) -> None:
 def test_background_cancel_tool_reports_task_id_validation_errors(tmp_path: Path) -> None:
     tool = BackgroundCancelTool(runtime=_StubBackgroundRuntime())
     task_id_type_error = (
-        r"background_cancel invalid arguments: taskId: "
+        r"background_cancel Validation error: taskId: "
         r"Input should be a valid string \(received int\)"
+        r"\. Please retry with corrected arguments that satisfy the tool schema\."
     )
 
     with pytest.raises(ValueError, match=task_id_type_error):
@@ -592,8 +593,9 @@ def test_background_cancel_tool_reports_task_id_validation_errors(tmp_path: Path
         )
 
     task_id_empty_error = (
-        r"background_cancel invalid arguments: taskId: Value error, "
+        r"background_cancel Validation error: taskId: Value error, "
         r"taskId must be a non-empty string when provided \(received str\)"
+        r"\. Please retry with corrected arguments that satisfy the tool schema\."
     )
     with pytest.raises(ValueError, match=task_id_empty_error):
         tool.invoke(
@@ -602,7 +604,7 @@ def test_background_cancel_tool_reports_task_id_validation_errors(tmp_path: Path
         )
 
     missing_task_id_error = (
-        r"background_cancel invalid arguments: taskId: Value error, "
+        r"background_cancel Validation error: taskId: Value error, "
         r"taskId is required when all is false \(received NoneType\)"
     )
     with pytest.raises(ValueError, match=missing_task_id_error):
@@ -615,11 +617,11 @@ def test_background_cancel_tool_reports_task_id_validation_errors(tmp_path: Path
 def test_background_cancel_tool_validates_coerced_boolean_inputs(tmp_path: Path) -> None:
     tool = BackgroundCancelTool(runtime=_StubBackgroundRuntime())
     all_true_error = (
-        r"background_cancel invalid arguments: all: Value error, "
+        r"background_cancel Validation error: all: Value error, "
         r"all=true is not supported in VoidCode yet \(received bool\)"
     )
     missing_task_id_error = (
-        r"background_cancel invalid arguments: taskId: Value error, "
+        r"background_cancel Validation error: taskId: Value error, "
         r"taskId is required when all is false \(received NoneType\)"
     )
 

--- a/tests/unit/tools/test_background_task_tools.py
+++ b/tests/unit/tools/test_background_task_tools.py
@@ -610,3 +610,39 @@ def test_background_cancel_tool_reports_task_id_validation_errors(tmp_path: Path
             ToolCall(tool_name="background_cancel", arguments={}),
             workspace=tmp_path,
         )
+
+
+def test_background_cancel_tool_validates_coerced_boolean_inputs(tmp_path: Path) -> None:
+    tool = BackgroundCancelTool(runtime=_StubBackgroundRuntime())
+    all_true_error = (
+        r"background_cancel invalid arguments: all: Value error, "
+        r"all=true is not supported in VoidCode yet \(received bool\)"
+    )
+    missing_task_id_error = (
+        r"background_cancel invalid arguments: taskId: Value error, "
+        r"taskId is required when all is false \(received NoneType\)"
+    )
+
+    with pytest.raises(ValueError, match=all_true_error):
+        tool.invoke(
+            ToolCall(tool_name="background_cancel", arguments={"all": 1}),
+            workspace=tmp_path,
+        )
+
+    with pytest.raises(ValueError, match=all_true_error):
+        tool.invoke(
+            ToolCall(tool_name="background_cancel", arguments={"all": "true"}),
+            workspace=tmp_path,
+        )
+
+    with pytest.raises(ValueError, match=missing_task_id_error):
+        tool.invoke(
+            ToolCall(tool_name="background_cancel", arguments={"all": 0}),
+            workspace=tmp_path,
+        )
+
+    with pytest.raises(ValueError, match=missing_task_id_error):
+        tool.invoke(
+            ToolCall(tool_name="background_cancel", arguments={"all": "false"}),
+            workspace=tmp_path,
+        )

--- a/tests/unit/tools/test_background_task_tools.py
+++ b/tests/unit/tools/test_background_task_tools.py
@@ -320,14 +320,11 @@ def test_background_output_tool_returns_task_summary(tmp_path: Path) -> None:
     assert "raw child output is not injected" in result.content
     assert result.reference == "session:child-session"
     assert result.data["task_id"] == "task-1"
-    delegation_payload = result.data["delegation"]
-    assert isinstance(delegation_payload, dict)
+    delegation_payload = cast(dict[str, object], result.data["delegation"])
     assert delegation_payload["delegated_task_id"] == "task-1"
-    message_payload = result.data["message"]
-    assert isinstance(message_payload, dict)
+    message_payload = cast(dict[str, object], result.data["message"])
     assert message_payload["status"] == "completed"
-    session_payload = result.data["session"]
-    assert isinstance(session_payload, dict)
+    session_payload = cast(dict[str, object], result.data["session"])
     assert session_payload["session_id"] == "child-session"
     assert session_payload["child_session_id"] == "child-session"
     assert session_payload["output_available"] is True
@@ -371,8 +368,7 @@ def test_background_output_full_session_preserves_approval_summary(tmp_path: Pat
     assert "Approval blocked on write_file: write_file alpha.txt" in result.content
     assert "Running child session" not in result.content
     assert result.data["summary_output"] == ("Approval blocked on write_file: write_file alpha.txt")
-    message_payload = result.data["message"]
-    assert isinstance(message_payload, dict)
+    message_payload = cast(dict[str, object], result.data["message"])
     assert message_payload["summary_output"] == (
         "Approval blocked on write_file: write_file alpha.txt"
     )
@@ -389,8 +385,7 @@ def test_background_output_tool_bounds_full_session_transcript(tmp_path: Path) -
         workspace=tmp_path,
     )
 
-    session_payload = result.data["session"]
-    assert isinstance(session_payload, dict)
+    session_payload = cast(dict[str, object], result.data["session"])
     assert session_payload["message_limit"] == 100
     assert session_payload["transcript_count"] == 100
     assert session_payload["transcript_truncated"] is True
@@ -465,8 +460,7 @@ def test_background_output_tool_handles_interrupted_terminal_state(tmp_path: Pat
     assert result.data["status"] == "interrupted"
     assert result.data["result_available"] is True
     assert result.data["retrieval_instruction"] == 'background_output(task_id="task-1")'
-    handoff = result.data["handoff_summary"]
-    assert isinstance(handoff, dict)
+    handoff = cast(dict[str, object], result.data["handoff_summary"])
     assert handoff["blocked_reason"] == "background task interrupted before completion"
     assert "interrupted before completion" in str(result.data["guidance"])
 
@@ -572,9 +566,47 @@ def test_background_cancel_tool_reports_unknown_task_deterministically(tmp_path:
 
 def test_background_cancel_tool_rejects_all_true(tmp_path: Path) -> None:
     tool = BackgroundCancelTool(runtime=_StubBackgroundRuntime())
+    all_true_error = (
+        r"background_cancel invalid arguments: all: Value error, "
+        r"all=true is not supported in VoidCode yet \(received bool\)"
+    )
 
-    with pytest.raises(ValueError, match="not supported"):
+    with pytest.raises(ValueError, match=all_true_error):
         tool.invoke(
             ToolCall(tool_name="background_cancel", arguments={"all": True}),
+            workspace=tmp_path,
+        )
+
+
+def test_background_cancel_tool_reports_task_id_validation_errors(tmp_path: Path) -> None:
+    tool = BackgroundCancelTool(runtime=_StubBackgroundRuntime())
+    task_id_type_error = (
+        r"background_cancel invalid arguments: taskId: "
+        r"Input should be a valid string \(received int\)"
+    )
+
+    with pytest.raises(ValueError, match=task_id_type_error):
+        tool.invoke(
+            ToolCall(tool_name="background_cancel", arguments={"taskId": 123}),
+            workspace=tmp_path,
+        )
+
+    task_id_empty_error = (
+        r"background_cancel invalid arguments: taskId: Value error, "
+        r"taskId must be a non-empty string when provided \(received str\)"
+    )
+    with pytest.raises(ValueError, match=task_id_empty_error):
+        tool.invoke(
+            ToolCall(tool_name="background_cancel", arguments={"taskId": "   "}),
+            workspace=tmp_path,
+        )
+
+    missing_task_id_error = (
+        r"background_cancel invalid arguments: taskId: Value error, "
+        r"taskId is required when all is false \(received NoneType\)"
+    )
+    with pytest.raises(ValueError, match=missing_task_id_error):
+        tool.invoke(
+            ToolCall(tool_name="background_cancel", arguments={}),
             workspace=tmp_path,
         )

--- a/tests/unit/tools/test_grep_tool.py
+++ b/tests/unit/tools/test_grep_tool.py
@@ -207,20 +207,32 @@ def test_grep_tool_rejects_invalid_arguments_and_non_utf8_files(tmp_path: Path) 
     binary_file = tmp_path / "sample.bin"
     _ = binary_file.write_bytes(b"\xff\xfe\x00x")
     tool = GrepTool()
+    pattern_type_error = (
+        r"grep invalid arguments: pattern: "
+        r"Input should be a valid string \(received int\)"
+    )
 
-    with pytest.raises(ValueError, match="string pattern"):
+    with pytest.raises(ValueError, match=pattern_type_error):
         tool.invoke(
             ToolCall(tool_name="grep", arguments={"pattern": 123, "path": "sample.txt"}),
             workspace=tmp_path,
         )
 
-    with pytest.raises(ValueError, match="string path"):
+    path_type_error = (
+        r"grep invalid arguments: path: "
+        r"Input should be a valid string \(received int\)"
+    )
+    with pytest.raises(ValueError, match=path_type_error):
         tool.invoke(
             ToolCall(tool_name="grep", arguments={"pattern": "alpha", "path": 123}),
             workspace=tmp_path,
         )
 
-    with pytest.raises(ValueError, match="must not be empty"):
+    empty_pattern_error = (
+        r"grep invalid arguments: pattern: Value error, "
+        r"pattern must not be empty \(received str\)"
+    )
+    with pytest.raises(ValueError, match=empty_pattern_error):
         tool.invoke(
             ToolCall(tool_name="grep", arguments={"pattern": "", "path": "sample.txt"}),
             workspace=tmp_path,
@@ -241,6 +253,39 @@ def test_grep_tool_rejects_invalid_arguments_and_non_utf8_files(tmp_path: Path) 
     )
     assert result.status == "ok"
     assert result.data["match_count"] == 0
+
+
+def test_grep_tool_reports_missing_required_args_and_invalid_regex(tmp_path: Path) -> None:
+    tool = GrepTool()
+    missing_pattern_error = (
+        r"grep invalid arguments: pattern: "
+        r"Input should be a valid string \(received NoneType\)"
+    )
+    missing_path_error = (
+        r"grep invalid arguments: path: "
+        r"Input should be a valid string \(received NoneType\)"
+    )
+
+    with pytest.raises(ValueError, match=missing_pattern_error):
+        tool.invoke(
+            ToolCall(tool_name="grep", arguments={"path": "sample.txt"}),
+            workspace=tmp_path,
+        )
+
+    with pytest.raises(ValueError, match=missing_path_error):
+        tool.invoke(ToolCall(tool_name="grep", arguments={"pattern": "alpha"}), workspace=tmp_path)
+
+    with pytest.raises(
+        ValueError,
+        match=r"grep invalid arguments: pattern: invalid regex pattern .* \(received str\)",
+    ):
+        tool.invoke(
+            ToolCall(
+                tool_name="grep",
+                arguments={"pattern": "[unclosed", "path": ".", "regex": True},
+            ),
+            workspace=tmp_path,
+        )
 
 
 def test_tools_package_and_default_registry_export_grep_tool() -> None:

--- a/tests/unit/tools/test_grep_tool.py
+++ b/tests/unit/tools/test_grep_tool.py
@@ -208,8 +208,9 @@ def test_grep_tool_rejects_invalid_arguments_and_non_utf8_files(tmp_path: Path) 
     _ = binary_file.write_bytes(b"\xff\xfe\x00x")
     tool = GrepTool()
     pattern_type_error = (
-        r"grep invalid arguments: pattern: "
+        r"grep Validation error: pattern: "
         r"Input should be a valid string \(received int\)"
+        r"\. Please retry with corrected arguments that satisfy the tool schema\."
     )
 
     with pytest.raises(ValueError, match=pattern_type_error):
@@ -219,8 +220,9 @@ def test_grep_tool_rejects_invalid_arguments_and_non_utf8_files(tmp_path: Path) 
         )
 
     path_type_error = (
-        r"grep invalid arguments: path: "
+        r"grep Validation error: path: "
         r"Input should be a valid string \(received int\)"
+        r"\. Please retry with corrected arguments that satisfy the tool schema\."
     )
     with pytest.raises(ValueError, match=path_type_error):
         tool.invoke(
@@ -229,8 +231,9 @@ def test_grep_tool_rejects_invalid_arguments_and_non_utf8_files(tmp_path: Path) 
         )
 
     empty_pattern_error = (
-        r"grep invalid arguments: pattern: Value error, "
+        r"grep Validation error: pattern: Value error, "
         r"pattern must not be empty \(received str\)"
+        r"\. Please retry with corrected arguments that satisfy the tool schema\."
     )
     with pytest.raises(ValueError, match=empty_pattern_error):
         tool.invoke(
@@ -258,12 +261,14 @@ def test_grep_tool_rejects_invalid_arguments_and_non_utf8_files(tmp_path: Path) 
 def test_grep_tool_reports_missing_required_args_and_invalid_regex(tmp_path: Path) -> None:
     tool = GrepTool()
     missing_pattern_error = (
-        r"grep invalid arguments: pattern: "
+        r"grep Validation error: pattern: "
         r"Input should be a valid string \(received NoneType\)"
+        r"\. Please retry with corrected arguments that satisfy the tool schema\."
     )
     missing_path_error = (
-        r"grep invalid arguments: path: "
+        r"grep Validation error: path: "
         r"Input should be a valid string \(received NoneType\)"
+        r"\. Please retry with corrected arguments that satisfy the tool schema\."
     )
 
     with pytest.raises(ValueError, match=missing_pattern_error):
@@ -277,7 +282,7 @@ def test_grep_tool_reports_missing_required_args_and_invalid_regex(tmp_path: Pat
 
     with pytest.raises(
         ValueError,
-        match=r"grep invalid arguments: pattern: invalid regex pattern .* \(received str\)",
+        match=r"grep Validation error: pattern: invalid regex pattern .* \(received str\)",
     ):
         tool.invoke(
             ToolCall(

--- a/tests/unit/tools/test_read_file_tool.py
+++ b/tests/unit/tools/test_read_file_tool.py
@@ -131,6 +131,51 @@ def test_read_file_tool_rejects_non_regular_target(tmp_path: Path) -> None:
         )
 
 
+def test_read_file_tool_reports_field_specific_validation_errors(tmp_path: Path) -> None:
+    tool = ReadFileTool()
+
+    file_path_error = (
+        r"read_file invalid arguments: filePath: "
+        r"Input should be a valid string \(received int\)"
+    )
+    with pytest.raises(ValueError, match=file_path_error):
+        tool.invoke(
+            ToolCall(tool_name="read_file", arguments={"filePath": 123}),
+            workspace=tmp_path,
+        )
+
+    offset_error = (
+        r"read_file invalid arguments: offset: Value error, "
+        r"offset must be greater than or equal to 1 \(received int\)"
+    )
+    with pytest.raises(ValueError, match=offset_error):
+        tool.invoke(
+            ToolCall(tool_name="read_file", arguments={"filePath": "sample.txt", "offset": 0}),
+            workspace=tmp_path,
+        )
+
+    limit_error = (
+        r"read_file invalid arguments: limit: Value error, "
+        r"limit must be greater than or equal to 1 \(received int\)"
+    )
+    with pytest.raises(ValueError, match=limit_error):
+        tool.invoke(
+            ToolCall(tool_name="read_file", arguments={"filePath": "sample.txt", "limit": 0}),
+            workspace=tmp_path,
+        )
+
+
+def test_read_file_tool_reports_missing_file_path(tmp_path: Path) -> None:
+    tool = ReadFileTool()
+    missing_file_path_error = (
+        r"read_file invalid arguments: filePath: "
+        r"Input should be a valid string \(received NoneType\)"
+    )
+
+    with pytest.raises(ValueError, match=missing_file_path_error):
+        tool.invoke(ToolCall(tool_name="read_file", arguments={}), workspace=tmp_path)
+
+
 def test_read_file_tool_rejects_oversized_attachment_before_read_bytes(tmp_path: Path) -> None:
     image = tmp_path / "image.png"
     _ = image.write_bytes(b"\x89PNG\r\n\x1a\n" + (b"x" * MAX_ATTACHMENT_BYTES))

--- a/tests/unit/tools/test_read_file_tool.py
+++ b/tests/unit/tools/test_read_file_tool.py
@@ -135,8 +135,9 @@ def test_read_file_tool_reports_field_specific_validation_errors(tmp_path: Path)
     tool = ReadFileTool()
 
     file_path_error = (
-        r"read_file invalid arguments: filePath: "
+        r"read_file Validation error: filePath: "
         r"Input should be a valid string \(received int\)"
+        r"\. Please retry with corrected arguments that satisfy the tool schema\."
     )
     with pytest.raises(ValueError, match=file_path_error):
         tool.invoke(
@@ -145,8 +146,9 @@ def test_read_file_tool_reports_field_specific_validation_errors(tmp_path: Path)
         )
 
     offset_error = (
-        r"read_file invalid arguments: offset: Value error, "
+        r"read_file Validation error: offset: Value error, "
         r"offset must be greater than or equal to 1 \(received int\)"
+        r"\. Please retry with corrected arguments that satisfy the tool schema\."
     )
     with pytest.raises(ValueError, match=offset_error):
         tool.invoke(
@@ -155,8 +157,9 @@ def test_read_file_tool_reports_field_specific_validation_errors(tmp_path: Path)
         )
 
     limit_error = (
-        r"read_file invalid arguments: limit: Value error, "
+        r"read_file Validation error: limit: Value error, "
         r"limit must be greater than or equal to 1 \(received int\)"
+        r"\. Please retry with corrected arguments that satisfy the tool schema\."
     )
     with pytest.raises(ValueError, match=limit_error):
         tool.invoke(
@@ -168,8 +171,9 @@ def test_read_file_tool_reports_field_specific_validation_errors(tmp_path: Path)
 def test_read_file_tool_reports_missing_file_path(tmp_path: Path) -> None:
     tool = ReadFileTool()
     missing_file_path_error = (
-        r"read_file invalid arguments: filePath: "
+        r"read_file Validation error: filePath: "
         r"Input should be a valid string \(received NoneType\)"
+        r"\. Please retry with corrected arguments that satisfy the tool schema\."
     )
 
     with pytest.raises(ValueError, match=missing_file_path_error):

--- a/tests/unit/tools/test_shell_exec_tool.py
+++ b/tests/unit/tools/test_shell_exec_tool.py
@@ -66,18 +66,50 @@ def test_shell_exec_tool_supports_shell_operators(tmp_path: Path) -> None:
 
 def test_shell_exec_tool_rejects_invalid_command_arguments(tmp_path: Path) -> None:
     tool = ShellExecTool()
+    command_type_error = (
+        r"shell_exec invalid arguments: command: "
+        r"Input should be a valid string \(received int\)"
+    )
 
-    with pytest.raises(ValueError, match="string command"):
+    with pytest.raises(ValueError, match=command_type_error):
         tool.invoke(
             ToolCall(tool_name="shell_exec", arguments={"command": 123}),
             workspace=tmp_path,
         )
 
-    with pytest.raises(ValueError, match="must not be empty"):
+    command_empty_error = (
+        r"shell_exec invalid arguments: command: Value error, "
+        r"command must not be empty \(received str\)"
+    )
+    with pytest.raises(ValueError, match=command_empty_error):
         tool.invoke(
             ToolCall(tool_name="shell_exec", arguments={"command": "   "}),
             workspace=tmp_path,
         )
+
+    description_error = (
+        r"shell_exec invalid arguments: description: Value error, "
+        r"description must not be empty when provided \(received str\)"
+    )
+    with pytest.raises(ValueError, match=description_error):
+        tool.invoke(
+            ToolCall(
+                tool_name="shell_exec",
+                arguments={"command": "pwd", "description": "   "},
+            ),
+            workspace=tmp_path,
+        )
+
+
+def test_shell_exec_tool_reports_missing_command(tmp_path: Path) -> None:
+    tool = ShellExecTool()
+    missing_command_error = (
+        r"shell_exec invalid arguments: command: "
+        r"Input should be a valid string \(received NoneType\)"
+    )
+
+    with pytest.raises(ValueError, match=missing_command_error):
+        tool.invoke(ToolCall(tool_name="shell_exec", arguments={}), workspace=tmp_path)
 
 
 def test_tools_package_and_default_registry_export_shell_exec_tool() -> None:

--- a/tests/unit/tools/test_shell_exec_tool.py
+++ b/tests/unit/tools/test_shell_exec_tool.py
@@ -67,8 +67,9 @@ def test_shell_exec_tool_supports_shell_operators(tmp_path: Path) -> None:
 def test_shell_exec_tool_rejects_invalid_command_arguments(tmp_path: Path) -> None:
     tool = ShellExecTool()
     command_type_error = (
-        r"shell_exec invalid arguments: command: "
+        r"shell_exec Validation error: command: "
         r"Input should be a valid string \(received int\)"
+        r"\. Please retry with corrected arguments that satisfy the tool schema\."
     )
 
     with pytest.raises(ValueError, match=command_type_error):
@@ -78,8 +79,9 @@ def test_shell_exec_tool_rejects_invalid_command_arguments(tmp_path: Path) -> No
         )
 
     command_empty_error = (
-        r"shell_exec invalid arguments: command: Value error, "
+        r"shell_exec Validation error: command: Value error, "
         r"command must not be empty \(received str\)"
+        r"\. Please retry with corrected arguments that satisfy the tool schema\."
     )
     with pytest.raises(ValueError, match=command_empty_error):
         tool.invoke(
@@ -88,8 +90,9 @@ def test_shell_exec_tool_rejects_invalid_command_arguments(tmp_path: Path) -> No
         )
 
     description_error = (
-        r"shell_exec invalid arguments: description: Value error, "
+        r"shell_exec Validation error: description: Value error, "
         r"description must not be empty when provided \(received str\)"
+        r"\. Please retry with corrected arguments that satisfy the tool schema\."
     )
     with pytest.raises(ValueError, match=description_error):
         tool.invoke(
@@ -104,8 +107,9 @@ def test_shell_exec_tool_rejects_invalid_command_arguments(tmp_path: Path) -> No
 def test_shell_exec_tool_reports_missing_command(tmp_path: Path) -> None:
     tool = ShellExecTool()
     missing_command_error = (
-        r"shell_exec invalid arguments: command: "
+        r"shell_exec Validation error: command: "
         r"Input should be a valid string \(received NoneType\)"
+        r"\. Please retry with corrected arguments that satisfy the tool schema\."
     )
 
     with pytest.raises(ValueError, match=missing_command_error):

--- a/tests/unit/tools/test_skill_tool.py
+++ b/tests/unit/tools/test_skill_tool.py
@@ -61,5 +61,11 @@ def test_skill_tool_rejects_missing_name(tmp_path: Path) -> None:
         list_skills=lambda: (), resolve_skill=lambda name: (_ for _ in ()).throw(ValueError(name))
     )
 
-    with pytest.raises(ValueError, match="non-empty string name"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"skill Validation error: name: Field required \(received dict\)\. "
+            r"Please retry with corrected arguments that satisfy the tool schema\."
+        ),
+    ):
         tool.invoke(ToolCall(tool_name="skill", arguments={}), workspace=tmp_path)

--- a/tests/unit/tools/test_task_tool.py
+++ b/tests/unit/tools/test_task_tool.py
@@ -44,7 +44,7 @@ class _StubTaskRuntime:
                 prompt=request.prompt,
                 session_id=request.session_id,
                 parent_session_id=request.parent_session_id,
-                metadata=dict(request.metadata),
+                metadata={key: value for key, value in request.metadata.items()},
                 allocate_session_id=request.allocate_session_id,
             ),
         )
@@ -93,6 +93,68 @@ def test_task_tool_starts_background_task_with_parent_context(tmp_path: Path) ->
         "force_load_skills": ["demo"],
         "delegation": {"mode": "background", "category": "quick"},
     }
+
+
+def test_task_tool_accepts_json_string_load_skills_from_provider(tmp_path: Path) -> None:
+    runtime = _StubTaskRuntime()
+    tool = TaskTool(runtime=runtime)
+
+    with bind_runtime_tool_context(RuntimeToolInvocationContext(session_id="leader-session")):
+        result = tool.invoke(
+            ToolCall(
+                tool_name="task",
+                arguments={
+                    "prompt": "Inspect this workspace",
+                    "run_in_background": True,
+                    "load_skills": "[]",
+                    "subagent_type": "explore",
+                    "description": "Workspace inspection",
+                },
+            ),
+            workspace=tmp_path,
+        )
+
+    assert result.status == "ok"
+    assert result.data["task_id"] == "task-123"
+    assert result.data["delegation"] == {
+        "mode": "background",
+        "subagent_type": "explore",
+        "description": "Workspace inspection",
+    }
+    assert result.data["load_skills"] == []
+    assert runtime.requests[0].metadata == {
+        "force_load_skills": [],
+        "delegation": {
+            "mode": "background",
+            "subagent_type": "explore",
+            "description": "Workspace inspection",
+        },
+    }
+
+
+def test_task_tool_validation_error_names_bad_argument_field(tmp_path: Path) -> None:
+    runtime = _StubTaskRuntime()
+    tool = TaskTool(runtime=runtime)
+
+    with bind_runtime_tool_context(RuntimeToolInvocationContext(session_id="leader-session")):
+        with pytest.raises(ValueError) as exc_info:
+            tool.invoke(
+                ToolCall(
+                    tool_name="task",
+                    arguments={
+                        "prompt": "Inspect this workspace",
+                        "run_in_background": True,
+                        "load_skills": "not-json",
+                        "subagent_type": "explore",
+                    },
+                ),
+                workspace=tmp_path,
+            )
+
+    message = str(exc_info.value)
+    assert "task invalid arguments" in message
+    assert "load_skills" in message
+    assert "received str" in message
 
 
 def test_task_tool_runs_sync_child_session(tmp_path: Path) -> None:

--- a/tests/unit/tools/test_task_tool.py
+++ b/tests/unit/tools/test_task_tool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -60,6 +61,29 @@ class _StubTaskRuntime:
 
     def session_result(self, *, session_id: str):
         raise AssertionError(session_id)
+
+
+def test_task_tool_exposes_agent_friendly_json_schema_contract() -> None:
+    schema = TaskTool.definition.input_schema
+
+    assert schema["type"] == "object"
+    assert schema["additionalProperties"] is False
+    assert schema["required"] == ["prompt", "run_in_background", "load_skills"]
+
+    properties = cast(dict[str, object], schema["properties"])
+    run_in_background = cast(dict[str, object], properties["run_in_background"])
+    load_skills = cast(dict[str, object], properties["load_skills"])
+
+    assert run_in_background["type"] == "boolean"
+    assert "Required." in cast(str, run_in_background["description"])
+    assert load_skills["type"] == "array"
+    assert "Pass []" in cast(str, load_skills["description"])
+
+    one_of = cast(list[object], schema["oneOf"])
+    assert len(one_of) == 2
+    examples = cast(list[object], schema["examples"])
+    assert cast(dict[str, object], examples[0])["run_in_background"] is True
+    assert cast(dict[str, object], examples[1])["run_in_background"] is False
 
 
 def test_task_tool_starts_background_task_with_parent_context(tmp_path: Path) -> None:
@@ -156,6 +180,16 @@ def test_task_tool_validation_error_names_bad_argument_field(tmp_path: Path) -> 
     assert "load_skills" in message
     assert "received str" in message
     assert "Please retry with corrected arguments" in message
+
+
+def test_task_tool_guidance_frontloads_required_arguments() -> None:
+    from voidcode.tools.guidance import guidance_for_tool
+
+    guidance = guidance_for_tool("task")
+
+    assert "Always include `prompt`, `run_in_background`, and `load_skills`" in guidance
+    assert "Provide exactly one of `category` or `subagent_type`" in guidance
+    assert "Prefer `run_in_background=true`" in guidance
 
 
 def test_task_tool_runs_sync_child_session(tmp_path: Path) -> None:

--- a/tests/unit/tools/test_task_tool.py
+++ b/tests/unit/tools/test_task_tool.py
@@ -152,9 +152,10 @@ def test_task_tool_validation_error_names_bad_argument_field(tmp_path: Path) -> 
             )
 
     message = str(exc_info.value)
-    assert "task invalid arguments" in message
+    assert "task Validation error" in message
     assert "load_skills" in message
     assert "received str" in message
+    assert "Please retry with corrected arguments" in message
 
 
 def test_task_tool_runs_sync_child_session(tmp_path: Path) -> None:

--- a/tests/unit/tools/test_websearch_tool.py
+++ b/tests/unit/tools/test_websearch_tool.py
@@ -21,8 +21,12 @@ def _json_response(payload: Mapping[str, object]) -> httpx.Response:
 
 def test_websearch_tool_rejects_empty_query() -> None:
     tool = WebSearchTool()
+    empty_query_error = (
+        r"web_search invalid arguments: query: Value error, "
+        r"query must not be empty \(received str\)"
+    )
 
-    with pytest.raises(ValueError, match="must not be empty"):
+    with pytest.raises(ValueError, match=empty_query_error):
         tool.invoke(
             ToolCall(tool_name="web_search", arguments={"query": "   "}),
             workspace=Path("/tmp"),
@@ -31,10 +35,35 @@ def test_websearch_tool_rejects_empty_query() -> None:
 
 def test_websearch_tool_rejects_non_string_query() -> None:
     tool = WebSearchTool()
+    query_type_error = (
+        r"web_search invalid arguments: query: "
+        r"Input should be a valid string \(received int\)"
+    )
 
-    with pytest.raises(ValueError, match="string query"):
+    with pytest.raises(ValueError, match=query_type_error):
         tool.invoke(
             ToolCall(tool_name="web_search", arguments={"query": 123}),
+            workspace=Path("/tmp"),
+        )
+
+
+def test_websearch_tool_reports_missing_query_and_invalid_num_results() -> None:
+    tool = WebSearchTool()
+    missing_query_error = (
+        r"web_search invalid arguments: query: "
+        r"Input should be a valid string \(received NoneType\)"
+    )
+    invalid_num_results_error = (
+        r"web_search invalid arguments: numResults: Value error, "
+        r"numResults must be greater than or equal to 1 \(received int\)"
+    )
+
+    with pytest.raises(ValueError, match=missing_query_error):
+        tool.invoke(ToolCall(tool_name="web_search", arguments={}), workspace=Path("/tmp"))
+
+    with pytest.raises(ValueError, match=invalid_num_results_error):
+        tool.invoke(
+            ToolCall(tool_name="web_search", arguments={"query": "test", "numResults": 0}),
             workspace=Path("/tmp"),
         )
 

--- a/tests/unit/tools/test_websearch_tool.py
+++ b/tests/unit/tools/test_websearch_tool.py
@@ -22,8 +22,9 @@ def _json_response(payload: Mapping[str, object]) -> httpx.Response:
 def test_websearch_tool_rejects_empty_query() -> None:
     tool = WebSearchTool()
     empty_query_error = (
-        r"web_search invalid arguments: query: Value error, "
+        r"web_search Validation error: query: Value error, "
         r"query must not be empty \(received str\)"
+        r"\. Please retry with corrected arguments that satisfy the tool schema\."
     )
 
     with pytest.raises(ValueError, match=empty_query_error):
@@ -36,8 +37,9 @@ def test_websearch_tool_rejects_empty_query() -> None:
 def test_websearch_tool_rejects_non_string_query() -> None:
     tool = WebSearchTool()
     query_type_error = (
-        r"web_search invalid arguments: query: "
+        r"web_search Validation error: query: "
         r"Input should be a valid string \(received int\)"
+        r"\. Please retry with corrected arguments that satisfy the tool schema\."
     )
 
     with pytest.raises(ValueError, match=query_type_error):
@@ -50,12 +52,14 @@ def test_websearch_tool_rejects_non_string_query() -> None:
 def test_websearch_tool_reports_missing_query_and_invalid_num_results() -> None:
     tool = WebSearchTool()
     missing_query_error = (
-        r"web_search invalid arguments: query: "
+        r"web_search Validation error: query: "
         r"Input should be a valid string \(received NoneType\)"
+        r"\. Please retry with corrected arguments that satisfy the tool schema\."
     )
     invalid_num_results_error = (
-        r"web_search invalid arguments: numResults: Value error, "
+        r"web_search Validation error: numResults: Value error, "
         r"numResults must be greater than or equal to 1 \(received int\)"
+        r"\. Please retry with corrected arguments that satisfy the tool schema\."
     )
 
     with pytest.raises(ValueError, match=missing_query_error):

--- a/tests/unit/tools/test_write_file_tool.py
+++ b/tests/unit/tools/test_write_file_tool.py
@@ -51,13 +51,26 @@ def test_write_file_tool_returns_diff_for_rewrite(tmp_path: Path) -> None:
 def test_write_file_tool_rejects_non_string_arguments(tmp_path: Path) -> None:
     tool = WriteFileTool()
 
-    with pytest.raises(ValueError, match="string path"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"write_file Validation error: path: Input should be a valid string \(received int\)\. "
+            r"Please retry with corrected arguments that satisfy the tool schema\."
+        ),
+    ):
         tool.invoke(
             ToolCall(tool_name="write_file", arguments={"path": 123, "content": "x"}),
             workspace=tmp_path,
         )
 
-    with pytest.raises(ValueError, match="string content"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"write_file Validation error: content: Input should be a valid string "
+            r"\(received int\)\. "
+            r"Please retry with corrected arguments that satisfy the tool schema\."
+        ),
+    ):
         tool.invoke(
             ToolCall(tool_name="write_file", arguments={"path": "out.txt", "content": 123}),
             workspace=tmp_path,
@@ -67,7 +80,14 @@ def test_write_file_tool_rejects_non_string_arguments(tmp_path: Path) -> None:
 def test_write_file_tool_rejects_empty_content(tmp_path: Path) -> None:
     tool = WriteFileTool()
 
-    with pytest.raises(ValueError, match="non-empty string content"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"write_file Validation error: content: Value error, content must not be empty "
+            r"\(received str\)\. "
+            r"Please retry with corrected arguments that satisfy the tool schema\."
+        ),
+    ):
         tool.invoke(
             ToolCall(tool_name="write_file", arguments={"path": "shader.frag", "content": ""}),
             workspace=tmp_path,


### PR DESCRIPTION
## Summary
- adopt a shared field-level validation formatter across task, prompt, file, and search tools so invalid inputs name the failing argument and received type
- harden tool-specific validation for `shell_exec`, `grep`, `web_search`, and `background_cancel`, including invalid regex, bad `numResults`, and clearer cancellation input failures
- add focused regression coverage for missing arguments and malformed inputs across the updated tools

## Verification
- uv run pytest tests/unit/tools/test_read_file_tool.py tests/unit/tools/test_shell_exec_tool.py tests/unit/tools/test_grep_tool.py tests/unit/tools/test_websearch_tool.py tests/unit/tools/test_background_task_tools.py
- uv run ruff check src/voidcode/tools/_pydantic_args.py src/voidcode/tools/read_file.py src/voidcode/tools/shell_exec.py src/voidcode/tools/grep.py src/voidcode/tools/web_search.py src/voidcode/tools/background_cancel.py tests/unit/tools/test_read_file_tool.py tests/unit/tools/test_shell_exec_tool.py tests/unit/tools/test_grep_tool.py tests/unit/tools/test_websearch_tool.py tests/unit/tools/test_background_task_tools.py
- mise run typecheck