### PR TITLE
Add remote HTTP MCP transport support

### DIFF
--- a/src/voidcode/mcp/README.md
+++ b/src/voidcode/mcp/README.md
@@ -3,7 +3,7 @@
 这里是 VoidCode 的 MCP 能力层，包含协议模型、配置 schema 和可观测性接口。
 
 > **状态**: 根据 Issue #107/#213，MCP 的静态类型、配置模型和边界约束已经提取到此目录。
-> runtime 实现仍保留在 `src/voidcode/runtime/mcp.py`，并基于官方 Python MCP SDK 提供受限、stdio-only、runtime-managed 的预发布集成。
+> runtime 实现保留在 `src/voidcode/runtime/mcp.py`，基于官方 Python MCP SDK 提供 stdio + remote-http (Streamable HTTP) 传输的 runtime-managed 集成。
 
 ## 定位
 
@@ -29,7 +29,7 @@
 
 参见 `contract.py` 中的 `SUPPORTED_CAPABILITIES`:
 
-- **Transport**: stdio-only
+- **Transport**: stdio + remote-http (Streamable HTTP)
 - **Discovery**: deferred (懒加载)
 - **Operations**: tools/list, tools/call
 - **Lifecycle**: runtime-owned
@@ -43,8 +43,31 @@
 
 - 完整 bidirectional MCP
 - MCP resources / prompts / sampling
-- Remote / non-stdio transports
 - Untrusted MCP servers
+
+### Builtin MCP 描述符说明
+
+`builtin.py` 定义了以下内置 MCP 描述符:
+
+| 名称 | 传输 | URL | 状态 |
+|------|------|-----|------|
+| `context7` | remote-http | `https://mcp.context7.com/mcp` | descriptor-only, config-gated |
+| `websearch` | remote-http | `https://mcp.exa.ai/mcp` | descriptor-only, config-gated |
+| `grep_app` | remote-http | `https://mcp.grep.app` | config-gated, 启用后可连接 |
+| `playwright` | stdio | N/A | skill-scoped, session scope |
+
+#### grep.app 端点说明
+
+grep.app 提供三个不同的端点，用途各不相同:
+
+- **Web 界面**: `https://grep.app` — 用于浏览器搜索的代码搜索网站
+- **公共 API**: `https://grep.app/api/search` — 用于程序化搜索的 REST API
+- **MCP 端点**: `https://mcp.grep.app` — MCP 协议端点（远程 HTTP 传输）
+
+内置 `grep_app` 描述符现在指向官方 MCP 端点 `https://mcp.grep.app`:
+- 需要在 `.voidcode.json` 中配置 `mcp.enabled: true` 才能启用
+- 启用后 runtime 会自动连接到远程 MCP 端点
+- 连接失败会作为 runtime MCP 诊断/状态输出，而不是模糊的工具错误
 
 ### 文件结构
 

--- a/src/voidcode/mcp/builtin.py
+++ b/src/voidcode/mcp/builtin.py
@@ -66,11 +66,12 @@ _BUILTIN_MCP_DESCRIPTORS: dict[str, BuiltinMcpDescriptor] = {
     ),
     "grep_app": BuiltinMcpDescriptor(
         name="grep_app",
-        transport="configured-server-intent",
+        transport="remote-http",
+        url="https://mcp.grep.app",
         lifecycle="descriptor_only_config_gated",
         description=(
-            "Optional code search MCP intent; execution requires a "
-            "user-configured server named grep_app."
+            "Code search MCP via grep.app remote endpoint. "
+            "Requires mcp.enabled=true in .voidcode.json to connect."
         ),
         tags=("code-search", "research"),
     ),

--- a/src/voidcode/mcp/config.py
+++ b/src/voidcode/mcp/config.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
-# Transport type - currently only stdio is supported
-McpTransport = Literal["stdio"]
+# Transport types supported by the runtime
+McpTransport = Literal["stdio", "remote-http"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -18,6 +18,13 @@ class McpServerConfig:
     transport: McpTransport = "stdio"
     command: tuple[str, ...] = ()
     env: dict[str, str] = field(default_factory=dict)
+    url: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.transport == "remote-http" and not self.url:
+            raise ValueError("remote-http transport requires a url")
+        if self.transport == "stdio" and not self.command:
+            raise ValueError("stdio transport requires a command")
 
 
 @dataclass(frozen=True, slots=True)
@@ -36,16 +43,18 @@ DEFAULT_MCP_TRANSPORT: McpTransport = "stdio"
 
 
 def create_mcp_server_config(
-    command: tuple[str, ...],
+    command: tuple[str, ...] = (),
     *,
     transport: McpTransport = "stdio",
     env: dict[str, str] | None = None,
+    url: str | None = None,
 ) -> McpServerConfig:
     """Factory function to create an McpServerConfig."""
     return McpServerConfig(
         transport=transport,
         command=command,
         env=env or {},
+        url=url,
     )
 
 

--- a/src/voidcode/mcp/config.py
+++ b/src/voidcode/mcp/config.py
@@ -20,12 +20,6 @@ class McpServerConfig:
     env: dict[str, str] = field(default_factory=dict)
     url: str | None = None
 
-    def __post_init__(self) -> None:
-        if self.transport == "remote-http" and not self.url:
-            raise ValueError("remote-http transport requires a url")
-        if self.transport == "stdio" and not self.command:
-            raise ValueError("stdio transport requires a command")
-
 
 @dataclass(frozen=True, slots=True)
 class McpConfig:

--- a/src/voidcode/mcp/contract.py
+++ b/src/voidcode/mcp/contract.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 SUPPORTED_CAPABILITIES = {
     # Transport
-    "transport": ["stdio"],
+    "transport": ["stdio", "remote-http"],
     # Discovery
     "discovery": ["deferred"],  # Tool discovery happens on first list_tools call
     # Operations
@@ -39,7 +39,6 @@ NOT_SUPPORTED = {
     "resources": "MCP resources not supported",
     "prompts": "MCP prompts not supported",
     "sampling": "MCP sampling not supported",
-    "remote_transport": "Remote/non-stdio transports not supported",
     "untrusted_servers": "Untrusted MCP servers not supported",
 }
 
@@ -71,6 +70,8 @@ class McpErrorCode:
     TOOL_NOT_FOUND = "tool_not_found"
     INVALID_REQUEST = "invalid_request"
     PROTOCOL_NEGOTIATION_FAILED = "protocol_negotiation_failed"
+    REMOTE_CONNECTION_FAILED = "remote_connection_failed"
+    REMOTE_HTTP_ERROR = "remote_http_error"
 
 
 # =============================================================================
@@ -81,18 +82,22 @@ DIAGNOSTIC_CATEGORIES = {
     "startup": [
         "server_command_missing",
         "server_command_empty",
+        "server_url_missing",
         "stdio_pipe_failed",
         "env_config_invalid",
+        "remote_connection_failed",
     ],
     "communication": [
         "json_decode_failed",
         "response_id_mismatch",
         "unexpected_response_type",
         "protocol_negotiation_failed",
+        "remote_http_error",
     ],
     "timeout": [
         "request_timeout",
         "server_unresponsive",
+        "remote_timeout",
     ],
     "shutdown": [
         "graceful_shutdown_failed",

--- a/src/voidcode/mcp/observability.py
+++ b/src/voidcode/mcp/observability.py
@@ -81,12 +81,16 @@ def diagnostic_message(
     messages: dict[str, str] = {
         "server_startup_failed": "MCP server failed to start",
         "server_command_missing": "MCP server command is missing",
+        "server_url_missing": "MCP server URL is missing for remote-http transport",
         "stdio_pipe_failed": "MCP server stdio pipe failed",
         "json_decode_failed": "MCP server returned invalid JSON",
         "request_timeout": "MCP server request timed out",
         "server_not_found": "MCP server not found in configuration",
         "tool_not_found": "MCP tool not found",
         "unexpected_response": "MCP server returned unexpected response",
+        "remote_connection_failed": "Failed to connect to remote MCP server",
+        "remote_http_error": "Remote MCP server returned HTTP error",
+        "remote_timeout": "Remote MCP server request timed out",
     }
     base = messages.get(code, f"MCP[{code}]")
     if server_name:

--- a/src/voidcode/mcp/types.py
+++ b/src/voidcode/mcp/types.py
@@ -107,6 +107,7 @@ class McpServerRuntimeState:
     stage: str | None = None
     error: str | None = None
     command: list[str] = field(default_factory=list)
+    url: str | None = None
     scope: Literal["runtime", "session"] = "runtime"
     retry_available: bool = False
 

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -164,7 +164,7 @@ _LSP_SERVER_CONFIG_KEYS = frozenset(
     {"preset", "command", "languages", "extensions", "root_markers", "settings", "init_options"}
 )
 _MCP_CONFIG_KEYS = frozenset({"enabled", "servers", "request_timeout_seconds"})
-_MCP_SERVER_CONFIG_KEYS = frozenset({"transport", "command", "env", "scope"})
+_MCP_SERVER_CONFIG_KEYS = frozenset({"transport", "command", "env", "scope", "url"})
 _TUI_CONFIG_KEYS = frozenset({"leader_key", "keymap", "preferences"})
 _TUI_PREFERENCES_CONFIG_KEYS = frozenset({"theme", "reading"})
 _TUI_THEME_CONFIG_KEYS = frozenset({"name", "mode"})
@@ -354,7 +354,7 @@ class RuntimeBackgroundTaskConfig:
     )
 
 
-type McpTransport = Literal["stdio"]
+type McpTransport = Literal["stdio", "remote-http"]
 type RuntimeMcpServerScope = Literal["runtime", "session"]
 
 
@@ -364,6 +364,7 @@ class RuntimeMcpServerConfig:
     command: tuple[str, ...] = ()
     env: dict[str, str] = field(default_factory=dict)
     scope: RuntimeMcpServerScope = "runtime"
+    url: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -1713,6 +1714,7 @@ class _RuntimeMcpServerValidationModel(BaseModel):
     command: tuple[str, ...] = ()
     env: dict[str, str] = Field(default_factory=dict)
     scope: RuntimeMcpServerScope = "runtime"
+    url: str | None = None
 
     @field_validator("transport", mode="before")
     @classmethod
@@ -1720,19 +1722,19 @@ class _RuntimeMcpServerValidationModel(BaseModel):
         if value is None:
             return "stdio"
         field_path = _validation_context_field_path(info, default="mcp.servers")
-        if value != "stdio":
-            raise ValueError(f"runtime config field '{field_path}.transport' must be one of: stdio")
-        return "stdio"
+        if value not in ("stdio", "remote-http"):
+            raise ValueError(
+                f"runtime config field '{field_path}.transport' must be one of: stdio, remote-http"
+            )
+        return cast(McpTransport, value)
 
     @field_validator("command", mode="before")
     @classmethod
     def _validate_command(cls, value: object, info: ValidationInfo) -> tuple[str, ...]:
         field_path = _validation_context_field_path(info, default="mcp.servers")
+        if value is None:
+            return ()
         command = _parse_string_list(value, field_path=f"{field_path}.command")
-        if not command:
-            raise ValueError(
-                f"runtime config field '{field_path}.command' must contain at least one string"
-            )
         return command
 
     @field_validator("env", mode="before")
@@ -1760,12 +1762,35 @@ class _RuntimeMcpServerValidationModel(BaseModel):
         field_path = _validation_context_field_path(info, default="mcp.servers")
         return _parse_runtime_mcp_server_scope(value, field_path=field_path)
 
+    @field_validator("url", mode="before")
+    @classmethod
+    def _validate_url(cls, value: object, info: ValidationInfo) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str) or not value.strip():
+            field_path = _validation_context_field_path(info, default="mcp.servers")
+            raise ValueError(f"runtime config field '{field_path}.url' must be a non-empty string")
+        return value.strip()
+
+    def model_post_init(self, __context) -> None:
+        if self.transport == "stdio" and not self.command:
+            raise ValueError(
+                f"MCP server '{getattr(self, '_field_path', 'unknown')}' using stdio transport "
+                "requires a command"
+            )
+        if self.transport == "remote-http" and not self.url:
+            raise ValueError(
+                f"MCP server '{getattr(self, '_field_path', 'unknown')}' using remote-http transport "
+                "requires a url"
+            )
+
     def to_runtime_config(self) -> RuntimeMcpServerConfig:
         return RuntimeMcpServerConfig(
             transport=self.transport,
             command=self.command,
             env=self.env,
             scope=self.scope,
+            url=self.url,
         )
 
 

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -1734,6 +1734,8 @@ class _RuntimeMcpServerValidationModel(BaseModel):
         field_path = _validation_context_field_path(info, default="mcp.servers")
         if value is None:
             return ()
+        if isinstance(value, tuple) and all(isinstance(item, str) for item in value):
+            return cast(tuple[str, ...], value)
         command = _parse_string_list(value, field_path=f"{field_path}.command")
         return command
 
@@ -1773,15 +1775,12 @@ class _RuntimeMcpServerValidationModel(BaseModel):
         return value.strip()
 
     def model_post_init(self, __context) -> None:
+        field_path = getattr(self, "_field_path", "unknown")
         if self.transport == "stdio" and not self.command:
-            raise ValueError(
-                f"MCP server '{getattr(self, '_field_path', 'unknown')}' using stdio transport "
-                "requires a command"
-            )
+            raise ValueError(f"MCP server '{field_path}' using stdio transport requires a command")
         if self.transport == "remote-http" and not self.url:
             raise ValueError(
-                f"MCP server '{getattr(self, '_field_path', 'unknown')}' using remote-http transport "
-                "requires a url"
+                f"MCP server '{field_path}' using remote-http transport requires a url"
             )
 
     def to_runtime_config(self) -> RuntimeMcpServerConfig:
@@ -1828,6 +1827,19 @@ class _RuntimeMcpValidationModel(BaseModel):
                 allowed_keys=_MCP_SERVER_CONFIG_KEYS,
                 field_path=f"mcp.servers.{server_name}",
             )
+            transport = cast(dict[str, object], raw_server).get("transport")
+            if transport is None:
+                transport = "stdio"
+            if transport == "stdio" and "command" not in raw_server:
+                raise ValueError(
+                    f"runtime config field 'mcp.servers.{server_name}.command' is required "
+                    "when transport is stdio"
+                )
+            if transport == "remote-http" and "url" not in raw_server:
+                raise ValueError(
+                    f"runtime config field 'mcp.servers.{server_name}.url' is required "
+                    "when transport is remote-http"
+                )
             parsed_servers[server_name] = _validate_runtime_config_model(
                 _RuntimeMcpServerValidationModel,
                 cast(dict[str, object], raw_server),

--- a/src/voidcode/runtime/config_schema.py
+++ b/src/voidcode/runtime/config_schema.py
@@ -150,13 +150,24 @@ def runtime_config_json_schema() -> dict[str, object]:
                         "additionalProperties": {
                             "type": "object",
                             "additionalProperties": False,
-                            "required": ["command"],
                             "properties": {
-                                "transport": {"type": "string", "enum": ["stdio"]},
+                                "transport": {
+                                    "type": "string",
+                                    "enum": ["stdio", "remote-http"],
+                                },
                                 "command": {
                                     "type": "array",
                                     "items": {"type": "string"},
                                     "minItems": 1,
+                                },
+                                "url": {
+                                    "type": "string",
+                                    "format": "uri",
+                                    "minLength": 1,
+                                    "description": (
+                                        "Remote HTTP MCP endpoint URL. Required when "
+                                        "transport is remote-http."
+                                    ),
                                 },
                                 "env": {
                                     "type": "object",
@@ -171,6 +182,16 @@ def runtime_config_json_schema() -> dict[str, object]:
                                     ),
                                 },
                             },
+                            "allOf": [
+                                {
+                                    "if": {
+                                        "properties": {"transport": {"const": "remote-http"}},
+                                        "required": ["transport"],
+                                    },
+                                    "then": {"required": ["url"]},
+                                    "else": {"required": ["command"]},
+                                }
+                            ],
                         },
                     },
                 },

--- a/src/voidcode/runtime/mcp.py
+++ b/src/voidcode/runtime/mcp.py
@@ -23,6 +23,7 @@ from typing import IO, Any, Literal, cast
 
 from anyio.from_thread import BlockingPortal, start_blocking_portal
 from mcp import ClientSession, StdioServerParameters
+from mcp.client.streamable_http import streamable_http_client
 from mcp.client.stdio import stdio_client
 from mcp.shared.exceptions import McpError
 from mcp.types import CallToolResult, Implementation, InitializeResult, ListToolsResult, Tool
@@ -45,7 +46,7 @@ from ..mcp import (
     create_diagnostic,
     redact_mcp_command,
 )
-from .config import RuntimeMcpConfig
+from .config import RuntimeMcpConfig, RuntimeMcpServerConfig
 from .events import (
     RUNTIME_MCP_SERVER_ACQUIRED,
     RUNTIME_MCP_SERVER_FAILED,
@@ -195,6 +196,7 @@ class _RunningMcpServer:
 
     scope: Literal["runtime", "session"]
     owner_session_id: str | None
+    transport: Literal["stdio", "remote-http"]
 
     def __init__(
         self,
@@ -204,10 +206,11 @@ class _RunningMcpServer:
         transport_context: AbstractContextManager[tuple[object, object]],
         session_context: AbstractContextManager[ClientSession],
         session: ClientSession,
-        stderr_log: IO[str],
+        stderr_log: IO[str] | None,
         initialize_result: InitializeResult,
         scope: Literal["runtime", "session"],
         owner_session_id: str | None,
+        transport: Literal["stdio", "remote-http"] = "stdio",
     ) -> None:
         self.server_name = server_name
         self.workspace_root = workspace_root
@@ -218,6 +221,7 @@ class _RunningMcpServer:
         self.initialize_result = initialize_result
         self.scope = scope
         self.owner_session_id = owner_session_id
+        self.transport = transport
         self.references = 0
         self.last_used_at = time.monotonic()
         # The Python SDK ClientSession is shared per configured server process.
@@ -257,6 +261,7 @@ class ManagedMcpManager:
                 server_name=name,
                 status="stopped",
                 command=list(server.command),
+                url=getattr(server, "url", None),
                 scope=getattr(server, "scope", "runtime"),
             )
             for name, server in self._configuration.servers.items()
@@ -465,6 +470,7 @@ class ManagedMcpManager:
             )
             raise ValueError(message)
 
+        transport = getattr(server_config, "transport", "stdio")
         scope = getattr(server_config, "scope", "runtime")
         key = self._server_key(
             server_name=server_name,
@@ -479,7 +485,7 @@ class ManagedMcpManager:
                 self._record_server_acquired(key=key, workspace_root=running.workspace_root)
                 return running
 
-        if not server_config.command:
+        if transport == "stdio" and not getattr(server_config, "command", None):
             diagnostic = create_diagnostic(
                 severity=McpDiagnosticSeverity.ERROR,
                 category="startup",
@@ -490,6 +496,27 @@ class ManagedMcpManager:
             message = (
                 f"MCP[{server_name}]: command is empty. "
                 "Please configure mcp.servers.{server_name}.command in .voidcode.json"
+            )
+            self._record_failure_event(
+                key=key,
+                workspace_root=workspace.resolve(),
+                stage="startup",
+                error=message,
+                diagnostic=diagnostic,
+            )
+            raise ValueError(message)
+
+        if transport == "remote-http" and not getattr(server_config, "url", None):
+            diagnostic = create_diagnostic(
+                severity=McpDiagnosticSeverity.ERROR,
+                category="startup",
+                code="server_url_missing",
+                server_name=server_name,
+            )
+            self._record_diagnostic(diagnostic)
+            message = (
+                f"MCP[{server_name}]: url is empty. "
+                "Please configure mcp.servers.{server_name}.url in .voidcode.json"
             )
             self._record_failure_event(
                 key=key,
@@ -515,22 +542,30 @@ class ManagedMcpManager:
 
             try:
                 portal = self._ensure_portal()
-                stderr_log = open(
-                    os.devnull,
-                    "w",
-                    encoding="utf-8",
-                )  # noqa: SIM115 - closed in shutdown
-                params = StdioServerParameters(
-                    command=server_config.command[0],
-                    args=list(server_config.command[1:]),
-                    env={**os.environ, **server_config.env},
-                    cwd=workspace_root,
-                )
-                pending_transport_context = portal.wrap_async_context_manager(
-                    cast(Any, stdio_client(params, errlog=stderr_log))
-                )
-                read_stream, write_stream = pending_transport_context.__enter__()
-                transport_context = pending_transport_context
+                if transport == "remote-http":
+                    url = server_config.url
+                    pending_transport_context = portal.wrap_async_context_manager(
+                        cast(Any, streamable_http_client(url))
+                    )
+                    read_stream, write_stream = pending_transport_context.__enter__()
+                    transport_context = pending_transport_context
+                else:
+                    stderr_log = open(
+                        os.devnull,
+                        "w",
+                        encoding="utf-8",
+                    )  # noqa: SIM115 - closed in shutdown
+                    params = StdioServerParameters(
+                        command=server_config.command[0],
+                        args=list(server_config.command[1:]),
+                        env={**os.environ, **server_config.env},
+                        cwd=workspace_root,
+                    )
+                    pending_transport_context = portal.wrap_async_context_manager(
+                        cast(Any, stdio_client(params, errlog=stderr_log))
+                    )
+                    read_stream, write_stream = pending_transport_context.__enter__()
+                    transport_context = pending_transport_context
                 pending_session_context = portal.wrap_async_context_manager(
                     ClientSession(
                         read_stream,
@@ -544,11 +579,19 @@ class ManagedMcpManager:
                 )
                 session = pending_session_context.__enter__()
                 session_context = pending_session_context
-                self._record_server_started(
-                    key=key,
-                    workspace_root=workspace_root,
-                    command=list(server_config.command),
-                )
+                if transport == "stdio":
+                    self._record_server_started(
+                        key=key,
+                        workspace_root=workspace_root,
+                        command=list(server_config.command),
+                    )
+                else:
+                    self._record_server_started(
+                        key=key,
+                        workspace_root=workspace_root,
+                        command=[],
+                        url=server_config.url,
+                    )
                 initialize_result = cast(
                     InitializeResult,
                     self._call_sdk_session(
@@ -571,20 +614,23 @@ class ManagedMcpManager:
                     category="startup",
                     code="server_startup_failed",
                     server_name=server_name,
-                    command=server_config.command[0],
+                    command=server_config.command[0] if transport == "stdio" else None,
                 )
                 self._record_diagnostic(diagnostic)
-                message = (
-                    f"MCP[{server_name}]: failed to start server - cmd not found "
-                    f"(command not found): "
-                    f"{server_config.command[0]}"
-                )
+                if transport == "stdio":
+                    message = (
+                        f"MCP[{server_name}]: failed to start server - cmd not found "
+                        f"(command not found): "
+                        f"{server_config.command[0]}"
+                    )
+                else:
+                    message = f"MCP[{server_name}]: failed to connect to remote server"
                 self._record_failure_event(
                     key=key,
                     workspace_root=workspace_root,
                     stage="startup",
                     error=message,
-                    command=list(server_config.command),
+                    command=list(server_config.command) if transport == "stdio" else None,
                     diagnostic=diagnostic,
                 )
                 raise ValueError(message) from exc
@@ -611,7 +657,7 @@ class ManagedMcpManager:
                     stage="startup",
                     error=message,
                     method="initialize",
-                    command=list(server_config.command),
+                    command=list(server_config.command) if transport == "stdio" else None,
                     diagnostic=diagnostic,
                 )
                 if transport_context is not None:
@@ -632,6 +678,7 @@ class ManagedMcpManager:
                 initialize_result=initialize_result,
                 scope=key.scope,
                 owner_session_id=key.owner_session_id,
+                transport=transport,
             )
             self._running_servers[key] = running
             self._record_server_acquired(key=key, workspace_root=running.workspace_root)
@@ -902,19 +949,19 @@ class ManagedMcpManager:
         key: _McpServerKey,
         workspace_root: Path,
         command: list[str] | None = None,
+        url: str | None = None,
     ) -> None:
         server_name = key.server_name
         with self._state_lock:
+            existing = self._server_states.get(
+                server_name, McpServerRuntimeState(server_name=server_name)
+            )
             self._server_states[server_name] = McpServerRuntimeState(
                 server_name=server_name,
                 status="running",
                 workspace_root=str(workspace_root),
-                command=list(
-                    command
-                    or self._server_states.get(
-                        server_name, McpServerRuntimeState(server_name=server_name)
-                    ).command
-                ),
+                command=list(command or existing.command),
+                url=url or existing.url,
                 scope=key.scope,
                 retry_available=False,
             )
@@ -932,6 +979,7 @@ class ManagedMcpManager:
                         "workspace_root": str(workspace_root),
                         "state": "starting",
                         "client_foundation": "python-mcp-sdk",
+                        **({"url": url} if url else {}),
                     },
                 )
             )
@@ -1150,7 +1198,8 @@ class ManagedMcpManager:
     def _terminate_running_server(running: _RunningMcpServer) -> None:
         running.session_context.__exit__(None, None, None)
         running.transport_context.__exit__(None, None, None)
-        running.stderr_log.close()
+        if running.stderr_log is not None:
+            running.stderr_log.close()
 
     def _record_event(self, event: McpRuntimeEvent) -> None:
         with self._state_lock:

--- a/src/voidcode/runtime/mcp.py
+++ b/src/voidcode/runtime/mcp.py
@@ -23,8 +23,8 @@ from typing import IO, Any, Literal, cast
 
 from anyio.from_thread import BlockingPortal, start_blocking_portal
 from mcp import ClientSession, StdioServerParameters
-from mcp.client.streamable_http import streamable_http_client
 from mcp.client.stdio import stdio_client
+from mcp.client.streamable_http import streamable_http_client
 from mcp.shared.exceptions import McpError
 from mcp.types import CallToolResult, Implementation, InitializeResult, ListToolsResult, Tool
 
@@ -46,7 +46,7 @@ from ..mcp import (
     create_diagnostic,
     redact_mcp_command,
 )
-from .config import RuntimeMcpConfig, RuntimeMcpServerConfig
+from .config import RuntimeMcpConfig
 from .events import (
     RUNTIME_MCP_SERVER_ACQUIRED,
     RUNTIME_MCP_SERVER_FAILED,

--- a/src/voidcode/runtime/mcp.py
+++ b/src/voidcode/runtime/mcp.py
@@ -90,6 +90,12 @@ def _validate_input_schema(raw_schema: object) -> dict[str, object]:
     return schema
 
 
+def _read_write_streams(transport_streams: tuple[object, ...]) -> tuple[object, object]:
+    if len(transport_streams) < 2:
+        raise ValueError("MCP transport context must provide read and write streams")
+    return transport_streams[0], transport_streams[1]
+
+
 def _validate_call_arguments_against_schema(
     *,
     tool_name: str,
@@ -203,7 +209,7 @@ class _RunningMcpServer:
         *,
         server_name: str,
         workspace_root: Path,
-        transport_context: AbstractContextManager[tuple[object, object]],
+        transport_context: AbstractContextManager[tuple[object, ...]],
         session_context: AbstractContextManager[ClientSession],
         session: ClientSession,
         stderr_log: IO[str] | None,
@@ -529,7 +535,7 @@ class ManagedMcpManager:
 
         workspace_root = workspace.resolve()
         stderr_log: IO[str] | None = None
-        transport_context: AbstractContextManager[tuple[object, object]] | None = None
+        transport_context: AbstractContextManager[tuple[object, ...]] | None = None
         session_context: AbstractContextManager[ClientSession] | None = None
 
         with self._state_lock:
@@ -547,7 +553,9 @@ class ManagedMcpManager:
                     pending_transport_context = portal.wrap_async_context_manager(
                         cast(Any, streamable_http_client(url))
                     )
-                    read_stream, write_stream = pending_transport_context.__enter__()
+                    read_stream, write_stream = _read_write_streams(
+                        pending_transport_context.__enter__()
+                    )
                     transport_context = pending_transport_context
                 else:
                     stderr_log = open(
@@ -564,12 +572,14 @@ class ManagedMcpManager:
                     pending_transport_context = portal.wrap_async_context_manager(
                         cast(Any, stdio_client(params, errlog=stderr_log))
                     )
-                    read_stream, write_stream = pending_transport_context.__enter__()
+                    read_stream, write_stream = _read_write_streams(
+                        pending_transport_context.__enter__()
+                    )
                     transport_context = pending_transport_context
                 pending_session_context = portal.wrap_async_context_manager(
                     ClientSession(
-                        read_stream,
-                        write_stream,
+                        cast(Any, read_stream),
+                        cast(Any, write_stream),
                         read_timeout_seconds=self._request_timeout,
                         client_info=Implementation(
                             name=MCP_CLIENT_NAME,

--- a/tests/unit/runtime/test_config_schema.py
+++ b/tests/unit/runtime/test_config_schema.py
@@ -135,8 +135,28 @@ def test_runtime_config_json_schema_exposes_core_fields() -> None:
     mcp_properties = cast(dict[str, object], mcp_schema["properties"])
     mcp_servers = cast(dict[str, object], mcp_properties["servers"])
     mcp_server_schema = cast(dict[str, object], mcp_servers["additionalProperties"])
-    assert mcp_server_schema["required"] == ["command"]
+    assert "required" not in mcp_server_schema
     mcp_server_properties = cast(dict[str, object], mcp_server_schema["properties"])
+    assert mcp_server_properties["transport"] == {
+        "type": "string",
+        "enum": ["stdio", "remote-http"],
+    }
+    assert mcp_server_properties["url"] == {
+        "type": "string",
+        "format": "uri",
+        "minLength": 1,
+        "description": ("Remote HTTP MCP endpoint URL. Required when transport is remote-http."),
+    }
+    assert mcp_server_schema["allOf"] == [
+        {
+            "if": {
+                "properties": {"transport": {"const": "remote-http"}},
+                "required": ["transport"],
+            },
+            "then": {"required": ["url"]},
+            "else": {"required": ["command"]},
+        }
+    ]
     assert mcp_server_properties["scope"] == {
         "type": "string",
         "enum": ["runtime", "session"],

--- a/tests/unit/runtime/test_mcp.py
+++ b/tests/unit/runtime/test_mcp.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import pytest
+from mcp.types import Implementation, InitializeResult, ListToolsResult, ServerCapabilities, Tool
 
 from voidcode.mcp import (
     MCP_PROTOCOL_VERSION,
@@ -205,6 +206,81 @@ for raw_line in sys.stdin:
 
     assert manager.list_tools(workspace=tmp_path) == ()
     assert protocol_path.read_text(encoding="utf-8") == MCP_PROTOCOL_VERSION
+
+
+def test_mcp_manager_accepts_remote_http_transport_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import voidcode.runtime.mcp as runtime_mcp
+
+    class FakeTransportContext:
+        def __init__(self, url: str) -> None:
+            self.url = url
+            self.closed = False
+
+        async def __aenter__(self) -> tuple[object, object, object]:
+            return object(), object(), lambda: "session-123"
+
+        async def __aexit__(self, exc_type: object, exc: object, traceback: object) -> None:
+            _ = exc_type, exc, traceback
+            self.closed = True
+
+    class FakeClientSession:
+        def __init__(self, read_stream: object, write_stream: object, **kwargs: object) -> None:
+            self.read_stream = read_stream
+            self.write_stream = write_stream
+            self.kwargs = kwargs
+
+        async def __aenter__(self) -> FakeClientSession:
+            return self
+
+        async def __aexit__(self, exc_type: object, exc: object, traceback: object) -> None:
+            _ = exc_type, exc, traceback
+            return None
+
+        async def initialize(self) -> InitializeResult:
+            return InitializeResult(
+                protocolVersion="2025-11-25",
+                capabilities=ServerCapabilities(),
+                serverInfo=Implementation(name="remote", version="0.1.0"),
+            )
+
+        async def list_tools(self) -> ListToolsResult:
+            return ListToolsResult(
+                tools=[
+                    Tool(
+                        name="search",
+                        description="Search code",
+                        inputSchema={"type": "object", "properties": {}},
+                    )
+                ]
+            )
+
+    requested_urls: list[str] = []
+
+    def fake_streamable_http_client(url: str) -> FakeTransportContext:
+        requested_urls.append(url)
+        return FakeTransportContext(url)
+
+    monkeypatch.setattr(runtime_mcp, "ClientSession", FakeClientSession)
+    monkeypatch.setattr(runtime_mcp, "streamable_http_client", fake_streamable_http_client)
+    manager = build_mcp_manager(
+        RuntimeMcpConfig(
+            enabled=True,
+            servers={
+                "remote": RuntimeMcpServerConfig(
+                    transport="remote-http",
+                    url="https://mcp.example.test",
+                )
+            },
+        )
+    )
+
+    tools = manager.list_tools(workspace=tmp_path)
+
+    assert requested_urls == ["https://mcp.example.test"]
+    assert [tool.tool_name for tool in tools] == ["search"]
 
 
 def test_mcp_manager_gracefully_closes_server_stdin_on_shutdown(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_mcp_config.py
+++ b/tests/unit/runtime/test_mcp_config.py
@@ -183,12 +183,12 @@ def test_builtin_mcp_descriptors_model_issue_405_capabilities() -> None:
     assert set(descriptors) == {"context7", "websearch", "grep_app", "playwright"}
     assert descriptors["context7"].transport == "remote-http"
     assert descriptors["websearch"].transport == "remote-http"
-    assert descriptors["grep_app"].transport == "configured-server-intent"
-    assert descriptors["grep_app"].url is None
+    assert descriptors["grep_app"].transport == "remote-http"
+    assert descriptors["grep_app"].url == "https://mcp.grep.app"
     assert descriptors["grep_app"].command == ()
     assert descriptors["grep_app"].lifecycle == "descriptor_only_config_gated"
     grep_app_payload = descriptors["grep_app"].to_payload()
-    assert "url" not in grep_app_payload
+    assert grep_app_payload["url"] == "https://mcp.grep.app"
     assert "command" not in grep_app_payload
     playwright = get_builtin_mcp_descriptor("playwright")
     assert playwright is not None
@@ -198,14 +198,66 @@ def test_builtin_mcp_descriptors_model_issue_405_capabilities() -> None:
     assert playwright.skill_name == "playwright"
 
 
-def test_builtin_grep_app_descriptor_is_not_configured_runtime_server() -> None:
+def test_builtin_grep_app_descriptor_has_remote_http_endpoint() -> None:
     descriptor = get_builtin_mcp_descriptor("grep_app")
 
     assert descriptor is not None
     assert descriptor.name == "grep_app"
-    assert descriptor.url is None
-    assert descriptor.command == ()
+    assert descriptor.transport == "remote-http"
+    assert descriptor.url == "https://mcp.grep.app"
 
     config = RuntimeMcpConfig(enabled=True)
 
     assert config.servers is None
+
+
+def test_runtime_config_parses_mcp_remote_http_servers(tmp_path: Path) -> None:
+    (tmp_path / ".voidcode.json").write_text(
+        json.dumps(
+            {
+                "mcp": {
+                    "enabled": True,
+                    "servers": {
+                        "grep_app": {
+                            "transport": "remote-http",
+                            "url": "https://mcp.grep.app",
+                        }
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.mcp == RuntimeMcpConfig(
+        enabled=True,
+        servers={
+            "grep_app": RuntimeMcpServerConfig(
+                transport="remote-http",
+                url="https://mcp.grep.app",
+            )
+        },
+    )
+
+
+def test_runtime_config_rejects_missing_mcp_url_for_remote_http(tmp_path: Path) -> None:
+    (tmp_path / ".voidcode.json").write_text(
+        json.dumps(
+            {
+                "mcp": {
+                    "enabled": True,
+                    "servers": {
+                        "grep_app": {
+                            "transport": "remote-http",
+                        }
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="mcp.servers.grep_app"):
+        load_runtime_config(tmp_path, env={})


### PR DESCRIPTION
## Summary
- Add Streamable HTTP MCP transport support for runtime-managed remote MCP servers while preserving stdio lifecycle behavior.
- Wire builtin `grep_app` to the official `https://mcp.grep.app` endpoint and update MCP docs/status contracts.
- Fix remote MCP config parsing/schema validation so `remote-http` requires `url`, stdio requires `command`, and doctor diagnostics can still inspect incomplete static configs.

Closes #411

## Verification
- `uv run pytest tests/unit/runtime/test_mcp_config.py`
- `uv run pytest tests/unit/doctor/test_checker.py::TestMcpServerChecker::test_check_with_no_command tests/unit/runtime/test_config_schema.py::test_runtime_config_json_schema_exposes_core_fields`
- `mise run check` (ruff, ty, 2146 pytest cases, frontend lint/typecheck, 162 frontend tests)

## Notes
- This supersedes closed PR #414 with the same branch plus CI fixes.