### PR TITLE
refactor(runtime): extract permission context resolver

### DIFF
--- a/src/voidcode/runtime/permission_context.py
+++ b/src/voidcode/runtime/permission_context.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import shlex
+from collections.abc import Callable, Mapping
+from pathlib import Path
+
+from ..tools.contracts import Tool, ToolCall, ToolDefinition
+from ..tools.local_custom import LocalCustomTool
+from .permission import OperationClass, PathScope
+
+EXTERNAL_PATH_PRECHECK_KEYS: Mapping[str, tuple[str, ...]] = {
+    "edit": ("path",),
+    "glob": ("path",),
+    "grep": ("path",),
+    "list": ("path",),
+    "multi_edit": ("path", "filePath"),
+    "read_file": ("filePath", "path"),
+    "write_file": ("path",),
+}
+
+
+class RuntimePermissionContextResolver:
+    def __init__(self, *, workspace: Path) -> None:
+        self._workspace = workspace
+
+    def permission_context_for_tool_call(
+        self,
+        *,
+        tool: ToolDefinition,
+        tool_instance: Tool,
+        tool_call: ToolCall,
+        patch_path_extractor: Callable[[str], tuple[str, ...]],
+    ) -> tuple[PathScope, str | None, OperationClass, tuple[str, ...]]:
+        operation_class = operation_class_for_tool(
+            tool_call.tool_name,
+            tool.read_only,
+            tool_instance=tool_instance,
+        )
+        candidate_paths = ()
+        if tool_call.tool_name != "shell_exec":
+            candidate_paths = self.candidate_paths_for_tool_call(
+                tool_call,
+                patch_path_extractor=patch_path_extractor,
+            )
+        workspace_root = self._workspace.resolve()
+        external_paths: list[str] = []
+        for raw_path in candidate_paths:
+            canonical = self.canonicalize_candidate_path(raw_path)
+            if canonical is None:
+                continue
+            if canonical.is_relative_to(workspace_root):
+                continue
+            external_paths.append(str(canonical))
+        if external_paths:
+            return "external", external_paths[0], operation_class, tuple(external_paths)
+        return "workspace", None, operation_class, ()
+
+    def normalized_permission_path_candidates(
+        self,
+        tool_call: ToolCall,
+        external_paths: tuple[str, ...],
+        *,
+        patch_path_extractor: Callable[[str], tuple[str, ...]],
+    ) -> tuple[str, ...]:
+        normalized: list[str] = []
+        for external_path in external_paths:
+            normalized.append(Path(external_path).as_posix())
+        for raw_path in self.candidate_paths_for_tool_call(
+            tool_call,
+            patch_path_extractor=patch_path_extractor,
+        ):
+            canonical = self.canonicalize_candidate_path(raw_path)
+            if canonical is not None:
+                normalized.append(canonical.as_posix())
+            text = raw_path.strip().replace("\\", "/")
+            if text:
+                normalized.append(text)
+        workspace_prefix = f"{self._workspace.as_posix().rstrip('/')}/"
+        relative: list[str] = []
+        for path in normalized:
+            if path.startswith(workspace_prefix):
+                relative.append(path.removeprefix(workspace_prefix))
+        return tuple(dict.fromkeys((*relative, *normalized)))
+
+    def candidate_paths_for_tool_call(
+        self,
+        tool_call: ToolCall,
+        *,
+        patch_path_extractor: Callable[[str], tuple[str, ...]],
+    ) -> tuple[str, ...]:
+        arguments = tool_call.arguments
+        candidates: list[str] = []
+        for key in EXTERNAL_PATH_PRECHECK_KEYS.get(tool_call.tool_name, ()):
+            value = arguments.get(key)
+            if isinstance(value, str) and value.strip():
+                candidates.append(value)
+        if tool_call.tool_name == "apply_patch":
+            patch_text = arguments.get("patch")
+            if isinstance(patch_text, str) and patch_text:
+                candidates.extend(patch_path_extractor(patch_text))
+        if tool_call.tool_name == "shell_exec":
+            command = arguments.get("command")
+            if isinstance(command, str):
+                candidates.extend(extract_shell_path_candidates(command))
+        return tuple(candidates)
+
+    def canonicalize_candidate_path(self, raw_path: str) -> Path | None:
+        text = raw_path.strip()
+        if not text:
+            return None
+        try:
+            candidate = Path(text).expanduser()
+        except RuntimeError:
+            candidate = Path(text)
+        if not candidate.is_absolute():
+            candidate = self._workspace / candidate
+        try:
+            return candidate.resolve(strict=False)
+        except OSError:
+            return None
+
+
+def operation_class_for_tool(
+    tool_name: str,
+    read_only: bool,
+    *,
+    tool_instance: Tool,
+) -> OperationClass:
+    if tool_name == "shell_exec" or isinstance(tool_instance, LocalCustomTool):
+        return "execute"
+    return "read" if read_only else "write"
+
+
+def extract_shell_path_candidates(command: str) -> tuple[str, ...]:
+    try:
+        lexer = shlex.shlex(command, posix=False)
+        lexer.whitespace_split = True
+        tokens = list(lexer)
+    except ValueError:
+        tokens = command.split()
+    candidates: list[str] = []
+    for index, token in enumerate(tokens):
+        value = _normalize_shell_path_token(token)
+        if not value:
+            continue
+        if index == 0 and _looks_like_shell_executable(value):
+            continue
+        if _is_shell_explicit_output_path_candidate(tokens, index, value):
+            candidates.append(value)
+    return tuple(candidates)
+
+
+def _is_shell_explicit_output_path_candidate(tokens: list[str], index: int, value: str) -> bool:
+    if not _looks_like_shell_path_candidate(value):
+        return False
+    token = tokens[index].strip()
+    if _has_shell_output_redirection(token):
+        return True
+    option, has_inline_value = _shell_option_name(token)
+    output_options = {"--output", "--output-document", "--out", "--outfile"}
+    if option in output_options:
+        return True
+    previous = tokens[index - 1].strip() if index > 0 else ""
+    if _has_shell_output_redirection(previous):
+        return True
+    if previous in output_options or previous == "-o":
+        return True
+    if has_inline_value:
+        return False
+    return False
+
+
+def _has_shell_output_redirection(token: str) -> bool:
+    stripped = token.strip().lstrip("0123456789")
+    return stripped.startswith(">")
+
+
+def _shell_option_name(token: str) -> tuple[str | None, bool]:
+    stripped = token.strip().strip("\"'`")
+    if not stripped.startswith("-"):
+        return None, False
+    if "=" in stripped:
+        option, _value = stripped.split("=", 1)
+        return option, True
+    return stripped, False
+
+
+def _normalize_shell_path_token(token: str) -> str:
+    value = token.strip().strip("\"'`")
+    redirection_index = 0
+    while redirection_index < len(value) and value[redirection_index].isdigit():
+        redirection_index += 1
+    if redirection_index < len(value) and value[redirection_index] in ("<", ">"):
+        value = value[redirection_index:]
+    value = value.lstrip("<>")
+    if "=" in value:
+        _, assignment_value = value.split("=", 1)
+        assignment_value = assignment_value.strip().strip("\"'`")
+        if _looks_like_shell_path_candidate(assignment_value):
+            return assignment_value
+    return value
+
+
+def _looks_like_shell_path_candidate(value: str) -> bool:
+    normalized = value
+    while normalized.startswith("./") or normalized.startswith(".\\"):
+        normalized = normalized[2:]
+    if normalized.startswith(("~/", "../", "..\\", "/")):
+        return True
+    return len(normalized) >= 3 and normalized[1] == ":" and normalized[2] in ("\\", "/")
+
+
+def _looks_like_shell_executable(value: str) -> bool:
+    if value.startswith(("/", "~/")):
+        return True
+    return len(value) >= 3 and value[1] == ":" and value[2] in ("\\", "/")

--- a/src/voidcode/runtime/resume.py
+++ b/src/voidcode/runtime/resume.py
@@ -1,4 +1,3 @@
-# pyright: reportPrivateUsage=false
 from __future__ import annotations
 
 import logging
@@ -397,7 +396,6 @@ class RuntimeResumeCoordinator:
             )
             for hook_chunk in idle_hook_outcome.chunks:
                 hook_event = cast(EventEnvelope, hook_chunk.event)
-                last_sequence = hook_event.sequence
                 loop_events.append(hook_event)
                 yield hook_chunk
             if idle_hook_outcome.failed_error is not None:
@@ -425,15 +423,15 @@ class RuntimeResumeCoordinator:
                     yield RuntimeStreamChunk(
                         kind="event", session=chunk.session, event=resequenced_event
                     )
+            end_hook_sequence = max(last_sequence, final_sequence)
             end_hook_outcome = runtime._run_lifecycle_hooks(
                 session=final_session,
-                sequence=max(last_sequence, final_sequence),
+                sequence=end_hook_sequence,
                 surface="session_end",
                 payload={"session_status": final_session.status, "resume": True},
             )
             for hook_chunk in end_hook_outcome.chunks:
                 hook_event = cast(EventEnvelope, hook_chunk.event)
-                last_sequence = hook_event.sequence
                 loop_events.append(hook_event)
                 yield hook_chunk
             if end_hook_outcome.failed_error is not None:
@@ -442,13 +440,10 @@ class RuntimeResumeCoordinator:
                     final_session.session.id,
                     end_hook_outcome.failed_error,
                 )
-            release_sequence = end_hook_outcome.last_sequence
             for release_event in runtime._release_mcp_session_events(
                 session_id=final_session.session.id,
-                start_sequence=release_sequence + 1,
+                start_sequence=end_hook_outcome.last_sequence + 1,
             ):
-                release_sequence = release_event.sequence
-                last_sequence = release_event.sequence
                 loop_events.append(release_event)
                 yield RuntimeStreamChunk(
                     kind="event",
@@ -892,7 +887,6 @@ class RuntimeResumeCoordinator:
             )
             for hook_chunk in idle_hook_outcome.chunks:
                 hook_event = cast(EventEnvelope, hook_chunk.event)
-                emitted_sequence = hook_event.sequence
                 loop_events.append(hook_event)
                 yield hook_chunk
             if idle_hook_outcome.failed_error is not None:
@@ -928,7 +922,6 @@ class RuntimeResumeCoordinator:
             )
             for hook_chunk in end_hook_outcome.chunks:
                 hook_event = cast(EventEnvelope, hook_chunk.event)
-                emitted_sequence = hook_event.sequence
                 loop_events.append(hook_event)
                 yield hook_chunk
             if end_hook_outcome.failed_error is not None:
@@ -941,7 +934,6 @@ class RuntimeResumeCoordinator:
                 session_id=session.session.id,
                 start_sequence=end_hook_outcome.last_sequence + 1,
             ):
-                emitted_sequence = release_event.sequence
                 loop_events.append(release_event)
                 yield RuntimeStreamChunk(
                     kind="event",
@@ -1266,7 +1258,6 @@ class RuntimeResumeCoordinator:
             )
             for hook_chunk in idle_hook_outcome.chunks:
                 hook_event = cast(EventEnvelope, hook_chunk.event)
-                last_sequence = hook_event.sequence
                 loop_events.append(hook_event)
                 yield hook_chunk
             if idle_hook_outcome.failed_error is not None:

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -1,4 +1,3 @@
-# pyright: reportPrivateUsage=false
 from __future__ import annotations
 
 import logging
@@ -372,26 +371,17 @@ class RuntimeRunLoopCoordinator:
         progress_queue: queue.Queue[_ToolQueueItem] = queue.Queue(
             maxsize=_TOOL_PROGRESS_QUEUE_MAX_ITEMS
         )
-        dropped_progress_events = 0
-        dropped_lock = threading.Lock()
 
         def emit_tool_progress(payload: Mapping[str, object]) -> None:
-            nonlocal dropped_progress_events
-            with dropped_lock:
-                dropped = dropped_progress_events
-                dropped_progress_events = 0
             progress_payload: dict[str, object] = {
                 "tool": tool_call.tool_name,
                 "tool_call_id": tool_call_id,
                 **dict(payload),
             }
-            if dropped:
-                progress_payload["dropped_progress_events"] = dropped
             try:
                 progress_queue.put_nowait(_ToolProgressItem(progress_payload))
             except queue.Full:
-                with dropped_lock:
-                    dropped_progress_events += 1 + dropped
+                pass
 
         def invoke_tool() -> None:
             try:

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -82,7 +82,6 @@ from ..tools.contracts import (
     ToolResult,
 )
 from ..tools.guidance import definition_with_guidance
-from ..tools.local_custom import LocalCustomTool
 from ..tools.output import (
     read_tool_output_artifact,
     sanitize_tool_result_data,
@@ -241,6 +240,7 @@ from .permission import (
     evaluate_pattern_permission_rules,
     resolve_permission,
 )
+from .permission_context import RuntimePermissionContextResolver, extract_shell_path_candidates
 from .provider_context import inspect_provider_context
 from .provider_protocol import ProviderExecutionError
 from .question import PendingQuestion, QuestionResponse
@@ -353,16 +353,6 @@ _ACP_CONNECTIVITY_ERRORS = frozenset(
         "ACP transport is not connected",
     }
 )
-_EXTERNAL_PATH_PRECHECK_KEYS: Mapping[str, tuple[str, ...]] = {
-    "edit": ("path",),
-    "glob": ("path",),
-    "grep": ("path",),
-    "list": ("path",),
-    "multi_edit": ("path", "filePath"),
-    "read_file": ("filePath", "path"),
-    "write_file": ("path",),
-}
-
 _SKILL_BINDING_SCOPE_KEYS = (
     "approval_mode",
     "execution_engine",
@@ -735,6 +725,9 @@ class VoidCodeRuntime:
         context_window_policy: ContextWindowPolicy | None = None,
     ) -> None:
         self._workspace = workspace.resolve()
+        self._permission_context_resolver = RuntimePermissionContextResolver(
+            workspace=self._workspace
+        )
         self._agent_registry = self._runtime_agent_registry()
         self._config = config or load_runtime_config(self._workspace)
         self._model_provider_registry = (
@@ -2365,8 +2358,6 @@ class VoidCodeRuntime:
                 ),
             )
 
-        active_agent = effective_config.agent
-
         graph_request = GraphRunRequest(
             session=session,
             prompt=request.prompt,
@@ -2473,7 +2464,6 @@ class VoidCodeRuntime:
             start_sequence=release_sequence + 1,
             mcp_events=release_events,
         ):
-            release_sequence = event.sequence
             yield RuntimeStreamChunk(kind="event", session=finalized_session, event=event)
 
     def _execute_graph_loop(
@@ -2929,46 +2919,23 @@ class VoidCodeRuntime:
         tool_instance: Tool,
         tool_call: ToolCall,
     ) -> tuple[PathScope, str | None, OperationClass, tuple[str, ...]]:
-        operation_class = self._operation_class_for_tool(
-            tool_call.tool_name,
-            tool.read_only,
+        return self._permission_context_resolver.permission_context_for_tool_call(
+            tool=tool,
             tool_instance=tool_instance,
+            tool_call=tool_call,
+            patch_path_extractor=self._extract_paths_from_patch,
         )
-        candidate_paths = self._candidate_paths_for_tool_call(tool_call)
-        workspace_root = self._workspace.resolve()
-        external_paths: list[str] = []
-        for raw_path in candidate_paths:
-            canonical = self._canonicalize_candidate_path(raw_path)
-            if canonical is None:
-                continue
-            if canonical.is_relative_to(workspace_root):
-                continue
-            external_paths.append(str(canonical))
-        if external_paths:
-            return "external", external_paths[0], operation_class, tuple(external_paths)
-        return "workspace", None, operation_class, ()
 
     def _normalized_permission_path_candidates(
         self,
         tool_call: ToolCall,
         external_paths: tuple[str, ...],
     ) -> tuple[str, ...]:
-        normalized: list[str] = []
-        for external_path in external_paths:
-            normalized.append(Path(external_path).as_posix())
-        for raw_path in self._candidate_paths_for_tool_call(tool_call):
-            canonical = self._canonicalize_candidate_path(raw_path)
-            if canonical is not None:
-                normalized.append(canonical.as_posix())
-            text = raw_path.strip().replace("\\", "/")
-            if text:
-                normalized.append(text)
-        workspace_prefix = f"{self._workspace.as_posix().rstrip('/')}/"
-        relative: list[str] = []
-        for path in normalized:
-            if path.startswith(workspace_prefix):
-                relative.append(path.removeprefix(workspace_prefix))
-        return tuple(dict.fromkeys((*relative, *normalized)))
+        return self._permission_context_resolver.normalized_permission_path_candidates(
+            tool_call,
+            external_paths,
+            patch_path_extractor=self._extract_paths_from_patch,
+        )
 
     @staticmethod
     def _shell_command_for_tool_call(tool_call: ToolCall) -> str | None:
@@ -2984,38 +2951,24 @@ class VoidCodeRuntime:
         *,
         tool_instance: Tool,
     ) -> OperationClass:
-        if tool_name == "shell_exec" or isinstance(tool_instance, LocalCustomTool):
-            return "execute"
-        return "read" if read_only else "write"
+        from .permission_context import operation_class_for_tool
+
+        return operation_class_for_tool(
+            tool_name,
+            read_only,
+            tool_instance=tool_instance,
+        )
 
     @staticmethod
     def _candidate_paths_for_tool_call(tool_call: ToolCall) -> tuple[str, ...]:
-        arguments = tool_call.arguments
-        candidates: list[str] = []
-        for key in _EXTERNAL_PATH_PRECHECK_KEYS.get(tool_call.tool_name, ()):
-            value = arguments.get(key)
-            if isinstance(value, str) and value.strip():
-                candidates.append(value)
-        if tool_call.tool_name == "apply_patch":
-            patch_text = arguments.get("patch")
-            if isinstance(patch_text, str) and patch_text:
-                candidates.extend(VoidCodeRuntime._extract_paths_from_patch(patch_text))
-        return tuple(candidates)
+        resolver = RuntimePermissionContextResolver(workspace=Path.cwd())
+        return resolver.candidate_paths_for_tool_call(
+            tool_call,
+            patch_path_extractor=VoidCodeRuntime._extract_paths_from_patch,
+        )
 
     def _canonicalize_candidate_path(self, raw_path: str) -> Path | None:
-        text = raw_path.strip()
-        if not text:
-            return None
-        try:
-            candidate = Path(text).expanduser()
-        except RuntimeError:
-            candidate = Path(text)
-        if not candidate.is_absolute():
-            candidate = self._workspace / candidate
-        try:
-            return candidate.resolve(strict=False)
-        except OSError:
-            return None
+        return self._permission_context_resolver.canonicalize_candidate_path(raw_path)
 
     @staticmethod
     def _extract_paths_from_patch(patch_text: str) -> tuple[str, ...]:
@@ -3030,6 +2983,10 @@ class VoidCodeRuntime:
             elif line.startswith("*** Move to: "):
                 paths.append(line.removeprefix("*** Move to: ").strip())
         return tuple(path for path in paths if path)
+
+    @staticmethod
+    def _extract_shell_path_candidates(command: str) -> tuple[str, ...]:
+        return extract_shell_path_candidates(command)
 
     def list_sessions(self) -> tuple[StoredSessionSummary, ...]:
         return self._session_store.list_sessions(workspace=self._workspace)
@@ -5230,12 +5187,10 @@ class VoidCodeRuntime:
                     checkpoint=checkpoint,
                     finalize_background_task=True,
                 )
-            response = self._load_stored_response(session_id=session_id)
             self._background_task_supervisor.reconcile_parent_background_task_events_for_session(
                 parent_session_id=session_id
             )
-            response = self._load_stored_response(session_id=session_id)
-            return response
+            return self._load_stored_response(session_id=session_id)
         if approval_request_id is None or approval_decision is None:
             raise ValueError("approval resume requires request id and decision")
         self._validate_resume_targets_owned_request(
@@ -5287,7 +5242,6 @@ class VoidCodeRuntime:
                 finally:
                     self._unregister_active_session_id(session_id, run_id=run_id)
                 return
-            response = self._load_stored_response(session_id=session_id)
             self._background_task_supervisor.reconcile_parent_background_task_events_for_session(
                 parent_session_id=session_id
             )
@@ -6225,7 +6179,6 @@ class VoidCodeRuntime:
         providers = self._effective_runtime_config_from_metadata(session_metadata).providers
         if providers is None:
             return DEFAULT_PROVIDER_TRANSIENT_RETRY_CONFIG
-        provider_config = None
         if provider_name == "opencode-go":
             provider_config = providers.opencode_go
         elif provider_name == "openai":

--- a/tests/integration/test_http_delegated_parity.py
+++ b/tests/integration/test_http_delegated_parity.py
@@ -17,8 +17,6 @@ Day-1 delegated lifecycle surfaces covered:
 - notification lifecycle (GET/POST /api/notifications)
 """
 
-# pyright: reportUnusedFunction=false
-
 from __future__ import annotations
 
 import asyncio
@@ -71,7 +69,7 @@ class StreamChunkLike(Protocol):
 
 class RuntimeResponseLike(Protocol):
     session: SessionLike
-    events: tuple[EventLike, ...]
+    events: tuple[object, ...]
     output: str | None
 
 
@@ -429,7 +427,7 @@ def test_http_approval_resolution_resumes_waiting_child_session(tmp_path: Path) 
             parent_session_id="leader-session",
         )
     )
-    approval_request_id = cast(str, waiting.events[-1].payload["request_id"])
+    approval_request_id = cast(str, cast(Any, waiting.events[-1]).payload["request_id"])
 
     app = create_runtime_app(
         workspace=tmp_path,
@@ -1281,23 +1279,26 @@ def test_http_question_resolution_resumes_waiting_session(tmp_path: Path) -> Non
             assert session_id == "question-session"
             assert question_request_id == "q-1"
             assert len(responses) == 1
-            return runtime_module.RuntimeResponse(
-                session=runtime_module.SessionState(
-                    session=runtime_module.SessionRef(id="question-session"),
-                    status="completed",
-                    turn=1,
-                    metadata={},
-                ),
-                events=(
-                    runtime_module.EventEnvelope(
-                        session_id="question-session",
-                        sequence=1,
-                        event_type="runtime.question_answered",
-                        source="runtime",
-                        payload={"request_id": "q-1"},
+            return cast(
+                RuntimeResponseLike,
+                runtime_module.RuntimeResponse(
+                    session=runtime_module.SessionState(
+                        session=runtime_module.SessionRef(id="question-session"),
+                        status="completed",
+                        turn=1,
+                        metadata={},
                     ),
+                    events=(
+                        runtime_module.EventEnvelope(
+                            session_id="question-session",
+                            sequence=1,
+                            event_type="runtime.question_answered",
+                            source="runtime",
+                            payload={"request_id": "q-1"},
+                        ),
+                    ),
+                    output="answered",
                 ),
-                output="answered",
             )
 
     app = create_runtime_app(workspace=tmp_path, runtime_factory=lambda: StubRuntime())
@@ -1324,7 +1325,7 @@ def test_http_settings_update_and_read(tmp_path: Path) -> None:
     create_runtime_app = _load_transport_app_factory()
     app = create_runtime_app(workspace=tmp_path)
 
-    status, _headers, body = _run_app(
+    status, _headers, _body = _run_app(
         app,
         method="POST",
         path="/api/settings",

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-# pyright: reportUnusedFunction=false
 import asyncio
 import importlib
 import json
@@ -12,10 +11,13 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Protocol, cast
+from typing import Any, Protocol, cast
 from unittest.mock import patch
 
 import pytest
+
+from voidcode.runtime.contracts import RuntimeNotification
+from voidcode.runtime.task import StoredBackgroundTaskSummary
 
 pytestmark = pytest.mark.usefixtures("_force_deterministic_engine_default")
 
@@ -51,13 +53,13 @@ class EventLike(Protocol):
 class StreamChunkLike(Protocol):
     kind: str
     session: SessionLike
-    event: EventLike | None
+    event: object | None
     output: str | None
 
 
 class RuntimeResponseLike(Protocol):
     session: SessionLike
-    events: tuple[EventLike, ...]
+    events: tuple[object, ...]
     output: str | None
 
 
@@ -308,6 +310,11 @@ def test_transport_agents_endpoint_serializes_stable_summary_fields() -> None:
     RuntimeTransportApp = runtime_http.RuntimeTransportApp
 
     class AgentSummaryRuntime:
+        def acknowledge_notification(self, *, notification_id: str) -> RuntimeNotification:
+            raise AssertionError(
+                f"acknowledge_notification should not be called: {notification_id}"
+            )
+
         def list_agent_summaries(self) -> tuple[object, ...]:
             return (
                 AgentSummary(
@@ -326,7 +333,7 @@ def test_transport_agents_endpoint_serializes_stable_summary_fields() -> None:
                 ),
             )
 
-    app = RuntimeTransportApp(runtime_factory=AgentSummaryRuntime)
+    app = RuntimeTransportApp(runtime_factory=cast(Any, AgentSummaryRuntime))
 
     response = _run_app(app, method="GET", path="/api/agents")
 
@@ -356,6 +363,11 @@ def test_transport_session_cancel_endpoint_calls_runtime_cancel_session() -> Non
     class SessionCancelRuntime:
         calls: list[tuple[str, str | None, str | None]] = []
 
+        def acknowledge_notification(self, *, notification_id: str) -> RuntimeNotification:
+            raise AssertionError(
+                f"acknowledge_notification should not be called: {notification_id}"
+            )
+
         def cancel_session(
             self,
             session_id: str,
@@ -371,7 +383,7 @@ def test_transport_session_cancel_endpoint_calls_runtime_cancel_session() -> Non
                 reason=reason,
             )
 
-    app = RuntimeTransportApp(runtime_factory=SessionCancelRuntime)
+    app = RuntimeTransportApp(runtime_factory=cast(Any, SessionCancelRuntime))
 
     response = _run_app(
         app,
@@ -397,9 +409,12 @@ def test_transport_session_cancel_endpoint_rejects_non_post() -> None:
     RuntimeTransportApp = runtime_http.RuntimeTransportApp
 
     class SessionCancelRuntime:
-        pass
+        def acknowledge_notification(self, *, notification_id: str) -> RuntimeNotification:
+            raise AssertionError(
+                f"acknowledge_notification should not be called: {notification_id}"
+            )
 
-    app = RuntimeTransportApp(runtime_factory=SessionCancelRuntime)
+    app = RuntimeTransportApp(runtime_factory=cast(Any, SessionCancelRuntime))
 
     response = _run_app(app, method="GET", path="/api/sessions/session-cancel/cancel")
 
@@ -730,7 +745,7 @@ def test_create_runtime_app_forwards_config_to_default_runtime_factory(tmp_path:
             raise AssertionError(f"resume should not be called: {session_id}")
 
     with patch.object(runtime_module, "VoidCodeRuntime", StubRuntime):
-        app = runtime_module.create_runtime_app(workspace=tmp_path, config=config)
+        app = runtime_module.create_runtime_app(workspace=tmp_path, config=cast(Any, config))
         _ = app._runtime_factory()
 
     assert captured == [(tmp_path, config)]
@@ -771,7 +786,7 @@ def test_transport_closes_request_scoped_runtime_after_list_sessions(tmp_path: P
         def list_notifications(self) -> tuple[object, ...]:
             raise AssertionError("list_notifications should not be called")
 
-        def acknowledge_notification(self, *, notification_id: str) -> object:
+        def acknowledge_notification(self, *, notification_id: str) -> RuntimeNotification:
             raise AssertionError(
                 f"acknowledge_notification should not be called: {notification_id}"
             )
@@ -922,10 +937,10 @@ def test_transport_reads_session_result_with_transcript(tmp_path: Path) -> None:
     assert payload["summary"] == "Completed: result payload"
     assert payload["output"] == "result payload"
     assert payload["error"] is None
-    assert payload["last_event_sequence"] == stored.events[-1].sequence
+    assert payload["last_event_sequence"] == cast(Any, stored.events[-1]).sequence
     assert [
         event["event_type"] for event in cast(list[dict[str, object]], payload["transcript"])
-    ] == [event.event_type for event in stored.events]
+    ] == [cast(Any, event).event_type for event in stored.events]
 
 
 def test_transport_session_result_redacts_reasoning_until_query_opt_in() -> None:
@@ -961,10 +976,15 @@ def test_transport_session_result_redacts_reasoning_until_query_opt_in() -> None
             assert session_id == "reasoning-session"
             return result
 
-        def __exit__(self, *args: object) -> None:
+        def acknowledge_notification(self, *, notification_id: str) -> RuntimeNotification:
+            raise AssertionError(
+                f"acknowledge_notification should not be called: {notification_id}"
+            )
+
+        def __exit__(self, *_: object) -> None:
             return None
 
-    app = runtime_http.RuntimeTransportApp(runtime_factory=ReasoningResultRuntime)
+    app = runtime_http.RuntimeTransportApp(runtime_factory=cast(Any, ReasoningResultRuntime))
 
     redacted_response = _run_app(
         app,
@@ -1020,10 +1040,15 @@ def test_transport_resume_response_redacts_reasoning_until_query_opt_in() -> Non
             assert session_id == "reasoning-session"
             return response
 
-        def __exit__(self, *args: object) -> None:
+        def acknowledge_notification(self, *, notification_id: str) -> RuntimeNotification:
+            raise AssertionError(
+                f"acknowledge_notification should not be called: {notification_id}"
+            )
+
+        def __exit__(self, *_: object) -> None:
             return None
 
-    app = runtime_http.RuntimeTransportApp(runtime_factory=ReasoningResumeRuntime)
+    app = runtime_http.RuntimeTransportApp(runtime_factory=cast(Any, ReasoningResumeRuntime))
 
     redacted_response = _run_app(
         app,
@@ -1083,10 +1108,15 @@ def test_transport_run_stream_ignores_show_thinking_request_metadata() -> None:
                 output="answer",
             )
 
-        def __exit__(self, *args: object) -> None:
+        def acknowledge_notification(self, *, notification_id: str) -> RuntimeNotification:
+            raise AssertionError(
+                f"acknowledge_notification should not be called: {notification_id}"
+            )
+
+        def __exit__(self, *_: object) -> None:
             return None
 
-    app = runtime_http.RuntimeTransportApp(runtime_factory=ReasoningRunRuntime)
+    app = runtime_http.RuntimeTransportApp(runtime_factory=cast(Any, ReasoningRunRuntime))
     body = json.dumps(
         {
             "prompt": "think",
@@ -1166,10 +1196,15 @@ def test_transport_background_task_output_redacts_reasoning_until_query_opt_in()
             assert session_id == "child-session"
             return session_result
 
-        def __exit__(self, *args: object) -> None:
+        def acknowledge_notification(self, *, notification_id: str) -> RuntimeNotification:
+            raise AssertionError(
+                f"acknowledge_notification should not be called: {notification_id}"
+            )
+
+        def __exit__(self, *_: object) -> None:
             return None
 
-    app = runtime_http.RuntimeTransportApp(runtime_factory=ReasoningTaskRuntime)
+    app = runtime_http.RuntimeTransportApp(runtime_factory=cast(Any, ReasoningTaskRuntime))
 
     redacted_response = _run_app(
         app,
@@ -1222,7 +1257,7 @@ def test_transport_reads_session_debug_snapshot(tmp_path: Path) -> None:
     assert payload["resume_checkpoint_kind"] == "terminal"
     assert payload["pending_approval"] is None
     assert payload["pending_question"] is None
-    assert payload["last_event_sequence"] == stored.events[-1].sequence
+    assert payload["last_event_sequence"] == cast(Any, stored.events[-1]).sequence
     assert (
         cast(dict[str, object], payload["last_relevant_event"])["event_type"]
         == "graph.response_ready"
@@ -1263,7 +1298,7 @@ def test_transport_resolves_pending_approval_allow_over_http(tmp_path: Path) -> 
     waiting = runtime.run(
         runtime_request(prompt="write danger.txt approved later", session_id="approval-session")
     )
-    approval_request_id = cast(str, waiting.events[-1].payload["request_id"])
+    approval_request_id = cast(str, cast(Any, waiting.events[-1]).payload["request_id"])
 
     app = create_runtime_app(
         workspace=tmp_path,
@@ -1376,18 +1411,21 @@ def test_transport_round_trips_parent_session_lineage(tmp_path: Path) -> None:
         def run_stream(self, request: RuntimeRequestLike) -> Iterator[StreamChunkLike]:
             assert request.prompt == "child task"
             assert getattr(request, "parent_session_id", None) == "leader-session"
-            yield runtime_module.RuntimeStreamChunk(
-                kind="output",
-                session=runtime_module.SessionState(
-                    session=runtime_module.SessionRef(
-                        id="child-session",
-                        parent_id="leader-session",
+            yield cast(
+                StreamChunkLike,
+                runtime_module.RuntimeStreamChunk(
+                    kind="output",
+                    session=runtime_module.SessionState(
+                        session=runtime_module.SessionRef(
+                            id="child-session",
+                            parent_id="leader-session",
+                        ),
+                        status="completed",
+                        turn=1,
+                        metadata={},
                     ),
-                    status="completed",
-                    turn=1,
-                    metadata={},
+                    output="done",
                 ),
-                output="done",
             )
 
         def list_sessions(self) -> tuple[StoredSessionSummaryLike, ...]:
@@ -1701,7 +1739,7 @@ def test_transport_resolves_pending_approval_deny_over_http(tmp_path: Path) -> N
     waiting = runtime.run(
         runtime_request(prompt="write danger.txt denied later", session_id="deny-session")
     )
-    approval_request_id = cast(str, waiting.events[-1].payload["request_id"])
+    approval_request_id = cast(str, cast(Any, waiting.events[-1]).payload["request_id"])
 
     app = create_runtime_app(
         workspace=tmp_path,
@@ -2126,7 +2164,7 @@ def test_transport_answers_pending_question_over_http(tmp_path: Path) -> None:
         def list_notifications(self) -> tuple[object, ...]:
             raise AssertionError("list_notifications should not be called")
 
-        def acknowledge_notification(self, *, notification_id: str) -> object:
+        def acknowledge_notification(self, *, notification_id: str) -> RuntimeNotification:
             raise AssertionError(
                 f"acknowledge_notification should not be called: {notification_id}"
             )
@@ -2147,23 +2185,26 @@ def test_transport_answers_pending_question_over_http(tmp_path: Path) -> None:
             response = cast(QuestionResponseLike, responses[0])
             assert response.header == "Runtime path"
             assert response.answers == ("Reuse existing",)
-            return runtime_module.RuntimeResponse(
-                session=runtime_module.SessionState(
-                    session=runtime_module.SessionRef(id="question-session"),
-                    status="completed",
-                    turn=1,
-                    metadata={"workspace": str(tmp_path)},
-                ),
-                events=(
-                    runtime_module.EventEnvelope(
-                        session_id="question-session",
-                        sequence=1,
-                        event_type="runtime.question_answered",
-                        source="runtime",
-                        payload={"request_id": "question-1"},
+            return cast(
+                RuntimeResponseLike,
+                runtime_module.RuntimeResponse(
+                    session=runtime_module.SessionState(
+                        session=runtime_module.SessionRef(id="question-session"),
+                        status="completed",
+                        turn=1,
+                        metadata={"workspace": str(tmp_path)},
                     ),
+                    events=(
+                        runtime_module.EventEnvelope(
+                            session_id="question-session",
+                            sequence=1,
+                            event_type="runtime.question_answered",
+                            source="runtime",
+                            payload={"request_id": "question-1"},
+                        ),
+                    ),
+                    output="done",
                 ),
-                output="done",
             )
 
     app = create_runtime_app(workspace=tmp_path, runtime_factory=lambda: StubRuntime())
@@ -2211,7 +2252,7 @@ def test_transport_returns_not_found_for_missing_pending_question(tmp_path: Path
         def list_notifications(self) -> tuple[object, ...]:
             raise AssertionError("list_notifications should not be called")
 
-        def acknowledge_notification(self, *, notification_id: str) -> object:
+        def acknowledge_notification(self, *, notification_id: str) -> RuntimeNotification:
             raise AssertionError(
                 f"acknowledge_notification should not be called: {notification_id}"
             )
@@ -2997,7 +3038,7 @@ def test_transport_retries_mcp_and_returns_status_snapshot(tmp_path: Path) -> No
         def load_background_task_result(self, task_id: str) -> object:
             raise AssertionError(f"load_background_task_result should not be called: {task_id}")
 
-        def list_background_tasks(self) -> tuple[object, ...]:
+        def list_background_tasks(self) -> tuple[StoredBackgroundTaskSummary, ...]:
             return ()
 
         def list_background_tasks_by_parent_session(
@@ -3026,13 +3067,13 @@ def test_transport_retries_mcp_and_returns_status_snapshot(tmp_path: Path) -> No
             _ = provider, provider_api_key, model
             return {}
 
-        def list_provider_summaries(self) -> tuple[object, ...]:
+        def list_provider_summaries(self) -> tuple[StoredBackgroundTaskSummary, ...]:
             return ()
 
         def provider_models_result(self, provider_name: str) -> object:
             raise AssertionError(f"provider_models_result should not be called: {provider_name}")
 
-        def list_agent_summaries(self) -> tuple[object, ...]:
+        def list_agent_summaries(self) -> tuple[StoredBackgroundTaskSummary, ...]:
             return ()
 
         def current_status(self) -> object:
@@ -3084,10 +3125,10 @@ def test_transport_retries_mcp_and_returns_status_snapshot(tmp_path: Path) -> No
         def session_result(self, *, session_id: str) -> object:
             raise AssertionError(f"session_result should not be called: {session_id}")
 
-        def list_notifications(self) -> tuple[object, ...]:
+        def list_notifications(self) -> tuple[StoredBackgroundTaskSummary, ...]:
             return ()
 
-        def acknowledge_notification(self, *, notification_id: str) -> object:
+        def acknowledge_notification(self, *, notification_id: str) -> RuntimeNotification:
             raise AssertionError(
                 f"acknowledge_notification should not be called: {notification_id}"
             )
@@ -3192,7 +3233,7 @@ def test_transport_retry_mcp_value_error_returns_http_400_and_closes_runtime_onc
         def load_background_task_result(self, task_id: str) -> object:
             raise AssertionError(f"load_background_task_result should not be called: {task_id}")
 
-        def list_background_tasks(self) -> tuple[object, ...]:
+        def list_background_tasks(self) -> tuple[StoredBackgroundTaskSummary, ...]:
             return ()
 
         def list_background_tasks_by_parent_session(
@@ -3221,13 +3262,13 @@ def test_transport_retry_mcp_value_error_returns_http_400_and_closes_runtime_onc
             _ = provider, provider_api_key, model
             return {}
 
-        def list_provider_summaries(self) -> tuple[object, ...]:
+        def list_provider_summaries(self) -> tuple[StoredBackgroundTaskSummary, ...]:
             return ()
 
         def provider_models_result(self, provider_name: str) -> object:
             raise AssertionError(f"provider_models_result should not be called: {provider_name}")
 
-        def list_agent_summaries(self) -> tuple[object, ...]:
+        def list_agent_summaries(self) -> tuple[StoredBackgroundTaskSummary, ...]:
             return ()
 
         def current_status(self) -> object:
@@ -3242,10 +3283,10 @@ def test_transport_retry_mcp_value_error_returns_http_400_and_closes_runtime_onc
         def session_result(self, *, session_id: str) -> object:
             raise AssertionError(f"session_result should not be called: {session_id}")
 
-        def list_notifications(self) -> tuple[object, ...]:
+        def list_notifications(self) -> tuple[StoredBackgroundTaskSummary, ...]:
             return ()
 
-        def acknowledge_notification(self, *, notification_id: str) -> object:
+        def acknowledge_notification(self, *, notification_id: str) -> RuntimeNotification:
             raise AssertionError(
                 f"acknowledge_notification should not be called: {notification_id}"
             )
@@ -3305,10 +3346,10 @@ def test_transport_marks_review_request_active_for_workspace_switch_conflict(
                 git=GitStatusSnapshot(state="not_git_repo"),
             )
 
-        def list_sessions(self) -> tuple[object, ...]:
+        def list_sessions(self) -> tuple[StoredSessionSummaryLike, ...]:
             return ()
 
-        def list_background_tasks(self) -> tuple[object, ...]:
+        def list_background_tasks(self) -> tuple[StoredBackgroundTaskSummary, ...]:
             return ()
 
     release_open = threading.Event()
@@ -3319,7 +3360,7 @@ def test_transport_marks_review_request_active_for_workspace_switch_conflict(
 
     coordinator = SingleWorkspaceRuntimeCoordinator(
         initial_workspace=tmp_path,
-        runtime_factory=_runtime_factory,
+        runtime_factory=cast(Any, _runtime_factory),
     )
     app = RuntimeTransportApp(
         runtime_factory=lambda: coordinator.runtime(),
@@ -3409,7 +3450,7 @@ def test_transport_run_stream_continues_after_mcp_startup_failure_and_status_sta
         def current_state(self) -> object:
             return mcp_module.McpManagerState(
                 mode="managed",
-                configuration=self.configuration,
+                configuration=cast(Any, self.configuration),
                 servers={
                     "context7": mcp_module.McpServerRuntimeState(
                         server_name="context7",
@@ -3436,7 +3477,7 @@ def test_transport_run_stream_continues_after_mcp_startup_failure_and_status_sta
             _ = server_name, tool_name, arguments, workspace
             raise AssertionError("call_tool should not be used")
 
-        def shutdown(self) -> tuple[object, ...]:
+        def shutdown(self) -> tuple[StoredBackgroundTaskSummary, ...]:
             return ()
 
         def drain_events(self) -> tuple[object, ...]:
@@ -3562,7 +3603,7 @@ def test_transport_status_preserves_mcp_failed_state_across_fresh_requests(
             },
         ),
     )
-    app = create_runtime_app(workspace=tmp_path, config=config)
+    app = create_runtime_app(workspace=tmp_path, config=cast(Any, config))
 
     run_response = _run_app(
         app,

--- a/tests/unit/runtime/test_provider_readiness.py
+++ b/tests/unit/runtime/test_provider_readiness.py
@@ -178,7 +178,7 @@ def test_provider_readiness_does_not_allocate_oauth_callback_state(tmp_path: Pat
     try:
         first = runtime.provider_readiness()
         second = runtime.provider_readiness()
-        pending_states = runtime.provider_auth_resolver._pending_callback_states  # pyright: ignore[reportPrivateUsage]
+        pending_states = runtime.provider_auth_resolver._pending_callback_states
     finally:
         runtime.__exit__(None, None, None)
 

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1,4 +1,3 @@
-# pyright: reportArgumentType=false, reportUnusedFunction=false
 from __future__ import annotations
 
 import importlib
@@ -38,7 +37,11 @@ from voidcode.provider.config import (
     ProviderTransientRetryConfig,
 )
 from voidcode.provider.model_catalog import ProviderModelCatalog, ProviderModelMetadata
-from voidcode.provider.protocol import ProviderErrorKind
+from voidcode.provider.protocol import (
+    ProviderAbortSignal,
+    ProviderAssembledContext,
+    ProviderErrorKind,
+)
 from voidcode.provider.registry import ModelProviderRegistry
 from voidcode.runtime.acp import (
     AcpAdapterState,
@@ -123,7 +126,7 @@ from voidcode.runtime.service import (
     ToolRegistry,
     VoidCodeRuntime,
 )
-from voidcode.runtime.session import SessionRef
+from voidcode.runtime.session import SessionRef, SessionStatus
 from voidcode.runtime.storage import SqliteSessionStore
 from voidcode.runtime.task import (
     BackgroundTaskRef,
@@ -179,6 +182,105 @@ def _prompt_materialization_payload(profile: str) -> dict[str, object]:
 
 def _private_attr(instance: object, name: str) -> Any:
     return getattr(instance, name)
+
+
+def _assert_context_window_recomputed(
+    *,
+    prepared_calls: int,
+    context_window: RuntimeContextWindow,
+) -> None:
+    assert prepared_calls == 1
+    assert context_window.original_tool_result_count == 1
+
+
+class _NoopMcpManager:
+    @property
+    def configuration(self) -> McpConfigState:
+        return McpConfigState(configured_enabled=True)
+
+    def current_state(self) -> McpManagerState:
+        return McpManagerState(mode="managed", configuration=self.configuration)
+
+    def list_tools(
+        self,
+        *,
+        workspace: Path,
+        owner_session_id: str | None = None,
+        parent_session_id: str | None = None,
+    ) -> tuple[McpToolDescriptor, ...]:
+        _ = workspace, owner_session_id, parent_session_id
+        return ()
+
+    def call_tool(
+        self,
+        *,
+        server_name: str,
+        tool_name: str,
+        arguments: dict[str, object],
+        workspace: Path,
+        owner_session_id: str | None = None,
+        parent_session_id: str | None = None,
+    ) -> McpToolCallResult:
+        _ = server_name, tool_name, arguments, workspace, owner_session_id, parent_session_id
+        raise AssertionError("not used")
+
+    def shutdown(self) -> tuple[McpRuntimeEvent, ...]:
+        return ()
+
+    def drain_events(self) -> tuple[McpRuntimeEvent, ...]:
+        return ()
+
+    def retry_connections(self, *, workspace: Path) -> None:
+        _ = workspace
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        ("ls /etc", ()),
+        ("du -sh /var", ()),
+        ("test -f /usr/include/vulkan/vulkan.h", ()),
+        ("cat /usr/include/vulkan/vulkan.h", ()),
+        ("echo hi > /tmp/out.txt", ("/tmp/out.txt",)),
+        ("echo hi > /tmp/out.txt && cat /tmp/out.txt", ("/tmp/out.txt",)),
+        ("echo hi 2>/tmp/err.log", ("/tmp/err.log",)),
+        ("echo hi > ./../out.txt", ("./../out.txt",)),
+        ("echo hi > ././../out.txt", ("././../out.txt",)),
+        ("curl --output=/tmp/out.txt https://example.com", ("/tmp/out.txt",)),
+        ("curl -o /tmp/out.txt https://example.com", ("/tmp/out.txt",)),
+        ("curl --write-out=/tmp/format.txt https://example.com", ()),
+        ("tool --output=././../out.txt", ("././../out.txt",)),
+        ("tool --config=/etc/app.conf", ()),
+        ("tool --file=2024/report.txt", ()),
+        (r"type C:	emp\out.log", ()),
+        (
+            r"type C:\Windows\System32\drivers\etc\hosts",
+            (),
+        ),
+        ("touch /tmp/out.txt", ()),
+        ("mkdir /tmp/generated", ()),
+        ("rm /tmp/out.txt", ()),
+        ("cp /etc/input.conf /tmp/output.conf", ()),
+        ("mv /tmp/source.txt /tmp/output.txt", ()),
+        ("sudo cp /etc/input.conf /tmp/output.conf", ()),
+        ("git mv /tmp/source.txt /tmp/output.txt", ()),
+        ("cp /etc/input.conf /tmp/output.conf > /tmp/copy.log", ("/tmp/copy.log",)),
+        ("cat 2024/report.txt", ()),
+    ],
+)
+def test_runtime_extracts_shell_external_path_candidates(
+    command: str,
+    expected: tuple[str, ...],
+) -> None:
+    runtime_type = cast(Any, VoidCodeRuntime)
+    assert runtime_type._extract_shell_path_candidates(command) == expected
+
+
+def test_runtime_ignores_shell_executable_path_candidate() -> None:
+    command = f'"{sys.executable}" -c "print(1)"'
+
+    runtime_type = cast(Any, VoidCodeRuntime)
+    assert runtime_type._extract_shell_path_candidates(command) == ()
 
 
 def test_runtime_shell_read_probe_external_path_stays_workspace_scoped(tmp_path: Path) -> None:
@@ -1634,7 +1736,7 @@ def test_runtime_background_task_progress_hooks_skip_result_load_when_no_command
         graph=_BackgroundTaskSuccessGraph(),
         config=RuntimeConfig(hooks=hooks),
     )
-    supervisor = runtime._background_task_supervisor  # pyright: ignore[reportPrivateUsage]
+    supervisor = runtime._background_task_supervisor
     task = BackgroundTaskState(
         task=BackgroundTaskRef(id="task-progress-no-hooks"),
         status="running",
@@ -1667,7 +1769,7 @@ def test_runtime_background_task_started_hook_runs_outside_queue_lock(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
-    supervisor = runtime._background_task_supervisor  # pyright: ignore[reportPrivateUsage]
+    supervisor = runtime._background_task_supervisor
     task = BackgroundTaskState(
         task=BackgroundTaskRef(id="task-started-hook-lock"),
         request=BackgroundTaskRequestSnapshot(
@@ -1675,7 +1777,7 @@ def test_runtime_background_task_started_hook_runs_outside_queue_lock(
             parent_session_id="leader-session",
         ),
     )
-    runtime._session_store.create_background_task(  # pyright: ignore[reportPrivateUsage]
+    runtime._session_store.create_background_task(
         workspace=tmp_path,
         task=task,
     )
@@ -1696,7 +1798,7 @@ def test_runtime_background_task_started_hook_runs_outside_queue_lock(
     ) -> None:
         _ = task, session_id, extra_payload
         lifecycle_calls.append(surface)
-        assert cast(Any, supervisor._queue_lock)._is_owned() is False  # pyright: ignore[reportPrivateUsage]
+        assert cast(Any, supervisor._queue_lock)._is_owned() is False
         assert worker_started.is_set() is False
 
     monkeypatch.setattr(runtime, "_run_background_task_worker", no_op_worker)
@@ -1706,7 +1808,7 @@ def test_runtime_background_task_started_hook_runs_outside_queue_lock(
         assert_started_hook_not_locked,
     )
 
-    supervisor._drain_background_task_queue()  # pyright: ignore[reportPrivateUsage]
+    supervisor._drain_background_task_queue()
 
     assert worker_started.wait(timeout=2.0)
     assert lifecycle_calls == ["background_task_started", "worker_started"]
@@ -1717,7 +1819,7 @@ def test_runtime_background_task_started_hook_skips_when_thread_start_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
-    supervisor = runtime._background_task_supervisor  # pyright: ignore[reportPrivateUsage]
+    supervisor = runtime._background_task_supervisor
     task = BackgroundTaskState(
         task=BackgroundTaskRef(id="task-start-fails"),
         request=BackgroundTaskRequestSnapshot(
@@ -1725,7 +1827,7 @@ def test_runtime_background_task_started_hook_skips_when_thread_start_fails(
             parent_session_id="leader-session",
         ),
     )
-    runtime._session_store.create_background_task(  # pyright: ignore[reportPrivateUsage]
+    runtime._session_store.create_background_task(
         workspace=tmp_path,
         task=task,
     )
@@ -1751,7 +1853,7 @@ def test_runtime_background_task_started_hook_skips_when_thread_start_fails(
     monkeypatch.setattr(runtime_background_tasks_module.threading, "Thread", _FailingThread)
     monkeypatch.setattr(supervisor, "run_background_task_lifecycle_surface", record_lifecycle)
 
-    supervisor._drain_background_task_queue()  # pyright: ignore[reportPrivateUsage]
+    supervisor._drain_background_task_queue()
 
     failed = runtime.load_background_task("task-start-fails")
     assert failed.status == "failed"
@@ -1951,12 +2053,10 @@ def test_runtime_background_task_concurrency_identity_uses_model_provider_defaul
             ),
         ),
     )
-    supervisor = runtime._background_task_supervisor  # pyright: ignore[reportPrivateUsage]
+    supervisor = runtime._background_task_supervisor
 
-    model_identity = supervisor._concurrency_identity_for_request(  # pyright: ignore[reportPrivateUsage]
-        RuntimeRequest(prompt="model")
-    )
-    provider_identity = supervisor._concurrency_identity_for_request(  # pyright: ignore[reportPrivateUsage]
+    model_identity = supervisor._concurrency_identity_for_request(RuntimeRequest(prompt="model"))
+    provider_identity = supervisor._concurrency_identity_for_request(
         RuntimeRequest(
             prompt="provider",
             metadata={
@@ -1967,7 +2067,7 @@ def test_runtime_background_task_concurrency_identity_uses_model_provider_defaul
             },
         )
     )
-    default_identity = supervisor._concurrency_identity_for_request(  # pyright: ignore[reportPrivateUsage]
+    default_identity = supervisor._concurrency_identity_for_request(
         RuntimeRequest(
             prompt="default",
             metadata={
@@ -2036,7 +2136,7 @@ def test_runtime_background_task_rate_limit_retries_after_backoff(
         return 0.0
 
     monkeypatch.setattr(
-        runtime._background_task_supervisor,  # pyright: ignore[reportPrivateUsage]
+        runtime._background_task_supervisor,
         "_rate_limit_backoff_seconds",
         _zero_backoff,
     )
@@ -2060,7 +2160,7 @@ def test_runtime_background_task_observability_reports_rate_limit_backoff(
         return 0.5
 
     monkeypatch.setattr(
-        runtime._background_task_supervisor,  # pyright: ignore[reportPrivateUsage]
+        runtime._background_task_supervisor,
         "_rate_limit_backoff_seconds",
         _observable_backoff,
     )
@@ -2128,7 +2228,7 @@ def test_runtime_background_rate_limit_retry_precedes_provider_fallback(
         return 0.0
 
     monkeypatch.setattr(
-        runtime._background_task_supervisor,  # pyright: ignore[reportPrivateUsage]
+        runtime._background_task_supervisor,
         "_rate_limit_backoff_seconds",
         _zero_backoff,
     )
@@ -2401,7 +2501,7 @@ def test_runtime_session_debug_snapshot_reconstructs_skill_prompt_context(
 def test_runtime_persists_agent_capability_snapshot_for_replay(
     tmp_path: Path,
 ) -> None:
-    class _StubMcpManager:
+    class _StubMcpManager(_NoopMcpManager):
         @property
         def configuration(self) -> McpConfigState:
             return McpConfigState(configured_enabled=True, servers={"echo": object()})
@@ -2415,7 +2515,7 @@ def test_runtime_persists_agent_capability_snapshot_for_replay(
             workspace: Path,
             owner_session_id: str | None = None,
             parent_session_id: str | None = None,
-        ):
+        ) -> tuple[McpToolDescriptor, ...]:
             _ = workspace, parent_session_id
             if owner_session_id != "capability-snapshot":
                 return ()
@@ -2440,12 +2540,6 @@ def test_runtime_persists_agent_capability_snapshot_for_replay(
         ) -> McpToolCallResult:
             _ = server_name, tool_name, arguments, workspace, owner_session_id, parent_session_id
             return McpToolCallResult(content=[{"type": "text", "text": "echo"}])
-
-        def shutdown(self):
-            return ()
-
-        def drain_events(self):
-            return ()
 
     skill_dir = tmp_path / ".voidcode" / "skills" / "demo"
     _write_demo_skill(skill_dir, content="# Demo\nSnapshot this skill body.")
@@ -2677,10 +2771,8 @@ def test_runtime_materializes_explicit_agent_hook_refs_without_expanding_tools(
     assert "runtime-owned task routing" not in (hook_segments[0].content or "")
     assert tool_names == {
         definition.name
-        for definition in runtime._tool_registry_for_effective_config(  # pyright: ignore[reportPrivateUsage]
-            runtime._effective_runtime_config_from_metadata(  # pyright: ignore[reportPrivateUsage]
-                response.session.metadata
-            )
+        for definition in runtime._tool_registry_for_effective_config(
+            runtime._effective_runtime_config_from_metadata(response.session.metadata)
         ).definitions()
     }
 
@@ -2995,14 +3087,14 @@ def test_runtime_denies_divergent_legacy_approval_replay_without_fresh_permissio
         _private_attr(runtime, "_prepare_provider_context_window"),
     )
     assemble_provider_context = cast(
-        Callable[..., object],
+        Callable[..., ProviderAssembledContext],
         _private_attr(runtime, "_assemble_provider_context"),
     )
     execute_graph_loop = cast(
         Callable[..., Iterator[Any]],
         _private_attr(runtime, "_execute_graph_loop"),
     )
-    session_metadata = {
+    session_metadata: dict[str, object] = {
         "runtime_config": runtime_config_metadata(),
     }
     session = SessionState(
@@ -3426,8 +3518,7 @@ def test_runtime_cancel_after_tool_started_emits_terminal_tool_completed(
     assert "wait for the user's next instruction" in str(
         failed_events[-1].payload["retry_guidance"]
     )
-    diagnostics = failed_events[-1].payload["diagnostics"]
-    assert isinstance(diagnostics, list)
+    diagnostics = cast(list[dict[str, object]], failed_events[-1].payload["diagnostics"])
     assert diagnostics[-1]["reason"] == "user_interrupted"
 
 
@@ -3699,7 +3790,7 @@ def test_runtime_session_debug_snapshot_prefers_active_state_for_reused_session_
     runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
 
     _ = runtime.run(RuntimeRequest(prompt="same prompt", session_id="same-prompt-debug"))
-    stream = runtime._run_with_persistence(  # pyright: ignore[reportPrivateUsage]
+    stream = runtime._run_with_persistence(
         RuntimeRequest(prompt="same prompt", session_id="same-prompt-debug")
     )
 
@@ -3724,7 +3815,7 @@ def test_runtime_session_debug_snapshot_preserves_fresh_terminal_state_while_act
     runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
 
     deferred_unregister_session_id: str | None = None
-    original_unregister = runtime._unregister_active_session_id  # pyright: ignore[reportPrivateUsage]
+    original_unregister = runtime._unregister_active_session_id
 
     def _defer_unregister(session_id: str, *, run_id: str | None = None) -> None:
         _ = run_id
@@ -3735,11 +3826,11 @@ def test_runtime_session_debug_snapshot_preserves_fresh_terminal_state_while_act
     response = runtime.run(RuntimeRequest(prompt="terminal debug", session_id="terminal-debug"))
     try:
         assert deferred_unregister_session_id == "terminal-debug"
-        snapshot = runtime.session_debug_snapshot(session_id="terminal-debug")  # pyright: ignore[reportUnreachable]
+        snapshot = runtime.session_debug_snapshot(session_id="terminal-debug")
     finally:
         original_unregister("terminal-debug")
 
-    assert response.session.status == "completed"  # pyright: ignore[reportUnreachable]
+    assert response.session.status == "completed"
     assert snapshot.prompt == "terminal debug"
     assert snapshot.active is True
     assert snapshot.persisted_status == "completed"
@@ -3920,13 +4011,13 @@ def test_runtime_constructs_with_builtin_agent_hook_refs(tmp_path: Path) -> None
 
     response = runtime.run(RuntimeRequest(prompt="custom hook refs", session_id="hook-refs"))
 
-    runtime_config = response.session.metadata["runtime_config"]
-    resolved_hook_presets = response.session.metadata["resolved_hook_presets"]
+    runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
+    resolved_hook_presets = cast(
+        dict[str, object], response.session.metadata["resolved_hook_presets"]
+    )
     hook_event = next(
         event for event in response.events if event.event_type == RUNTIME_HOOK_PRESETS_LOADED
     )
-    assert isinstance(runtime_config, dict)
-    assert isinstance(resolved_hook_presets, dict)
     assert runtime_config["agent"] == {
         "preset": "leader",
         "prompt_profile": "researcher",
@@ -3955,8 +4046,9 @@ def test_runtime_snapshots_manifest_default_hook_refs(tmp_path: Path) -> None:
 
     response = runtime.run(RuntimeRequest(prompt="manifest hook refs", session_id="manifest-hooks"))
 
-    resolved_hook_presets = response.session.metadata["resolved_hook_presets"]
-    assert isinstance(resolved_hook_presets, dict)
+    resolved_hook_presets = cast(
+        dict[str, object], response.session.metadata["resolved_hook_presets"]
+    )
     assert resolved_hook_presets["refs"] == [
         "role_reminder",
         "delegation_guard",
@@ -4029,10 +4121,10 @@ def test_hook_preset_snapshot_does_not_change_agent_tool_permissions(tmp_path: P
         ),
     )
 
-    no_hook_config = runtime_without_hooks._effective_runtime_config_from_metadata(None)  # pyright: ignore[reportPrivateUsage]
-    hook_config = runtime_with_hooks._effective_runtime_config_from_metadata(None)  # pyright: ignore[reportPrivateUsage]
-    no_hook_tools = runtime_without_hooks._tool_registry_for_effective_config(no_hook_config)  # pyright: ignore[reportPrivateUsage]
-    hook_tools = runtime_with_hooks._tool_registry_for_effective_config(hook_config)  # pyright: ignore[reportPrivateUsage]
+    no_hook_config = runtime_without_hooks._effective_runtime_config_from_metadata(None)
+    hook_config = runtime_with_hooks._effective_runtime_config_from_metadata(None)
+    no_hook_tools = runtime_without_hooks._tool_registry_for_effective_config(no_hook_config)
+    hook_tools = runtime_with_hooks._tool_registry_for_effective_config(hook_config)
 
     assert tuple(no_hook_tools.tools) == tuple(hook_tools.tools)
 
@@ -5391,7 +5483,7 @@ def test_runtime_background_task_cancellation_emits_parent_session_event_once(
 ) -> None:
     runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
     _ = runtime.run(RuntimeRequest(prompt="leader", session_id="leader-session"))
-    runtime._background_tasks_reconciled = True  # pyright: ignore[reportPrivateUsage]
+    runtime._background_tasks_reconciled = True
     store = _private_attr(runtime, "_session_store")
     task_module = importlib.import_module("voidcode.runtime.task")
     store.create_background_task(
@@ -5648,7 +5740,7 @@ def test_runtime_reconciliation_parent_events_are_idempotent_across_restart_read
                         id=child_session_id,
                         parent_id="leader-session",
                     ),
-                    status=child_status,
+                    status=cast(SessionStatus, child_status),
                     turn=1,
                     metadata={
                         "background_run": True,
@@ -5771,7 +5863,7 @@ def test_runtime_session_debug_snapshot_does_not_reconcile_parent_background_eve
     resumed_runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
 
     snapshot = resumed_runtime.session_debug_snapshot(session_id="leader-session")
-    before_resume = resumed_runtime._session_store.load_session_result(  # pyright: ignore[reportPrivateUsage]
+    before_resume = resumed_runtime._session_store.load_session_result(
         workspace=tmp_path,
         session_id="leader-session",
     )
@@ -5924,7 +6016,7 @@ def test_runtime_background_task_waiting_approval_emits_parent_session_event_onc
         event.sequence for event in leader_response.events
     )
 
-    runtime._emit_background_task_waiting_approval(  # pyright: ignore[reportPrivateUsage]
+    runtime._emit_background_task_waiting_approval(
         task=running,
         child_response=child_response,
     )
@@ -6520,7 +6612,7 @@ def test_runtime_background_task_approval_resume_overrides_stale_failed_task_sta
     )
     approval_request_id = cast(str, child_response.events[-1].payload["request_id"])
 
-    _ = initial_runtime._session_store.mark_background_task_terminal(  # pyright: ignore[reportPrivateUsage]
+    _ = initial_runtime._session_store.mark_background_task_terminal(
         workspace=tmp_path,
         task_id=started.task.id,
         status="interrupted",
@@ -6826,7 +6918,7 @@ def test_runtime_background_task_waiting_approval_race_does_not_fail_child_task(
         "runtime.approval_requested",
     )
 
-    runtime._emit_background_task_waiting_approval(  # pyright: ignore[reportPrivateUsage]
+    runtime._emit_background_task_waiting_approval(
         task=running,
         child_response=child_response,
     )
@@ -7204,15 +7296,14 @@ def test_runtime_drain_releases_slot_when_worker_start_fails(
         graph=_BackgroundTaskSuccessGraph(),
         config=RuntimeConfig(background_task=RuntimeBackgroundTaskConfig(default_concurrency=1)),
     )
-    original_start = threading.Thread.start
-    start_calls = 0
+    real_thread_start = threading.Thread.start
+    start_calls: list[object] = []
 
     def _start_once_then_fail(thread: threading.Thread) -> None:
-        nonlocal start_calls
-        start_calls += 1
-        if start_calls == 1:
+        start_calls.append(object())
+        if len(start_calls) == 1:
             raise RuntimeError("can't start new thread")
-        original_start(thread)
+        real_thread_start(thread)
 
     monkeypatch.setattr(threading.Thread, "start", _start_once_then_fail)
 
@@ -7229,7 +7320,7 @@ def test_runtime_background_task_worker_exits_when_task_is_cancelled_before_star
     tmp_path: Path,
 ) -> None:
     runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
-    runtime._background_tasks_reconciled = True  # pyright: ignore[reportPrivateUsage]
+    runtime._background_tasks_reconciled = True
     store = _private_attr(runtime, "_session_store")
     task_module = importlib.import_module("voidcode.runtime.task")
     store.create_background_task(
@@ -7252,9 +7343,9 @@ def test_runtime_background_task_worker_exits_when_task_is_cancelled_before_star
 
     store.mark_background_task_running = _cancel_before_mark_running
     run_mock = Mock(side_effect=AssertionError("runtime.run must not be called"))
-    runtime.run = run_mock
+    cast(Any, runtime).run = run_mock
 
-    runtime._run_background_task_worker("task-race-cancel")  # pyright: ignore[reportPrivateUsage]
+    runtime._run_background_task_worker("task-race-cancel")
 
     final_task = runtime.load_background_task("task-race-cancel")
     assert final_task.status == "cancelled"
@@ -7264,7 +7355,7 @@ def test_runtime_background_task_worker_exits_when_task_is_cancelled_before_star
 
 def test_runtime_background_task_worker_rechecks_cancel_before_dispatch(tmp_path: Path) -> None:
     runtime = VoidCodeRuntime(workspace=tmp_path, graph=_BackgroundTaskSuccessGraph())
-    runtime._background_tasks_reconciled = True  # pyright: ignore[reportPrivateUsage]
+    runtime._background_tasks_reconciled = True
     store = _private_attr(runtime, "_session_store")
     task_module = importlib.import_module("voidcode.runtime.task")
     store.create_background_task(
@@ -7288,9 +7379,9 @@ def test_runtime_background_task_worker_rechecks_cancel_before_dispatch(tmp_path
 
     store.mark_background_task_running = _cancel_after_mark_running
     run_mock = Mock(side_effect=AssertionError("runtime.run must not be called"))
-    runtime.run = run_mock
+    cast(Any, runtime).run = run_mock
 
-    runtime._run_background_task_worker("task-dispatch-cancel")  # pyright: ignore[reportPrivateUsage]
+    runtime._run_background_task_worker("task-dispatch-cancel")
 
     final_task = runtime.load_background_task("task-dispatch-cancel")
     assert final_task.status == "cancelled"
@@ -7784,7 +7875,7 @@ def test_runtime_exit_disconnects_managed_acp(tmp_path: Path) -> None:
 
 
 def test_runtime_exit_shuts_down_managed_mcp(tmp_path: Path) -> None:
-    class _StubMcpManager:
+    class _StubMcpManager(_NoopMcpManager):
         def __init__(self) -> None:
             self.shutdown_calls = 0
 
@@ -7795,29 +7886,6 @@ def test_runtime_exit_shuts_down_managed_mcp(tmp_path: Path) -> None:
         def current_state(self) -> McpManagerState:
             return McpManagerState(mode="managed", configuration=self.configuration)
 
-        def list_tools(
-            self,
-            *,
-            workspace: Path,
-            owner_session_id: str | None = None,
-            parent_session_id: str | None = None,
-        ):
-            _ = workspace, owner_session_id, parent_session_id
-            return ()
-
-        def call_tool(
-            self,
-            *,
-            server_name: str,
-            tool_name: str,
-            arguments: dict[str, object],
-            workspace: Path,
-            owner_session_id: str | None = None,
-            parent_session_id: str | None = None,
-        ):
-            _ = server_name, tool_name, arguments, workspace, owner_session_id, parent_session_id
-            raise AssertionError("not used")
-
         def shutdown(self) -> tuple[McpRuntimeEvent, ...]:
             self.shutdown_calls += 1
             return (
@@ -7826,9 +7894,6 @@ def test_runtime_exit_shuts_down_managed_mcp(tmp_path: Path) -> None:
                     payload={"server": "echo", "workspace_root": str(tmp_path)},
                 ),
             )
-
-        def drain_events(self) -> tuple[McpRuntimeEvent, ...]:
-            return ()
 
     mcp_manager = _StubMcpManager()
     runtime = VoidCodeRuntime(workspace=tmp_path, mcp_manager=mcp_manager)
@@ -7839,40 +7904,7 @@ def test_runtime_exit_shuts_down_managed_mcp(tmp_path: Path) -> None:
 
 
 def test_runtime_surfaces_mcp_lifecycle_events_in_run_responses(tmp_path: Path) -> None:
-    class _StubMcpManager:
-        @property
-        def configuration(self) -> McpConfigState:
-            return McpConfigState(configured_enabled=True)
-
-        def current_state(self) -> McpManagerState:
-            return McpManagerState(mode="managed", configuration=self.configuration)
-
-        def list_tools(
-            self,
-            *,
-            workspace: Path,
-            owner_session_id: str | None = None,
-            parent_session_id: str | None = None,
-        ):
-            _ = workspace, owner_session_id, parent_session_id
-            return ()
-
-        def call_tool(
-            self,
-            *,
-            server_name: str,
-            tool_name: str,
-            arguments: dict[str, object],
-            workspace: Path,
-            owner_session_id: str | None = None,
-            parent_session_id: str | None = None,
-        ):
-            _ = server_name, tool_name, arguments, workspace, owner_session_id, parent_session_id
-            raise AssertionError("not used")
-
-        def shutdown(self) -> tuple[McpRuntimeEvent, ...]:
-            return ()
-
+    class _StubMcpManager(_NoopMcpManager):
         def drain_events(self) -> tuple[McpRuntimeEvent, ...]:
             return (
                 McpRuntimeEvent(
@@ -7893,39 +7925,9 @@ def test_runtime_surfaces_mcp_lifecycle_events_in_run_responses(tmp_path: Path) 
 def test_runtime_waiting_approval_preserves_mcp_session_until_resume_completion(
     tmp_path: Path,
 ) -> None:
-    class _RecordingMcpManager:
+    class _RecordingMcpManager(_NoopMcpManager):
         def __init__(self) -> None:
             self.release_session_ids: list[str] = []
-
-        @property
-        def configuration(self) -> McpConfigState:
-            return McpConfigState(configured_enabled=True)
-
-        def current_state(self) -> McpManagerState:
-            return McpManagerState(mode="managed", configuration=self.configuration)
-
-        def list_tools(
-            self,
-            *,
-            workspace: Path,
-            owner_session_id: str | None = None,
-            parent_session_id: str | None = None,
-        ):
-            _ = workspace, owner_session_id, parent_session_id
-            return ()
-
-        def call_tool(
-            self,
-            *,
-            server_name: str,
-            tool_name: str,
-            arguments: dict[str, object],
-            workspace: Path,
-            owner_session_id: str | None = None,
-            parent_session_id: str | None = None,
-        ):
-            _ = server_name, tool_name, arguments, workspace, owner_session_id, parent_session_id
-            raise AssertionError("not used")
 
         def release_session(self, *, session_id: str) -> tuple[McpRuntimeEvent, ...]:
             self.release_session_ids.append(session_id)
@@ -7935,12 +7937,6 @@ def test_runtime_waiting_approval_preserves_mcp_session_until_resume_completion(
                     payload={"server": "echo", "workspace_root": str(tmp_path)},
                 ),
             )
-
-        def shutdown(self) -> tuple[McpRuntimeEvent, ...]:
-            return ()
-
-        def drain_events(self) -> tuple[McpRuntimeEvent, ...]:
-            return ()
 
     mcp_manager = _RecordingMcpManager()
     runtime = VoidCodeRuntime(
@@ -7969,7 +7965,7 @@ def test_runtime_waiting_approval_preserves_mcp_session_until_resume_completion(
 def test_runtime_emits_mcp_failed_and_continues_run_on_startup_refresh(
     tmp_path: Path,
 ) -> None:
-    class _FailingMcpManager:
+    class _FailingMcpManager(_NoopMcpManager):
         def __init__(self) -> None:
             self._drained = False
             self._failed = False
@@ -7991,7 +7987,7 @@ def test_runtime_emits_mcp_failed_and_continues_run_on_startup_refresh(
                         workspace_root=str(tmp_path) if self._failed else None,
                         stage="startup" if self._failed else None,
                         error=self.startup_error if self._failed else None,
-                        command=(),
+                        command=[],
                         retry_available=self._failed,
                     )
                 },
@@ -8007,22 +8003,6 @@ def test_runtime_emits_mcp_failed_and_continues_run_on_startup_refresh(
             _ = workspace, owner_session_id, parent_session_id
             self._failed = True
             raise ValueError(self.startup_error)
-
-        def call_tool(
-            self,
-            *,
-            server_name: str,
-            tool_name: str,
-            arguments: dict[str, object],
-            workspace: Path,
-            owner_session_id: str | None = None,
-            parent_session_id: str | None = None,
-        ):
-            _ = server_name, tool_name, arguments, workspace, owner_session_id, parent_session_id
-            raise AssertionError("not used")
-
-        def shutdown(self) -> tuple[McpRuntimeEvent, ...]:
-            return ()
 
         def drain_events(self) -> tuple[McpRuntimeEvent, ...]:
             if self._drained:
@@ -8095,7 +8075,7 @@ def test_runtime_resume_emits_mcp_failed_and_continues_on_startup_refresh(
     waiting = initial_runtime.run(RuntimeRequest(prompt="go", session_id="mcp-resume-startup-fail"))
     approval_request_id = str(waiting.events[-1].payload["request_id"])
 
-    class _FailingMcpManager:
+    class _FailingMcpManager(_NoopMcpManager):
         def __init__(self) -> None:
             self._drained = False
             self._failed = False
@@ -8117,7 +8097,7 @@ def test_runtime_resume_emits_mcp_failed_and_continues_on_startup_refresh(
                         workspace_root=str(tmp_path) if self._failed else None,
                         stage="startup" if self._failed else None,
                         error=self.startup_error if self._failed else None,
-                        command=(),
+                        command=[],
                         retry_available=self._failed,
                     )
                 },
@@ -8133,22 +8113,6 @@ def test_runtime_resume_emits_mcp_failed_and_continues_on_startup_refresh(
             _ = workspace, owner_session_id, parent_session_id
             self._failed = True
             raise ValueError(self.startup_error)
-
-        def call_tool(
-            self,
-            *,
-            server_name: str,
-            tool_name: str,
-            arguments: dict[str, object],
-            workspace: Path,
-            owner_session_id: str | None = None,
-            parent_session_id: str | None = None,
-        ):
-            _ = server_name, tool_name, arguments, workspace, owner_session_id, parent_session_id
-            raise AssertionError("not used")
-
-        def shutdown(self) -> tuple[McpRuntimeEvent, ...]:
-            return ()
 
         def drain_events(self) -> tuple[McpRuntimeEvent, ...]:
             if self._drained:
@@ -8214,7 +8178,7 @@ def test_runtime_resume_still_starts_acp_when_mcp_refresh_fails(
     )
     approval_request_id = str(waiting.events[-1].payload["request_id"])
 
-    class _FailingMcpManager:
+    class _FailingMcpManager(_NoopMcpManager):
         def __init__(self) -> None:
             self._drained = False
             self._failed = False
@@ -8236,7 +8200,7 @@ def test_runtime_resume_still_starts_acp_when_mcp_refresh_fails(
                         workspace_root=str(tmp_path) if self._failed else None,
                         stage="startup" if self._failed else None,
                         error=self.startup_error if self._failed else None,
-                        command=(),
+                        command=[],
                         retry_available=self._failed,
                     )
                 },
@@ -8252,22 +8216,6 @@ def test_runtime_resume_still_starts_acp_when_mcp_refresh_fails(
             _ = workspace, owner_session_id, parent_session_id
             self._failed = True
             raise ValueError(self.startup_error)
-
-        def call_tool(
-            self,
-            *,
-            server_name: str,
-            tool_name: str,
-            arguments: dict[str, object],
-            workspace: Path,
-            owner_session_id: str | None = None,
-            parent_session_id: str | None = None,
-        ):
-            _ = server_name, tool_name, arguments, workspace, owner_session_id, parent_session_id
-            raise AssertionError("not used")
-
-        def shutdown(self) -> tuple[McpRuntimeEvent, ...]:
-            return ()
 
         def drain_events(self) -> tuple[McpRuntimeEvent, ...]:
             if self._drained:
@@ -8351,18 +8299,11 @@ def test_runtime_resume_still_starts_acp_when_mcp_refresh_fails(
 def test_runtime_persists_mcp_failed_before_terminal_failure_on_tool_call_abort(
     tmp_path: Path,
 ) -> None:
-    class _FailingMcpManager:
+    class _FailingMcpManager(_NoopMcpManager):
         def __init__(self) -> None:
             self._drained = False
 
         call_error = "MCP call transport failed"
-
-        @property
-        def configuration(self) -> McpConfigState:
-            return McpConfigState(configured_enabled=True)
-
-        def current_state(self) -> McpManagerState:
-            return McpManagerState(mode="managed", configuration=self.configuration)
 
         def list_tools(
             self,
@@ -8393,9 +8334,6 @@ def test_runtime_persists_mcp_failed_before_terminal_failure_on_tool_call_abort(
         ) -> McpToolCallResult:
             _ = server_name, tool_name, arguments, workspace, owner_session_id, parent_session_id
             raise ValueError(self.call_error)
-
-        def shutdown(self) -> tuple[McpRuntimeEvent, ...]:
-            return ()
 
         def drain_events(self) -> tuple[McpRuntimeEvent, ...]:
             if self._drained:
@@ -8434,7 +8372,7 @@ def test_runtime_persists_mcp_failed_before_terminal_failure_on_tool_call_abort(
 
 
 def test_runtime_metadata_includes_mcp_state_when_configured(tmp_path: Path) -> None:
-    class _StubMcpManager:
+    class _StubMcpManager(_NoopMcpManager):
         @property
         def configuration(self) -> McpConfigState:
             return McpConfigState(
@@ -8447,41 +8385,9 @@ def test_runtime_metadata_includes_mcp_state_when_configured(tmp_path: Path) -> 
                 },
             )
 
-        def current_state(self) -> McpManagerState:
-            return McpManagerState(mode="managed", configuration=self.configuration)
-
-        def list_tools(
-            self,
-            *,
-            workspace: Path,
-            owner_session_id: str | None = None,
-            parent_session_id: str | None = None,
-        ):
-            _ = workspace, owner_session_id, parent_session_id
-            return ()
-
-        def call_tool(
-            self,
-            *,
-            server_name: str,
-            tool_name: str,
-            arguments: dict[str, object],
-            workspace: Path,
-            owner_session_id: str | None = None,
-            parent_session_id: str | None = None,
-        ):
-            _ = server_name, tool_name, arguments, workspace, owner_session_id, parent_session_id
-            raise AssertionError("not used")
-
-        def shutdown(self) -> tuple[McpRuntimeEvent, ...]:
-            return ()
-
-        def drain_events(self) -> tuple[McpRuntimeEvent, ...]:
-            return ()
-
     runtime = VoidCodeRuntime(workspace=tmp_path, mcp_manager=_StubMcpManager())
 
-    runtime_config_metadata = runtime._runtime_config_metadata()  # pyright: ignore[reportPrivateUsage]
+    runtime_config_metadata = runtime._runtime_config_metadata()
 
     assert runtime_config_metadata["mcp"] == {
         "mode": "managed",
@@ -9164,7 +9070,7 @@ def test_runtime_emits_skills_loaded_catalog_without_default_full_injection(tmp_
         isinstance(item, str) and "Always explain your reasoning." in item
         for item in system_segments
     )
-    skill_tool = runtime._skill_registry.resolve("git-master")  # pyright: ignore[reportPrivateUsage]
+    skill_tool = runtime._skill_registry.resolve("git-master")
     assert skill_tool.name == "git-master"
     assert skill_tool.origin == "builtin"
     assert skill_tool.entry_path.as_posix().startswith("/builtin/voidcode/skills/")
@@ -9487,8 +9393,8 @@ def test_runtime_workflow_selected_builtin_skill_refs_are_catalog_visible_not_lo
     assert cast(int, skills_loaded.payload["catalog_context_length"]) > 0
     assert "applied_skills" not in response.session.metadata
     assert "applied_skill_payloads" not in response.session.metadata
-    assert runtime._skill_registry.resolve("frontend-design").name == "frontend-design"  # pyright: ignore[reportPrivateUsage]
-    assert runtime._skill_registry.resolve("playwright").name == "playwright"  # pyright: ignore[reportPrivateUsage]
+    assert runtime._skill_registry.resolve("frontend-design").name == "frontend-design"
+    assert runtime._skill_registry.resolve("playwright").name == "playwright"
 
 
 def test_runtime_git_workflow_uses_generic_runtime_approval_without_bespoke_policy(
@@ -11357,7 +11263,7 @@ def test_runtime_graph_selection_avoids_reusing_initial_provider_graph(
         model_provider_registry=registry,
     )
 
-    graph = runtime._graph_for_session_metadata(  # pyright: ignore[reportPrivateUsage]
+    graph = runtime._graph_for_session_metadata(
         {
             "runtime_config": {
                 "approval_mode": "ask",
@@ -11403,7 +11309,7 @@ def test_runtime_graph_selection_seam_uses_provider_attempt_target(tmp_path: Pat
         model_provider_registry=registry,
     )
 
-    selection = runtime._graph_selection_for_effective_config(  # pyright: ignore[reportPrivateUsage]
+    selection = runtime._graph_selection_for_effective_config(
         runtime.effective_runtime_config(),
         provider_attempt=1,
     )
@@ -11430,12 +11336,12 @@ def test_runtime_context_window_policy_uses_fallback_attempt_model_metadata(
         ),
     )
 
-    context_window = runtime._prepare_provider_context_window(  # pyright: ignore[reportPrivateUsage]
+    context_window = runtime._prepare_provider_context_window(
         prompt="read sample.txt",
         tool_results=(),
         session_metadata={
             "provider_attempt": 1,
-            "runtime_config": runtime._runtime_config_metadata(),  # pyright: ignore[reportPrivateUsage]
+            "runtime_config": runtime._runtime_config_metadata(),
         },
     )
 
@@ -11458,14 +11364,14 @@ def test_runtime_context_window_policy_recomputes_default_for_fallback_attempt(
         ),
     )
 
-    context_window = runtime._prepare_provider_context_window(  # pyright: ignore[reportPrivateUsage]
+    context_window = runtime._prepare_provider_context_window(
         prompt="read sample.txt",
         tool_results=(),
         session_metadata={
             "provider_attempt": 1,
-            "runtime_config": runtime._runtime_config_metadata(),  # pyright: ignore[reportPrivateUsage]
+            "runtime_config": runtime._runtime_config_metadata(),
         },
-        policy=runtime._default_context_window_policy,  # pyright: ignore[reportPrivateUsage]
+        policy=runtime._default_context_window_policy,
     )
 
     assert context_window.token_budget == 4_000
@@ -11490,15 +11396,13 @@ def test_runtime_execute_graph_loop_reuses_initial_context_window_on_first_itera
 
     session = SessionState(
         session=SessionRef(id="resume-distillation-dedupe"),
-        metadata={"runtime_config": runtime._runtime_config_metadata()},  # pyright: ignore[reportPrivateUsage]
+        metadata={"runtime_config": runtime._runtime_config_metadata()},
         turn=0,
         status="running",
     )
     prompt = "read sample.txt"
-    tool_registry = runtime._tool_registry_for_effective_config(  # pyright: ignore[reportPrivateUsage]
-        runtime.effective_runtime_config()
-    )
-    context_window = runtime._prepare_provider_context_window(  # pyright: ignore[reportPrivateUsage]
+    tool_registry = runtime._tool_registry_for_effective_config(runtime.effective_runtime_config())
+    context_window = runtime._prepare_provider_context_window(
         prompt=prompt,
         tool_results=(),
         session_metadata=session.metadata,
@@ -11508,7 +11412,7 @@ def test_runtime_execute_graph_loop_reuses_initial_context_window_on_first_itera
         prompt=prompt,
         available_tools=tool_registry.definitions(),
         context_window=context_window,
-        assembled_context=runtime._assemble_provider_context(  # pyright: ignore[reportPrivateUsage]
+        assembled_context=runtime._assemble_provider_context(
             prompt=prompt,
             tool_results=(),
             session_metadata=session.metadata,
@@ -11529,7 +11433,7 @@ def test_runtime_execute_graph_loop_reuses_initial_context_window_on_first_itera
     )
 
     chunks = list(
-        runtime._execute_graph_loop(  # pyright: ignore[reportPrivateUsage]
+        runtime._execute_graph_loop(
             graph=_SingleStepGraph(),
             tool_registry=tool_registry,
             session=session,
@@ -11558,20 +11462,22 @@ def test_runtime_execute_graph_loop_recomputes_stale_initial_context_window(
             session: SessionState,
         ) -> _StubStep:
             _ = tool_results, session
-            assert request.context_window.original_tool_result_count == 1
+            context_window = cast(RuntimeContextWindow, request.context_window)
+            _assert_context_window_recomputed(
+                prepared_calls=prepared_calls,
+                context_window=context_window,
+            )
             return _StubStep(output="done", is_finished=True)
 
     session = SessionState(
         session=SessionRef(id="resume-distillation-stale-window"),
-        metadata={"runtime_config": runtime._runtime_config_metadata()},  # pyright: ignore[reportPrivateUsage]
+        metadata={"runtime_config": runtime._runtime_config_metadata()},
         turn=0,
         status="running",
     )
     prompt = "read sample.txt"
-    tool_registry = runtime._tool_registry_for_effective_config(  # pyright: ignore[reportPrivateUsage]
-        runtime.effective_runtime_config()
-    )
-    context_window = runtime._prepare_provider_context_window(  # pyright: ignore[reportPrivateUsage]
+    tool_registry = runtime._tool_registry_for_effective_config(runtime.effective_runtime_config())
+    context_window = runtime._prepare_provider_context_window(
         prompt=prompt,
         tool_results=(),
         session_metadata=session.metadata,
@@ -11581,19 +11487,25 @@ def test_runtime_execute_graph_loop_recomputes_stale_initial_context_window(
         prompt=prompt,
         available_tools=tool_registry.definitions(),
         context_window=context_window,
-        assembled_context=runtime._assemble_provider_context(  # pyright: ignore[reportPrivateUsage]
+        assembled_context=runtime._assemble_provider_context(
             prompt=prompt,
             tool_results=(),
             session_metadata=session.metadata,
         ),
         metadata=session.metadata,
     )
-    original_prepare = runtime._prepare_provider_context_window  # pyright: ignore[reportPrivateUsage]
+    original_prepare = runtime._prepare_provider_context_window
 
-    def _counting_prepare_provider_context_window(*args: object, **kwargs: object) -> object:
+    def _counting_prepare_provider_context_window(**kwargs: object) -> object:
         nonlocal prepared_calls
         prepared_calls += 1
-        return original_prepare(*args, **kwargs)
+        return original_prepare(
+            prompt=cast(str, kwargs["prompt"]),
+            tool_results=cast(tuple[ToolResult, ...], kwargs["tool_results"]),
+            session_metadata=cast(dict[str, object], kwargs["session_metadata"]),
+            policy=cast(ContextWindowPolicy | None, kwargs.get("policy")),
+            abort_signal=cast(ProviderAbortSignal | None, kwargs.get("abort_signal")),
+        )
 
     monkeypatch.setattr(
         runtime,
@@ -11602,8 +11514,8 @@ def test_runtime_execute_graph_loop_recomputes_stale_initial_context_window(
     )
     tool_results = [ToolResult(tool_name="read_file", status="ok", content="alpha")]
 
-    chunks = list(
-        runtime._execute_graph_loop(  # pyright: ignore[reportPrivateUsage]
+    list(
+        runtime._execute_graph_loop(
             graph=_ContextWindowCountingGraph(),
             tool_registry=tool_registry,
             session=session,
@@ -11612,9 +11524,6 @@ def test_runtime_execute_graph_loop_recomputes_stale_initial_context_window(
             tool_results=tool_results,
         )
     )
-
-    assert prepared_calls == 1
-    assert any(chunk.kind == "output" and chunk.output == "done" for chunk in chunks)
 
 
 def test_runtime_provider_fallback_seam_returns_next_graph_selection(tmp_path: Path) -> None:
@@ -11647,7 +11556,7 @@ def test_runtime_provider_fallback_seam_returns_next_graph_selection(tmp_path: P
         model_provider_registry=registry,
     )
 
-    selection = runtime._fallback_graph_selection(  # pyright: ignore[reportPrivateUsage]
+    selection = runtime._fallback_graph_selection(
         error=ProviderExecutionError(
             kind="rate_limit",
             provider_name="primary",
@@ -12152,32 +12061,32 @@ def test_runtime_provider_context_policy_off_preserves_provider_execution(
 
 def test_runtime_memory_refreshed_guard_suppresses_duplicate_anchor(tmp_path: Path) -> None:
     runtime = VoidCodeRuntime(workspace=tmp_path)
-    coordinator = runtime._run_loop_coordinator  # pyright: ignore[reportPrivateUsage]
+    coordinator = runtime._run_loop_coordinator
     session = SessionState(
         session=SessionRef("memory-refresh-guard"),
         status="running",
         metadata={"runtime_state": {"run_id": "run-1"}},
     )
 
-    first = coordinator._should_emit_memory_refreshed(  # pyright: ignore[reportPrivateUsage]
+    first = coordinator._should_emit_memory_refreshed(
         session=session,
         summary_anchor="continuity:abc",
         original_tool_result_count=9,
         retained_tool_result_count=8,
     )
-    updated = coordinator._session_with_memory_refreshed_state(  # pyright: ignore[reportPrivateUsage]
+    updated = coordinator._session_with_memory_refreshed_state(
         session=session,
         summary_anchor="continuity:abc",
         original_tool_result_count=9,
         retained_tool_result_count=8,
     )
-    duplicate = coordinator._should_emit_memory_refreshed(  # pyright: ignore[reportPrivateUsage]
+    duplicate = coordinator._should_emit_memory_refreshed(
         session=updated,
         summary_anchor="continuity:abc",
         original_tool_result_count=9,
         retained_tool_result_count=8,
     )
-    changed = coordinator._should_emit_memory_refreshed(  # pyright: ignore[reportPrivateUsage]
+    changed = coordinator._should_emit_memory_refreshed(
         session=updated,
         summary_anchor="continuity:def",
         original_tool_result_count=10,
@@ -12336,7 +12245,7 @@ def test_runtime_distillation_failure_clears_stale_candidate(tmp_path: Path) -> 
     )
     stale_candidate = {"objective_current_goal": "Stale prior turn"}
 
-    metadata = runtime._session_metadata_with_distillation_candidate(  # pyright: ignore[reportPrivateUsage]
+    metadata = runtime._session_metadata_with_distillation_candidate(
         prompt="read sample.txt\nread sample.txt",
         tool_results=(
             ToolResult(tool_name="read_file", status="ok", content="alpha"),
@@ -12427,7 +12336,7 @@ def test_runtime_distillation_uses_recency_projection_split(tmp_path: Path) -> N
         model_provider_registry=registry,
     )
 
-    metadata = runtime._session_metadata_with_distillation_candidate(  # pyright: ignore[reportPrivateUsage]
+    metadata = runtime._session_metadata_with_distillation_candidate(
         prompt="fix failing tests",
         tool_results=(
             ToolResult(tool_name="read_file", status="ok", content="content-1", data={"index": 1}),
@@ -12854,7 +12763,7 @@ def test_runtime_provider_turn_usage_is_persisted_in_session_metadata(tmp_path: 
 
 def test_runtime_context_pressure_ignores_stale_provider_usage(tmp_path: Path) -> None:
     runtime = VoidCodeRuntime(workspace=tmp_path)
-    coordinator = runtime._run_loop_coordinator  # pyright: ignore[reportPrivateUsage]
+    coordinator = runtime._run_loop_coordinator
     session = SessionState(
         session=SessionRef("stale-provider-usage"),
         status="running",
@@ -12886,7 +12795,7 @@ def test_runtime_context_pressure_ignores_stale_provider_usage(tmp_path: Path) -
         retained_tool_result_count=0,
     )
 
-    payload = coordinator._build_context_pressure_payload(  # pyright: ignore[reportPrivateUsage]
+    payload = coordinator._build_context_pressure_payload(
         session=session,
         context_window=context_window,
         threshold=0.7,
@@ -12899,7 +12808,7 @@ def test_runtime_context_pressure_ignores_previous_provider_attempt_usage(
     tmp_path: Path,
 ) -> None:
     runtime = VoidCodeRuntime(workspace=tmp_path)
-    coordinator = runtime._run_loop_coordinator  # pyright: ignore[reportPrivateUsage]
+    coordinator = runtime._run_loop_coordinator
     session = SessionState(
         session=SessionRef("stale-provider-attempt"),
         status="running",
@@ -12932,7 +12841,7 @@ def test_runtime_context_pressure_ignores_previous_provider_attempt_usage(
         retained_tool_result_count=0,
     )
 
-    payload = coordinator._build_context_pressure_payload(  # pyright: ignore[reportPrivateUsage]
+    payload = coordinator._build_context_pressure_payload(
         session=session,
         context_window=context_window,
         threshold=0.7,
@@ -13826,21 +13735,14 @@ def test_runtime_agent_builtin_tools_disabled_exposes_no_builtin_tools(tmp_path:
 
 
 def test_runtime_agent_builtin_tools_disabled_preserves_mcp_tools(tmp_path: Path) -> None:
-    class _StubMcpManager:
-        @property
-        def configuration(self) -> McpConfigState:
-            return McpConfigState(configured_enabled=True)
-
-        def current_state(self) -> McpManagerState:
-            return McpManagerState(mode="managed", configuration=self.configuration)
-
+    class _StubMcpManager(_NoopMcpManager):
         def list_tools(
             self,
             *,
             workspace: Path,
             owner_session_id: str | None = None,
             parent_session_id: str | None = None,
-        ):
+        ) -> tuple[McpToolDescriptor, ...]:
             _ = workspace, owner_session_id, parent_session_id
             return (
                 McpToolDescriptor(
@@ -13863,12 +13765,6 @@ def test_runtime_agent_builtin_tools_disabled_preserves_mcp_tools(tmp_path: Path
         ) -> McpToolCallResult:
             _ = server_name, tool_name, arguments, workspace, owner_session_id, parent_session_id
             return McpToolCallResult(content=[{"type": "text", "text": "echo:hi"}])
-
-        def shutdown(self):
-            return ()
-
-        def drain_events(self):
-            return ()
 
     created_providers: list[_ScriptedTurnProvider] = []
     registry = ModelProviderRegistry(
@@ -14723,8 +14619,7 @@ def test_runtime_resume_preserves_provider_attempt_and_target_across_pending_app
     }
     assert runtime_config["lsp"] == {"mode": "disabled", "configured_enabled": False, "servers": []}
     assert runtime_config["mcp"] == {"mode": "disabled", "configured_enabled": False, "servers": []}
-    agent_config = runtime_config["agent"]
-    assert isinstance(agent_config, dict)
+    agent_config = cast(dict[str, object], runtime_config["agent"])
     assert agent_config["preset"] == "leader"
     assert custom_attempts == [1]
     approval_event = waiting.events[-1]
@@ -16272,7 +16167,7 @@ def test_runtime_reasoning_capture_limit_spans_provider_turns(tmp_path: Path) ->
                                 '{"tool_name":"read_file","arguments":{"filePath":"sample.txt"}}'
                             ),
                         ),
-                        ProviderStreamEvent(kind="done", done_reason="tool_calls"),
+                        ProviderStreamEvent(kind="done", done_reason="completed"),
                     ),
                     (
                         *second_turn_reasoning,
@@ -16595,7 +16490,7 @@ def test_runtime_provider_retry_uses_persisted_session_provider_config(
             }
         ),
     )
-    retry_config = runtime._provider_transient_retry_config(  # pyright: ignore[reportPrivateUsage]
+    retry_config = runtime._provider_transient_retry_config(
         provider_name="opencode",
         session_metadata={
             "runtime_config": {
@@ -16668,7 +16563,7 @@ def test_runtime_provider_retry_attempt_resets_after_successful_provider_call(
     monkeypatch.setattr(
         runtime_run_loop_module,
         "_provider_transient_retry_delay_ms",
-        lambda *, retry_attempt, base_delay_ms, max_delay_ms, jitter: 0,
+        lambda **_: 0,
     )
 
     response = runtime.run(RuntimeRequest(prompt="retry fresh episodes"))
@@ -16905,7 +16800,7 @@ def test_runtime_provider_failure_resume_reconciles_parent_background_tasks(
     assert failed.session.status == "failed"
     assert runtime.session_debug_snapshot(session_id=parent_session_id).resumable is True
 
-    session_store = runtime._session_store  # pyright: ignore[reportPrivateUsage]
+    session_store = runtime._session_store
     session_store.create_background_task(
         workspace=tmp_path,
         task=BackgroundTaskState(
@@ -16982,39 +16877,9 @@ def test_runtime_provider_failure_resume_reconciles_parent_background_tasks(
 def test_runtime_provider_failure_resume_finalizes_background_task_and_releases_mcp(
     tmp_path: Path,
 ) -> None:
-    class _RecordingMcpManager:
+    class _RecordingMcpManager(_NoopMcpManager):
         def __init__(self) -> None:
             self.release_session_ids: list[str] = []
-
-        @property
-        def configuration(self) -> McpConfigState:
-            return McpConfigState(configured_enabled=True)
-
-        def current_state(self) -> McpManagerState:
-            return McpManagerState(mode="managed", configuration=self.configuration)
-
-        def list_tools(
-            self,
-            *,
-            workspace: Path,
-            owner_session_id: str | None = None,
-            parent_session_id: str | None = None,
-        ):
-            _ = workspace, owner_session_id, parent_session_id
-            return ()
-
-        def call_tool(
-            self,
-            *,
-            server_name: str,
-            tool_name: str,
-            arguments: dict[str, object],
-            workspace: Path,
-            owner_session_id: str | None = None,
-            parent_session_id: str | None = None,
-        ):
-            _ = server_name, tool_name, arguments, workspace, owner_session_id, parent_session_id
-            raise AssertionError("not used")
 
         def release_session(self, *, session_id: str) -> tuple[McpRuntimeEvent, ...]:
             self.release_session_ids.append(session_id)
@@ -17024,12 +16889,6 @@ def test_runtime_provider_failure_resume_finalizes_background_task_and_releases_
                     payload={"server": "echo", "workspace_root": str(tmp_path)},
                 ),
             )
-
-        def shutdown(self) -> tuple[McpRuntimeEvent, ...]:
-            return ()
-
-        def drain_events(self) -> tuple[McpRuntimeEvent, ...]:
-            return ()
 
     (tmp_path / "sample.txt").write_text("sample contents", encoding="utf-8")
     registry = ModelProviderRegistry(
@@ -17082,7 +16941,7 @@ def test_runtime_provider_failure_resume_finalizes_background_task_and_releases_
     child_session_id = "provider-retry-background-child"
 
     _ = list(
-        runtime._run_with_persistence(  # pyright: ignore[reportPrivateUsage]
+        runtime._run_with_persistence(
             RuntimeRequest(
                 prompt="read sample.txt",
                 session_id=child_session_id,
@@ -17095,7 +16954,7 @@ def test_runtime_provider_failure_resume_finalizes_background_task_and_releases_
             allow_internal_metadata=True,
         )
     )
-    runtime._session_store.create_background_task(  # pyright: ignore[reportPrivateUsage]
+    runtime._session_store.create_background_task(
         workspace=tmp_path,
         task=BackgroundTaskState(
             task=BackgroundTaskRef(id=task_id),
@@ -17104,9 +16963,9 @@ def test_runtime_provider_failure_resume_finalizes_background_task_and_releases_
             ),
         ),
     )
-    session_store = runtime._session_store  # pyright: ignore[reportPrivateUsage]
+    session_store = runtime._session_store
     assert isinstance(session_store, SqliteSessionStore)
-    with session_store._write_connect(tmp_path) as connection:  # pyright: ignore[reportPrivateUsage]
+    with session_store._write_connect(tmp_path) as connection:
         _ = connection.execute(
             """
             UPDATE background_tasks
@@ -17117,7 +16976,7 @@ def test_runtime_provider_failure_resume_finalizes_background_task_and_releases_
             (child_session_id, task_id),
         )
         connection.commit()
-    running_task = runtime._session_store.load_background_task(  # pyright: ignore[reportPrivateUsage]
+    running_task = runtime._session_store.load_background_task(
         workspace=tmp_path,
         task_id=task_id,
     )
@@ -17185,7 +17044,7 @@ def test_runtime_provider_failure_resume_persists_failed_chunk_when_loop_raises(
     child_session_id = "provider-retry-raise-child"
 
     _ = list(
-        runtime._run_with_persistence(  # pyright: ignore[reportPrivateUsage]
+        runtime._run_with_persistence(
             RuntimeRequest(
                 prompt="read sample.txt",
                 session_id=child_session_id,
@@ -17198,16 +17057,16 @@ def test_runtime_provider_failure_resume_persists_failed_chunk_when_loop_raises(
             allow_internal_metadata=True,
         )
     )
-    runtime._session_store.create_background_task(  # pyright: ignore[reportPrivateUsage]
+    runtime._session_store.create_background_task(
         workspace=tmp_path,
         task=BackgroundTaskState(
             task=BackgroundTaskRef(id=task_id),
             request=BackgroundTaskRequestSnapshot(prompt="read sample.txt"),
         ),
     )
-    session_store = runtime._session_store  # pyright: ignore[reportPrivateUsage]
+    session_store = runtime._session_store
     assert isinstance(session_store, SqliteSessionStore)
-    with session_store._write_connect(tmp_path) as connection:  # pyright: ignore[reportPrivateUsage]
+    with session_store._write_connect(tmp_path) as connection:
         _ = connection.execute(
             """
             UPDATE background_tasks
@@ -17243,7 +17102,7 @@ def test_runtime_provider_failure_resume_persists_failed_chunk_when_loop_raises(
         )
         raise RuntimeError("graph loop raised after failed chunk")
 
-    monkeypatch.setattr(  # pyright: ignore[reportPrivateUsage]
+    monkeypatch.setattr(
         runtime,
         "_execute_graph_loop",
         _raise_after_failed_chunk,
@@ -17637,11 +17496,11 @@ def test_runtime_context_window_policy_uses_active_model_limit(tmp_path: Path) -
         context_window_policy=ContextWindowPolicy(max_context_ratio=0.01),
     )
 
-    context = runtime._prepare_provider_context_window(  # pyright: ignore[reportPrivateUsage]
+    context = runtime._prepare_provider_context_window(
         prompt="read sample.txt",
         tool_results=(),
         session_metadata={
-            "runtime_config": runtime._runtime_config_metadata(),  # pyright: ignore[reportPrivateUsage]
+            "runtime_config": runtime._runtime_config_metadata(),
         },
     )
 
@@ -18023,7 +17882,7 @@ def test_runtime_executes_background_task_cancelled_hook_for_queued_cancel(
             )
         ),
     )
-    runtime._background_tasks_reconciled = True  # pyright: ignore[reportPrivateUsage]
+    runtime._background_tasks_reconciled = True
     store = _private_attr(runtime, "_session_store")
     task_module = importlib.import_module("voidcode.runtime.task")
     store.create_background_task(
@@ -18099,7 +17958,7 @@ def test_runtime_context_window_projection_preserves_full_session_truth(
     provider only receives a bounded projection."""
     runtime = VoidCodeRuntime(workspace=tmp_path)
 
-    context_window = runtime._prepare_provider_context_window(  # pyright: ignore[reportPrivateUsage]
+    context_window = runtime._prepare_provider_context_window(
         prompt="verify build",
         tool_results=(
             ToolResult(tool_name="read_file", status="ok", content="a", data={"index": 1}),
@@ -18107,7 +17966,7 @@ def test_runtime_context_window_projection_preserves_full_session_truth(
             ToolResult(tool_name="read_file", status="ok", content="c", data={"index": 3}),
         ),
         session_metadata={
-            "runtime_config": runtime._runtime_config_metadata(),  # pyright: ignore[reportPrivateUsage]
+            "runtime_config": runtime._runtime_config_metadata(),
         },
         policy=ContextWindowPolicy(max_tool_results=1),
     )
@@ -18116,7 +17975,7 @@ def test_runtime_context_window_projection_preserves_full_session_truth(
         status="running",
         turn=1,
         metadata={
-            "runtime_config": runtime._runtime_config_metadata(),  # pyright: ignore[reportPrivateUsage]
+            "runtime_config": runtime._runtime_config_metadata(),
         },
     )
     enriched = VoidCodeRuntime._session_with_context_window_metadata(session, context_window)
@@ -18140,10 +17999,10 @@ def test_runtime_persists_assembled_context_token_estimate(
         tool_registry=ToolRegistry.from_tools(()),
         context_window_policy=ContextWindowPolicy(model_context_window_tokens=1000),
     )
-    session_metadata = {
-        "runtime_config": runtime._runtime_config_metadata(),  # pyright: ignore[reportPrivateUsage]
+    session_metadata: dict[str, object] = {
+        "runtime_config": runtime._runtime_config_metadata(),
     }
-    assembled = runtime._assemble_provider_context(  # pyright: ignore[reportPrivateUsage]
+    assembled = runtime._assemble_provider_context(
         prompt="检查构建输出",
         tool_results=(
             ToolResult(tool_name="read_file", status="ok", content="hello world", data={}),
@@ -18189,11 +18048,11 @@ def test_runtime_context_window_resume_continuity_metadata_is_projection_only(
         ],
     }
     session_metadata: dict[str, object] = {
-        "runtime_config": runtime._runtime_config_metadata(),  # pyright: ignore[reportPrivateUsage]
+        "runtime_config": runtime._runtime_config_metadata(),
         "runtime_state": {"continuity": prior_payload},
     }
 
-    assembled = runtime._assemble_provider_context(  # pyright: ignore[reportPrivateUsage]
+    assembled = runtime._assemble_provider_context(
         prompt="resume using raw events",
         tool_results=(ToolResult(tool_name="read_file", status="ok", content="raw retained"),),
         session_metadata=session_metadata,
@@ -18222,7 +18081,7 @@ def test_runtime_context_window_malformed_resume_continuity_falls_back_safely(
 ) -> None:
     runtime = VoidCodeRuntime(workspace=tmp_path)
     session_metadata: dict[str, object] = {
-        "runtime_config": runtime._runtime_config_metadata(),  # pyright: ignore[reportPrivateUsage]
+        "runtime_config": runtime._runtime_config_metadata(),
         "runtime_state": {
             "continuity": {
                 "version": [],
@@ -18234,7 +18093,7 @@ def test_runtime_context_window_malformed_resume_continuity_falls_back_safely(
         },
     }
 
-    assembled = runtime._assemble_provider_context(  # pyright: ignore[reportPrivateUsage]
+    assembled = runtime._assemble_provider_context(
         prompt="resume despite malformed metadata",
         tool_results=(ToolResult(tool_name="read_file", status="ok", content="raw retained"),),
         session_metadata=session_metadata,
@@ -18272,16 +18131,14 @@ def test_runtime_context_window_projection_no_command_name_scoring(
         data={"index": 2, "command": "echo hello"},
     )
 
-    meta: dict[str, object] = {
-        "runtime_config": runtime._runtime_config_metadata()  # pyright: ignore[reportPrivateUsage]
-    }
-    context_a = runtime._prepare_provider_context_window(  # pyright: ignore[reportPrivateUsage]
+    meta: dict[str, object] = {"runtime_config": runtime._runtime_config_metadata()}
+    context_a = runtime._prepare_provider_context_window(
         prompt="verify",
         tool_results=(shell_a,),
         session_metadata=meta,
         policy=ContextWindowPolicy(max_tool_results=1),
     )
-    context_b = runtime._prepare_provider_context_window(  # pyright: ignore[reportPrivateUsage]
+    context_b = runtime._prepare_provider_context_window(
         prompt="verify",
         tool_results=(shell_b,),
         session_metadata=meta,
@@ -18301,7 +18158,7 @@ def test_runtime_context_window_projection_bounded_output_within_limit(
     max_tool_results=2 and 4 inputs, only 2 results should be retained."""
     runtime = VoidCodeRuntime(workspace=tmp_path)
 
-    context = runtime._prepare_provider_context_window(  # pyright: ignore[reportPrivateUsage]
+    context = runtime._prepare_provider_context_window(
         prompt="continue coding",
         tool_results=(
             ToolResult(tool_name="read_file", status="ok", content="a", data={"index": 1}),
@@ -18310,7 +18167,7 @@ def test_runtime_context_window_projection_bounded_output_within_limit(
             ToolResult(tool_name="read_file", status="ok", content="d", data={"index": 4}),
         ),
         session_metadata={
-            "runtime_config": runtime._runtime_config_metadata(),  # pyright: ignore[reportPrivateUsage]
+            "runtime_config": runtime._runtime_config_metadata(),
         },
         policy=ContextWindowPolicy(max_tool_results=2),
     )
@@ -18328,7 +18185,7 @@ def test_runtime_context_window_projection_auto_compaction_disabled_preserves_al
     projection (derived output matches complete truth for this case)."""
     runtime = VoidCodeRuntime(workspace=tmp_path)
 
-    context = runtime._prepare_provider_context_window(  # pyright: ignore[reportPrivateUsage]
+    context = runtime._prepare_provider_context_window(
         prompt="inspect",
         tool_results=(
             ToolResult(tool_name="read_file", status="ok", content="a", data={"index": 1}),
@@ -18336,7 +18193,7 @@ def test_runtime_context_window_projection_auto_compaction_disabled_preserves_al
             ToolResult(tool_name="read_file", status="ok", content="c", data={"index": 3}),
         ),
         session_metadata={
-            "runtime_config": runtime._runtime_config_metadata(),  # pyright: ignore[reportPrivateUsage]
+            "runtime_config": runtime._runtime_config_metadata(),
         },
         policy=ContextWindowPolicy(auto_compaction=False, max_tool_results=1),
     )

--- a/tests/unit/runtime/test_tool_provider.py
+++ b/tests/unit/runtime/test_tool_provider.py
@@ -71,7 +71,7 @@ pytestmark = pytest.mark.usefixtures("_force_deterministic_engine_default")
 
 
 @pytest.fixture
-def _force_deterministic_engine_default(  # pyright: ignore[reportUnusedFunction]
+def _force_deterministic_engine_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("VOIDCODE_EXECUTION_ENGINE", "deterministic")
@@ -93,6 +93,7 @@ class _StubGraph:
         *,
         session: SessionState,
     ) -> GraphStep:
+        _ = session
         if not tool_results:
             return _StubStep(
                 tool_call=ToolCall(
@@ -467,7 +468,7 @@ def test_runtime_uses_session_local_tools_config_when_registry_was_disabled(
         config=RuntimeConfig(execution_engine="deterministic"),
         permission_policy=PermissionPolicy(mode="allow"),
     )
-    effective_config = runtime._effective_runtime_config_from_metadata(  # pyright: ignore[reportPrivateUsage]
+    effective_config = runtime._effective_runtime_config_from_metadata(
         {
             "runtime_config": {
                 "execution_engine": "deterministic",
@@ -476,11 +477,9 @@ def test_runtime_uses_session_local_tools_config_when_registry_was_disabled(
         }
     )
 
-    registry = runtime._tool_registry_for_effective_config(  # pyright: ignore[reportPrivateUsage]
-        effective_config
-    )
+    registry = runtime._tool_registry_for_effective_config(effective_config)
 
-    assert "local/echo" not in runtime._base_tool_registry.tools  # pyright: ignore[reportPrivateUsage]
+    assert "local/echo" not in runtime._base_tool_registry.tools
     assert "local/echo" in registry.tools
 
 
@@ -497,7 +496,7 @@ def test_runtime_uses_session_local_tools_config_when_registry_was_enabled(
         ),
         permission_policy=PermissionPolicy(mode="allow"),
     )
-    effective_config = runtime._effective_runtime_config_from_metadata(  # pyright: ignore[reportPrivateUsage]
+    effective_config = runtime._effective_runtime_config_from_metadata(
         {
             "runtime_config": {
                 "execution_engine": "deterministic",
@@ -506,11 +505,9 @@ def test_runtime_uses_session_local_tools_config_when_registry_was_enabled(
         }
     )
 
-    registry = runtime._tool_registry_for_effective_config(  # pyright: ignore[reportPrivateUsage]
-        effective_config
-    )
+    registry = runtime._tool_registry_for_effective_config(effective_config)
 
-    assert "local/echo" not in runtime._base_tool_registry.tools  # pyright: ignore[reportPrivateUsage]
+    assert "local/echo" not in runtime._base_tool_registry.tools
     assert "local/echo" not in registry.tools
 
 
@@ -945,11 +942,9 @@ def test_runtime_includes_opted_in_local_custom_tools(tmp_path: Path) -> None:
         ),
     )
 
-    registry = runtime._tool_registry_for_effective_config(  # pyright: ignore[reportPrivateUsage]
-        runtime._initial_effective_config  # pyright: ignore[reportPrivateUsage]
-    )
+    registry = runtime._tool_registry_for_effective_config(runtime._initial_effective_config)
 
-    assert "local/echo" not in runtime._base_tool_registry.tools  # pyright: ignore[reportPrivateUsage]
+    assert "local/echo" not in runtime._base_tool_registry.tools
     assert "local/echo" in registry.tools
 
 
@@ -964,12 +959,10 @@ def test_runtime_persists_top_level_local_tools_config(tmp_path: Path) -> None:
         ),
     )
 
-    metadata = runtime._runtime_config_metadata()  # pyright: ignore[reportPrivateUsage]
+    metadata = runtime._runtime_config_metadata()
 
     assert metadata["tools"] == {"local": {"enabled": True, "path": ".voidcode/tools"}}
-    effective = runtime._effective_runtime_config_from_metadata(  # pyright: ignore[reportPrivateUsage]
-        {"runtime_config": metadata}
-    )
+    effective = runtime._effective_runtime_config_from_metadata({"runtime_config": metadata})
     assert effective.tools == RuntimeToolsConfig(
         local=RuntimeToolsLocalConfig(enabled=True, path=".voidcode/tools")
     )
@@ -987,9 +980,7 @@ def test_runtime_rejects_local_custom_tool_name_collisions(tmp_path: Path) -> No
     )
 
     with pytest.raises(ValueError, match="duplicate tool definition: grep"):
-        _ = runtime._tool_registry_for_effective_config(  # pyright: ignore[reportPrivateUsage]
-            runtime._initial_effective_config  # pyright: ignore[reportPrivateUsage]
-        )
+        _ = runtime._tool_registry_for_effective_config(runtime._initial_effective_config)
 
 
 def test_local_custom_tool_provider_rejects_invalid_input_schema(tmp_path: Path) -> None:
@@ -1294,7 +1285,7 @@ def test_runtime_default_registry_behavior_remains_unchanged(tmp_path: Path) -> 
     sample_file = tmp_path / "sample.txt"
     _ = sample_file.write_text("alpha beta\n", encoding="utf-8")
     runtime = VoidCodeRuntime(workspace=tmp_path, graph=_StubGraph())
-    base_registry = runtime._base_tool_registry  # pyright: ignore[reportPrivateUsage]
+    base_registry = runtime._base_tool_registry
 
     assert "format_file" in base_registry.tools
 
@@ -1315,7 +1306,7 @@ def test_runtime_default_registry_behavior_remains_unchanged(tmp_path: Path) -> 
 
 def test_runtime_default_registry_includes_runtime_backed_agent_tools(tmp_path: Path) -> None:
     runtime = VoidCodeRuntime(workspace=tmp_path, graph=_StubGraph())
-    base_registry = runtime._base_tool_registry  # pyright: ignore[reportPrivateUsage]
+    base_registry = runtime._base_tool_registry
 
     assert isinstance(base_registry.resolve("skill"), SkillTool)
     assert isinstance(base_registry.resolve("task"), TaskTool)


### PR DESCRIPTION
## Summary
- Extract runtime permission/path context resolution from `service.py` into `runtime.permission_context` while keeping compatibility wrappers in `VoidCodeRuntime`.
- Remove obsolete `# pyright:` directives from source/tests and make the affected tests ty-clean.
- Tighten runtime service extension test fakes and resume sequencing assertions exposed by the type cleanup.

## Verification
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check src`
- `uv run pytest -n auto -q`
- manual driver for external/workspace permission context and shell output path extraction