### PR TITLE
test: add issue #425 contract parity coverage

### DIFF
--- a/docs/contracts/client-api.md
+++ b/docs/contracts/client-api.md
@@ -42,7 +42,7 @@ SessionState(
 )
 
 StoredSessionSummary(
-    session: SessionRef(id: str),
+    session: SessionRef(id: str, parent_id: str | None = None),
     status: SessionStatus,
     turn: int,
     prompt: str,

--- a/frontend/src/lib/runtime/client.integration.test.ts
+++ b/frontend/src/lib/runtime/client.integration.test.ts
@@ -43,6 +43,16 @@ describe("RuntimeClient integration contract", () => {
             last_request_type: "handshake",
           },
         },
+        background_tasks: {
+          active_worker_slots: 2,
+          queued_count: 3,
+          running_count: 1,
+          terminal_count: 5,
+          default_concurrency: 4,
+          provider_concurrency: { "opencode-go": 2 },
+          model_concurrency: { "opencode-go/glm-5.1": 1 },
+          status_counts: { queued: 3, running: 1, completed: 5 },
+        },
       }),
     } as Response);
 
@@ -61,6 +71,16 @@ describe("RuntimeClient integration contract", () => {
       },
     ]);
     expect(snapshot.acp?.details?.last_request_type).toBe("handshake");
+    expect(snapshot.background_tasks).toEqual({
+      active_worker_slots: 2,
+      queued_count: 3,
+      running_count: 1,
+      terminal_count: 5,
+      default_concurrency: 4,
+      provider_concurrency: { "opencode-go": 2 },
+      model_concurrency: { "opencode-go/glm-5.1": 1 },
+      status_counts: { queued: 3, running: 1, completed: 5 },
+    });
   });
 
   it("parses streamed SSE chunks and preserves backend tool status display payloads", async () => {

--- a/frontend/src/lib/runtime/types.ts
+++ b/frontend/src/lib/runtime/types.ts
@@ -119,11 +119,23 @@ export interface McpServerStatusDetail {
   retry_available?: boolean;
 }
 
+export interface RuntimeBackgroundTaskStatusSnapshot {
+  active_worker_slots: number;
+  queued_count: number;
+  running_count: number;
+  terminal_count: number;
+  default_concurrency: number;
+  provider_concurrency: Record<string, number>;
+  model_concurrency: Record<string, number>;
+  status_counts: Record<string, number>;
+}
+
 export interface RuntimeStatusSnapshot {
   git: GitStatusSnapshot;
   lsp: CapabilityStatusSnapshot;
   mcp: CapabilityStatusSnapshot;
   acp?: CapabilityStatusSnapshot;
+  background_tasks: RuntimeBackgroundTaskStatusSnapshot;
 }
 
 export interface ReviewChangedFile {

--- a/frontend/src/store.integration.test.ts
+++ b/frontend/src/store.integration.test.ts
@@ -61,6 +61,16 @@ const emptyStatusSnapshot: RuntimeStatusSnapshot = {
   lsp: { state: "stopped", error: null, details: {} },
   mcp: { state: "stopped", error: null, details: {} },
   acp: { state: "unconfigured", error: null, details: {} },
+  background_tasks: {
+    active_worker_slots: 0,
+    queued_count: 0,
+    running_count: 0,
+    terminal_count: 0,
+    default_concurrency: 1,
+    provider_concurrency: {},
+    model_concurrency: {},
+    status_counts: {},
+  },
 };
 
 function makeSessionState(
@@ -2108,6 +2118,16 @@ describe("useAppStore integration flow", () => {
             },
           ],
         },
+      },
+      background_tasks: {
+        active_worker_slots: 1,
+        queued_count: 2,
+        running_count: 1,
+        terminal_count: 4,
+        default_concurrency: 3,
+        provider_concurrency: { "opencode-go": 2 },
+        model_concurrency: { "opencode-go/glm-5.1": 1 },
+        status_counts: { queued: 2, running: 1, completed: 4 },
       },
     };
     runtimeClientMocks.retryMcpConnectionsMock.mockResolvedValue(retrySnapshot);

--- a/src/voidcode/cli_support.py
+++ b/src/voidcode/cli_support.py
@@ -71,9 +71,12 @@ def serialize_session_state(session: SessionState) -> dict[str, object]:
 
 
 def serialize_stored_session_summary(session: StoredSessionSummary) -> dict[str, object]:
+    session_payload: dict[str, object] = {"id": session.session.id}
+    parent_id = getattr(session.session, "parent_id", None)
+    if parent_id is not None:
+        session_payload["parent_id"] = parent_id
     return {
-        "id": session.session.id,
-        "parent_id": getattr(session.session, "parent_id", None),
+        "session": session_payload,
         "status": session.status,
         "turn": session.turn,
         "updated_at": session.updated_at,

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -777,7 +777,8 @@ def test_sessions_list_outputs_json() -> None:
     assert setup_result.returncode == 0
     assert list_result.returncode == 0
     assert payload["workspace"] == str(workspace)
-    assert payload["sessions"][0]["id"] == "list-json-session"
+    assert payload["sessions"][0]["session"] == {"id": "list-json-session"}
+    assert "id" not in payload["sessions"][0]
     assert payload["sessions"][0]["prompt"] == "read sample.txt"
 
 


### PR DESCRIPTION
## Summary
- align CLI `sessions list --json` session summaries with the nested runtime/HTTP contract and update the client API doc to match
- add frontend runtime status parity coverage for the backend-owned `background_tasks` snapshot in shared types plus client/store integration tests
- pin the issue #425 boundary with targeted Python/Bun verification and manual CLI/HTTP surface checks

## Verification
- `uv run pytest tests/unit/interface/test_cli_smoke.py -k "sessions_list_outputs_json or config_show_delegates_to_runtime_effective_config"`
- `uv run pytest tests/integration/test_http_transport.py -k "reads_runtime_web_settings_as_json or updates_runtime_web_settings_and_hides_api_key_on_read or retry_mcp_retries_runtime_owned_status_snapshot"`
- `bun run test:run src/lib/runtime/client.integration.test.ts src/store.integration.test.ts`
- `bun run typecheck`
- `bun run build`
- manual QA: exercised `voidcode --help`, deterministic `voidcode run`, `voidcode sessions list --json`, bad `sessions debug`, and live `/api/status`, `/api/settings`, `/api/sessions` endpoints via local `voidcode serve`
