### PR TITLE
test(runtime): cover session restart persistence

### DIFF
--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -1346,6 +1346,27 @@ def test_transport_lists_and_acknowledges_notifications(tmp_path: Path) -> None:
     assert ack_payload["status"] == "acknowledged"
     assert ack_payload["acknowledged_at"] is not None
 
+    restarted_app = create_runtime_app(
+        workspace=tmp_path,
+        runtime_factory=lambda: runtime_class(
+            workspace=tmp_path,
+            permission_policy=permission_policy,
+        ),
+    )
+    restarted_list_response = _run_app(
+        restarted_app,
+        method="GET",
+        path="/api/notifications",
+    )
+    restarted_notifications = cast(list[dict[str, object]], restarted_list_response.json())
+
+    assert restarted_list_response.status == 200
+    assert len(restarted_notifications) == 1
+    assert restarted_notifications[0]["id"] == notification_id
+    assert restarted_notifications[0]["kind"] == "approval_blocked"
+    assert restarted_notifications[0]["status"] == "acknowledged"
+    assert restarted_notifications[0]["acknowledged_at"] == ack_payload["acknowledged_at"]
+
 
 def test_transport_round_trips_parent_session_lineage(tmp_path: Path) -> None:
     create_runtime_app = _load_transport_app_factory()

--- a/tests/unit/runtime/test_session_storage.py
+++ b/tests/unit/runtime/test_session_storage.py
@@ -10,6 +10,7 @@ import pytest
 
 from voidcode.runtime.contracts import RuntimeRequest, RuntimeResponse
 from voidcode.runtime.events import EventEnvelope
+from voidcode.runtime.permission import PendingApproval
 from voidcode.runtime.question import PendingQuestion, PendingQuestionOption, PendingQuestionPrompt
 from voidcode.runtime.session import SessionRef, SessionState
 from voidcode.runtime.storage import SqliteSessionStore
@@ -224,9 +225,13 @@ def test_session_storage_persists_runtime_todos_and_filters_reverted_state(
 
     raw_runtime_state = loaded.session.metadata["runtime_state"]
     assert isinstance(raw_runtime_state, dict)
-    todos_state = cast(dict[str, object], raw_runtime_state)["todos"]
+    runtime_state = cast(dict[str, object], raw_runtime_state)
+    todos_state = runtime_state.get("todos")
     assert isinstance(todos_state, dict)
-    assert cast(list[dict[str, object]], todos_state["todos"])[0]["content"] == "persist me"
+    todos_state_payload = cast(dict[str, object], todos_state)
+    todos = todos_state_payload.get("todos")
+    assert isinstance(todos, list)
+    assert cast(dict[str, object], todos[0])["content"] == "persist me"
 
     store.revert_session(workspace=tmp_path, session_id="todo-session", sequence=3)
     reverted = store.load_session(workspace=tmp_path, session_id="todo-session")
@@ -1037,6 +1042,153 @@ def test_session_storage_persists_pending_question_and_question_notification(
     assert notifications[0].kind == "question_blocked"
     assert notifications[0].status == "unread"
     assert notifications[0].payload["request_id"] == "question-1"
+
+
+def test_session_storage_persists_pending_question_across_store_reopen(
+    tmp_path: Path,
+) -> None:
+    store = SqliteSessionStore()
+    request = RuntimeRequest(prompt="need input", session_id="question-reopen-session")
+    response = RuntimeResponse(
+        session=SessionState(
+            session=SessionRef(id="question-reopen-session"),
+            status="waiting",
+            turn=1,
+            metadata={},
+        ),
+        events=(
+            EventEnvelope(
+                session_id="question-reopen-session",
+                sequence=1,
+                event_type="runtime.question_requested",
+                source="runtime",
+                payload={
+                    "request_id": "question-reopen-1",
+                    "tool": "question",
+                    "question_count": 1,
+                    "questions": [
+                        {
+                            "header": "Runtime path",
+                            "question": "Which runtime path should we use?",
+                            "multiple": False,
+                            "options": [
+                                {"label": "Reuse existing", "description": "Keep current path"},
+                            ],
+                        }
+                    ],
+                },
+            ),
+        ),
+    )
+    pending_question = PendingQuestion(
+        request_id="question-reopen-1",
+        tool_name="question",
+        arguments={},
+        prompts=(
+            PendingQuestionPrompt(
+                question="Which runtime path should we use?",
+                header="Runtime path",
+                options=(
+                    PendingQuestionOption(
+                        label="Reuse existing",
+                        description="Keep current path",
+                    ),
+                ),
+                multiple=False,
+            ),
+        ),
+    )
+    store.save_pending_question(
+        workspace=tmp_path,
+        request=request,
+        response=response,
+        pending_question=pending_question,
+    )
+
+    reopened_store = SqliteSessionStore()
+    loaded_question = reopened_store.load_pending_question(
+        workspace=tmp_path,
+        session_id="question-reopen-session",
+    )
+    checkpoint = reopened_store.load_resume_checkpoint(
+        workspace=tmp_path,
+        session_id="question-reopen-session",
+    )
+    notifications = reopened_store.list_notifications(workspace=tmp_path)
+
+    assert loaded_question == pending_question
+    assert checkpoint is not None
+    assert checkpoint["kind"] == "question_wait"
+    assert checkpoint["pending_question_request_id"] == "question-reopen-1"
+    assert len(notifications) == 1
+    assert notifications[0].kind == "question_blocked"
+    assert notifications[0].status == "unread"
+    assert notifications[0].payload["request_id"] == "question-reopen-1"
+
+
+def test_session_storage_persists_pending_approval_across_store_reopen(
+    tmp_path: Path,
+) -> None:
+    store = SqliteSessionStore()
+    request = RuntimeRequest(prompt="write guarded file", session_id="approval-reopen-session")
+    response = RuntimeResponse(
+        session=SessionState(
+            session=SessionRef(id="approval-reopen-session"),
+            status="waiting",
+            turn=1,
+            metadata={},
+        ),
+        events=(
+            EventEnvelope(
+                session_id="approval-reopen-session",
+                sequence=1,
+                event_type="runtime.approval_requested",
+                source="runtime",
+                payload={
+                    "request_id": "approval-reopen-1",
+                    "tool": "write_file",
+                    "arguments": {"path": "danger.txt"},
+                    "target_summary": "write_file danger.txt",
+                    "reason": "write requires approval",
+                    "policy": {"mode": "ask"},
+                },
+            ),
+        ),
+    )
+    pending_approval = PendingApproval(
+        request_id="approval-reopen-1",
+        tool_name="write_file",
+        arguments={"path": "danger.txt"},
+        target_summary="write_file danger.txt",
+        reason="write requires approval",
+        request_event_sequence=1,
+    )
+    store.save_pending_approval(
+        workspace=tmp_path,
+        request=request,
+        response=response,
+        pending_approval=pending_approval,
+    )
+
+    reopened_store = SqliteSessionStore()
+    loaded_approval = reopened_store.load_pending_approval(
+        workspace=tmp_path,
+        session_id="approval-reopen-session",
+    )
+    checkpoint = reopened_store.load_resume_checkpoint(
+        workspace=tmp_path,
+        session_id="approval-reopen-session",
+    )
+    notifications = reopened_store.list_notifications(workspace=tmp_path)
+
+    assert loaded_approval == pending_approval
+    assert checkpoint is not None
+    assert checkpoint["kind"] == "approval_wait"
+    assert checkpoint["pending_approval_request_id"] == "approval-reopen-1"
+    assert len(notifications) == 1
+    assert notifications[0].kind == "approval_blocked"
+    assert notifications[0].status == "unread"
+    assert notifications[0].payload["request_id"] == "approval-reopen-1"
 
 
 def test_session_storage_fail_incomplete_background_tasks_keeps_question_waiting_children(


### PR DESCRIPTION
## Summary
- Add storage reopen regressions for pending approval and question resume checkpoints.
- Extend HTTP notification coverage to prove acknowledgement state survives a fresh runtime instance.
- Preserve issue #426 restart/replay guarantees without changing runtime behavior.

## Verification
- uv run pytest tests/unit/runtime/test_session_storage.py tests/integration/test_http_transport.py -k "pending_question_across_store_reopen or pending_approval_across_store_reopen or lists_and_acknowledges_notifications or session_replay_persists_across_runtime_reinstantiation or answers_pending_question_over_http or resolves_pending_approval_allow_over_http"
- uv run ruff check tests/unit/runtime/test_session_storage.py tests/integration/test_http_transport.py
- uv run ty check tests/unit/runtime/test_session_storage.py
- Manual CLI QA: deterministic run -> sessions list -> sessions resume in /tmp/opencode/voidcode-issue426-qa

Closes #426