### PR TITLE
fix(tools): improve edit mismatch diagnostics

### DIFF
--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -24,6 +24,7 @@ from ..provider.protocol import (
     ProviderAssembledContext,
     ProviderContextSegmentLike,
 )
+from ..tools._repair import ToolDiagnosticError
 from ..tools.contracts import (
     RuntimeTimeoutAwareTool,
     RuntimeToolTimeoutError,
@@ -148,6 +149,47 @@ def _tool_error_payload(
     if retry_guidance is not None:
         payload["retry_guidance"] = retry_guidance
     return payload
+
+
+def _tool_diagnostic_payload(
+    *,
+    tool_name: str,
+    error: ToolDiagnosticError,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "error_kind": error.error_kind,
+        "error_summary": _tool_error_summary(str(error)),
+        "error_details": _tool_error_details(
+            tool_name=tool_name,
+            error=str(error),
+            error_kind=error.error_kind,
+            extra=error.error_details,
+        ),
+    }
+    if error.retry_guidance is not None:
+        payload["retry_guidance"] = error.retry_guidance
+    return payload
+
+
+def _user_interrupted_payload(*, run_id: str | None, reason: str | None) -> dict[str, object]:
+    return {
+        "kind": "interrupted",
+        "cancelled": True,
+        "run_id": run_id,
+        "reason": reason,
+        "retry_guidance": (
+            "User interrupted the run. Stop autonomous continuation, preserve current state, "
+            "and wait for the user's next instruction before retrying."
+        ),
+        "diagnostics": [
+            {
+                "source": "runtime",
+                "severity": "info",
+                "reason": "user_interrupted",
+                "message": "The current run was interrupted by the user.",
+            }
+        ],
+    }
 
 
 def _metadata_without_provider_attempt(metadata: Mapping[str, object]) -> dict[str, object]:
@@ -301,12 +343,10 @@ class RuntimeRunLoopCoordinator:
             session=session,
             sequence=sequence + 2,
             error="run interrupted",
-            payload={
-                "kind": "interrupted",
-                "cancelled": True,
-                "run_id": runtime._run_id_from_session_metadata(session.metadata),
-                "reason": _abort_signal_reason(abort_signal),
-            },
+            payload=_user_interrupted_payload(
+                run_id=runtime._run_id_from_session_metadata(session.metadata),
+                reason=_abort_signal_reason(abort_signal),
+            ),
         )
         return completed_chunk, failed_chunk
 
@@ -708,6 +748,20 @@ class RuntimeRunLoopCoordinator:
                 )
                 yield runtime._failed_chunk(session=session, sequence=sequence + 1, error=str(exc))
                 raise
+            error_summary = _tool_error_summary(str(exc))
+            error_details = _tool_error_details(tool_name=tool_call.tool_name, error=str(exc))
+            retry_guidance = _tool_error_retry_guidance(str(exc))
+            error_kind: str | None = None
+            if isinstance(exc, ToolDiagnosticError):
+                error_kind = exc.error_kind
+                error_details = _tool_error_details(
+                    tool_name=tool_call.tool_name,
+                    error=str(exc),
+                    error_kind=exc.error_kind,
+                    extra=exc.error_details,
+                )
+                retry_guidance = exc.retry_guidance
+
             tool_result = ToolResult(
                 tool_name=tool_call.tool_name,
                 status="error",
@@ -717,9 +771,10 @@ class RuntimeRunLoopCoordinator:
                     "tool_call_id": tool_call_id,
                     "arguments": dict(tool_call.arguments),
                 },
-                error_summary=_tool_error_summary(str(exc)),
-                error_details=_tool_error_details(tool_name=tool_call.tool_name, error=str(exc)),
-                retry_guidance=_tool_error_retry_guidance(str(exc)),
+                error_kind=error_kind,
+                error_summary=error_summary,
+                error_details=error_details,
+                retry_guidance=retry_guidance,
             )
 
         sanitized_arguments = sanitize_tool_arguments(dict(tool_call.arguments))
@@ -791,12 +846,10 @@ class RuntimeRunLoopCoordinator:
                 session=session,
                 sequence=sequence + 1,
                 error="run interrupted",
-                payload={
-                    "kind": "interrupted",
-                    "cancelled": True,
-                    "run_id": runtime._run_id_from_session_metadata(session.metadata),
-                    "reason": _abort_signal_reason(abort_signal),
-                },
+                payload=_user_interrupted_payload(
+                    run_id=runtime._run_id_from_session_metadata(session.metadata),
+                    reason=_abort_signal_reason(abort_signal),
+                ),
             )
             return
 
@@ -1120,12 +1173,10 @@ class RuntimeRunLoopCoordinator:
                         session=session,
                         sequence=sequence + 1,
                         error="run interrupted",
-                        payload={
-                            "kind": "interrupted",
-                            "cancelled": True,
-                            "run_id": runtime._run_id_from_session_metadata(session.metadata),
-                            "reason": _abort_reason(active_graph_request),
-                        },
+                        payload=_user_interrupted_payload(
+                            run_id=runtime._run_id_from_session_metadata(session.metadata),
+                            reason=_abort_reason(active_graph_request),
+                        ),
                     )
                     return
                 graph_step = graph.step(
@@ -1423,12 +1474,10 @@ class RuntimeRunLoopCoordinator:
                     session=session,
                     sequence=sequence + 1,
                     error="run interrupted",
-                    payload={
-                        "kind": "interrupted",
-                        "cancelled": True,
-                        "run_id": runtime._run_id_from_session_metadata(session.metadata),
-                        "reason": _abort_reason(active_graph_request),
-                    },
+                    payload=_user_interrupted_payload(
+                        run_id=runtime._run_id_from_session_metadata(session.metadata),
+                        reason=_abort_reason(active_graph_request),
+                    ),
                 )
                 return
             session = runtime._session_with_provider_usage_metadata(
@@ -1939,6 +1988,23 @@ class RuntimeRunLoopCoordinator:
                         session=session, sequence=sequence + 1, error=str(exc)
                     )
                     raise
+                error_summary = _tool_error_summary(str(exc))
+                error_details = _tool_error_details(
+                    tool_name=plan_tool_call.tool_name,
+                    error=str(exc),
+                )
+                retry_guidance = _tool_error_retry_guidance(str(exc))
+                error_kind: str | None = None
+                if isinstance(exc, ToolDiagnosticError):
+                    error_kind = exc.error_kind
+                    error_details = _tool_error_details(
+                        tool_name=plan_tool_call.tool_name,
+                        error=str(exc),
+                        error_kind=exc.error_kind,
+                        extra=exc.error_details,
+                    )
+                    retry_guidance = exc.retry_guidance
+
                 tool_result = ToolResult(
                     tool_name=plan_tool_call.tool_name,
                     status="error",
@@ -1948,12 +2014,10 @@ class RuntimeRunLoopCoordinator:
                         "tool_call_id": tool_call_id,
                         "arguments": dict(plan_tool_call.arguments),
                     },
-                    error_summary=_tool_error_summary(str(exc)),
-                    error_details=_tool_error_details(
-                        tool_name=plan_tool_call.tool_name,
-                        error=str(exc),
-                    ),
-                    retry_guidance=_tool_error_retry_guidance(str(exc)),
+                    error_kind=error_kind,
+                    error_summary=error_summary,
+                    error_details=error_details,
+                    retry_guidance=retry_guidance,
                 )
 
             runtime_tool_result_data = dict(tool_result.data)
@@ -2127,12 +2191,10 @@ class RuntimeRunLoopCoordinator:
                     session=session,
                     sequence=sequence + 1,
                     error="run interrupted",
-                    payload={
-                        "kind": "interrupted",
-                        "cancelled": True,
-                        "run_id": runtime._run_id_from_session_metadata(session.metadata),
-                        "reason": _abort_reason(active_graph_request),
-                    },
+                    payload=_user_interrupted_payload(
+                        run_id=runtime._run_id_from_session_metadata(session.metadata),
+                        reason=_abort_reason(active_graph_request),
+                    ),
                 )
                 return
 

--- a/src/voidcode/tools/_repair.py
+++ b/src/voidcode/tools/_repair.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import difflib
+import re
+from typing import NoReturn
+
+
+class ToolDiagnosticError(ValueError):
+    def __init__(
+        self,
+        *,
+        message: str,
+        error_kind: str,
+        error_details: dict[str, object] | None = None,
+        retry_guidance: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.error_kind = error_kind
+        self.error_details = dict(error_details or {})
+        self.retry_guidance = retry_guidance
+
+
+def raise_tool_diagnostic(
+    *,
+    message: str,
+    error_kind: str,
+    reason: str,
+    retry_guidance: str | None = None,
+    details: dict[str, object] | None = None,
+) -> NoReturn:
+    payload: dict[str, object] = {"reason": reason}
+    if details:
+        payload.update(details)
+    raise ToolDiagnosticError(
+        message=message,
+        error_kind=error_kind,
+        error_details=payload,
+        retry_guidance=retry_guidance,
+    )
+
+
+def preview_line(text: str, *, max_length: int = 96) -> str:
+    line = text.replace("\t", "\\t")
+    if len(line) <= max_length:
+        return line
+    return f"{line[: max_length - 3]}..."
+
+
+def bounded_block_preview(lines: list[str], start: int, length: int) -> str:
+    context_before = 1
+    context_after = 1
+    first = max(0, start - context_before)
+    last = min(len(lines), start + length + context_after)
+    preview_lines: list[str] = []
+    for index in range(first, last):
+        marker = ">" if start <= index < start + length else " "
+        preview_lines.append(f"    {marker} L{index + 1}: {preview_line(lines[index])}")
+    return "\n".join(preview_lines)
+
+
+def bounded_candidate_diff(expected: str, candidate: str, *, max_lines: int = 14) -> str:
+    diff_lines = list(
+        difflib.unified_diff(
+            expected.splitlines(),
+            candidate.splitlines(),
+            fromfile="expected",
+            tofile="current",
+            lineterm="",
+            n=1,
+        )
+    )
+    if not diff_lines:
+        return ""
+
+    if len(diff_lines) > max_lines:
+        diff_lines = [*diff_lines[: max_lines - 1], "... diff truncated ..."]
+
+    return "\n".join(f"    {line}" for line in diff_lines)
+
+
+def looks_line_number_prefixed(text: str) -> bool:
+    non_empty_lines = [line for line in text.split("\n") if line.strip()]
+    if not non_empty_lines:
+        return False
+
+    prefixed_count = sum(1 for line in non_empty_lines if re.match(r"^\s*\d+\s*[:|]\s?", line))
+    return prefixed_count >= max(1, len(non_empty_lines) // 2)
+
+
+def line_prefix_retry_guidance(*, argument_name: str = "oldString") -> str:
+    return (
+        f"{argument_name} appears to include read output line prefixes like '42: '; "
+        "remove those prefixes and retry with only file text."
+    )
+
+
+def near_text_matches(
+    content: str,
+    expected: str,
+    *,
+    limit: int = 2,
+    min_ratio: float = 0.58,
+) -> list[tuple[float, int, str]]:
+    expected_lines = expected.split("\n")
+    if expected_lines and expected_lines[-1] == "":
+        expected_lines = expected_lines[:-1]
+    if not expected_lines:
+        return []
+
+    lines = content.split("\n")
+    window_size = min(len(expected_lines), len(lines))
+    if window_size == 0:
+        return []
+
+    candidates: list[tuple[float, int, str]] = []
+    for start in range(len(lines) - window_size + 1):
+        block = "\n".join(lines[start : start + window_size])
+        ratio = difflib.SequenceMatcher(None, expected.strip(), block.strip()).ratio()
+        if ratio >= min_ratio:
+            candidates.append((ratio, start, block))
+
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    return candidates[:limit]
+
+
+def format_text_repair_hints(
+    *,
+    content: str,
+    expected: str,
+    label: str = "Near-match hints",
+    note_for_match: str = "near text match",
+) -> list[str]:
+    lines = content.split("\n")
+    expected_lines = expected.split("\n")
+    if expected_lines and expected_lines[-1] == "":
+        expected_lines = expected_lines[:-1]
+    window_size = min(len(expected_lines), len(lines))
+    if window_size == 0:
+        return []
+
+    hints = []
+    for ratio, start, block in near_text_matches(content, expected):
+        hints.append(
+            f"  - L{start + 1} ({round(ratio * 100)}% similar; {note_for_match})\n"
+            f"{bounded_block_preview(lines, start, window_size)}\n"
+            "    Diff (- expected, + current):\n"
+            f"{bounded_candidate_diff(expected, block)}"
+        )
+
+    if not hints:
+        return []
+    return [f"{label}:", *hints]

--- a/src/voidcode/tools/apply_patch.py
+++ b/src/voidcode/tools/apply_patch.py
@@ -14,6 +14,7 @@ from unidiff.errors import UnidiffParseError
 from ..hook.config import RuntimeHooksConfig
 from ..security.path_policy import resolve_workspace_path
 from ._formatter import FormatterExecutor, formatter_diagnostics, formatter_payload
+from ._repair import format_text_repair_hints, raise_tool_diagnostic
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 
@@ -282,7 +283,31 @@ def _derive_marker_update_content_from_text(
             found = _seek_sequence(original_lines, pattern, line_index, eof=chunk.is_end_of_file)
         if found == -1:
             expected = "\n".join(chunk.old_lines)
-            raise ValueError(f"Failed to find expected lines in {file_path}:\n{expected}")
+            lines = [
+                f"Failed to find expected lines in {file_path}:",
+                expected,
+                "Retry guidance: re-read this file and rebuild the patch hunk from current text.",
+            ]
+            hints = format_text_repair_hints(
+                content="\n".join(original_lines),
+                expected=expected,
+                label="Nearest current file context",
+            )
+            if hints:
+                lines.extend(hints)
+            raise_tool_diagnostic(
+                message="\n".join(lines),
+                error_kind="tool_input_mismatch",
+                reason="expected_lines_not_found",
+                retry_guidance=(
+                    "Re-read the target file and rebuild this patch hunk from current content."
+                ),
+                details={
+                    "path": str(file_path),
+                    "expected_preview": expected[:500],
+                    "has_candidate_matches": bool(hints),
+                },
+            )
         replacements.append((found, len(pattern), new_slice))
         line_index = found + len(pattern)
 

--- a/src/voidcode/tools/edit.py
+++ b/src/voidcode/tools/edit.py
@@ -34,6 +34,106 @@ def _convert_line_endings(text: str, ending: str) -> str:
     return text.replace("\n", "\r\n")
 
 
+def _preview_line(text: str, *, max_length: int = 96) -> str:
+    line = text.replace("\t", "\\t")
+    if len(line) <= max_length:
+        return line
+    return f"{line[: max_length - 3]}..."
+
+
+def _bounded_block_preview(lines: list[str], start: int, length: int) -> str:
+    context_before = 1
+    context_after = 1
+    first = max(0, start - context_before)
+    last = min(len(lines), start + length + context_after)
+    preview_lines: list[str] = []
+    for index in range(first, last):
+        marker = ">" if start <= index < start + length else " "
+        preview_lines.append(f"    {marker} L{index + 1}: {_preview_line(lines[index])}")
+    return "\n".join(preview_lines)
+
+
+def _near_match_hints(content: str, old_string: str, *, limit: int = 2) -> list[str]:
+    old_lines = old_string.split("\n")
+    if old_lines and old_lines[-1] == "":
+        old_lines = old_lines[:-1]
+    if not old_lines:
+        return []
+
+    lines = content.split("\n")
+    window_size = min(len(old_lines), len(lines))
+    if window_size == 0:
+        return []
+
+    candidates: list[tuple[float, int, str]] = []
+    normalized_old = WhitespaceNormalizedReplacer.normalize(old_string)
+    dedented_old = IndentationFlexibleReplacer.remove_indentation(old_string)
+
+    for start in range(len(lines) - window_size + 1):
+        block = "\n".join(lines[start : start + window_size])
+        ratio = difflib.SequenceMatcher(None, old_string.strip(), block.strip()).ratio()
+        if ratio < 0.58:
+            continue
+
+        notes: list[str] = []
+        if WhitespaceNormalizedReplacer.normalize(block) == normalized_old:
+            notes.append("whitespace-only mismatch")
+        if IndentationFlexibleReplacer.remove_indentation(block) == dedented_old:
+            notes.append("indentation-only mismatch")
+        if len(old_lines) >= 3:
+            first_close = BlockAnchorReplacer._similar(lines[start].strip(), old_lines[0].strip())
+            last_close = BlockAnchorReplacer._similar(
+                lines[start + window_size - 1].strip(), old_lines[-1].strip()
+            )
+            if first_close and last_close:
+                notes.append("block anchors are close")
+            elif first_close:
+                notes.append("first block anchor is close; check the ending line")
+            elif last_close:
+                notes.append("last block anchor is close; check the starting line")
+        if not notes:
+            notes.append("near text match")
+
+        candidates.append((ratio, start, ", ".join(notes)))
+
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    hints: list[str] = []
+    for ratio, start, note in candidates[:limit]:
+        hints.append(
+            f"  - L{start + 1} ({round(ratio * 100)}% similar; {note})\n"
+            f"{_bounded_block_preview(lines, start, window_size)}"
+        )
+    return hints
+
+
+def _edit_mismatch_message(
+    *,
+    content: str,
+    old_string: str,
+    attempted_replacers: list[str],
+) -> str:
+    lines = [
+        "Could not find oldString in the file.",
+        "Replacers attempted:",
+        *(f"  - {name}" for name in attempted_replacers),
+    ]
+
+    hints = _near_match_hints(content, old_string)
+    if hints:
+        lines.extend(
+            [
+                "Near-match hints:",
+                *hints,
+                "Tip: re-read the shown lines and retry with exact current text, "
+                "including indentation.",
+            ]
+        )
+    else:
+        lines.append("No nearby text match found; re-read the file before retrying the edit.")
+
+    return "\n".join(lines)
+
+
 def _trim_diff(diff: str) -> str:
     lines = diff.split("\n")
     content_lines = [
@@ -308,12 +408,13 @@ def _replace(
     current = content
 
     # Try each replacer in order until we find at least one match
+    attempted_replacers: list[str] = []
     for replacer in replacers:
-        matches = []
+        attempted_replacers.append(replacer.__name__)
         try:
             matches = replacer.find(current, old_string)
         except Exception:
-            matches = []
+            continue
         if not matches:
             continue
 
@@ -342,7 +443,13 @@ def _replace(
             return current, total_replacements
 
     # If we reach here, no replacer found any match
-    raise ValueError("Could not find oldString in the file using replacers.")
+    raise ValueError(
+        _edit_mismatch_message(
+            content=current,
+            old_string=old_string,
+            attempted_replacers=attempted_replacers,
+        )
+    )
 
 
 class EscapeNormalizedReplacer:

--- a/src/voidcode/tools/edit.py
+++ b/src/voidcode/tools/edit.py
@@ -15,6 +15,13 @@ from ._formatter import (
     formatter_diagnostics,
     formatter_payload,
 )
+from ._repair import (
+    bounded_block_preview,
+    bounded_candidate_diff,
+    line_prefix_retry_guidance,
+    looks_line_number_prefixed,
+    raise_tool_diagnostic,
+)
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 
@@ -32,54 +39,6 @@ def _convert_line_endings(text: str, ending: str) -> str:
     if ending == "\n":
         return _normalize_line_endings(text)
     return text.replace("\n", "\r\n")
-
-
-def _preview_line(text: str, *, max_length: int = 96) -> str:
-    line = text.replace("\t", "\\t")
-    if len(line) <= max_length:
-        return line
-    return f"{line[: max_length - 3]}..."
-
-
-def _bounded_block_preview(lines: list[str], start: int, length: int) -> str:
-    context_before = 1
-    context_after = 1
-    first = max(0, start - context_before)
-    last = min(len(lines), start + length + context_after)
-    preview_lines: list[str] = []
-    for index in range(first, last):
-        marker = ">" if start <= index < start + length else " "
-        preview_lines.append(f"    {marker} L{index + 1}: {_preview_line(lines[index])}")
-    return "\n".join(preview_lines)
-
-
-def _bounded_candidate_diff(old_string: str, candidate: str, *, max_lines: int = 14) -> str:
-    diff_lines = list(
-        difflib.unified_diff(
-            old_string.splitlines(),
-            candidate.splitlines(),
-            fromfile="oldString",
-            tofile="current",
-            lineterm="",
-            n=1,
-        )
-    )
-    if not diff_lines:
-        return ""
-
-    if len(diff_lines) > max_lines:
-        diff_lines = [*diff_lines[: max_lines - 1], "... diff truncated ..."]
-
-    return "\n".join(f"    {line}" for line in diff_lines)
-
-
-def _looks_line_number_prefixed(text: str) -> bool:
-    non_empty_lines = [line for line in text.split("\n") if line.strip()]
-    if not non_empty_lines:
-        return False
-
-    prefixed_count = sum(1 for line in non_empty_lines if re.match(r"^\s*\d+\s*[:|]\s?", line))
-    return prefixed_count >= max(1, len(non_empty_lines) // 2)
 
 
 def _near_match_hints(content: str, old_string: str, *, limit: int = 2) -> list[str]:
@@ -130,9 +89,9 @@ def _near_match_hints(content: str, old_string: str, *, limit: int = 2) -> list[
     for ratio, start, note, block in candidates[:limit]:
         hints.append(
             f"  - L{start + 1} ({round(ratio * 100)}% similar; {note})\n"
-            f"{_bounded_block_preview(lines, start, window_size)}\n"
+            f"{bounded_block_preview(lines, start, window_size)}\n"
             "    Diff (- oldString, + current):\n"
-            f"{_bounded_candidate_diff(old_string, block)}"
+            f"{bounded_candidate_diff(old_string, block).replace('expected', 'oldString')}"
         )
     return hints
 
@@ -162,11 +121,8 @@ def _edit_mismatch_message(
     else:
         lines.append("No nearby text match found; re-read the file before retrying the edit.")
 
-    if _looks_line_number_prefixed(old_string):
-        lines.append(
-            "oldString appears to include read output line prefixes like '42: '; "
-            "remove those prefixes and retry with only file text."
-        )
+    if looks_line_number_prefixed(old_string):
+        lines.append(line_prefix_retry_guidance())
 
     return "\n".join(lines)
 
@@ -377,6 +333,9 @@ class IndentationFlexibleReplacer:
             if match and match.group(1):
                 min_indent = min(min_indent, len(match.group(1)))
 
+        if min_indent == float("inf"):
+            return text
+
         dedented = [line[min_indent:] if len(line) >= min_indent else line for line in lines]
         return "\n".join(dedented)
 
@@ -480,12 +439,21 @@ def _replace(
             return current, total_replacements
 
     # If we reach here, no replacer found any match
-    raise ValueError(
-        _edit_mismatch_message(
-            content=current,
-            old_string=old_string,
-            attempted_replacers=attempted_replacers,
-        )
+    raise_tool_diagnostic(
+        message=_edit_mismatch_message(
+            content=current, old_string=old_string, attempted_replacers=attempted_replacers
+        ),
+        error_kind="tool_input_mismatch",
+        reason="old_string_not_found",
+        retry_guidance=(
+            "Use read_file on the target path, copy exact current file text without line-number "
+            "prefixes, then retry edit with that exact oldString."
+        ),
+        details={
+            "attempted_replacers": attempted_replacers,
+            "old_string_line_count": len(old_string.splitlines()),
+            "line_number_prefix_suspected": looks_line_number_prefixed(old_string),
+        },
     )
 
 

--- a/src/voidcode/tools/edit.py
+++ b/src/voidcode/tools/edit.py
@@ -53,6 +53,35 @@ def _bounded_block_preview(lines: list[str], start: int, length: int) -> str:
     return "\n".join(preview_lines)
 
 
+def _bounded_candidate_diff(old_string: str, candidate: str, *, max_lines: int = 14) -> str:
+    diff_lines = list(
+        difflib.unified_diff(
+            old_string.splitlines(),
+            candidate.splitlines(),
+            fromfile="oldString",
+            tofile="current",
+            lineterm="",
+            n=1,
+        )
+    )
+    if not diff_lines:
+        return ""
+
+    if len(diff_lines) > max_lines:
+        diff_lines = [*diff_lines[: max_lines - 1], "... diff truncated ..."]
+
+    return "\n".join(f"    {line}" for line in diff_lines)
+
+
+def _looks_line_number_prefixed(text: str) -> bool:
+    non_empty_lines = [line for line in text.split("\n") if line.strip()]
+    if not non_empty_lines:
+        return False
+
+    prefixed_count = sum(1 for line in non_empty_lines if re.match(r"^\s*\d+\s*[:|]\s?", line))
+    return prefixed_count >= max(1, len(non_empty_lines) // 2)
+
+
 def _near_match_hints(content: str, old_string: str, *, limit: int = 2) -> list[str]:
     old_lines = old_string.split("\n")
     if old_lines and old_lines[-1] == "":
@@ -65,7 +94,7 @@ def _near_match_hints(content: str, old_string: str, *, limit: int = 2) -> list[
     if window_size == 0:
         return []
 
-    candidates: list[tuple[float, int, str]] = []
+    candidates: list[tuple[float, int, str, str]] = []
     normalized_old = WhitespaceNormalizedReplacer.normalize(old_string)
     dedented_old = IndentationFlexibleReplacer.remove_indentation(old_string)
 
@@ -94,14 +123,16 @@ def _near_match_hints(content: str, old_string: str, *, limit: int = 2) -> list[
         if not notes:
             notes.append("near text match")
 
-        candidates.append((ratio, start, ", ".join(notes)))
+        candidates.append((ratio, start, ", ".join(notes), block))
 
     candidates.sort(key=lambda item: item[0], reverse=True)
     hints: list[str] = []
-    for ratio, start, note in candidates[:limit]:
+    for ratio, start, note, block in candidates[:limit]:
         hints.append(
             f"  - L{start + 1} ({round(ratio * 100)}% similar; {note})\n"
-            f"{_bounded_block_preview(lines, start, window_size)}"
+            f"{_bounded_block_preview(lines, start, window_size)}\n"
+            "    Diff (- oldString, + current):\n"
+            f"{_bounded_candidate_diff(old_string, block)}"
         )
     return hints
 
@@ -130,6 +161,12 @@ def _edit_mismatch_message(
         )
     else:
         lines.append("No nearby text match found; re-read the file before retrying the edit.")
+
+    if _looks_line_number_prefixed(old_string):
+        lines.append(
+            "oldString appears to include read output line prefixes like '42: '; "
+            "remove those prefixes and retry with only file text."
+        )
 
     return "\n".join(lines)
 

--- a/src/voidcode/tools/grep.py
+++ b/src/voidcode/tools/grep.py
@@ -249,31 +249,34 @@ class GrepTool:
                 }
             )
 
+        data: dict[str, object] = {
+            "path": path_display,
+            "pattern": args.pattern,
+            "regex": args.regex,
+            "context": args.context,
+            "match_count": total_occurrences,
+            "truncated": truncated,
+            "partial": truncated,
+            "matches": [
+                {
+                    "file": match.file,
+                    "line": match.line,
+                    "text": match.text,
+                    "columns": match.columns,
+                    "before": match.before,
+                    "after": match.after,
+                }
+                for match in matches
+            ],
+        }
+        if diagnostics:
+            data["diagnostics"] = diagnostics
+
         return ToolResult(
             tool_name=self.definition.name,
             status="ok",
             content=summary,
-            data={
-                "path": path_display,
-                "pattern": args.pattern,
-                "regex": args.regex,
-                "context": args.context,
-                "match_count": total_occurrences,
-                "truncated": truncated,
-                "partial": truncated,
-                "matches": [
-                    {
-                        "file": match.file,
-                        "line": match.line,
-                        "text": match.text,
-                        "columns": match.columns,
-                        "before": match.before,
-                        "after": match.after,
-                    }
-                    for match in matches
-                ],
-                "diagnostics": diagnostics,
-            },
+            data=data,
             truncated=truncated,
             partial=truncated,
         )

--- a/src/voidcode/tools/grep.py
+++ b/src/voidcode/tools/grep.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 
 from ..security.path_policy import resolve_workspace_path as resolve_workspace_path_policy
 from ._pydantic_args import GrepArgs, format_validation_error
+from ._repair import raise_tool_diagnostic
 from .contracts import ToolCall, ToolDefinition, ToolResult
 
 MAX_MATCHES = 200
@@ -151,11 +152,19 @@ class GrepTool:
         try:
             pattern = re.compile(args.pattern if args.regex else re.escape(args.pattern))
         except re.error as exc:
-            raise ValueError(
-                "grep Validation error: pattern: invalid regex pattern "
-                f"({exc.msg}) (received str). "
-                "Please retry with corrected arguments that satisfy the tool schema."
-            ) from exc
+            raise_tool_diagnostic(
+                message=(
+                    "grep Validation error: pattern: invalid regex pattern "
+                    f"({exc.msg}) (received str). "
+                    "Please retry with corrected arguments that satisfy the tool schema."
+                ),
+                error_kind="tool_input_validation",
+                reason="invalid_regex",
+                retry_guidance=(
+                    "Retry with a valid regex pattern, or set regex=false for a literal search."
+                ),
+                details={"pattern": args.pattern, "regex_error": exc.msg},
+            )
         targets = self._collect_targets(
             candidate,
             project_root=effective_root,
@@ -206,6 +215,39 @@ class GrepTool:
         summary = f"Found {total_occurrences} match(es) for {args.pattern!r} in {path_display}"
         if preview_lines:
             summary = summary + "\n" + "\n".join(preview_lines)
+        truncated = len(matches) >= MAX_MATCHES
+        if truncated:
+            summary += (
+                "\n[TRUNCATED] Results truncated at "
+                f"{MAX_MATCHES} matching lines. Refine the path, include/exclude filters, "
+                "or pattern before relying on this as complete."
+            )
+        diagnostics: list[dict[str, object]] = []
+        if total_occurrences == 0:
+            diagnostics.append(
+                {
+                    "source": self.definition.name,
+                    "severity": "info",
+                    "reason": "no_matches",
+                    "message": (
+                        "No matches found. Broaden the path/include filter, verify the search "
+                        "text with read_file, or retry with regex=false for literal text."
+                    ),
+                }
+            )
+        if truncated:
+            diagnostics.append(
+                {
+                    "source": self.definition.name,
+                    "severity": "warning",
+                    "reason": "results_truncated",
+                    "message": f"grep stopped after {MAX_MATCHES} matching lines.",
+                    "retry_guidance": (
+                        "Refine path/include/exclude filters or use a more specific pattern before "
+                        "treating these results as complete."
+                    ),
+                }
+            )
 
         return ToolResult(
             tool_name=self.definition.name,
@@ -217,8 +259,8 @@ class GrepTool:
                 "regex": args.regex,
                 "context": args.context,
                 "match_count": total_occurrences,
-                "truncated": len(matches) >= MAX_MATCHES,
-                "partial": len(matches) >= MAX_MATCHES,
+                "truncated": truncated,
+                "partial": truncated,
                 "matches": [
                     {
                         "file": match.file,
@@ -230,7 +272,8 @@ class GrepTool:
                     }
                     for match in matches
                 ],
+                "diagnostics": diagnostics,
             },
-            truncated=len(matches) >= MAX_MATCHES,
-            partial=len(matches) >= MAX_MATCHES,
+            truncated=truncated,
+            partial=truncated,
         )

--- a/src/voidcode/tools/multi_edit.py
+++ b/src/voidcode/tools/multi_edit.py
@@ -14,6 +14,7 @@ from ._formatter import (
     formatter_payload,
 )
 from ._pydantic_args import MultiEditArgs
+from ._repair import ToolDiagnosticError
 from .contracts import ToolCall, ToolDefinition, ToolResult
 from .edit import (
     EditTool,
@@ -99,18 +100,51 @@ class MultiEditTool:
         applied = 0
         details: list[dict[str, object]] = []
         for idx, item in enumerate(args.edits, start=1):
-            result = self._edit_tool.invoke(
-                ToolCall(
-                    tool_name="edit",
-                    arguments={
+            try:
+                result = self._edit_tool.invoke(
+                    ToolCall(
+                        tool_name="edit",
+                        arguments={
+                            "path": relative_target,
+                            "oldString": item.oldString,
+                            "newString": item.newString,
+                            "replaceAll": item.replaceAll,
+                        },
+                    ),
+                    workspace=workspace,
+                )
+            except ValueError as exc:
+                message = (
+                    "multi_edit failed at edit "
+                    f"#{idx} of {len(args.edits)} for {relative_target}.\n"
+                    f"Applied edits before failure: {applied}.\n"
+                    "Retry guidance: re-read the file, keep the successful earlier edits in mind, "
+                    "and retry from this failing edit with current file text.\n"
+                    f"Underlying edit diagnostic:\n{exc}"
+                )
+                cause_details: dict[str, object] = {}
+                if isinstance(exc, ToolDiagnosticError):
+                    cause_details = {
+                        "error_kind": exc.error_kind,
+                        "error_details": exc.error_details,
+                        "retry_guidance": exc.retry_guidance,
+                    }
+                raise ToolDiagnosticError(
+                    message=message,
+                    error_kind="tool_input_mismatch",
+                    retry_guidance=(
+                        "Re-read the file after the successfully applied edits, then retry "
+                        "multi_edit with only the remaining corrected edits."
+                    ),
+                    error_details={
+                        "reason": "edit_failed",
                         "path": relative_target,
-                        "oldString": item.oldString,
-                        "newString": item.newString,
-                        "replaceAll": item.replaceAll,
+                        "failed_edit_index": idx,
+                        "applied_edits": applied,
+                        "remaining_edits": len(args.edits) - idx + 1,
+                        "cause": cause_details,
                     },
-                ),
-                workspace=workspace,
-            )
+                ) from exc
             applied += 1
             details.append({"index": idx, "result": result.data})
 

--- a/src/voidcode/tools/output.py
+++ b/src/voidcode/tools/output.py
@@ -170,6 +170,15 @@ def _safe_artifact_segment(value: str | None, *, fallback: str) -> str:
     return safe[:96] or fallback
 
 
+def _diagnostics_with(
+    existing_data: dict[str, object], diagnostic: dict[str, object]
+) -> list[object]:
+    current = existing_data.get("diagnostics")
+    if isinstance(current, list):
+        return [*cast(list[object], current), diagnostic]
+    return [diagnostic]
+
+
 def _user_cache_root() -> Path:
     if sys.platform == "win32":
         cache_home = os.environ.get("LOCALAPPDATA") or os.environ.get("APPDATA")
@@ -471,7 +480,8 @@ def cap_tool_result_output(
         hint = (
             "\n\n[Tool error truncated: "
             f"artifact_id={artifact['artifact_id']}. "
-            "Use artifact retrieval by artifact_id or tool_call_id to read/search the full error.]"
+            "Use background_output with full_session=true, or artifact retrieval by artifact_id "
+            "or tool_call_id, to read/search the full error.]"
         )
         return replace(
             result,
@@ -479,6 +489,24 @@ def cap_tool_result_output(
             data={
                 **result.data,
                 "truncated": True,
+                "diagnostics": _diagnostics_with(
+                    result.data,
+                    {
+                        "source": "tool_output",
+                        "severity": "warning",
+                        "reason": "tool_error_truncated",
+                        "message": "Tool error was truncated before being sent to the model.",
+                        "retry_guidance": (
+                            "Use background_output with full_session=true, or artifact retrieval "
+                            "by artifact_id/tool_call_id, to inspect the full error before "
+                            "retrying."
+                        ),
+                    },
+                ),
+                "retry_guidance": (
+                    "Use background_output with full_session=true, or artifact retrieval by "
+                    "artifact_id/tool_call_id, to inspect the full error before retrying."
+                ),
                 "artifact": artifact,
                 "artifact_id": artifact["artifact_id"],
                 "artifact_status": "available",
@@ -516,7 +544,8 @@ def cap_tool_result_output(
         "\n\n[Tool output truncated: "
         f"omitted {omitted_bytes} bytes and {omitted_lines} lines. "
         f"artifact_id={artifact['artifact_id']}. "
-        "Use artifact retrieval by artifact_id or tool_call_id to read/search the full output.]"
+        "Use background_output with full_session=true, or artifact retrieval by artifact_id "
+        "or tool_call_id, to read/search the full output.]"
     )
 
     return replace(
@@ -525,6 +554,23 @@ def cap_tool_result_output(
         data={
             **result.data,
             "truncated": True,
+            "diagnostics": _diagnostics_with(
+                result.data,
+                {
+                    "source": "tool_output",
+                    "severity": "warning",
+                    "reason": "tool_output_truncated",
+                    "message": "Tool output was truncated before being sent to the model.",
+                    "retry_guidance": (
+                        "Use background_output with full_session=true, or artifact retrieval by "
+                        "artifact_id/tool_call_id, to inspect the full output before retrying."
+                    ),
+                },
+            ),
+            "retry_guidance": (
+                "Use background_output with full_session=true, or artifact retrieval by "
+                "artifact_id/tool_call_id, to inspect the full output before retrying."
+            ),
             "artifact": artifact,
             "artifact_id": artifact["artifact_id"],
             "artifact_status": "available",

--- a/src/voidcode/tools/read_file.py
+++ b/src/voidcode/tools/read_file.py
@@ -189,6 +189,10 @@ def _render_file(candidate: Path, *, relative_path: str, offset: int, limit: int
             "truncated": content_truncated,
             "partial": content_truncated,
             "byte_count": bytes_used,
+            "copy_guidance": (
+                "Displayed lines include '<line>: ' prefixes for navigation. "
+                "When passing text to edit oldString, omit those prefixes and use only file text."
+            ),
         },
     )
 

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -921,6 +921,46 @@ class _EmptyWriteThenResultAwareModelProvider:
         return provider
 
 
+class _InvalidRegexGrepThenResultAwareTurnProvider:
+    def __init__(self, *, name: str) -> None:
+        self.name = name
+        self.requests: list[ProviderTurnRequest] = []
+
+    def propose_turn(self, request: object) -> ProviderTurnResult:
+        turn_request = cast(ProviderTurnRequest, request)
+        self.requests.append(turn_request)
+        if not turn_request.tool_results:
+            return ProviderTurnResult(
+                tool_call=ToolCall(
+                    tool_name="grep",
+                    arguments={"pattern": "[unclosed", "path": ".", "regex": True},
+                )
+            )
+        return ProviderTurnResult(output="recovered from diagnostic error")
+
+    def stream_turn(self, request: object):
+        result = self.propose_turn(request)
+        if result.output is not None:
+            return iter(
+                (
+                    ProviderStreamEvent(kind="delta", channel="text", text=result.output),
+                    ProviderStreamEvent(kind="done", done_reason="completed"),
+                )
+            )
+        return iter((ProviderStreamEvent(kind="done", done_reason="completed"),))
+
+
+@dataclass(frozen=True, slots=True)
+class _InvalidRegexGrepThenResultAwareModelProvider:
+    name: str
+    created_providers: list[_InvalidRegexGrepThenResultAwareTurnProvider]
+
+    def turn_provider(self) -> _InvalidRegexGrepThenResultAwareTurnProvider:
+        provider = _InvalidRegexGrepThenResultAwareTurnProvider(name=self.name)
+        self.created_providers.append(provider)
+        return provider
+
+
 @dataclass(frozen=True, slots=True)
 class _DeniedWriteThenReadModelProvider:
     name: str
@@ -2873,6 +2913,48 @@ def test_runtime_tool_validation_error_includes_actionable_content(tmp_path: Pat
     assert failed_tool_result.retry_guidance == tool_completed.payload["retry_guidance"]
 
 
+def test_runtime_tool_diagnostic_error_propagates_structured_payload(tmp_path: Path) -> None:
+    created_providers: list[_InvalidRegexGrepThenResultAwareTurnProvider] = []
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+        model_provider_registry=ModelProviderRegistry(
+            providers={
+                "opencode": _InvalidRegexGrepThenResultAwareModelProvider(
+                    name="opencode",
+                    created_providers=created_providers,
+                )
+            }
+        ),
+        permission_policy=PermissionPolicy(mode="allow"),
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="invalid regex grep", session_id="invalid-regex"))
+
+    assert response.session.status == "completed"
+    assert response.output == "recovered from diagnostic error"
+    tool_completed = next(
+        event for event in response.events if event.event_type == "runtime.tool_completed"
+    )
+    assert tool_completed.payload["tool"] == "grep"
+    assert tool_completed.payload["status"] == "error"
+    assert tool_completed.payload["error_kind"] == "tool_input_validation"
+    assert "invalid regex pattern" in str(tool_completed.payload["error"])
+    assert "regex=false" in str(tool_completed.payload["retry_guidance"])
+    assert "Please correct the tool arguments and retry." in str(tool_completed.payload["content"])
+    error_details = cast(dict[str, object], tool_completed.payload["error_details"])
+    assert error_details["tool_name"] == "grep"
+    assert error_details["error_kind"] == "tool_input_validation"
+    assert error_details["reason"] == "invalid_regex"
+
+    failed_tool_result = created_providers[-1].requests[-1].tool_results[-1]
+    assert isinstance(failed_tool_result.error, str)
+    assert failed_tool_result.error_kind == tool_completed.payload["error_kind"]
+    assert failed_tool_result.error_summary == tool_completed.payload["error_summary"]
+    assert failed_tool_result.error_details == error_details
+    assert failed_tool_result.retry_guidance == tool_completed.payload["retry_guidance"]
+
+
 def test_runtime_session_debug_snapshot_reports_failure_classification_and_last_tool(
     tmp_path: Path,
 ) -> None:
@@ -3351,6 +3433,12 @@ def test_runtime_cancel_after_tool_started_emits_terminal_tool_completed(
     assert failed_events[-1].payload["cancelled"] is True
     assert failed_events[-1].payload["run_id"] == run_id
     assert failed_events[-1].payload["reason"] == "stop before invoke"
+    assert "wait for the user's next instruction" in str(
+        failed_events[-1].payload["retry_guidance"]
+    )
+    diagnostics = failed_events[-1].payload["diagnostics"]
+    assert isinstance(diagnostics, list)
+    assert diagnostics[-1]["reason"] == "user_interrupted"
 
 
 def test_runtime_cancel_session_preserves_older_overlapping_run_after_newer_run_finishes(
@@ -3380,6 +3468,9 @@ def test_runtime_cancel_session_preserves_older_overlapping_run_after_newer_run_
     assert first_failed_events
     assert first_failed_events[-1].payload["kind"] == "interrupted"
     assert first_failed_events[-1].payload["reason"] == "cancel older run"
+    assert "wait for the user's next instruction" in str(
+        first_failed_events[-1].payload["retry_guidance"]
+    )
 
 
 def test_runtime_cancel_session_rejects_stale_run_id(tmp_path: Path) -> None:
@@ -3453,6 +3544,9 @@ def test_runtime_cancel_session_interrupts_active_approval_resume_run(tmp_path: 
     assert failed_events[-1].payload["cancelled"] is True
     assert failed_events[-1].payload["run_id"] == run_id
     assert failed_events[-1].payload["reason"] == "resume cancellation"
+    assert "wait for the user's next instruction" in str(
+        failed_events[-1].payload["retry_guidance"]
+    )
     assert any(state.get("run_id") == run_id for state in resumed_runtime_states)
 
 

--- a/tests/unit/runtime/test_tool_execution_timeout.py
+++ b/tests/unit/runtime/test_tool_execution_timeout.py
@@ -474,6 +474,13 @@ def test_runtime_caps_large_tool_output_before_feedback(tmp_path: Path) -> None:
     artifact_root = tool_output_artifact_temp_root().resolve()
     assert artifact_root in output_path.parents
     assert payload["artifact_missing"] is False
+    assert payload["retry_guidance"] == (
+        "Use background_output with full_session=true, or artifact retrieval by "
+        "artifact_id/tool_call_id, to inspect the full output before retrying."
+    )
+    diagnostics = payload["diagnostics"]
+    assert isinstance(diagnostics, list)
+    assert diagnostics[-1]["reason"] == "tool_output_truncated"
     assert isinstance(payload["artifact_id"], str)
     artifact = payload["artifact"]
     assert isinstance(artifact, dict)

--- a/tests/unit/tools/test_apply_patch_tool.py
+++ b/tests/unit/tools/test_apply_patch_tool.py
@@ -417,6 +417,34 @@ def test_apply_patch_structured_insert_only_update_uses_matched_context(
     assert result.data["changes"] == [{"path": "sample.txt", "status": "M"}]
 
 
+def test_apply_patch_structured_update_failure_reports_repair_context(tmp_path: Path) -> None:
+    target = tmp_path / "sample.txt"
+    target.write_text("before\ncurrent beta\nafter\n", encoding="utf-8")
+    patch_text = "\n".join(
+        [
+            "*** Begin Patch",
+            "*** Update File: sample.txt",
+            "@@",
+            "-curent beta",
+            "+updated beta",
+            "*** End Patch",
+        ]
+    )
+
+    with pytest.raises(ValueError, match="Retry guidance") as exc_info:
+        ApplyPatchTool().invoke(
+            ToolCall(tool_name="apply_patch", arguments={"patch": patch_text}),
+            workspace=tmp_path,
+        )
+
+    message = str(exc_info.value)
+    assert "Failed to find expected lines" in message
+    assert "Nearest current file context" in message
+    assert "Diff (- expected, + current):" in message
+    assert "current beta" in message
+    assert target.read_text(encoding="utf-8") == "before\ncurrent beta\nafter\n"
+
+
 def test_apply_patch_reports_context_for_corrupt_unified_diff(tmp_path: Path) -> None:
     _init_git_repo(tmp_path)
     patch_text = "\n".join(

--- a/tests/unit/tools/test_edit_tool.py
+++ b/tests/unit/tools/test_edit_tool.py
@@ -227,8 +227,39 @@ def test_edit_tool_reports_near_match_context_when_old_string_is_stale(
     assert "BlockAnchorReplacer" in message
     assert "L1" in message
     assert "message = 'hello'" in message
+    assert "Diff (- oldString, + current):" in message
+    assert "-    message = 'hullo'" in message
+    assert "+    message = 'hello'" in message
+    assert " def greet():" in message
+    assert "+    return message" in message
     assert "first block anchor is close" in message
     assert "retry with exact current text" in message
+
+
+def test_edit_tool_warns_when_old_string_includes_read_line_prefixes(
+    tmp_path: Path,
+) -> None:
+    file_path = tmp_path / "test.py"
+    file_path.write_text("alpha\nbeta\ngamma\n", encoding="utf-8")
+
+    tool = EditTool()
+
+    with pytest.raises(ValueError, match="line prefixes") as exc_info:
+        tool.invoke(
+            ToolCall(
+                tool_name="edit",
+                arguments={
+                    "path": "test.py",
+                    "oldString": "1: alpha\n2: beta",
+                    "newString": "alpha\nupdated",
+                },
+            ),
+            workspace=tmp_path,
+        )
+
+    message = str(exc_info.value)
+    assert "oldString appears to include read output line prefixes" in message
+    assert "remove those prefixes" in message
 
 
 def test_edit_tool_preserves_line_endings(tmp_path: Path) -> None:

--- a/tests/unit/tools/test_edit_tool.py
+++ b/tests/unit/tools/test_edit_tool.py
@@ -198,6 +198,26 @@ def test_edit_tool_rejects_when_old_string_not_found(tmp_path: Path) -> None:
     assert "No nearby text match found" in message
 
 
+def test_edit_tool_no_match_with_unindented_old_string_keeps_diagnostics(
+    tmp_path: Path,
+) -> None:
+    file_path = tmp_path / "test.txt"
+    file_path.write_text("hello", encoding="utf-8")
+
+    tool = EditTool()
+
+    with pytest.raises(ValueError, match="Could not find oldString") as exc_info:
+        tool.invoke(
+            ToolCall(
+                tool_name="edit",
+                arguments={"path": "test.txt", "oldString": "missing", "newString": "b"},
+            ),
+            workspace=tmp_path,
+        )
+
+    assert "Replacers attempted:" in str(exc_info.value)
+
+
 def test_edit_tool_reports_near_match_context_when_old_string_is_stale(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/tools/test_edit_tool.py
+++ b/tests/unit/tools/test_edit_tool.py
@@ -182,7 +182,7 @@ def test_edit_tool_rejects_when_old_string_not_found(tmp_path: Path) -> None:
 
     tool = EditTool()
 
-    with pytest.raises(ValueError, match="Could not find oldString"):
+    with pytest.raises(ValueError, match="Could not find oldString") as exc_info:
         tool.invoke(
             ToolCall(
                 tool_name="edit",
@@ -190,6 +190,45 @@ def test_edit_tool_rejects_when_old_string_not_found(tmp_path: Path) -> None:
             ),
             workspace=tmp_path,
         )
+
+    message = str(exc_info.value)
+    assert "Replacers attempted:" in message
+    assert "SimpleReplacer" in message
+    assert "ContextAwareReplacer" in message
+    assert "No nearby text match found" in message
+
+
+def test_edit_tool_reports_near_match_context_when_old_string_is_stale(
+    tmp_path: Path,
+) -> None:
+    file_path = tmp_path / "test.py"
+    file_path.write_text(
+        "def greet():\n    message = 'hello'\n    return message\n",
+        encoding="utf-8",
+    )
+
+    tool = EditTool()
+
+    with pytest.raises(ValueError, match="Near-match hints") as exc_info:
+        tool.invoke(
+            ToolCall(
+                tool_name="edit",
+                arguments={
+                    "path": "test.py",
+                    "oldString": "def greet():\n    message = 'hullo'\n    return value",
+                    "newString": "def greet():\n    message = 'hi'\n    return message",
+                },
+            ),
+            workspace=tmp_path,
+        )
+
+    message = str(exc_info.value)
+    assert "Replacers attempted:" in message
+    assert "BlockAnchorReplacer" in message
+    assert "L1" in message
+    assert "message = 'hello'" in message
+    assert "first block anchor is close" in message
+    assert "retry with exact current text" in message
 
 
 def test_edit_tool_preserves_line_endings(tmp_path: Path) -> None:

--- a/tests/unit/tools/test_grep_tool.py
+++ b/tests/unit/tools/test_grep_tool.py
@@ -52,7 +52,6 @@ def test_grep_tool_searches_utf8_file_inside_workspace(tmp_path: Path) -> None:
                 "after": [],
             },
         ],
-        "diagnostics": [],
     }
 
 
@@ -196,10 +195,10 @@ def test_grep_tool_truncated_results_include_agent_guidance(tmp_path: Path) -> N
     assert result.truncated is True
     assert "[TRUNCATED]" in (result.content or "")
     assert result.data["match_count"] == MAX_MATCHES
-    diagnostics = result.data["diagnostics"]
-    assert isinstance(diagnostics, list)
+    diagnostics = cast(list[dict[str, object]], result.data["diagnostics"])
     assert diagnostics[-1]["reason"] == "results_truncated"
-    assert "Refine path" in diagnostics[-1]["retry_guidance"]
+    retry_guidance = cast(str, diagnostics[-1]["retry_guidance"])
+    assert "Refine path" in retry_guidance
 
 
 def test_grep_tool_returns_zero_matches_summary(tmp_path: Path) -> None:

--- a/tests/unit/tools/test_grep_tool.py
+++ b/tests/unit/tools/test_grep_tool.py
@@ -7,6 +7,8 @@ import pytest
 
 from voidcode.runtime.service import ToolRegistry
 from voidcode.tools import GrepTool, ToolCall
+from voidcode.tools._repair import ToolDiagnosticError
+from voidcode.tools.grep import MAX_MATCHES
 
 
 def test_grep_tool_searches_utf8_file_inside_workspace(tmp_path: Path) -> None:
@@ -50,6 +52,7 @@ def test_grep_tool_searches_utf8_file_inside_workspace(tmp_path: Path) -> None:
                 "after": [],
             },
         ],
+        "diagnostics": [],
     }
 
 
@@ -180,6 +183,25 @@ def test_grep_tool_ignores_common_directories_by_default(tmp_path: Path) -> None
     assert "node_modules/ignored.py" not in (result.content or "")
 
 
+def test_grep_tool_truncated_results_include_agent_guidance(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("".join("needle\n" for _ in range(MAX_MATCHES + 3)), encoding="utf-8")
+    tool = GrepTool()
+
+    result = tool.invoke(
+        ToolCall(tool_name="grep", arguments={"pattern": "needle", "path": "sample.txt"}),
+        workspace=tmp_path,
+    )
+
+    assert result.truncated is True
+    assert "[TRUNCATED]" in (result.content or "")
+    assert result.data["match_count"] == MAX_MATCHES
+    diagnostics = result.data["diagnostics"]
+    assert isinstance(diagnostics, list)
+    assert diagnostics[-1]["reason"] == "results_truncated"
+    assert "Refine path" in diagnostics[-1]["retry_guidance"]
+
+
 def test_grep_tool_returns_zero_matches_summary(tmp_path: Path) -> None:
     sample_file = tmp_path / "sample.txt"
     _ = sample_file.write_text("alpha beta\n", encoding="utf-8")
@@ -200,6 +222,17 @@ def test_grep_tool_returns_zero_matches_summary(tmp_path: Path) -> None:
         "truncated": False,
         "partial": False,
         "matches": [],
+        "diagnostics": [
+            {
+                "source": "grep",
+                "severity": "info",
+                "reason": "no_matches",
+                "message": (
+                    "No matches found. Broaden the path/include filter, verify the search "
+                    "text with read_file, or retry with regex=false for literal text."
+                ),
+            }
+        ],
     }
 
 
@@ -283,7 +316,7 @@ def test_grep_tool_reports_missing_required_args_and_invalid_regex(tmp_path: Pat
     with pytest.raises(
         ValueError,
         match=r"grep Validation error: pattern: invalid regex pattern .* \(received str\)",
-    ):
+    ) as exc_info:
         tool.invoke(
             ToolCall(
                 tool_name="grep",
@@ -291,6 +324,12 @@ def test_grep_tool_reports_missing_required_args_and_invalid_regex(tmp_path: Pat
             ),
             workspace=tmp_path,
         )
+
+    assert isinstance(exc_info.value, ToolDiagnosticError)
+    assert exc_info.value.error_kind == "tool_input_validation"
+    assert exc_info.value.error_details["reason"] == "invalid_regex"
+    assert exc_info.value.retry_guidance is not None
+    assert "regex=false" in exc_info.value.retry_guidance
 
 
 def test_tools_package_and_default_registry_export_grep_tool() -> None:

--- a/tests/unit/tools/test_multi_edit_tool.py
+++ b/tests/unit/tools/test_multi_edit_tool.py
@@ -79,6 +79,35 @@ def test_multi_edit_rejects_empty_edits(tmp_path: Path) -> None:
         )
 
 
+def test_multi_edit_reports_failing_edit_index_with_underlying_diagnostic(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "sample.txt"
+    target.write_text("alpha\nbeta\ngamma\n", encoding="utf-8")
+    tool = MultiEditTool()
+
+    with pytest.raises(ValueError, match="failed at edit #2") as exc_info:
+        tool.invoke(
+            ToolCall(
+                tool_name="multi_edit",
+                arguments={
+                    "path": "sample.txt",
+                    "edits": [
+                        {"oldString": "alpha", "newString": "ALPHA"},
+                        {"oldString": "2: beta", "newString": "BETA"},
+                    ],
+                },
+            ),
+            workspace=tmp_path,
+        )
+
+    message = str(exc_info.value)
+    assert "Applied edits before failure: 1" in message
+    assert "Underlying edit diagnostic" in message
+    assert "oldString appears to include read output line prefixes" in message
+    assert target.read_text(encoding="utf-8") == "ALPHA\nbeta\ngamma\n"
+
+
 def test_multi_edit_formats_once_after_all_edits(tmp_path: Path) -> None:
     target = tmp_path / "sample.py"
     target.write_text("value = 'a'\nother = 'b'\n", encoding="utf-8")

--- a/tests/unit/tools/test_read_file_tool.py
+++ b/tests/unit/tools/test_read_file_tool.py
@@ -32,6 +32,7 @@ def test_read_file_tool_reads_text_file_with_offset_and_limit(tmp_path: Path) ->
     assert result.data["offset"] == 2
     assert result.data["limit"] == 2
     assert result.data["next_offset"] == 4
+    assert "omit those prefixes" in str(result.data["copy_guidance"])
 
 
 def test_read_file_tool_rejects_directories_with_suggestions(tmp_path: Path) -> None:

--- a/tests/unit/tools/test_tool_output_truncation.py
+++ b/tests/unit/tools/test_tool_output_truncation.py
@@ -47,6 +47,10 @@ def test_cap_tool_result_output_caps_by_line_count_and_saves_full_output(tmp_pat
     assert artifact["status"] == "available"
     assert artifact["producer"] == "voidcode.tool_output.v1"
     assert capped.data["artifact_id"] == artifact["artifact_id"]
+    assert "retry_guidance" in capped.data
+    diagnostics = capped.data["diagnostics"]
+    assert isinstance(diagnostics, list)
+    assert diagnostics[-1]["reason"] == "tool_output_truncated"
     artifact_path = Path(cast(str, artifact["path"]))
     assert artifact_path.read_text(encoding="utf-8") == content
     assert artifact_path.stat().st_mode & 0o777 == 0o600
@@ -127,7 +131,7 @@ def test_tool_output_artifact_reference_metadata_is_bounded_and_safe(tmp_path: P
     assert "artifact-line-0" in capped.content
     assert "artifact-line-10" not in capped.content
     assert capped.reference == f"artifact:{capped.data['artifact_id']}"
-    assert "Use artifact retrieval by artifact_id or tool_call_id" in capped.content
+    assert "Use background_output with full_session=true" in capped.content
     raw_artifact = capped.data["artifact"]
     assert isinstance(raw_artifact, dict)
     artifact = cast(dict[str, object], raw_artifact)
@@ -385,6 +389,10 @@ def test_cap_tool_result_output_caps_large_errors(tmp_path: Path) -> None:
     assert "error-4" not in capped.error
     assert "Tool error truncated" in capped.error
     assert capped.truncated is True
+    diagnostics = capped.data["diagnostics"]
+    assert isinstance(diagnostics, list)
+    assert diagnostics[-1]["reason"] == "tool_error_truncated"
+    assert "full error" in diagnostics[-1]["retry_guidance"]
     assert isinstance(capped.reference, str)
     raw_artifact = capped.data["artifact"]
     assert isinstance(raw_artifact, dict)


### PR DESCRIPTION
## Summary
- Lists every edit replacer attempted when `oldString` cannot be matched.
- Adds bounded near-match context with line numbers and actionable block/indent hints.
- Covers both no-match and stale near-match failure cases in edit tool unit tests.

Closes #427.

## Verification
- `uv run pytest tests/unit/tools/test_edit_tool.py -v`
- `uv run ruff check src/voidcode/tools/edit.py tests/unit/tools/test_edit_tool.py`
- `uv run ty check src`
- Manual driver script invoking `EditTool` mismatch failure and inspecting the returned diagnostic message.

## Notes
- `mise run lint` / `mise run typecheck` could not run in this new worktree because mise refused untrusted `mise.toml`; equivalent direct `uv` commands were run instead.