### PR TITLE
fix web/provider/runtime approval flow regressions

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -81,10 +81,10 @@ frontend/
 
 **注意：** 当前前端已经具备可工作的运行时传输客户端和本地后端路径，能够消费会话列表、重放数据、流式运行事件、审批/question 处理结果、review tree / diff、workspace registry、runtime status 和设置投影。它仍然不是一个完整产品化的 runtime-driven Web 客户端，但已经不只是概念验证或纯静态壳层。
 
-默认 Web 提交会使用 `leader` 单 agent 路径和 `opencode-go/glm-5.1` 模型；除非调用方显式传入正整数预算，否则前端不会向运行时发送 `max_steps`。API Key 不会进入浏览器状态或请求体；启动后端时通过环境变量提供：
+默认 Web 提交会使用 `leader` 单 agent 路径和 `deepseek/deepseek-v4-pro` 模型；除非调用方显式传入正整数预算，否则前端不会向运行时发送 `max_steps`。API Key 不会进入浏览器状态或请求体；启动后端时通过环境变量提供：
 
 ```bash
-OPENCODE_API_KEY=<your-key> uv run voidcode serve --workspace . --port 8000
+DEEPSEEK_API_KEY=<your-key> uv run voidcode serve --workspace . --port 8000
 ```
 
 如果需要启动完整 Web launcher，则先构建前端资源，然后运行：

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -30,6 +30,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/node": "^24.10.1",
         "@types/prismjs": "^1.26.5",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
@@ -281,7 +282,7 @@
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
-    "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
+    "@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
     "@types/prismjs": ["@types/prismjs@1.26.6", "", {}, "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw=="],
 
@@ -911,7 +912,7 @@
 
     "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
 
-    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 
@@ -995,6 +996,8 @@
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
+    "@types/ws/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
+
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
@@ -1018,6 +1021,8 @@
     "vite/postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
 
     "vitest/tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "@types/ws/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 

--- a/frontend/e2e/launcher.spec.ts
+++ b/frontend/e2e/launcher.spec.ts
@@ -267,28 +267,34 @@ async function installMockRuntime(page: Page) {
     route.fulfill(
       jsonResponse([
         {
-          name: "opencode-go",
-          label: "OpenCode Go",
+          name: "deepseek",
+          label: "DeepSeek",
           configured: true,
           current: true,
         },
       ]),
     ),
   );
-  await page.route("**/api/providers/opencode-go/models", async (route) =>
+  await page.route("**/api/providers/deepseek/models", async (route) =>
     route.fulfill(
       jsonResponse({
-        provider: "opencode-go",
+        provider: "deepseek",
         configured: true,
-        models: ["glm-5.1"],
+        models: ["deepseek-v4-pro", "deepseek-v4-flash"],
         source: null,
         last_refresh_status: "ok",
         last_error: null,
         discovery_mode: "configured_endpoint",
         model_metadata: {
-          "glm-5.1": {
-            context_window: 128000,
-            max_output_tokens: 8192,
+          "deepseek-v4-pro": {
+            context_window: 1000000,
+            max_output_tokens: 384000,
+            supports_reasoning_effort: true,
+            default_reasoning_effort: "medium",
+          },
+          "deepseek-v4-flash": {
+            context_window: 1000000,
+            max_output_tokens: 384000,
             supports_reasoning_effort: true,
             default_reasoning_effort: "medium",
           },
@@ -296,10 +302,10 @@ async function installMockRuntime(page: Page) {
       }),
     ),
   );
-  await page.route("**/api/providers/opencode-go/validate", async (route) =>
+  await page.route("**/api/providers/deepseek/validate", async (route) =>
     route.fulfill(
       jsonResponse({
-        provider: "opencode-go",
+        provider: "deepseek",
         configured: true,
         ok: true,
         status: "ok",
@@ -338,8 +344,8 @@ async function installMockRuntime(page: Page) {
   await page.route("**/api/settings", async (route) =>
     route.fulfill(
       jsonResponse({
-        provider: "opencode-go",
-        model: "opencode-go/glm-5.1",
+        provider: "deepseek",
+        model: "deepseek/deepseek-v4-pro",
         provider_api_key_present: true,
       }),
     ),
@@ -496,12 +502,12 @@ test.describe("VoidCode Web Launcher", () => {
     });
   });
 
-  test("should run a task using env-backed key without browser-side API key entry", async ({
+  test("should run a task using env-backed DeepSeek key without browser-side API key entry", async ({
     page,
   }) => {
     test.skip(
-      !process.env.OPENCODE_API_KEY,
-      "Skipping live smoke test because OPENCODE_API_KEY is not set in environment.",
+      !process.env.DEEPSEEK_API_KEY,
+      "Skipping live smoke test because DEEPSEEK_API_KEY is not set in environment.",
     );
 
     await page.goto(launcherUrl);
@@ -514,6 +520,9 @@ test.describe("VoidCode Web Launcher", () => {
     await expect(input).toBeVisible({ timeout: 20000 });
     await input.fill("read README.md");
     await input.press("Enter");
+
+    await expect(page.getByText("Agent Busy")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText("Agent Idle")).toBeVisible({ timeout: 60000 });
 
     await expect(page.getByText(/^Error:/)).not.toBeVisible();
 
@@ -712,7 +721,7 @@ test.describe("VoidCode Web Launcher", () => {
 
     await page.goto(launcherUrl);
     await expect(page.getByRole("button", { name: "Model" })).toHaveText(
-      /OpenCode Go/,
+      /DeepSeek/,
     );
     await expect(page.getByText("workspace", { exact: true })).toBeVisible();
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/prismjs": "^1.26.5",
+    "@types/node": "^24.10.1",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
     "@types/ws": "^8.18.0",

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -17,7 +17,7 @@ describe("App", () => {
     language: "en",
     setLanguage: vi.fn(),
     agentPreset: "leader",
-    providerModel: "opencode-go/glm-5.1",
+    providerModel: "deepseek/deepseek-v4-pro",
     setAgentPreset: vi.fn(),
     setProviderModel: vi.fn(),
     workspaces: null,
@@ -475,6 +475,120 @@ describe("App", () => {
 
     expect(screen.queryByText("Agent Busy")).not.toBeInTheDocument();
     expect(screen.queryByText("Agent Idle")).not.toBeInTheDocument();
+  });
+
+  it("shows delegated child session transcript and switches back to the parent session", () => {
+    const loadBackgroundTaskOutput = vi.fn();
+    (useAppStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      ...mockStore,
+      workspaces: {
+        current: {
+          path: "/workspace",
+          label: "workspace",
+          available: true,
+          current: true,
+          last_opened_at: 1,
+        },
+        recent: [],
+        candidates: [],
+      },
+      currentSessionId: "parent-session",
+      currentSessionState: {
+        session: { id: "parent-session" },
+        status: "completed",
+        turn: 1,
+        metadata: {},
+      },
+      currentSessionEvents: [
+        {
+          session_id: "parent-session",
+          sequence: 1,
+          event_type: "runtime.request_received",
+          source: "runtime",
+          payload: { prompt: "parent prompt" },
+        },
+        {
+          session_id: "parent-session",
+          sequence: 2,
+          event_type: "graph.response_ready",
+          source: "graph",
+          payload: { output: "parent output" },
+        },
+      ],
+      currentSessionOutput: "parent output",
+      backgroundTasks: [
+        {
+          task: { id: "task-child-1" },
+          status: "completed",
+          prompt: "delegate child",
+          session_id: "child-session-1",
+          error: null,
+          created_at: 1,
+          updated_at: 1,
+        },
+      ],
+      selectedBackgroundTaskOutputId: "task-child-1",
+      backgroundTaskOutputStatus: "success",
+      backgroundTaskOutput: {
+        task: {
+          task_id: "task-child-1",
+          status: "completed",
+          parent_session_id: "parent-session",
+          requested_child_session_id: "requested-child-1",
+          child_session_id: "child-session-1",
+          approval_request_id: null,
+          question_request_id: null,
+          approval_blocked: false,
+          summary_output: "child summary",
+          error: null,
+          result_available: true,
+          cancellation_cause: null,
+          routing: { mode: "subagent", subagent_type: "explore" },
+        },
+        session_result: {
+          session: {
+            session: { id: "child-session-1", parent_id: "parent-session" },
+            status: "completed" as const,
+            turn: 1,
+            metadata: {},
+          },
+          prompt: "child prompt",
+          status: "completed",
+          summary: "child summary",
+          output: "child output",
+          error: null,
+          last_event_sequence: 2,
+          transcript: [
+            {
+              session_id: "child-session-1",
+              sequence: 1,
+              event_type: "runtime.request_received",
+              source: "runtime",
+              payload: { prompt: "child prompt" },
+            },
+            {
+              session_id: "child-session-1",
+              sequence: 2,
+              event_type: "graph.response_ready",
+              source: "graph",
+              payload: { output: "child output" },
+            },
+          ],
+        },
+        output: "child output",
+      },
+      loadBackgroundTaskOutput,
+    });
+
+    render(<App />);
+
+    expect(screen.getByText("child prompt")).toBeInTheDocument();
+    expect(screen.getByText("child output")).toBeInTheDocument();
+    expect(screen.queryByText("parent output")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Parent session"));
+
+    expect(loadBackgroundTaskOutput).toHaveBeenCalledWith(null);
   });
 
   it("renders project-picker-first empty state when no current workspace exists", () => {
@@ -1220,17 +1334,17 @@ describe("App", () => {
       agentPresets: [{ id: "leader", label: "Leader", description: null }],
       providers: [
         {
-          name: "opencode-go",
-          label: "OpenCode Go",
+          name: "deepseek",
+          label: "DeepSeek",
           configured: true,
           current: true,
         },
       ],
       providerModels: {
-        "opencode-go": {
-          provider: "opencode-go",
+        deepseek: {
+          provider: "deepseek",
           configured: true,
-          models: ["opencode-go/glm-5.1", "new-model/v1"],
+          models: ["deepseek-v4-pro", "deepseek-v4-flash"],
           source: null,
           last_refresh_status: null,
           last_error: null,
@@ -1242,12 +1356,12 @@ describe("App", () => {
     render(<App />);
 
     const modelInput = screen.getByRole("button", { name: "Model" });
-    expect(modelInput).toHaveTextContent("OpenCode Go / glm-5.1");
+    expect(modelInput).toHaveTextContent("DeepSeek / deepseek-v4-pro");
 
     fireEvent.click(modelInput);
-    fireEvent.click(screen.getByRole("button", { name: "new-model/v1" }));
+    fireEvent.click(screen.getByRole("button", { name: "deepseek-v4-flash" }));
     expect(mockStore.setProviderModel).toHaveBeenCalledWith(
-      "opencode-go/new-model/v1",
+      "deepseek/deepseek-v4-flash",
     );
   });
 

--- a/frontend/src/components/Composer.test.tsx
+++ b/frontend/src/components/Composer.test.tsx
@@ -142,10 +142,10 @@ describe("Composer", () => {
           context_window: { model_context_window_tokens: 512_000 },
         }}
         providerModels={{
-          "opencode-go": {
-            ...baseProps.providerModels["opencode-go"],
+          deepseek: {
+            ...baseProps.providerModels.deepseek,
             model_metadata: {
-              "opencode-go/glm-5.1": {
+              "deepseek-v4-pro": {
                 context_window: 198_000,
                 max_output_tokens: 128_000,
               },

--- a/frontend/src/components/Composer.test.tsx
+++ b/frontend/src/components/Composer.test.tsx
@@ -7,21 +7,21 @@ const baseProps = {
   disabled: false,
   isRunning: false,
   agentPreset: "leader" as const,
-  providerModel: "opencode-go/glm-5.1",
+  providerModel: "deepseek/deepseek-v4-pro",
   agentPresets: [{ id: "leader", label: "Leader", description: null }],
   providers: [
     {
-      name: "opencode-go",
-      label: "OpenCode",
+      name: "deepseek",
+      label: "DeepSeek",
       configured: true,
       current: true,
     },
   ],
   providerModels: {
-    "opencode-go": {
-      provider: "opencode-go",
+    deepseek: {
+      provider: "deepseek",
       configured: true,
-      models: ["opencode-go/glm-5.1", "opencode-go/glm-5.2"],
+      models: ["deepseek-v4-pro", "deepseek-v4-flash"],
       source: null,
       last_refresh_status: null,
       last_error: null,
@@ -47,7 +47,7 @@ describe("Composer", () => {
 
     const modelTrigger = screen.getByRole("button", { name: "Model" });
     expect(modelTrigger).toBeInTheDocument();
-    expect(modelTrigger).toHaveTextContent("OpenCode / glm-5.1");
+    expect(modelTrigger).toHaveTextContent("DeepSeek / deepseek-v4-pro");
   });
 
   it("keeps composer selectors accessible while rendering them as flat footer controls", () => {
@@ -73,9 +73,11 @@ describe("Composer", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Model" }));
-    fireEvent.click(screen.getByRole("button", { name: "glm-5.2" }));
+    fireEvent.click(screen.getByRole("button", { name: "deepseek-v4-flash" }));
 
-    expect(onProviderModelChange).toHaveBeenCalledWith("opencode-go/glm-5.2");
+    expect(onProviderModelChange).toHaveBeenCalledWith(
+      "deepseek/deepseek-v4-flash",
+    );
   });
 
   it("keeps selector menus above the composer shell", () => {
@@ -83,7 +85,7 @@ describe("Composer", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Model" }));
 
-    expect(screen.getByText("OpenCode").closest(".absolute")).toHaveClass(
+    expect(screen.getByText("DeepSeek").closest(".absolute")).toHaveClass(
       "z-[100]",
     );
   });
@@ -102,10 +104,10 @@ describe("Composer", () => {
         }}
         onReasoningEffortChange={onReasoningEffortChange}
         providerModels={{
-          "opencode-go": {
-            ...baseProps.providerModels["opencode-go"],
+          deepseek: {
+            ...baseProps.providerModels.deepseek,
             model_metadata: {
-              "opencode-go/glm-5.1": {
+              "deepseek-v4-pro": {
                 context_window: 198_000,
                 max_output_tokens: 128_000,
                 supports_reasoning: true,
@@ -162,10 +164,10 @@ describe("Composer", () => {
       <Composer
         {...baseProps}
         providerModels={{
-          "opencode-go": {
-            ...baseProps.providerModels["opencode-go"],
+          deepseek: {
+            ...baseProps.providerModels.deepseek,
             model_metadata: {
-              "opencode-go/glm-5.1": {
+              "deepseek-v4-pro": {
                 context_window: 198_000,
                 supports_reasoning: true,
                 supports_reasoning_effort: false,
@@ -243,10 +245,10 @@ describe("Composer", () => {
         {...baseProps}
         providerModel=""
         providerModels={{
-          "opencode-go": {
-            provider: "opencode-go",
+          deepseek: {
+            provider: "deepseek",
             configured: true,
-            models: ["glm-5.1"],
+            models: ["deepseek-v4-pro"],
             source: null,
             last_refresh_status: null,
             last_error: null,
@@ -258,9 +260,11 @@ describe("Composer", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Model" }));
-    fireEvent.click(screen.getByRole("button", { name: "glm-5.1" }));
+    fireEvent.click(screen.getByRole("button", { name: "deepseek-v4-pro" }));
 
-    expect(onProviderModelChange).toHaveBeenCalledWith("opencode-go/glm-5.1");
+    expect(onProviderModelChange).toHaveBeenCalledWith(
+      "deepseek/deepseek-v4-pro",
+    );
   });
 
   it("calls onAgentPresetChange when agent is changed", () => {
@@ -357,8 +361,8 @@ describe("Composer", () => {
         {...baseProps}
         providerModel=""
         providerModels={{
-          "opencode-go": {
-            provider: "opencode-go",
+          deepseek: {
+            provider: "deepseek",
             configured: true,
             models: [],
             source: null,
@@ -380,10 +384,10 @@ describe("Composer", () => {
     render(
       <Composer
         {...baseProps}
-        providerModel="opencode-go/kimi-k2.6"
+        providerModel="deepseek/deepseek-v4-pro"
         providerModels={{
-          "opencode-go": {
-            provider: "opencode-go",
+          deepseek: {
+            provider: "deepseek",
             configured: true,
             models: [],
             source: null,
@@ -395,7 +399,9 @@ describe("Composer", () => {
       />,
     );
 
-    expect(screen.queryByText("OpenCode / kimi-k2.6")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("DeepSeek / deepseek-v4-pro"),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Model" }),
     ).not.toBeInTheDocument();
@@ -470,8 +476,8 @@ describe("Composer", () => {
         {...baseProps}
         providers={[
           {
-            name: "opencode-go",
-            label: "OpenCode",
+            name: "deepseek",
+            label: "DeepSeek",
             configured: true,
             current: true,
           },
@@ -483,10 +489,10 @@ describe("Composer", () => {
           },
         ]}
         providerModels={{
-          "opencode-go": {
-            provider: "opencode-go",
+          deepseek: {
+            provider: "deepseek",
             configured: true,
-            models: ["opencode-go/glm-5.1"],
+            models: ["deepseek-v4-pro"],
             source: null,
             last_refresh_status: null,
             last_error: null,
@@ -507,7 +513,7 @@ describe("Composer", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Model" }));
 
-    expect(screen.getByText("glm-5.1")).toBeInTheDocument();
+    expect(screen.getByText("deepseek-v4-pro")).toBeInTheDocument();
     expect(screen.getByText("glm-5")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/SettingsPanel.test.tsx
+++ b/frontend/src/components/SettingsPanel.test.tsx
@@ -229,11 +229,11 @@ describe("SettingsPanel", () => {
     });
   });
 
-  it("renders the API key as a masked text field without password semantics", () => {
+  it("renders the API key with native password semantics", () => {
     render(<SettingsPanel {...baseProps} />);
 
     const apiKeyField = screen.getByLabelText("API Key");
-    expect(apiKeyField).toHaveAttribute("type", "text");
+    expect(apiKeyField).toHaveAttribute("type", "password");
     expect(apiKeyField).toHaveAttribute("autocomplete", "off");
   });
 

--- a/frontend/src/components/SettingsPanel.test.tsx
+++ b/frontend/src/components/SettingsPanel.test.tsx
@@ -229,6 +229,14 @@ describe("SettingsPanel", () => {
     });
   });
 
+  it("renders the API key as a masked text field without password semantics", () => {
+    render(<SettingsPanel {...baseProps} />);
+
+    const apiKeyField = screen.getByLabelText("API Key");
+    expect(apiKeyField).toHaveAttribute("type", "text");
+    expect(apiKeyField).toHaveAttribute("autocomplete", "off");
+  });
+
   it("preserves existing settings provider and model on save", () => {
     const onSave = vi.fn();
     render(

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -353,14 +353,14 @@ export function SettingsPanel({
             </label>
             <input
               id="settings-api-key"
-              type="text"
+              type="password"
               autoComplete="off"
               value={apiKey}
               onChange={(e) => setApiKey(e.target.value)}
               placeholder={t("settings.apiKeyPlaceholder")}
               disabled={isLoading}
               spellCheck={false}
-              className="w-full bg-[var(--vc-surface-1)] border border-[color:var(--vc-border-subtle)] rounded-lg px-3 py-2.5 text-sm text-[var(--vc-text-primary)] placeholder:text-[var(--vc-text-subtle)] focus:outline-none focus:border-[color:var(--vc-border-strong)] focus:ring-1 focus:ring-[color:var(--vc-border-strong)] transition-colors disabled:opacity-50 [-webkit-text-security:disc]"
+              className="w-full bg-[var(--vc-surface-1)] border border-[color:var(--vc-border-subtle)] rounded-lg px-3 py-2.5 text-sm text-[var(--vc-text-primary)] placeholder:text-[var(--vc-text-subtle)] focus:outline-none focus:border-[color:var(--vc-border-strong)] focus:ring-1 focus:ring-[color:var(--vc-border-strong)] transition-colors disabled:opacity-50"
             />
             <p className="text-xs text-[var(--vc-text-subtle)]">
               {t("settings.apiKeyHint")}

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -105,11 +105,6 @@ export function SettingsPanel({
     });
   };
 
-  const handleSubmit = (event: { preventDefault: () => void }) => {
-    event.preventDefault();
-    handleSave();
-  };
-
   if (!isOpen) return null;
 
   const isLoading = settingsStatus === "loading";
@@ -152,7 +147,10 @@ export function SettingsPanel({
       />
       <form
         className="relative w-full max-w-lg bg-[var(--vc-bg)] border border-[color:var(--vc-border-subtle)] rounded-2xl flex flex-col shadow-2xl max-h-[90vh]"
-        onSubmit={handleSubmit}
+        onSubmit={(event) => {
+          event.preventDefault();
+          handleSave();
+        }}
       >
         <div className="flex items-center justify-between px-6 h-14 border-b border-[color:var(--vc-border-subtle)]">
           <h2 className="text-base font-semibold text-[var(--vc-text-primary)]">
@@ -355,13 +353,14 @@ export function SettingsPanel({
             </label>
             <input
               id="settings-api-key"
-              type="password"
-              autoComplete="new-password"
+              type="text"
+              autoComplete="off"
               value={apiKey}
               onChange={(e) => setApiKey(e.target.value)}
               placeholder={t("settings.apiKeyPlaceholder")}
               disabled={isLoading}
-              className="w-full bg-[var(--vc-surface-1)] border border-[color:var(--vc-border-subtle)] rounded-lg px-3 py-2.5 text-sm text-[var(--vc-text-primary)] placeholder:text-[var(--vc-text-subtle)] focus:outline-none focus:border-[color:var(--vc-border-strong)] focus:ring-1 focus:ring-[color:var(--vc-border-strong)] transition-colors disabled:opacity-50"
+              spellCheck={false}
+              className="w-full bg-[var(--vc-surface-1)] border border-[color:var(--vc-border-subtle)] rounded-lg px-3 py-2.5 text-sm text-[var(--vc-text-primary)] placeholder:text-[var(--vc-text-subtle)] focus:outline-none focus:border-[color:var(--vc-border-strong)] focus:ring-1 focus:ring-[color:var(--vc-border-strong)] transition-colors disabled:opacity-50 [-webkit-text-security:disc]"
             />
             <p className="text-xs text-[var(--vc-text-subtle)]">
               {t("settings.apiKeyHint")}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -6,7 +6,7 @@
   "config.maxSteps": "Max Steps",
   "config.leaderMode.direct": "Direct Execute",
   "config.leaderMode.plan": "Plan First",
-  "config.helpText": "Start the backend with OPENCODE_API_KEY set; the web client sends only runtime metadata, never secrets.",
+  "config.helpText": "Start the backend with DEEPSEEK_API_KEY set; the web client sends only runtime metadata, never secrets.",
   "app.title": "VoidCode",
   "app.tagline": "AI Coding Agent",
   "nav.workspace": "Workspace",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -6,7 +6,7 @@
   "config.maxSteps": "最大步骤",
   "config.leaderMode.direct": "直接执行",
   "config.leaderMode.plan": "先计划",
-  "config.helpText": "启动后端时设置 OPENCODE_API_KEY；Web 客户端只发送运行时元数据，不传递密钥。",
+  "config.helpText": "启动后端时设置 DEEPSEEK_API_KEY；Web 客户端只发送运行时元数据，不传递密钥。",
   "app.title": "VoidCode",
   "app.tagline": "AI编程助手",
   "nav.workspace": "工作区",

--- a/frontend/src/store.integration.test.ts
+++ b/frontend/src/store.integration.test.ts
@@ -1687,6 +1687,10 @@ describe("useAppStore integration flow", () => {
         skills: ["demo"],
         max_steps: 5,
         provider_stream: true,
+        agent: {
+          execution_engine: "provider",
+          custom_flag: "kept",
+        },
       },
     });
 
@@ -1700,7 +1704,7 @@ describe("useAppStore integration flow", () => {
         agent: {
           preset: "leader",
           model: "deepseek/deepseek-v4-pro",
-          execution_engine: "provider",
+          custom_flag: "kept",
         },
       },
     });
@@ -1737,7 +1741,6 @@ describe("useAppStore integration flow", () => {
         agent: {
           preset: "leader",
           model: "deepseek/deepseek-v4-pro",
-          execution_engine: "provider",
         },
       },
     });

--- a/frontend/src/store.integration.test.ts
+++ b/frontend/src/store.integration.test.ts
@@ -1688,7 +1688,6 @@ describe("useAppStore integration flow", () => {
         max_steps: 5,
         provider_stream: true,
         agent: {
-          execution_engine: "provider",
           custom_flag: "kept",
         },
       },
@@ -1796,7 +1795,6 @@ describe("useAppStore integration flow", () => {
         agent: {
           preset: "leader",
           model: "glm/glm-5",
-          execution_engine: "provider",
         },
       },
     });
@@ -1858,7 +1856,6 @@ describe("useAppStore integration flow", () => {
         agent: {
           preset: "leader",
           model: "deepseek/deepseek-v4-pro",
-          execution_engine: "provider",
         },
       },
     });
@@ -1921,7 +1918,6 @@ describe("useAppStore integration flow", () => {
         agent: {
           preset: "leader",
           model: "opencode-go/kimi-k2.6",
-          execution_engine: "provider",
         },
       },
     });
@@ -1980,7 +1976,6 @@ describe("useAppStore integration flow", () => {
         agent: {
           preset: "leader",
           model: "kimi/kimi-k2.6",
-          execution_engine: "provider",
         },
       },
     });
@@ -2039,7 +2034,6 @@ describe("useAppStore integration flow", () => {
         agent: {
           preset: "leader",
           model: "kimi/kimi-k2.6",
-          execution_engine: "provider",
         },
       },
     });
@@ -2104,7 +2098,6 @@ describe("useAppStore integration flow", () => {
         agent: {
           preset: "leader",
           model: "kimi-k2.6",
-          execution_engine: "provider",
         },
       },
     });
@@ -2163,7 +2156,6 @@ describe("useAppStore integration flow", () => {
         agent: {
           preset: "leader",
           model: "mystery-model",
-          execution_engine: "provider",
         },
       },
     });
@@ -2241,7 +2233,6 @@ describe("useAppStore integration flow", () => {
         agent: {
           preset: "leader",
           model: "deepseek/deepseek-v4-pro",
-          execution_engine: "provider",
         },
       },
     });
@@ -2281,7 +2272,6 @@ describe("useAppStore integration flow", () => {
         agent: {
           preset: "leader",
           model: "deepseek/deepseek-v4-pro",
-          execution_engine: "provider",
         },
       },
     });
@@ -2364,7 +2354,6 @@ describe("useAppStore integration flow", () => {
         agent: {
           preset: "leader",
           model: "opencode-go/kimi-k2.6",
-          execution_engine: "provider",
         },
       },
     });
@@ -2417,7 +2406,6 @@ describe("useAppStore integration flow", () => {
         agent: {
           preset: "leader",
           model: "opencode-go/kimi-k2.6",
-          execution_engine: "provider",
         },
       },
     });

--- a/frontend/src/store.integration.test.ts
+++ b/frontend/src/store.integration.test.ts
@@ -280,7 +280,7 @@ describe("useAppStore integration flow", () => {
     useAppStore.setState({
       language: "en",
       agentPreset: "leader",
-      providerModel: "opencode-go/glm-5.1",
+      providerModel: "deepseek/deepseek-v4-pro",
       workspaces: null,
       workspacesStatus: "idle",
       workspacesError: null,
@@ -424,7 +424,7 @@ describe("useAppStore integration flow", () => {
       operator_guidance: null,
     });
     runtimeClientMocks.validateProviderCredentialsMock.mockResolvedValue({
-      provider: "opencode-go",
+      provider: "deepseek",
       configured: true,
       ok: true,
       status: "ok",
@@ -1331,6 +1331,73 @@ describe("useAppStore integration flow", () => {
     expect(state.backgroundTaskOutputError).toBeNull();
   });
 
+  it("keeps delegated child output selected while refreshing session-scoped task lists", async () => {
+    const childTask = makeBackgroundTaskSummary("task-child", "child task");
+    const childOutput: BackgroundTaskOutput = {
+      task: {
+        task_id: "task-child",
+        status: "completed",
+        parent_session_id: "session-parent",
+        requested_child_session_id: "requested-child",
+        child_session_id: "child-session",
+        approval_request_id: null,
+        question_request_id: null,
+        approval_blocked: false,
+        summary_output: "child summary",
+        error: null,
+        result_available: true,
+        cancellation_cause: null,
+        routing: { mode: "subagent", subagent_type: "explore" },
+      },
+      session_result: {
+        session: makeSessionState("child-session", "completed"),
+        prompt: "child prompt",
+        status: "completed",
+        summary: "child summary",
+        output: "child output",
+        error: null,
+        last_event_sequence: 2,
+        transcript: [
+          makeEvent(
+            1,
+            "runtime.request_received",
+            { prompt: "child prompt" },
+            "runtime",
+            "child-session",
+          ),
+          makeEvent(
+            2,
+            "graph.response_ready",
+            { output: "child output" },
+            "graph",
+            "child-session",
+          ),
+        ],
+      },
+      output: "child output",
+    };
+
+    useAppStore.setState({
+      currentSessionId: "session-parent",
+      selectedBackgroundTaskOutputId: "task-child",
+      backgroundTaskOutput: childOutput,
+      backgroundTaskOutputStatus: "success",
+    });
+    runtimeClientMocks.listSessionBackgroundTasksMock.mockResolvedValue([
+      childTask,
+    ]);
+
+    await useAppStore.getState().loadBackgroundTasks();
+
+    const state = useAppStore.getState();
+    expect(state.backgroundTasks).toEqual([childTask]);
+    expect(state.selectedBackgroundTaskOutputId).toBe("task-child");
+    expect(state.backgroundTaskOutput).toEqual(childOutput);
+    expect(
+      runtimeClientMocks.listSessionBackgroundTasksMock,
+    ).toHaveBeenCalledWith("session-parent");
+  });
+
   it("surfaces approval lookup failure when no pending request exists", async () => {
     const sessionId = "broken-session";
     const requestReceived = makeEvent(
@@ -1632,7 +1699,7 @@ describe("useAppStore integration flow", () => {
         provider_stream: true,
         agent: {
           preset: "leader",
-          model: "opencode-go/glm-5.1",
+          model: "deepseek/deepseek-v4-pro",
           execution_engine: "provider",
         },
       },
@@ -1669,7 +1736,7 @@ describe("useAppStore integration flow", () => {
       metadata: {
         agent: {
           preset: "leader",
-          model: "opencode-go/glm-5.1",
+          model: "deepseek/deepseek-v4-pro",
           execution_engine: "provider",
         },
       },
@@ -1753,22 +1820,22 @@ describe("useAppStore integration flow", () => {
     ]);
     useAppStore.setState({
       reasoningEffort: "high",
-      providerModel: "opencode-go/glm-5.1",
+      providerModel: "deepseek/deepseek-v4-pro",
       providers: [
         {
-          name: "opencode-go",
-          label: "OpenCode Go",
+          name: "deepseek",
+          label: "DeepSeek",
           configured: true,
           current: true,
         },
       ],
       providerModels: {
-        "opencode-go": {
-          provider: "opencode-go",
+        deepseek: {
+          provider: "deepseek",
           configured: true,
-          models: ["glm-5.1"],
+          models: ["deepseek-v4-pro"],
           model_metadata: {
-            "glm-5.1": {
+            "deepseek-v4-pro": {
               supports_reasoning_effort: false,
               default_reasoning_effort: null,
             },
@@ -1787,7 +1854,7 @@ describe("useAppStore integration flow", () => {
       metadata: {
         agent: {
           preset: "leader",
-          model: "opencode-go/glm-5.1",
+          model: "deepseek/deepseek-v4-pro",
           execution_engine: "provider",
         },
       },
@@ -2170,7 +2237,7 @@ describe("useAppStore integration flow", () => {
       metadata: {
         agent: {
           preset: "leader",
-          model: "opencode-go/glm-5.1",
+          model: "deepseek/deepseek-v4-pro",
           execution_engine: "provider",
         },
       },
@@ -2210,7 +2277,7 @@ describe("useAppStore integration flow", () => {
       metadata: {
         agent: {
           preset: "leader",
-          model: "opencode-go/glm-5.1",
+          model: "deepseek/deepseek-v4-pro",
           execution_engine: "provider",
         },
       },
@@ -2355,29 +2422,29 @@ describe("useAppStore integration flow", () => {
 
   it("updates runtime-owned settings without expecting provider_api_key in the response", async () => {
     runtimeClientMocks.updateSettingsMock.mockResolvedValue({
-      provider: "opencode-go",
+      provider: "deepseek",
       provider_api_key_present: true,
-      model: "opencode-go/glm-5.1",
+      model: "deepseek/deepseek-v4-pro",
     });
 
     await useAppStore.getState().updateSettings({
-      provider: "opencode-go",
+      provider: "deepseek",
       provider_api_key: "secret-key",
-      model: "opencode-go/glm-5.1",
+      model: "deepseek/deepseek-v4-pro",
     });
 
     const state = useAppStore.getState();
     expect(runtimeClientMocks.updateSettingsMock).toHaveBeenCalledWith({
-      provider: "opencode-go",
+      provider: "deepseek",
       provider_api_key: "secret-key",
-      model: "opencode-go/glm-5.1",
+      model: "deepseek/deepseek-v4-pro",
     });
     expect(state.settings).toEqual({
-      provider: "opencode-go",
+      provider: "deepseek",
       provider_api_key_present: true,
-      model: "opencode-go/glm-5.1",
+      model: "deepseek/deepseek-v4-pro",
     });
-    expect(state.providerModel).toBe("opencode-go/glm-5.1");
+    expect(state.providerModel).toBe("deepseek/deepseek-v4-pro");
   });
 
   it("records provider credential validation results by provider", async () => {

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -934,7 +934,9 @@ export const useAppStore = create<AppState>()(
           ),
         );
         const forwardAgentMetadata = Object.fromEntries(
-          Object.entries(rawAgentMetadata),
+          Object.entries(rawAgentMetadata).filter(
+            ([key]) => key !== "execution_engine",
+          ),
         );
 
         const modelMetadata = selectedModelMetadata(
@@ -966,7 +968,6 @@ export const useAppStore = create<AppState>()(
               get().providerModels,
             ),
             ...forwardAgentMetadata,
-            execution_engine: "provider",
           },
         };
 

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -353,7 +353,7 @@ export const useAppStore = create<AppState>()(
     (set, get) => ({
       language: "en",
       agentPreset: "leader",
-      providerModel: "opencode-go/glm-5.1",
+      providerModel: "deepseek/deepseek-v4-pro",
       reasoningEffort: "",
       workspaces: null,
       workspacesStatus: "idle",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -16,11 +16,11 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "baseUrl": ".",
-    "types": ["vitest/globals", "@testing-library/jest-dom"],
+    "types": ["vitest/globals", "@testing-library/jest-dom", "node"],
     "paths": {
       "@/*": ["src/*"]
     }
   },
-  "include": ["src"],
+  "include": ["src", "e2e", "playwright.config.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/src/voidcode/provider/litellm_backend.py
+++ b/src/voidcode/provider/litellm_backend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
@@ -44,6 +45,8 @@ _SYNTHETIC_TOOL_FEEDBACK_PREFIX = "Completed tool calls for current request:"
 _CONTINUITY_SUMMARY_PREFIX = "Runtime continuity summary:"
 
 logger = logging.getLogger(__name__)
+_PROVIDER_TOOL_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+_PROVIDERS_REQUIRING_REASONING_CONTENT_WITH_TOOL_CALLS = frozenset({"deepseek"})
 
 
 def _usage_int(raw: object) -> int:
@@ -139,6 +142,39 @@ def _normalize_tool_call_id(value: str | None, *, fallback: str) -> str:
     return normalized or fallback
 
 
+def _sanitize_provider_tool_name(tool_name: str) -> str:
+    if _PROVIDER_TOOL_NAME_PATTERN.fullmatch(tool_name):
+        return tool_name
+    normalized = re.sub(r"[^a-zA-Z0-9_-]", "_", tool_name).strip("_") or "tool"
+    suffix = hashlib.sha1(tool_name.encode("utf-8")).hexdigest()[:8]
+    return f"{normalized}_{suffix}"
+
+
+def _reasoning_content_for_tool_message(segment: object) -> str | None:
+    metadata = getattr(segment, "metadata", None)
+    if not isinstance(metadata, dict):
+        return None
+    data = metadata.get("data")
+    if isinstance(data, dict):
+        reasoning_content = data.get("reasoning_content")
+        if isinstance(reasoning_content, str) and reasoning_content:
+            return reasoning_content
+    return None
+
+
+def _reasoning_content_from_tool_data(segment: object) -> str | None:
+    metadata = getattr(segment, "metadata", None)
+    if not isinstance(metadata, dict):
+        return None
+    data = metadata.get("data")
+    if not isinstance(data, dict):
+        return None
+    reasoning_content = data.get("reasoning_content")
+    if isinstance(reasoning_content, str) and reasoning_content:
+        return reasoning_content
+    return None
+
+
 @dataclass(frozen=True, slots=True)
 class _StreamedToolCallAccumulator:
     tool_call_id: str | None = None
@@ -157,7 +193,57 @@ class LiteLLMBackendSingleAgentProvider:
     )
 
     @staticmethod
-    def _to_tool_schema(tool: ToolDefinition) -> dict[str, object]:
+    def _provider_tool_name_maps(
+        request: ProviderTurnRequest,
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        original_to_provider: dict[str, str] = {}
+        provider_to_original: dict[str, str] = {}
+        tool_names = dict.fromkeys(
+            tool.name
+            for tool in request.available_tools
+            if isinstance(tool.name, str) and tool.name
+        )
+        for segment in request.assembled_context.segments:
+            tool_name = segment.tool_name
+            if isinstance(tool_name, str) and tool_name:
+                tool_names.setdefault(tool_name, None)
+        for tool_name in tool_names:
+            base_candidate = _sanitize_provider_tool_name(tool_name)
+            candidate = base_candidate
+            if provider_to_original.get(candidate) not in {None, tool_name}:
+                suffix = hashlib.sha1(tool_name.encode("utf-8")).hexdigest()
+                index = 8
+                while provider_to_original.get(candidate) not in {None, tool_name}:
+                    candidate = f"{base_candidate}_{suffix[:index]}"
+                    index += 2
+            original_to_provider[tool_name] = candidate
+            provider_to_original[candidate] = tool_name
+        return original_to_provider, provider_to_original
+
+    @staticmethod
+    def _provider_tool_name(
+        tool_name: str | None,
+        *,
+        original_to_provider: Mapping[str, str],
+    ) -> str | None:
+        if tool_name is None:
+            return None
+        return original_to_provider.get(tool_name, tool_name)
+
+    @staticmethod
+    def _runtime_tool_name(
+        tool_name: str,
+        *,
+        provider_to_original: Mapping[str, str],
+    ) -> str:
+        return provider_to_original.get(tool_name, tool_name)
+
+    @staticmethod
+    def _to_tool_schema(
+        tool: ToolDefinition,
+        *,
+        original_to_provider: Mapping[str, str],
+    ) -> dict[str, object]:
         input_schema = tool.input_schema or {}
         parameters: dict[str, object]
         if _is_object_json_schema(input_schema):
@@ -172,7 +258,10 @@ class LiteLLMBackendSingleAgentProvider:
         return {
             "type": "function",
             "function": {
-                "name": tool.name,
+                "name": LiteLLMBackendSingleAgentProvider._provider_tool_name(
+                    tool.name,
+                    original_to_provider=original_to_provider,
+                ),
                 "description": tool.description,
                 "parameters": parameters,
             },
@@ -283,6 +372,20 @@ class LiteLLMBackendSingleAgentProvider:
 
     def _build_messages(self, request: ProviderTurnRequest) -> list[dict[str, object]]:
         assembled_context = request.assembled_context
+        original_to_provider, _provider_to_original = self._provider_tool_name_maps(request)
+        requires_reasoning_content = (request.provider_name or self.name) in (
+            _PROVIDERS_REQUIRING_REASONING_CONTENT_WITH_TOOL_CALLS
+        )
+        reasoning_content_by_tool_call_id: dict[str, str] = {}
+        if requires_reasoning_content:
+            for segment in assembled_context.segments:
+                if segment.role != "tool":
+                    continue
+                if not isinstance(segment.tool_call_id, str) or not segment.tool_call_id:
+                    continue
+                reasoning_content = _reasoning_content_from_tool_data(segment)
+                if reasoning_content:
+                    reasoning_content_by_tool_call_id[segment.tool_call_id] = reasoning_content
         messages: list[dict[str, object]] = []
         if self._tool_feedback_mode_for_request(request) == "synthetic_user_message":
             tool_feedback_lines: list[str] = []
@@ -305,7 +408,10 @@ class LiteLLMBackendSingleAgentProvider:
                         else {}
                     )
                     payload = {
-                        "tool_name": segment.tool_name,
+                        "tool_name": self._provider_tool_name(
+                            segment.tool_name,
+                            original_to_provider=original_to_provider,
+                        ),
                         "arguments": sanitized_arguments,
                         "status": metadata.get("status"),
                         "content": segment.content or "",
@@ -363,12 +469,27 @@ class LiteLLMBackendSingleAgentProvider:
                     {
                         "role": "assistant",
                         "content": segment.content,
+                        **(
+                            {
+                                "reasoning_content": (
+                                    reasoning_content_by_tool_call_id.get(
+                                        segment.tool_call_id or ""
+                                    )
+                                    or " "
+                                )
+                            }
+                            if requires_reasoning_content
+                            else {}
+                        ),
                         "tool_calls": [
                             {
                                 "id": tool_call_id,
                                 "type": "function",
                                 "function": {
-                                    "name": segment.tool_name,
+                                    "name": self._provider_tool_name(
+                                        segment.tool_name,
+                                        original_to_provider=original_to_provider,
+                                    ),
                                     "arguments": arguments,
                                 },
                             }
@@ -385,7 +506,10 @@ class LiteLLMBackendSingleAgentProvider:
                     else {}
                 )
                 payload = {
-                    "tool_name": segment.tool_name,
+                    "tool_name": self._provider_tool_name(
+                        segment.tool_name,
+                        original_to_provider=original_to_provider,
+                    ),
                     "content": segment.content or "",
                     "status": metadata.get("status"),
                     "error": metadata.get("error"),
@@ -494,7 +618,11 @@ class LiteLLMBackendSingleAgentProvider:
         return {"api_key": self.config.api_key}
 
     @staticmethod
-    def _extract_first_tool_call(message: dict[str, object]) -> ToolCall | None:
+    def _extract_first_tool_call(
+        message: dict[str, object],
+        *,
+        provider_to_original: Mapping[str, str] | None = None,
+    ) -> ToolCall | None:
         raw_tool_calls = message.get("tool_calls")
         if not isinstance(raw_tool_calls, list) or not raw_tool_calls:
             return None
@@ -510,6 +638,10 @@ class LiteLLMBackendSingleAgentProvider:
         tool_name_obj = function.get("name")
         if not isinstance(tool_name_obj, str) or not tool_name_obj:
             return None
+        runtime_tool_name = LiteLLMBackendSingleAgentProvider._runtime_tool_name(
+            tool_name_obj,
+            provider_to_original=provider_to_original or {},
+        )
         parsed_arguments: dict[str, object] = {}
         arguments_obj = function.get("arguments")
         if isinstance(arguments_obj, str) and arguments_obj.strip():
@@ -523,10 +655,10 @@ class LiteLLMBackendSingleAgentProvider:
         tool_call_id_obj = first_tool_call.get("id")
         tool_call_id = _normalize_tool_call_id(
             tool_call_id_obj if isinstance(tool_call_id_obj, str) else None,
-            fallback=tool_name_obj,
+            fallback=runtime_tool_name,
         )
         return ToolCall(
-            tool_name=tool_name_obj,
+            tool_name=runtime_tool_name,
             arguments=parsed_arguments,
             tool_call_id=tool_call_id,
         )
@@ -574,6 +706,7 @@ class LiteLLMBackendSingleAgentProvider:
 
     def propose_turn(self, request: ProviderTurnRequest) -> ProviderTurnResult:
         model_identifier = self._model_identifier(request)
+        original_to_provider, provider_to_original = self._provider_tool_name_maps(request)
         timeout_seconds = (
             _DEFAULT_COMPLETION_TIMEOUT_SECONDS
             if self.config is None or self.config.timeout_seconds is None
@@ -593,7 +726,10 @@ class LiteLLMBackendSingleAgentProvider:
         payload.update(self._completion_kwargs_for_request(request))
         self._apply_ssl_verify_payload(payload)
         if request.available_tools:
-            payload["tools"] = [self._to_tool_schema(tool) for tool in request.available_tools]
+            payload["tools"] = [
+                self._to_tool_schema(tool, original_to_provider=original_to_provider)
+                for tool in request.available_tools
+            ]
             payload["tool_choice"] = "auto"
 
         try:
@@ -612,7 +748,10 @@ class LiteLLMBackendSingleAgentProvider:
                 return ProviderTurnResult(output="", usage=usage)
             message = cast(dict[str, object], message_obj)
 
-            tool_call = self._extract_first_tool_call(message)
+            tool_call = self._extract_first_tool_call(
+                message,
+                provider_to_original=provider_to_original,
+            )
             if tool_call is not None:
                 return ProviderTurnResult(tool_call=tool_call, usage=usage)
 
@@ -629,6 +768,7 @@ class LiteLLMBackendSingleAgentProvider:
 
     def stream_turn(self, request: ProviderTurnRequest) -> Iterator[ProviderStreamEvent]:
         model_identifier = self._model_identifier(request)
+        original_to_provider, provider_to_original = self._provider_tool_name_maps(request)
         timeout_seconds = (
             _DEFAULT_COMPLETION_TIMEOUT_SECONDS
             if self.config is None or self.config.timeout_seconds is None
@@ -648,7 +788,10 @@ class LiteLLMBackendSingleAgentProvider:
         payload.update(self._stream_completion_kwargs_for_request(request))
         self._apply_ssl_verify_payload(payload)
         if request.available_tools:
-            payload["tools"] = [self._to_tool_schema(tool) for tool in request.available_tools]
+            payload["tools"] = [
+                self._to_tool_schema(tool, original_to_provider=original_to_provider)
+                for tool in request.available_tools
+            ]
             payload["tool_choice"] = "auto"
 
         try:
@@ -769,7 +912,8 @@ class LiteLLMBackendSingleAgentProvider:
                             },
                         }
                     ]
-                }
+                },
+                provider_to_original=provider_to_original,
             )
             if tool_payload is not None:
                 event_payload: dict[str, object] = {

--- a/src/voidcode/provider/litellm_backend.py
+++ b/src/voidcode/provider/litellm_backend.py
@@ -46,6 +46,8 @@ _CONTINUITY_SUMMARY_PREFIX = "Runtime continuity summary:"
 
 logger = logging.getLogger(__name__)
 _PROVIDER_TOOL_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+_MAX_PROVIDER_TOOL_NAME_LENGTH = 64
+_PROVIDER_TOOL_NAME_HASH_LENGTH = 8
 _PROVIDERS_REQUIRING_REASONING_CONTENT_WITH_TOOL_CALLS = frozenset({"deepseek"})
 
 
@@ -142,12 +144,28 @@ def _normalize_tool_call_id(value: str | None, *, fallback: str) -> str:
     return normalized or fallback
 
 
+def _truncate_provider_tool_name(base: str, *, suffix: str = "") -> str:
+    limit = _MAX_PROVIDER_TOOL_NAME_LENGTH - len(suffix)
+    if limit <= 0:
+        raise ValueError("provider tool name suffix exceeds maximum length")
+    truncated = base[:limit].rstrip("_-")
+    if not truncated:
+        truncated = "tool"[:limit]
+    if not truncated:
+        raise ValueError("provider tool name limit is too small")
+    return f"{truncated}{suffix}"
+
+
 def _sanitize_provider_tool_name(tool_name: str) -> str:
-    if _PROVIDER_TOOL_NAME_PATTERN.fullmatch(tool_name):
+    if (
+        _PROVIDER_TOOL_NAME_PATTERN.fullmatch(tool_name)
+        and len(tool_name) <= _MAX_PROVIDER_TOOL_NAME_LENGTH
+    ):
         return tool_name
     normalized = re.sub(r"[^a-zA-Z0-9_-]", "_", tool_name).strip("_") or "tool"
-    suffix = hashlib.sha1(tool_name.encode("utf-8")).hexdigest()[:8]
-    return f"{normalized}_{suffix}"
+    digest = hashlib.sha1(tool_name.encode("utf-8")).hexdigest()
+    suffix = f"_{digest[:_PROVIDER_TOOL_NAME_HASH_LENGTH]}"
+    return _truncate_provider_tool_name(normalized, suffix=suffix)
 
 
 def _reasoning_content_for_tool_message(segment: object) -> str | None:
@@ -212,9 +230,11 @@ class LiteLLMBackendSingleAgentProvider:
             candidate = base_candidate
             if provider_to_original.get(candidate) not in {None, tool_name}:
                 suffix = hashlib.sha1(tool_name.encode("utf-8")).hexdigest()
-                index = 8
+                index = _PROVIDER_TOOL_NAME_HASH_LENGTH + 2
+                normalized = re.sub(r"[^a-zA-Z0-9_-]", "_", tool_name).strip("_") or "tool"
                 while provider_to_original.get(candidate) not in {None, tool_name}:
-                    candidate = f"{base_candidate}_{suffix[:index]}"
+                    collision_suffix = f"_{suffix[:index]}"
+                    candidate = _truncate_provider_tool_name(normalized, suffix=collision_suffix)
                     index += 2
             original_to_provider[tool_name] = candidate
             provider_to_original[candidate] = tool_name

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -1786,10 +1786,11 @@ def _merge_builtin_mcp_server_defaults(
     if descriptor is None:
         return dict(raw_server)
     merged = dict(raw_server)
-    merged.setdefault("transport", descriptor.transport)
-    if descriptor.command:
+    if "transport" not in merged:
+        merged["transport"] = "stdio" if "command" in merged else descriptor.transport
+    if descriptor.command and merged.get("transport") == "stdio":
         merged.setdefault("command", list(descriptor.command))
-    if descriptor.url is not None:
+    if descriptor.url is not None and merged.get("transport") == "remote-http":
         merged.setdefault("url", descriptor.url)
     if descriptor.scope:
         merged.setdefault("scope", descriptor.scope)

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -28,6 +28,7 @@ from ..hook.config import FormatterCwdPolicy, RuntimeFormatterPresetConfig, Runt
 from ..hook.presets import validate_hook_preset_refs
 from ..lsp import LspServerConfigOverride as RuntimeLspServerConfig
 from ..lsp import derive_workspace_lsp_defaults, has_builtin_lsp_server_preset
+from ..mcp.builtin import get_builtin_mcp_descriptor
 from ..provider import config as provider_config
 from ..skills import SkillRegistry, list_builtin_skills
 from .permission import (
@@ -1777,6 +1778,24 @@ def _validation_context_field_path(info: ValidationInfo, *, default: str) -> str
     return default
 
 
+def _merge_builtin_mcp_server_defaults(
+    server_name: str,
+    raw_server: dict[str, object],
+) -> dict[str, object]:
+    descriptor = get_builtin_mcp_descriptor(server_name)
+    if descriptor is None:
+        return dict(raw_server)
+    merged = dict(raw_server)
+    merged.setdefault("transport", descriptor.transport)
+    if descriptor.command:
+        merged.setdefault("command", list(descriptor.command))
+    if descriptor.url is not None:
+        merged.setdefault("url", descriptor.url)
+    if descriptor.scope:
+        merged.setdefault("scope", descriptor.scope)
+    return merged
+
+
 class _RuntimeMcpServerValidationModel(BaseModel):
     model_config = ConfigDict(extra="forbid", validate_default=True)
 
@@ -1892,27 +1911,31 @@ class _RuntimeMcpValidationModel(BaseModel):
                 raise ValueError(
                     f"runtime config field 'mcp.servers.{server_name}' must be an object"
                 )
-            _reject_unknown_config_keys(
+            server_payload = _merge_builtin_mcp_server_defaults(
+                server_name,
                 cast(dict[str, object], raw_server),
+            )
+            _reject_unknown_config_keys(
+                server_payload,
                 allowed_keys=_MCP_SERVER_CONFIG_KEYS,
                 field_path=f"mcp.servers.{server_name}",
             )
-            transport = cast(dict[str, object], raw_server).get("transport")
+            transport = server_payload.get("transport")
             if transport is None:
                 transport = "stdio"
-            if transport == "stdio" and "command" not in raw_server:
+            if transport == "stdio" and "command" not in server_payload:
                 raise ValueError(
                     f"runtime config field 'mcp.servers.{server_name}.command' is required "
                     "when transport is stdio"
                 )
-            if transport == "remote-http" and "url" not in raw_server:
+            if transport == "remote-http" and "url" not in server_payload:
                 raise ValueError(
                     f"runtime config field 'mcp.servers.{server_name}.url' is required "
                     "when transport is remote-http"
                 )
             parsed_servers[server_name] = _validate_runtime_config_model(
                 _RuntimeMcpServerValidationModel,
-                cast(dict[str, object], raw_server),
+                server_payload,
                 context={"field_path": f"mcp.servers.{server_name}"},
             )
         return parsed_servers

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -871,7 +871,7 @@ def _parse_permission_config(raw_permission: object) -> ExternalDirectoryPermiss
     write_rules = _parse_permission_rules(
         permission_payload.get("external_directory_write"),
         field_path="permission.external_directory_write",
-        default=(("*", "deny"),),
+        default=(("*", "ask"),),
     )
     pattern_rules = _parse_pattern_permission_rules(permission_payload.get("rules"))
     return ExternalDirectoryPermissionConfig(

--- a/src/voidcode/runtime/permission.py
+++ b/src/voidcode/runtime/permission.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from fnmatch import fnmatchcase
 from pathlib import Path
@@ -46,7 +47,7 @@ class PatternPermissionRule:
 class ExternalDirectoryPermissionConfig:
     read: ExternalDirectoryPolicy = field(default_factory=ExternalDirectoryPolicy)
     write: ExternalDirectoryPolicy = field(
-        default_factory=lambda: ExternalDirectoryPolicy(rules=(("*", "deny"),))
+        default_factory=lambda: ExternalDirectoryPolicy(rules=(("*", "ask"),))
     )
     rules: tuple[PatternPermissionRule, ...] = ()
 
@@ -230,7 +231,25 @@ def _tool_matches_rule(*, tool_name: str, pattern: str) -> bool:
 def _command_matches_rule(*, command: str | None, pattern: str) -> bool:
     if command is None:
         return False
-    return fnmatchcase(command, pattern)
+    if fnmatchcase(command, pattern):
+        return True
+    for candidate in _command_match_candidates(command):
+        if fnmatchcase(candidate, pattern):
+            return True
+    return False
+
+
+def _command_match_candidates(command: str) -> tuple[str, ...]:
+    candidates: list[str] = []
+    for segment in re.split(r"[;&|]+", command):
+        stripped = segment.strip()
+        if not stripped:
+            continue
+        candidates.append(stripped)
+        first_token = stripped.split(None, 1)[0].strip()
+        if first_token:
+            candidates.append(first_token)
+    return tuple(dict.fromkeys(candidates))
 
 
 def _path_candidates_match_rule(*, path_candidates: tuple[str, ...], pattern: str) -> bool:

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -8728,7 +8728,7 @@ def _parse_persisted_external_permission_config(
             rules=_parse_persisted_external_permission_rules(
                 payload.get("external_directory_write"),
                 field_path="permission.external_directory_write",
-                default=(("*", "deny"),),
+                default=(("*", "ask"),),
             )
         ),
         rules=_parse_persisted_pattern_permission_rules(payload.get("rules")),

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import shlex
 import subprocess
 import threading
 from collections.abc import Callable, Iterable, Iterator, Mapping
@@ -3001,10 +3000,6 @@ class VoidCodeRuntime:
             patch_text = arguments.get("patch")
             if isinstance(patch_text, str) and patch_text:
                 candidates.extend(VoidCodeRuntime._extract_paths_from_patch(patch_text))
-        if tool_call.tool_name == "shell_exec":
-            command = arguments.get("command")
-            if isinstance(command, str):
-                candidates.extend(VoidCodeRuntime._extract_shell_path_candidates(command))
         return tuple(candidates)
 
     def _canonicalize_candidate_path(self, raw_path: str) -> Path | None:
@@ -3035,91 +3030,6 @@ class VoidCodeRuntime:
             elif line.startswith("*** Move to: "):
                 paths.append(line.removeprefix("*** Move to: ").strip())
         return tuple(path for path in paths if path)
-
-    @staticmethod
-    def _extract_shell_path_candidates(command: str) -> tuple[str, ...]:
-        try:
-            lexer = shlex.shlex(command, posix=False)
-            lexer.whitespace_split = True
-            tokens = list(lexer)
-        except ValueError:
-            tokens = command.split()
-        candidates: list[str] = []
-        for index, token in enumerate(tokens):
-            value = VoidCodeRuntime._normalize_shell_path_token(token)
-            if not value:
-                continue
-            if index == 0 and VoidCodeRuntime._looks_like_shell_executable(value):
-                continue
-            if VoidCodeRuntime._is_shell_explicit_output_path_candidate(tokens, index, value):
-                candidates.append(value)
-        return tuple(candidates)
-
-    @staticmethod
-    def _is_shell_explicit_output_path_candidate(tokens: list[str], index: int, value: str) -> bool:
-        if not VoidCodeRuntime._looks_like_shell_path_candidate(value):
-            return False
-        token = tokens[index].strip()
-        if VoidCodeRuntime._has_shell_output_redirection(token):
-            return True
-        option, has_inline_value = VoidCodeRuntime._shell_option_name(token)
-        output_options = {"--output", "--output-document", "--out", "--outfile"}
-        if option in output_options:
-            return True
-        previous = tokens[index - 1].strip() if index > 0 else ""
-        if VoidCodeRuntime._has_shell_output_redirection(previous):
-            return True
-        if previous in output_options or previous == "-o":
-            return True
-        if has_inline_value:
-            return False
-        return False
-
-    @staticmethod
-    def _has_shell_output_redirection(token: str) -> bool:
-        stripped = token.strip().lstrip("0123456789")
-        return stripped.startswith(">")
-
-    @staticmethod
-    def _shell_option_name(token: str) -> tuple[str | None, bool]:
-        stripped = token.strip().strip("\"'`")
-        if not stripped.startswith("-"):
-            return None, False
-        if "=" in stripped:
-            option, _value = stripped.split("=", 1)
-            return option, True
-        return stripped, False
-
-    @staticmethod
-    def _normalize_shell_path_token(token: str) -> str:
-        value = token.strip().strip("\"'`")
-        redirection_index = 0
-        while redirection_index < len(value) and value[redirection_index].isdigit():
-            redirection_index += 1
-        if redirection_index < len(value) and value[redirection_index] in ("<", ">"):
-            value = value[redirection_index:]
-        value = value.lstrip("<>")
-        if "=" in value:
-            _, assignment_value = value.split("=", 1)
-            assignment_value = assignment_value.strip().strip("\"'`")
-            if VoidCodeRuntime._looks_like_shell_path_candidate(assignment_value):
-                return assignment_value
-        return value
-
-    @staticmethod
-    def _looks_like_shell_path_candidate(value: str) -> bool:
-        normalized = value
-        while normalized.startswith("./") or normalized.startswith(".\\"):
-            normalized = normalized[2:]
-        if normalized.startswith(("~/", "../", "..\\", "/")):
-            return True
-        return len(normalized) >= 3 and normalized[1] == ":" and normalized[2] in ("\\", "/")
-
-    @staticmethod
-    def _looks_like_shell_executable(value: str) -> bool:
-        if value.startswith(("/", "~/")):
-            return True
-        return len(value) >= 3 and value[1] == ":" and value[2] in ("\\", "/")
 
     def list_sessions(self) -> tuple[StoredSessionSummary, ...]:
         return self._session_store.list_sessions(workspace=self._workspace)

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -24,7 +24,7 @@ pytestmark = pytest.mark.usefixtures("force_deterministic_engine_default")
 
 _DEFAULT_PERMISSION_METADATA = {
     "external_directory_read": {"*": "ask"},
-    "external_directory_write": {"*": "deny"},
+    "external_directory_write": {"*": "ask"},
 }
 _LEADER_HOOK_PRESET_SNAPSHOT = {
     "refs": [
@@ -3187,12 +3187,7 @@ def test_runtime_denies_external_write_when_permission_rule_denies(tmp_path: Pat
     assert outside_file.exists() is False
 
 
-def test_runtime_denies_shell_exec_external_write_when_permission_rule_denies(
-    tmp_path: Path,
-) -> None:
-    if sys.platform.startswith("win"):
-        pytest.skip("POSIX shell redirection syntax is required for this regression")
-
+def test_runtime_denies_shell_exec_when_command_rule_denies(tmp_path: Path) -> None:
     runtime_request, runtime_class = _load_runtime_types()
     permission_module = importlib.import_module("voidcode.runtime.permission")
     config_module = importlib.import_module("voidcode.runtime.config")
@@ -3203,11 +3198,6 @@ def test_runtime_denies_shell_exec_external_write_when_permission_rule_denies(
         Callable[..., object],
         config_module.ExternalDirectoryPermissionConfig,
     )
-    policy_config = cast(Callable[..., object], config_module.ExternalDirectoryPolicy)
-
-    outside_root = tmp_path.parent / "external-shell-write-fixture"
-    outside_root.mkdir(parents=True, exist_ok=True)
-    outside_file = outside_root / "out.txt"
 
     runtime = cast(
         RuntimeRunner,
@@ -3218,13 +3208,18 @@ def test_runtime_denies_shell_exec_external_write_when_permission_rule_denies(
                 config=runtime_config(
                     approval_mode="allow",
                     permission=permission_config(
-                        read=policy_config(rules=(("*", "allow"),)),
-                        write=policy_config(rules=(("*", "deny"),)),
+                        rules=(
+                            permission_module.PatternPermissionRule(
+                                tool="shell_exec",
+                                command="printf blocked*",
+                                decision="deny",
+                            ),
+                        ),
                     ),
                 ),
                 graph=_SingleToolGraph(
                     "shell_exec",
-                    {"command": f"printf blocked > {shlex.quote(str(outside_file))}"},
+                    {"command": "printf blocked > ./out.txt"},
                 ),
                 permission_policy=policy,
             ),
@@ -3232,18 +3227,17 @@ def test_runtime_denies_shell_exec_external_write_when_permission_rule_denies(
     )
 
     denied = runtime.run(
-        runtime_request(prompt="external shell write", session_id="external-shell-write-deny")
+        runtime_request(prompt="deny shell command", session_id="shell-command-rule-deny")
     )
     assert denied.session.status == "completed"
     denial = next(
         event for event in denied.events if event.event_type == "runtime.approval_resolved"
     )
     assert denial.payload["decision"] == "deny"
-    assert denial.payload["path_scope"] == "external"
-    assert denial.payload["operation_class"] == "execute"
-    assert denial.payload["matched_rule"] == "*"
-    assert denial.payload["policy_surface"] == "external_directory_write"
-    assert denial.payload["canonical_path"] == str(outside_file.resolve())
+    assert denial.payload["matched_rule"] == (
+        "permission.rules[0] tool='shell_exec' command='printf blocked*' decision='deny'"
+    )
+    assert denial.payload["policy_surface"] == "permission.rules"
     feedback = next(
         event
         for event in denied.events
@@ -3251,90 +3245,17 @@ def test_runtime_denies_shell_exec_external_write_when_permission_rule_denies(
         and event.payload.get("permission_denied") is True
     )
     assert feedback.payload["status"] == "error"
-    assert outside_file.exists() is False
 
 
-def test_runtime_denies_shell_exec_dot_parent_external_write_when_rule_denies(
-    tmp_path: Path,
-) -> None:
-    if sys.platform.startswith("win"):
-        pytest.skip("POSIX shell redirection syntax is required for this regression")
-
-    runtime_request, runtime_class = _load_runtime_types()
-    permission_module = importlib.import_module("voidcode.runtime.permission")
-    config_module = importlib.import_module("voidcode.runtime.config")
-
-    policy = cast(Callable[..., object], permission_module.PermissionPolicy)(mode="allow")
-    runtime_config = cast(Callable[..., object], config_module.RuntimeConfig)
-    permission_config = cast(
-        Callable[..., object],
-        config_module.ExternalDirectoryPermissionConfig,
-    )
-    policy_config = cast(Callable[..., object], config_module.ExternalDirectoryPolicy)
-
-    outside_file = tmp_path.parent / "dot-parent-shell-write.txt"
-    relative_external = "./../dot-parent-shell-write.txt"
-
-    runtime = cast(
-        RuntimeRunner,
-        cast(
-            object,
-            runtime_class(
-                workspace=tmp_path,
-                config=runtime_config(
-                    approval_mode="allow",
-                    permission=permission_config(
-                        read=policy_config(rules=(("*", "allow"),)),
-                        write=policy_config(rules=(("*", "deny"),)),
-                    ),
-                ),
-                graph=_SingleToolGraph(
-                    "shell_exec",
-                    {"command": f"printf blocked > {shlex.quote(relative_external)}"},
-                ),
-                permission_policy=policy,
-            ),
-        ),
-    )
-
-    denied = runtime.run(
-        runtime_request(prompt="dot parent shell write", session_id="dot-parent-shell-write-deny")
-    )
-
-    assert denied.session.status == "completed"
-    denial = next(
-        event for event in denied.events if event.event_type == "runtime.approval_resolved"
-    )
-    assert denial.payload["decision"] == "deny"
-    assert denial.payload["path_scope"] == "external"
-    assert denial.payload["operation_class"] == "execute"
-    assert denial.payload["policy_surface"] == "external_directory_write"
-    assert denial.payload["canonical_path"] == str(outside_file.resolve())
-    feedback = next(
-        event
-        for event in denied.events
-        if event.event_type == "runtime.tool_completed"
-        and event.payload.get("permission_denied") is True
-    )
-    assert feedback.payload["status"] == "error"
-    assert outside_file.exists() is False
-
-
-def test_runtime_denies_shell_exec_flag_absolute_path_when_rule_denies(
+def test_runtime_shell_exec_write_command_requests_approval_without_path_inference(
     tmp_path: Path,
 ) -> None:
     runtime_request, runtime_class = _load_runtime_types()
     permission_module = importlib.import_module("voidcode.runtime.permission")
     config_module = importlib.import_module("voidcode.runtime.config")
 
-    policy = cast(Callable[..., object], permission_module.PermissionPolicy)(mode="allow")
+    policy = cast(Callable[..., object], permission_module.PermissionPolicy)(mode="ask")
     runtime_config = cast(Callable[..., object], config_module.RuntimeConfig)
-    permission_config = cast(
-        Callable[..., object],
-        config_module.ExternalDirectoryPermissionConfig,
-    )
-    policy_config = cast(Callable[..., object], config_module.ExternalDirectoryPolicy)
-    outside_file = tmp_path.parent / "flag-shell-write.txt"
 
     runtime = cast(
         RuntimeRunner,
@@ -3344,41 +3265,28 @@ def test_runtime_denies_shell_exec_flag_absolute_path_when_rule_denies(
                 workspace=tmp_path,
                 config=runtime_config(
                     approval_mode="allow",
-                    permission=permission_config(
-                        read=policy_config(rules=(("*", "allow"),)),
-                        write=policy_config(rules=(("*", "deny"),)),
-                    ),
                 ),
                 graph=_SingleToolGraph(
                     "shell_exec",
-                    {"command": f"curl --output={shlex.quote(str(outside_file))} example.test"},
+                    {"command": "printf blocked > ./../dot-parent-shell-write.txt"},
                 ),
                 permission_policy=policy,
             ),
         ),
     )
 
-    denied = runtime.run(
-        runtime_request(prompt="flag shell write", session_id="flag-shell-write-deny")
+    waiting = runtime.run(
+        runtime_request(prompt="ask shell command", session_id="shell-command-ask")
     )
-
-    assert denied.session.status == "completed"
-    denial = next(
-        event for event in denied.events if event.event_type == "runtime.approval_resolved"
+    assert waiting.session.status == "waiting"
+    approval = next(
+        event for event in waiting.events if event.event_type == "runtime.approval_requested"
     )
-    assert denial.payload["decision"] == "deny"
-    assert denial.payload["path_scope"] == "external"
-    assert denial.payload["operation_class"] == "execute"
-    assert denial.payload["policy_surface"] == "external_directory_write"
-    assert denial.payload["canonical_path"] == str(outside_file.resolve())
-    feedback = next(
-        event
-        for event in denied.events
-        if event.event_type == "runtime.tool_completed"
-        and event.payload.get("permission_denied") is True
-    )
-    assert feedback.payload["status"] == "error"
-    assert outside_file.exists() is False
+    assert approval.payload["tool"] == "shell_exec"
+    assert approval.payload["path_scope"] == "workspace"
+    assert approval.payload["operation_class"] == "execute"
+    assert approval.payload["canonical_path"] is None
+    assert approval.payload["policy_surface"] is None
 
 
 def test_runtime_uses_persisted_external_permission_rules_after_resume(

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -2623,7 +2623,7 @@ def test_config_show_outputs_mcp_visibility_without_secrets() -> None:
     assert server["server"] == "context7"
     assert server["status"] == "disabled"
     assert server["scope"] == "session"
-    assert server["transport"] == "stdio"
+    assert server["transport"] == "remote-http"
     assert server["command"] == [
         "env",
         "API_KEY=<redacted>",

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -2623,7 +2623,7 @@ def test_config_show_outputs_mcp_visibility_without_secrets() -> None:
     assert server["server"] == "context7"
     assert server["status"] == "disabled"
     assert server["scope"] == "session"
-    assert server["transport"] == "remote-http"
+    assert server["transport"] == "stdio"
     assert server["command"] == [
         "env",
         "API_KEY=<redacted>",

--- a/tests/unit/provider/test_provider_adapters.py
+++ b/tests/unit/provider/test_provider_adapters.py
@@ -1806,6 +1806,69 @@ def test_provider_adapter_sanitizes_provider_tool_schema_and_decodes_runtime_too
     assert result.tool_call.arguments == {"query": "triangle"}
 
 
+def test_provider_adapter_caps_long_sanitized_tool_names_to_provider_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = LiteLLMBackendSingleAgentProvider(name="deepseek", config=None)
+    long_tool_name = "mcp/" + "very-long-server-name-" * 3 + "tool/" + "search-github-results-" * 2
+    request = _build_turn_request(model_name="deepseek")
+    request = ProviderTurnRequest(
+        assembled_context=_assembled_from_legacy(
+            prompt=request.prompt,
+            tool_results=request.tool_results,
+            context_window=request.context_window,
+            applied_skills=request.applied_skills,
+        ),
+        available_tools=(
+            ToolDefinition(
+                name=long_tool_name,
+                description="search github code",
+                input_schema={"query": {"type": "string"}},
+                read_only=True,
+            ),
+        ),
+        raw_model="deepseek/deepseek-v4-pro",
+        provider_name="deepseek",
+        model_name="deepseek-v4-pro",
+        attempt=request.attempt,
+        abort_signal=request.abort_signal,
+    )
+    original_to_provider, _provider_to_original = provider._provider_tool_name_maps(request)
+    provider_tool_name = original_to_provider[long_tool_name]
+    assert len(provider_tool_name) <= 64
+    assert provider_tool_name.endswith("_" + provider_tool_name.split("_")[-1])
+    _patch_litellm_completion(
+        monkeypatch,
+        mode="completion",
+        tool_calls=[
+            {
+                "id": "call-1",
+                "function": {
+                    "name": provider_tool_name,
+                    "arguments": json.dumps({"query": "triangle"}),
+                },
+            }
+        ],
+    )
+
+    result = provider.propose_turn(request)
+
+    payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
+    assert isinstance(payload_obj, dict)
+    payload = cast(dict[str, object], payload_obj)
+    tools_obj = payload.get("tools")
+    assert isinstance(tools_obj, list)
+    tool_payload = cast(dict[str, object], tools_obj[0])
+    function_obj = tool_payload.get("function")
+    assert isinstance(function_obj, dict)
+    function = cast(dict[str, object], function_obj)
+    assert function["name"] == provider_tool_name
+    assert len(cast(str, function["name"])) <= 64
+    assert result.tool_call is not None
+    assert result.tool_call.tool_name == long_tool_name
+    assert result.tool_call.arguments == {"query": "triangle"}
+
+
 def test_deepseek_provider_reinjects_reasoning_content_for_tool_history(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/provider/test_provider_adapters.py
+++ b/tests/unit/provider/test_provider_adapters.py
@@ -1747,6 +1747,171 @@ def test_provider_adapter_synthetic_feedback_strips_argument_sentinels(
     assert '"byte_count"' not in feedback
 
 
+def test_provider_adapter_sanitizes_provider_tool_schema_and_decodes_runtime_tool_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = LiteLLMBackendSingleAgentProvider(name="deepseek", config=None)
+    request = _build_turn_request(model_name="deepseek")
+    request = ProviderTurnRequest(
+        assembled_context=_assembled_from_legacy(
+            prompt=request.prompt,
+            tool_results=request.tool_results,
+            context_window=request.context_window,
+            applied_skills=request.applied_skills,
+        ),
+        available_tools=(
+            ToolDefinition(
+                name="mcp/grep_app/searchGitHub",
+                description="search github code",
+                input_schema={"query": {"type": "string"}},
+                read_only=True,
+            ),
+        ),
+        raw_model="deepseek/deepseek-v4-pro",
+        provider_name="deepseek",
+        model_name="deepseek-v4-pro",
+        attempt=request.attempt,
+        abort_signal=request.abort_signal,
+    )
+    original_to_provider, _provider_to_original = provider._provider_tool_name_maps(request)
+    provider_tool_name = original_to_provider["mcp/grep_app/searchGitHub"]
+    _patch_litellm_completion(
+        monkeypatch,
+        mode="completion",
+        tool_calls=[
+            {
+                "id": "call-1",
+                "function": {
+                    "name": provider_tool_name,
+                    "arguments": json.dumps({"query": "triangle"}),
+                },
+            }
+        ],
+    )
+
+    result = provider.propose_turn(request)
+
+    payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
+    assert isinstance(payload_obj, dict)
+    payload = cast(dict[str, object], payload_obj)
+    tools_obj = payload.get("tools")
+    assert isinstance(tools_obj, list)
+    tool_payload = cast(dict[str, object], tools_obj[0])
+    function_obj = tool_payload.get("function")
+    assert isinstance(function_obj, dict)
+    function = cast(dict[str, object], function_obj)
+    assert function["name"] == provider_tool_name
+    assert result.tool_call is not None
+    assert result.tool_call.tool_name == "mcp/grep_app/searchGitHub"
+    assert result.tool_call.arguments == {"query": "triangle"}
+
+
+def test_deepseek_provider_reinjects_reasoning_content_for_tool_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = LiteLLMBackendSingleAgentProvider(name="deepseek", config=None)
+    tool_results = (
+        ToolResult(
+            tool_name="glob",
+            status="ok",
+            content=".voidcode.json",
+            data={
+                "tool_call_id": "glob_0",
+                "arguments": {"pattern": "*"},
+                "reasoning_content": "Need to inspect the workspace before coding.",
+            },
+        ),
+    )
+    request = ProviderTurnRequest(
+        assembled_context=_assembled_from_legacy(
+            prompt="build the triangle app",
+            tool_results=tool_results,
+            context_window=_StubContextWindow(
+                prompt="build the triangle app",
+                tool_results=tool_results,
+            ),
+            applied_skills=(),
+        ),
+        available_tools=(ToolDefinition(name="glob", description="glob files", read_only=True),),
+        raw_model="deepseek/deepseek-v4-pro",
+        provider_name="deepseek",
+        model_name="deepseek-v4-pro",
+        attempt=0,
+        abort_signal=None,
+    )
+    _patch_litellm_completion(
+        monkeypatch,
+        mode="completion",
+        completion_content="ok",
+    )
+
+    _ = provider.propose_turn(request)
+
+    payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
+    assert isinstance(payload_obj, dict)
+    payload = cast(dict[str, object], payload_obj)
+    messages_obj = payload.get("messages")
+    assert isinstance(messages_obj, list)
+    messages = cast(list[dict[str, object]], messages_obj)
+    assistant_message = messages[1]
+    assert assistant_message["role"] == "assistant"
+    assert assistant_message["reasoning_content"] == (
+        "Need to inspect the workspace before coding."
+    )
+    assert "tool_calls" in assistant_message
+
+
+def test_deepseek_provider_falls_back_to_blank_reasoning_content_for_tool_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = LiteLLMBackendSingleAgentProvider(name="deepseek", config=None)
+    tool_results = (
+        ToolResult(
+            tool_name="glob",
+            status="ok",
+            content=".voidcode.json",
+            data={
+                "tool_call_id": "glob_0",
+                "arguments": {"pattern": "*"},
+            },
+        ),
+    )
+    request = ProviderTurnRequest(
+        assembled_context=_assembled_from_legacy(
+            prompt="build the triangle app",
+            tool_results=tool_results,
+            context_window=_StubContextWindow(
+                prompt="build the triangle app",
+                tool_results=tool_results,
+            ),
+            applied_skills=(),
+        ),
+        available_tools=(ToolDefinition(name="glob", description="glob files", read_only=True),),
+        raw_model="deepseek/deepseek-v4-pro",
+        provider_name="deepseek",
+        model_name="deepseek-v4-pro",
+        attempt=0,
+        abort_signal=None,
+    )
+    _patch_litellm_completion(
+        monkeypatch,
+        mode="completion",
+        completion_content="ok",
+    )
+
+    _ = provider.propose_turn(request)
+
+    payload_obj = _LAST_REQUEST_PAYLOAD.get("kwargs")
+    assert isinstance(payload_obj, dict)
+    payload = cast(dict[str, object], payload_obj)
+    messages_obj = payload.get("messages")
+    assert isinstance(messages_obj, list)
+    messages = cast(list[dict[str, object]], messages_obj)
+    assistant_message = messages[1]
+    assert assistant_message["role"] == "assistant"
+    assert assistant_message["reasoning_content"] == " "
+
+
 def test_provider_adapter_infers_tool_feedback_when_metadata_omits_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/runtime/test_mcp_config.py
+++ b/tests/unit/runtime/test_mcp_config.py
@@ -242,6 +242,34 @@ def test_runtime_config_parses_mcp_remote_http_servers(tmp_path: Path) -> None:
     )
 
 
+def test_runtime_config_expands_builtin_mcp_server_shorthand(tmp_path: Path) -> None:
+    (tmp_path / ".voidcode.json").write_text(
+        json.dumps(
+            {
+                "mcp": {
+                    "enabled": True,
+                    "servers": {
+                        "grep_app": {},
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.mcp == RuntimeMcpConfig(
+        enabled=True,
+        servers={
+            "grep_app": RuntimeMcpServerConfig(
+                transport="remote-http",
+                url="https://mcp.grep.app",
+            )
+        },
+    )
+
+
 def test_runtime_config_rejects_missing_mcp_url_for_remote_http(tmp_path: Path) -> None:
     (tmp_path / ".voidcode.json").write_text(
         json.dumps(
@@ -249,7 +277,7 @@ def test_runtime_config_rejects_missing_mcp_url_for_remote_http(tmp_path: Path) 
                 "mcp": {
                     "enabled": True,
                     "servers": {
-                        "grep_app": {
+                        "custom_remote": {
                             "transport": "remote-http",
                         }
                     },
@@ -259,5 +287,5 @@ def test_runtime_config_rejects_missing_mcp_url_for_remote_http(tmp_path: Path) 
         encoding="utf-8",
     )
 
-    with pytest.raises(ValueError, match="mcp.servers.grep_app"):
+    with pytest.raises(ValueError, match="mcp.servers.custom_remote"):
         load_runtime_config(tmp_path, env={})

--- a/tests/unit/runtime/test_mcp_config.py
+++ b/tests/unit/runtime/test_mcp_config.py
@@ -48,6 +48,38 @@ def test_runtime_config_parses_mcp_stdio_servers(tmp_path: Path) -> None:
     )
 
 
+def test_runtime_config_preserves_stdio_for_builtin_command_server(tmp_path: Path) -> None:
+    (tmp_path / ".voidcode.json").write_text(
+        json.dumps(
+            {
+                "mcp": {
+                    "enabled": False,
+                    "servers": {
+                        "context7": {
+                            "command": ["context7", "--api-key", "secret-token"],
+                            "scope": "session",
+                        }
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.mcp == RuntimeMcpConfig(
+        enabled=False,
+        servers={
+            "context7": RuntimeMcpServerConfig(
+                transport="stdio",
+                command=("context7", "--api-key", "secret-token"),
+                scope="session",
+            )
+        },
+    )
+
+
 def test_runtime_config_rejects_unknown_mcp_transport(tmp_path: Path) -> None:
     (tmp_path / ".voidcode.json").write_text(
         json.dumps(

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -227,7 +227,7 @@ def test_runtime_config_defaults_to_ask_without_file_or_env(tmp_path: Path) -> N
     assert config.background_task == RuntimeBackgroundTaskConfig()
     assert config.hooks is None
     assert config.permission.read.rules == (("*", "ask"),)
-    assert config.permission.write.rules == (("*", "deny"),)
+    assert config.permission.write.rules == (("*", "ask"),)
 
 
 def test_runtime_config_loads_external_directory_permission_rules(tmp_path: Path) -> None:
@@ -239,7 +239,7 @@ def test_runtime_config_loads_external_directory_permission_rules(tmp_path: Path
                         "~/.config/voidcode/skills/**": "allow",
                         "*": "ask",
                     },
-                    "external_directory_write": {"*": "deny"},
+                    "external_directory_write": {"*": "ask"},
                 }
             }
         ),
@@ -252,7 +252,7 @@ def test_runtime_config_loads_external_directory_permission_rules(tmp_path: Path
         ("~/.config/voidcode/skills/**", "allow"),
         ("*", "ask"),
     )
-    assert config.permission.write.rules == (("*", "deny"),)
+    assert config.permission.write.rules == (("*", "ask"),)
 
 
 def test_runtime_config_loads_pattern_permission_rules(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -255,6 +255,20 @@ def test_runtime_config_loads_external_directory_permission_rules(tmp_path: Path
     assert config.permission.write.rules == (("*", "ask"),)
 
 
+def test_runtime_config_defaults_missing_external_write_rule_to_ask(tmp_path: Path) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps(
+            {"permission": {"external_directory_read": {"~/.config/voidcode/skills/**": "allow"}}}
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.permission.read.rules == (("~/.config/voidcode/skills/**", "allow"),)
+    assert config.permission.write.rules == (("*", "ask"),)
+
+
 def test_runtime_config_loads_pattern_permission_rules(tmp_path: Path) -> None:
     runtime_config_path(tmp_path).write_text(
         json.dumps(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -103,6 +103,7 @@ from voidcode.runtime.permission import (
     PatternPermissionRule,
     PendingApproval,
     PermissionPolicy,
+    evaluate_pattern_permission_rules,
 )
 from voidcode.runtime.provider_protocol import (
     ProviderExecutionError,
@@ -180,55 +181,6 @@ def _private_attr(instance: object, name: str) -> Any:
     return getattr(instance, name)
 
 
-@pytest.mark.parametrize(
-    ("command", "expected"),
-    [
-        ("ls /etc", ()),
-        ("du -sh /var", ()),
-        ("test -f /usr/include/vulkan/vulkan.h", ()),
-        ("cat /usr/include/vulkan/vulkan.h", ()),
-        ("echo hi > /tmp/out.txt", ("/tmp/out.txt",)),
-        ("echo hi > /tmp/out.txt && cat /tmp/out.txt", ("/tmp/out.txt",)),
-        ("echo hi 2>/tmp/err.log", ("/tmp/err.log",)),
-        ("echo hi > ./../out.txt", ("./../out.txt",)),
-        ("echo hi > ././../out.txt", ("././../out.txt",)),
-        ("curl --output=/tmp/out.txt https://example.com", ("/tmp/out.txt",)),
-        ("curl -o /tmp/out.txt https://example.com", ("/tmp/out.txt",)),
-        ("curl --write-out=/tmp/format.txt https://example.com", ()),
-        ("tool --output=././../out.txt", ("././../out.txt",)),
-        ("tool --config=/etc/app.conf", ()),
-        ("tool --file=2024/report.txt", ()),
-        (r"type C:\temp\out.log", ()),
-        (
-            r"type C:\Windows\System32\drivers\etc\hosts",
-            (),
-        ),
-        ("touch /tmp/out.txt", ()),
-        ("mkdir /tmp/generated", ()),
-        ("rm /tmp/out.txt", ()),
-        ("cp /etc/input.conf /tmp/output.conf", ()),
-        ("mv /tmp/source.txt /tmp/output.txt", ()),
-        ("sudo cp /etc/input.conf /tmp/output.conf", ()),
-        ("git mv /tmp/source.txt /tmp/output.txt", ()),
-        ("cp /etc/input.conf /tmp/output.conf > /tmp/copy.log", ("/tmp/copy.log",)),
-        ("cat 2024/report.txt", ()),
-    ],
-)
-def test_runtime_extracts_shell_external_path_candidates(
-    command: str,
-    expected: tuple[str, ...],
-) -> None:
-    runtime_type = cast(Any, VoidCodeRuntime)
-    assert runtime_type._extract_shell_path_candidates(command) == expected
-
-
-def test_runtime_ignores_shell_executable_path_candidate() -> None:
-    command = f'"{sys.executable}" -c "print(1)"'
-
-    runtime_type = cast(Any, VoidCodeRuntime)
-    assert runtime_type._extract_shell_path_candidates(command) == ()
-
-
 def test_runtime_shell_read_probe_external_path_stays_workspace_scoped(tmp_path: Path) -> None:
     runtime = VoidCodeRuntime(workspace=tmp_path)
     shell_tool = ToolRegistry.with_defaults().resolve("shell_exec")
@@ -244,6 +196,44 @@ def test_runtime_shell_read_probe_external_path_stays_workspace_scoped(tmp_path:
     )
 
     assert context == ("workspace", None, "execute", ())
+
+
+def test_pattern_permission_rule_matches_shell_exec_command_segments() -> None:
+    matched = evaluate_pattern_permission_rules(
+        rules=(
+            PatternPermissionRule(
+                tool="shell_exec",
+                command="cmake*",
+                decision="allow",
+            ),
+        ),
+        tool_name="shell_exec",
+        command="which cmake ninja 2>/dev/null; cmake --version",
+    )
+
+    assert matched == (
+        "allow",
+        "permission.rules[0] tool='shell_exec' command='cmake*' decision='allow'",
+    )
+
+
+def test_pattern_permission_rule_matches_shell_exec_first_token_of_segment() -> None:
+    matched = evaluate_pattern_permission_rules(
+        rules=(
+            PatternPermissionRule(
+                tool="shell_exec",
+                command="pkg-config*",
+                decision="allow",
+            ),
+        ),
+        tool_name="shell_exec",
+        command="echo ready && pkg-config --cflags --libs sdl3",
+    )
+
+    assert matched == (
+        "allow",
+        "permission.rules[0] tool='shell_exec' command='pkg-config*' decision='allow'",
+    )
 
 
 def test_runtime_canonicalize_candidate_path_handles_unknown_user_tilde(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -144,7 +144,7 @@ from voidcode.tools.runtime_context import current_runtime_tool_context
 
 _DEFAULT_PERMISSION_METADATA = {
     "external_directory_read": {"*": "ask"},
-    "external_directory_write": {"*": "deny"},
+    "external_directory_write": {"*": "ask"},
 }
 
 
@@ -11096,6 +11096,57 @@ def test_runtime_effective_runtime_config_recovers_persisted_max_steps(tmp_path:
     assert effective.model == "session/model"
     assert effective.execution_engine == "deterministic"
     assert effective.max_steps == 7
+
+
+def test_runtime_effective_runtime_config_defaults_missing_persisted_external_write_to_ask(
+    tmp_path: Path,
+) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("config session\n", encoding="utf-8")
+
+    initial_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            approval_mode="allow",
+            execution_engine="deterministic",
+            model="session/model",
+        ),
+    )
+    response = initial_runtime.run(
+        RuntimeRequest(prompt="read sample.txt", session_id="persisted-missing-external-write")
+    )
+    runtime_config_metadata = cast(dict[str, object], response.session.metadata["runtime_config"])
+    permission_metadata = cast(dict[str, object], runtime_config_metadata["permission"])
+    del permission_metadata["external_directory_write"]
+
+    store = _private_attr(initial_runtime, "_session_store")
+    stored = store.load_session(
+        workspace=tmp_path,
+        session_id="persisted-missing-external-write",
+    )
+    session_metadata = dict(stored.session.metadata)
+    session_runtime_config = cast(dict[str, object], session_metadata["runtime_config"])
+    session_permission = cast(dict[str, object], session_runtime_config["permission"])
+    del session_permission["external_directory_write"]
+    store.save_run(
+        workspace=tmp_path,
+        request=RuntimeRequest(
+            prompt="read sample.txt",
+            session_id="persisted-missing-external-write",
+        ),
+        response=RuntimeResponse(
+            session=replace(stored.session, metadata=session_metadata),
+            output=stored.output,
+            events=stored.events,
+        ),
+        clear_pending_approval=False,
+    )
+
+    effective = VoidCodeRuntime(workspace=tmp_path).effective_runtime_config(
+        session_id="persisted-missing-external-write"
+    )
+
+    assert effective.permission.write.rules == (("*", "ask"),)
 
 
 def test_runtime_effective_runtime_config_recovers_persisted_tool_timeout(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- remove the redundant web settings warning and stop the web client from sending unsupported `agent.execution_engine` metadata
- preserve DeepSeek/LiteLLM tool-call continuity, add builtin MCP shorthand config support, and simplify `shell_exec` approvals to ask-or-rule-based routing
- expand runtime QA coverage around approvals, shell execution, MCP config parsing, and provider compatibility

## Verification
- `uv run pytest tests/unit/provider/test_provider_adapters.py -k "reasoning_content_for_tool_history or sanitizes_provider_tool_schema_and_decodes_runtime_tool_name"`
- `uv run pytest tests/unit/runtime/test_mcp_config.py -k "builtin_mcp_server_shorthand or parses_mcp_remote_http_servers or rejects_missing_mcp_url_for_remote_http"`
- `uv run pytest tests/unit/runtime/test_runtime_config.py -k "external_directory_permission_rules"`
- `uv run pytest tests/unit/runtime/test_runtime_service_extensions.py -k "approval or shell_exec or permission_rule or external_write or external_read"`
- `uv run pytest tests/integration/test_read_only_slice.py -k "approval or shell_exec or external_permission or permission_rule or external_write"`
- manual CLI QA: `uv run voidcode --help` and deterministic `voidcode run` approval allow/deny flow for `shell_exec`

Closes #424
Closes #429
