### PR TITLE
refactor(provider): move config projection into adapters

### DIFF
--- a/src/voidcode/provider/anthropic.py
+++ b/src/voidcode/provider/anthropic.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from .config import AnthropicProviderConfig, LiteLLMProviderConfig
 from .litellm_backend import LiteLLMBackendSingleAgentProvider
+from .litellm_config import anthropic_provider_config
 from .protocol import TurnProvider
 
 
@@ -11,6 +12,9 @@ from .protocol import TurnProvider
 class AnthropicModelProvider:
     name: str = "anthropic"
     config: AnthropicProviderConfig | None = None
+
+    def provider_config(self) -> LiteLLMProviderConfig:
+        return anthropic_provider_config(self.config)
 
     def turn_provider(self) -> TurnProvider:
         adapted_config = LiteLLMProviderConfig(

--- a/src/voidcode/provider/config.py
+++ b/src/voidcode/provider/config.py
@@ -388,6 +388,7 @@ _SIMPLIFIED_DEFAULTS: dict[str, tuple[str, str | None, dict[str, str]]] = {
 
 
 _SIMPLIFIED_PROVIDER_NAMES = frozenset(_SIMPLIFIED_DEFAULTS)
+_SIMPLIFIED_PROVIDERS_USING_BASE_URL_DISCOVERY = frozenset({"deepseek"})
 
 
 def simplified_defaults(provider_name: str) -> tuple[str, dict[str, str]]:
@@ -412,11 +413,19 @@ def simplified_config_to_litellm(
         raise ValueError(f"Unknown simplified provider: {provider_name!r}")
     default_base_url, default_model_map = simplified_defaults(provider_name)
     default_discovery_base_url = simplified_discovery_base_url(provider_name)
-    discovery_base_url = (
-        config.discovery_base_url
-        if config.discovery_base_url is not None
-        else default_discovery_base_url
-    )
+    if config.discovery_base_url is not None:
+        discovery_base_url = config.discovery_base_url
+    elif config.base_url is not None and default_discovery_base_url == "":
+        discovery_base_url = ""
+    elif (
+        config.base_url is not None
+        and provider_name in _SIMPLIFIED_PROVIDERS_USING_BASE_URL_DISCOVERY
+    ):
+        discovery_base_url = None
+    elif config.base_url is not None:
+        discovery_base_url = default_discovery_base_url
+    else:
+        discovery_base_url = default_discovery_base_url
     return LiteLLMProviderConfig(
         api_key=config.api_key,
         base_url=config.base_url if config.base_url else default_base_url,

--- a/src/voidcode/provider/copilot.py
+++ b/src/voidcode/provider/copilot.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from .config import CopilotProviderConfig, LiteLLMProviderConfig
 from .litellm_backend import LiteLLMBackendSingleAgentProvider
+from .litellm_config import copilot_provider_config
 from .protocol import TurnProvider
 
 
@@ -11,6 +12,9 @@ from .protocol import TurnProvider
 class CopilotModelProvider:
     name: str = "copilot"
     config: CopilotProviderConfig | None = None
+
+    def provider_config(self) -> LiteLLMProviderConfig:
+        return copilot_provider_config(self.config)
 
     def turn_provider(self) -> TurnProvider:
         token = None

--- a/src/voidcode/provider/deepseek.py
+++ b/src/voidcode/provider/deepseek.py
@@ -14,6 +14,9 @@ class DeepSeekModelProvider:
     name: str = "deepseek"
     config: SimplifiedProviderConfig | None = None
 
+    def provider_config(self):
+        return simplified_config_to_litellm(self.name, self.config)
+
     def turn_provider(self) -> TurnProvider:
         adapted_config = simplified_config_to_litellm(self.name, self.config)
         return LiteLLMBackendSingleAgentProvider(name=self.name, config=adapted_config)

--- a/src/voidcode/provider/glm.py
+++ b/src/voidcode/provider/glm.py
@@ -29,6 +29,9 @@ class GLMModelProvider:
     name: str = "glm"
     config: SimplifiedProviderConfig | None = None
 
+    def provider_config(self):
+        return simplified_config_to_litellm(self.name, self.config)
+
     def turn_provider(self) -> TurnProvider:
         adapted_config = simplified_config_to_litellm(self.name, self.config)
         return LiteLLMBackendSingleAgentProvider(name=self.name, config=adapted_config)

--- a/src/voidcode/provider/google.py
+++ b/src/voidcode/provider/google.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from .config import GoogleProviderConfig, LiteLLMProviderConfig
 from .litellm_backend import LiteLLMBackendSingleAgentProvider
+from .litellm_config import google_provider_config
 from .protocol import TurnProvider
 
 
@@ -11,6 +12,9 @@ from .protocol import TurnProvider
 class GoogleModelProvider:
     name: str = "google"
     config: GoogleProviderConfig | None = None
+
+    def provider_config(self) -> LiteLLMProviderConfig:
+        return google_provider_config(self.config)
 
     def turn_provider(self) -> TurnProvider:
         api_key = None

--- a/src/voidcode/provider/grok.py
+++ b/src/voidcode/provider/grok.py
@@ -14,6 +14,9 @@ class GrokModelProvider:
     name: str = "grok"
     config: SimplifiedProviderConfig | None = None
 
+    def provider_config(self):
+        return simplified_config_to_litellm(self.name, self.config)
+
     def turn_provider(self) -> TurnProvider:
         adapted_config = simplified_config_to_litellm(self.name, self.config)
         return LiteLLMBackendSingleAgentProvider(name=self.name, config=adapted_config)

--- a/src/voidcode/provider/kimi.py
+++ b/src/voidcode/provider/kimi.py
@@ -28,6 +28,9 @@ class KimiModelProvider:
     name: str = "kimi"
     config: SimplifiedProviderConfig | None = None
 
+    def provider_config(self):
+        return simplified_config_to_litellm(self.name, self.config)
+
     def turn_provider(self) -> TurnProvider:
         adapted_config = simplified_config_to_litellm(self.name, self.config)
         return LiteLLMBackendSingleAgentProvider(name=self.name, config=adapted_config)

--- a/src/voidcode/provider/litellm.py
+++ b/src/voidcode/provider/litellm.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from .config import LiteLLMProviderConfig
 from .litellm_backend import LiteLLMBackendSingleAgentProvider
+from .litellm_config import litellm_provider_config
 from .protocol import TurnProvider
 
 
@@ -11,6 +12,9 @@ from .protocol import TurnProvider
 class LiteLLMModelProvider:
     name: str = "litellm"
     config: LiteLLMProviderConfig | None = None
+
+    def provider_config(self) -> LiteLLMProviderConfig:
+        return litellm_provider_config(self.config)
 
     def turn_provider(self) -> TurnProvider:
         return LiteLLMBackendSingleAgentProvider(name=self.name, config=self.config)

--- a/src/voidcode/provider/litellm_config.py
+++ b/src/voidcode/provider/litellm_config.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from .config import (
+    AnthropicProviderConfig,
+    CopilotProviderConfig,
+    GoogleProviderConfig,
+    LiteLLMProviderConfig,
+    OpenAIProviderConfig,
+)
+
+_DEFAULT_DISCOVERY_BASE_URLS: dict[str, str] = {
+    "openai": "https://api.openai.com",
+    "anthropic": "https://api.anthropic.com",
+    "google": "https://generativelanguage.googleapis.com",
+    "litellm": "http://127.0.0.1:4000",
+}
+
+_DEFAULT_MODEL_MAPS: dict[str, dict[str, str]] = {
+    "openai": {
+        "gpt-5.5": "gpt-5.5",
+        "gpt-5.4": "gpt-5.4",
+        "gpt-5.4-mini": "gpt-5.4-mini",
+        "gpt-5.4-nano": "gpt-5.4-nano",
+        "gpt-5.2": "gpt-5.2",
+        "gpt-5.2-pro": "gpt-5.2-pro",
+        "gpt-5.2-codex": "gpt-5.2-codex",
+        "gpt-5.1": "gpt-5.1",
+        "gpt-5.1-codex": "gpt-5.1-codex",
+        "gpt-5.1-codex-max": "gpt-5.1-codex-max",
+        "gpt-5": "gpt-5",
+        "gpt-5-mini": "gpt-5-mini",
+        "gpt-5-nano": "gpt-5-nano",
+        "gpt-4.1": "gpt-4.1",
+        "gpt-4.1-mini": "gpt-4.1-mini",
+        "gpt-4.1-nano": "gpt-4.1-nano",
+    },
+    "anthropic": {
+        "claude-opus-4-7": "claude-opus-4-7",
+        "claude-sonnet-4-6": "claude-sonnet-4-6",
+        "claude-haiku-4-5": "claude-haiku-4-5",
+        "claude-haiku-4-5-20251001": "claude-haiku-4-5-20251001",
+    },
+    "google": {
+        "gemini-3-pro-preview": "gemini-3-pro-preview",
+        "gemini-3-flash-preview": "gemini-3-flash-preview",
+        "gemini-2.5-pro": "gemini-2.5-pro",
+        "gemini-2.5-flash": "gemini-2.5-flash",
+        "gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
+        "gemini-3.1-flash-live-preview": "gemini-3.1-flash-live-preview",
+        "gemini-3.1-flash-tts-preview": "gemini-3.1-flash-tts-preview",
+    },
+}
+
+
+def default_discovery_base_url(
+    provider_name: str,
+    *,
+    configured_base_url: str | None,
+    configured_discovery_base_url: str | None,
+) -> str | None:
+    if configured_discovery_base_url is not None:
+        return configured_discovery_base_url
+    if configured_base_url is not None:
+        return None
+    return _DEFAULT_DISCOVERY_BASE_URLS.get(provider_name)
+
+
+def openai_provider_config(config: OpenAIProviderConfig | None) -> LiteLLMProviderConfig:
+    return LiteLLMProviderConfig(
+        api_key=None if config is None else config.api_key,
+        base_url=None if config is None else config.base_url,
+        discovery_base_url=default_discovery_base_url(
+            "openai",
+            configured_base_url=None if config is None else config.base_url,
+            configured_discovery_base_url=None if config is None else config.discovery_base_url,
+        ),
+        timeout_seconds=None if config is None else config.timeout_seconds,
+        model_map=dict(_DEFAULT_MODEL_MAPS["openai"]),
+    )
+
+
+def anthropic_provider_config(config: AnthropicProviderConfig | None) -> LiteLLMProviderConfig:
+    return LiteLLMProviderConfig(
+        api_key=None if config is None else config.api_key,
+        base_url=None if config is None else config.base_url,
+        discovery_base_url=default_discovery_base_url(
+            "anthropic",
+            configured_base_url=None if config is None else config.base_url,
+            configured_discovery_base_url=None if config is None else config.discovery_base_url,
+        ),
+        timeout_seconds=None if config is None else config.timeout_seconds,
+        model_map=dict(_DEFAULT_MODEL_MAPS["anthropic"]),
+    )
+
+
+def google_provider_config(config: GoogleProviderConfig | None) -> LiteLLMProviderConfig:
+    api_key = None
+    auth_header = None
+    auth_scheme = "bearer"
+    if config is not None and config.auth is not None:
+        if config.auth.method == "api_key":
+            api_key = config.auth.api_key
+            auth_header = "x-goog-api-key"
+            auth_scheme = "token"
+        elif config.auth.method == "oauth":
+            api_key = config.auth.access_token
+    return LiteLLMProviderConfig(
+        api_key=api_key,
+        base_url=None if config is None else config.base_url,
+        discovery_base_url=default_discovery_base_url(
+            "google",
+            configured_base_url=None if config is None else config.base_url,
+            configured_discovery_base_url=None if config is None else config.discovery_base_url,
+        ),
+        auth_header=auth_header,
+        auth_scheme=auth_scheme,
+        timeout_seconds=None if config is None else config.timeout_seconds,
+        model_map=dict(_DEFAULT_MODEL_MAPS["google"]),
+    )
+
+
+def copilot_provider_config(config: CopilotProviderConfig | None) -> LiteLLMProviderConfig:
+    token = None
+    if config is not None and config.auth is not None:
+        token = config.auth.token
+    return LiteLLMProviderConfig(
+        api_key=token,
+        base_url=None if config is None else config.base_url,
+        timeout_seconds=None if config is None else config.timeout_seconds,
+    )
+
+
+def litellm_provider_config(config: LiteLLMProviderConfig | None) -> LiteLLMProviderConfig:
+    if config is None:
+        return LiteLLMProviderConfig(discovery_base_url=_DEFAULT_DISCOVERY_BASE_URLS["litellm"])
+    return LiteLLMProviderConfig(
+        api_key=config.api_key,
+        api_key_env_var=config.api_key_env_var,
+        base_url=config.base_url,
+        discovery_base_url=default_discovery_base_url(
+            "litellm",
+            configured_base_url=config.base_url,
+            configured_discovery_base_url=config.discovery_base_url,
+        ),
+        auth_header=config.auth_header,
+        auth_scheme=config.auth_scheme,
+        ssl_verify=config.ssl_verify,
+        timeout_seconds=config.timeout_seconds,
+        model_map=dict(config.model_map),
+    )

--- a/src/voidcode/provider/minimax.py
+++ b/src/voidcode/provider/minimax.py
@@ -29,6 +29,9 @@ class MiniMaxModelProvider:
     name: str = "minimax"
     config: SimplifiedProviderConfig | None = None
 
+    def provider_config(self):
+        return simplified_config_to_litellm(self.name, self.config)
+
     def turn_provider(self) -> TurnProvider:
         adapted_config = simplified_config_to_litellm(self.name, self.config)
         return LiteLLMBackendSingleAgentProvider(name=self.name, config=adapted_config)

--- a/src/voidcode/provider/openai.py
+++ b/src/voidcode/provider/openai.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from .config import LiteLLMProviderConfig, OpenAIProviderConfig
 from .litellm_backend import LiteLLMBackendSingleAgentProvider
+from .litellm_config import openai_provider_config
 from .protocol import TurnProvider
 
 
@@ -11,6 +12,9 @@ from .protocol import TurnProvider
 class OpenAIModelProvider:
     name: str = "openai"
     config: OpenAIProviderConfig | None = None
+
+    def provider_config(self) -> LiteLLMProviderConfig:
+        return openai_provider_config(self.config)
 
     def turn_provider(self) -> TurnProvider:
         adapted_config = LiteLLMProviderConfig(

--- a/src/voidcode/provider/opencode_go.py
+++ b/src/voidcode/provider/opencode_go.py
@@ -62,6 +62,9 @@ class OpenCodeGoModelProvider:
     name: str = "opencode-go"
     config: SimplifiedProviderConfig | None = None
 
+    def provider_config(self):
+        return simplified_config_to_litellm(self.name, self.config)
+
     def turn_provider(self) -> TurnProvider:
         adapted_config = simplified_config_to_litellm(self.name, self.config)
         return OpenCodeGoSingleAgentProvider(

--- a/src/voidcode/provider/qwen.py
+++ b/src/voidcode/provider/qwen.py
@@ -27,6 +27,9 @@ class QwenModelProvider:
     name: str = "qwen"
     config: SimplifiedProviderConfig | None = None
 
+    def provider_config(self):
+        return simplified_config_to_litellm(self.name, self.config)
+
     def turn_provider(self) -> TurnProvider:
         adapted_config = simplified_config_to_litellm(self.name, self.config)
         return LiteLLMBackendSingleAgentProvider(name=self.name, config=adapted_config)

--- a/src/voidcode/provider/registry.py
+++ b/src/voidcode/provider/registry.py
@@ -2,15 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import cast
 
 from .anthropic import AnthropicModelProvider
-from .config import (
-    LiteLLMProviderConfig,
-    ProviderConfigs,
-    SimplifiedProviderConfig,
-    simplified_config_to_litellm,
-)
+from .config import LiteLLMProviderConfig, ProviderConfigs
 from .copilot import CopilotModelProvider
 from .deepseek import DeepSeekModelProvider
 from .glm import GLMModelProvider
@@ -31,73 +26,6 @@ from .openai import OpenAIModelProvider
 from .opencode_go import OpenCodeGoModelProvider
 from .protocol import ModelTurnProvider, StubTurnProvider, TurnProvider
 from .qwen import QwenModelProvider
-
-_DEFAULT_DISCOVERY_BASE_URLS: dict[str, str] = {
-    "openai": "https://api.openai.com",
-    "anthropic": "https://api.anthropic.com",
-    "google": "https://generativelanguage.googleapis.com",
-    "litellm": "http://127.0.0.1:4000",
-}
-
-_DEFAULT_MODEL_MAPS: dict[str, dict[str, str]] = {
-    "openai": {
-        "gpt-5.5": "gpt-5.5",
-        "gpt-5.4": "gpt-5.4",
-        "gpt-5.4-mini": "gpt-5.4-mini",
-        "gpt-5.4-nano": "gpt-5.4-nano",
-        "gpt-5.2": "gpt-5.2",
-        "gpt-5.2-pro": "gpt-5.2-pro",
-        "gpt-5.2-codex": "gpt-5.2-codex",
-        "gpt-5.1": "gpt-5.1",
-        "gpt-5.1-codex": "gpt-5.1-codex",
-        "gpt-5.1-codex-max": "gpt-5.1-codex-max",
-        "gpt-5": "gpt-5",
-        "gpt-5-mini": "gpt-5-mini",
-        "gpt-5-nano": "gpt-5-nano",
-        "gpt-4.1": "gpt-4.1",
-        "gpt-4.1-mini": "gpt-4.1-mini",
-        "gpt-4.1-nano": "gpt-4.1-nano",
-    },
-    "anthropic": {
-        "claude-opus-4-7": "claude-opus-4-7",
-        "claude-sonnet-4-6": "claude-sonnet-4-6",
-        "claude-haiku-4-5": "claude-haiku-4-5",
-        "claude-haiku-4-5-20251001": "claude-haiku-4-5-20251001",
-    },
-    "google": {
-        "gemini-3-pro-preview": "gemini-3-pro-preview",
-        "gemini-3-flash-preview": "gemini-3-flash-preview",
-        "gemini-2.5-pro": "gemini-2.5-pro",
-        "gemini-2.5-flash": "gemini-2.5-flash",
-        "gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
-        "gemini-3.1-flash-live-preview": "gemini-3.1-flash-live-preview",
-        "gemini-3.1-flash-tts-preview": "gemini-3.1-flash-tts-preview",
-    },
-}
-
-
-def _default_discovery_base_url(
-    provider_name: str,
-    *,
-    configured_base_url: str | None,
-    configured_discovery_base_url: str | None,
-) -> str | None:
-    if configured_discovery_base_url is not None:
-        return configured_discovery_base_url
-    if configured_base_url is not None:
-        return None
-    return _DEFAULT_DISCOVERY_BASE_URLS.get(provider_name)
-
-
-_SIMPLIFIED_PROVIDER_MAP: dict[str, type] = {
-    "deepseek": DeepSeekModelProvider,
-    "glm": GLMModelProvider,
-    "grok": GrokModelProvider,
-    "minimax": MiniMaxModelProvider,
-    "kimi": KimiModelProvider,
-    "opencode-go": OpenCodeGoModelProvider,
-    "qwen": QwenModelProvider,
-}
 
 
 @dataclass(frozen=True, slots=True)
@@ -178,132 +106,11 @@ class ModelProviderRegistry:
         return self.resolve_with_metadata(provider_name).provider
 
     def provider_config(self, provider_name: str) -> LiteLLMProviderConfig | None:
-        if provider_name == "openai":
-            provider = self.providers.get("openai")
-            if isinstance(provider, OpenAIModelProvider):
-                return LiteLLMProviderConfig(
-                    api_key=None if provider.config is None else provider.config.api_key,
-                    base_url=None if provider.config is None else provider.config.base_url,
-                    discovery_base_url=(
-                        _default_discovery_base_url(
-                            "openai",
-                            configured_base_url=(
-                                None if provider.config is None else provider.config.base_url
-                            ),
-                            configured_discovery_base_url=(
-                                None
-                                if provider.config is None
-                                else provider.config.discovery_base_url
-                            ),
-                        )
-                    ),
-                    timeout_seconds=None
-                    if provider.config is None
-                    else provider.config.timeout_seconds,
-                    model_map=dict(_DEFAULT_MODEL_MAPS["openai"]),
-                )
-        if provider_name == "anthropic":
-            provider = self.providers.get("anthropic")
-            if isinstance(provider, AnthropicModelProvider):
-                return LiteLLMProviderConfig(
-                    api_key=None if provider.config is None else provider.config.api_key,
-                    base_url=None if provider.config is None else provider.config.base_url,
-                    discovery_base_url=(
-                        _default_discovery_base_url(
-                            "anthropic",
-                            configured_base_url=(
-                                None if provider.config is None else provider.config.base_url
-                            ),
-                            configured_discovery_base_url=(
-                                None
-                                if provider.config is None
-                                else provider.config.discovery_base_url
-                            ),
-                        )
-                    ),
-                    timeout_seconds=None
-                    if provider.config is None
-                    else provider.config.timeout_seconds,
-                    model_map=dict(_DEFAULT_MODEL_MAPS["anthropic"]),
-                )
-        if provider_name == "google":
-            provider = self.providers.get("google")
-            if isinstance(provider, GoogleModelProvider):
-                api_key = None
-                auth_header = None
-                auth_scheme = "bearer"
-                if provider.config is not None and provider.config.auth is not None:
-                    if provider.config.auth.method == "api_key":
-                        api_key = provider.config.auth.api_key
-                        auth_header = "x-goog-api-key"
-                        auth_scheme = "token"
-                    elif provider.config.auth.method == "oauth":
-                        api_key = provider.config.auth.access_token
-                return LiteLLMProviderConfig(
-                    api_key=api_key,
-                    base_url=None if provider.config is None else provider.config.base_url,
-                    discovery_base_url=(
-                        _default_discovery_base_url(
-                            "google",
-                            configured_base_url=(
-                                None if provider.config is None else provider.config.base_url
-                            ),
-                            configured_discovery_base_url=(
-                                None
-                                if provider.config is None
-                                else provider.config.discovery_base_url
-                            ),
-                        )
-                    ),
-                    auth_header=auth_header,
-                    auth_scheme=auth_scheme,
-                    timeout_seconds=None
-                    if provider.config is None
-                    else provider.config.timeout_seconds,
-                    model_map=dict(_DEFAULT_MODEL_MAPS["google"]),
-                )
-        if provider_name == "copilot":
-            provider = self.providers.get("copilot")
-            if isinstance(provider, CopilotModelProvider):
-                token = None
-                if provider.config is not None and provider.config.auth is not None:
-                    token = provider.config.auth.token
-                return LiteLLMProviderConfig(
-                    api_key=token,
-                    base_url=None if provider.config is None else provider.config.base_url,
-                    timeout_seconds=None
-                    if provider.config is None
-                    else provider.config.timeout_seconds,
-                )
-        if provider_name == "litellm":
-            provider = self.providers.get("litellm")
-            if isinstance(provider, LiteLLMModelProvider):
-                if provider.config is None:
-                    return LiteLLMProviderConfig(
-                        discovery_base_url=_DEFAULT_DISCOVERY_BASE_URLS["litellm"]
-                    )
-                return LiteLLMProviderConfig(
-                    api_key=provider.config.api_key,
-                    api_key_env_var=provider.config.api_key_env_var,
-                    base_url=provider.config.base_url,
-                    discovery_base_url=_default_discovery_base_url(
-                        "litellm",
-                        configured_base_url=provider.config.base_url,
-                        configured_discovery_base_url=provider.config.discovery_base_url,
-                    ),
-                    auth_header=provider.config.auth_header,
-                    auth_scheme=provider.config.auth_scheme,
-                    ssl_verify=provider.config.ssl_verify,
-                    timeout_seconds=provider.config.timeout_seconds,
-                    model_map=dict(provider.config.model_map),
-                )
-        provider_cls = _SIMPLIFIED_PROVIDER_MAP.get(provider_name)
-        if provider_cls is not None:
-            provider = self.providers.get(provider_name)
-            if isinstance(provider, provider_cls):
-                return simplified_config_to_litellm(
-                    provider_name, cast(SimplifiedProviderConfig | None, cast(Any, provider).config)
-                )
+        provider = self.providers.get(provider_name)
+        if provider is not None:
+            provider_config = getattr(provider, "provider_config", None)
+            if callable(provider_config):
+                return cast(LiteLLMProviderConfig | None, provider_config())
         if (
             self.custom_provider_configs is not None
             and provider_name in self.custom_provider_configs

--- a/tests/unit/provider/test_registry.py
+++ b/tests/unit/provider/test_registry.py
@@ -337,6 +337,23 @@ def test_registry_registers_deepseek_provider() -> None:
     assert "deepseek-v4-pro" in config.model_map.values()
 
 
+def test_registry_deepseek_custom_base_url_uses_configured_base_url_discovery() -> None:
+    registry = ModelProviderRegistry.with_defaults(
+        provider_configs=ProviderConfigs(
+            deepseek=SimplifiedProviderConfig(
+                api_key="deepseek-key",
+                base_url="https://deepseek-proxy.example.test/v1",
+            )
+        )
+    )
+
+    config = registry.provider_config("deepseek")
+
+    assert config is not None
+    assert config.base_url == "https://deepseek-proxy.example.test/v1"
+    assert config.discovery_base_url is None
+
+
 def test_registry_registers_grok_provider() -> None:
     registry = ModelProviderRegistry.with_defaults(
         provider_configs=ProviderConfigs(grok=SimplifiedProviderConfig(api_key="grok-key"))
@@ -413,6 +430,23 @@ def test_registry_registers_opencode_go_provider() -> None:
     assert "qwen-flash" not in config.model_map
     assert "qwen3.5-flash" in config.model_map
     assert "qwen3.6-plus" in config.model_map
+
+
+def test_registry_opencode_go_custom_base_url_keeps_discovery_disabled() -> None:
+    registry = ModelProviderRegistry.with_defaults(
+        provider_configs=ProviderConfigs(
+            opencode_go=SimplifiedProviderConfig(
+                api_key="opencode-go-key",
+                base_url="https://opencode-go-proxy.example.test/zen/go",
+            )
+        )
+    )
+
+    config = registry.provider_config("opencode-go")
+
+    assert config is not None
+    assert config.base_url == "https://opencode-go-proxy.example.test/zen/go"
+    assert config.discovery_base_url == ""
 
 
 def test_registry_registers_qwen_provider() -> None:


### PR DESCRIPTION
## Summary
- move provider config projection out of `ModelProviderRegistry` and into provider adapters plus a shared LiteLLM projection helper
- keep `opencode-go` on the fallback-only discovery path while making `deepseek` follow a configured base URL when discovery is not explicitly overridden
- add regression coverage for `deepseek` and `opencode-go` discovery projection behavior

## Verification
- `uv run ruff check src/voidcode/provider/config.py tests/unit/provider/test_registry.py`
- `uv run pytest tests/unit/provider/test_registry.py tests/unit/provider/test_provider_config_parser.py tests/unit/provider/test_model_catalog.py tests/unit/runtime/test_runtime_config.py tests/unit/runtime/test_provider_readiness.py -q`
- manual QA: `uv run voidcode provider models opencode-go --workspace .`
- manual QA: `uv run voidcode provider models deepseek --workspace .`
- manual QA: `uv run voidcode provider models --help`