### PR TITLE
fix: improve default MCP and LSP agent ergonomics

### DIFF
--- a/src/voidcode/cli/app.py
+++ b/src/voidcode/cli/app.py
@@ -200,9 +200,11 @@ def _handle_run_command(args: argparse.Namespace) -> int:
         raise _CliUsageError("--json and --trace cannot be used together")
     show_thinking = cast(bool, getattr(args, "show_thinking", False))
     cli_reasoning_effort = cast(str | None, getattr(args, "reasoning_effort", None))
+    cli_model = cast(str | None, getattr(args, "model", None))
     config = load_runtime_config(
         workspace,
         approval_mode=cast(PermissionDecision | None, getattr(args, "approval_mode", None)),
+        model=cli_model,
         reasoning_effort=cli_reasoning_effort,
     )
     runtime = VoidCodeRuntime(workspace=workspace, config=config)
@@ -494,6 +496,7 @@ class _TracePrinter:
     def __init__(self, *, show_thinking: bool = False) -> None:
         self._show_thinking = show_thinking
         self._model_text_open = False
+        self._reasoning_open = False
 
     def handle_event(self, event: EventEnvelope) -> None:
         payload = redact_reasoning_payload(
@@ -502,7 +505,7 @@ class _TracePrinter:
             show_thinking=self._show_thinking,
         )
         if event.event_type == "graph.model_turn":
-            self._close_model_text()
+            self._close_open_streams()
             provider = _trace_string(payload.get("provider"))
             model = _trace_string(payload.get("model"))
             turn = payload.get("turn")
@@ -513,56 +516,83 @@ class _TracePrinter:
                 print(f"\n● Model turn {turn}", flush=True)
             return
         if event.event_type == "graph.provider_stream":
-            if _trace_string(payload.get("channel")) == "text" and payload.get("kind") in {
+            channel = _trace_string(payload.get("channel"))
+            if channel == "text" and payload.get("kind") in {
                 "delta",
                 "content",
             }:
                 text = _trace_string(payload.get("text"))
                 if text:
+                    self._close_reasoning_text()
                     print(text, end="", flush=True)
                     self._model_text_open = True
+            elif channel == "reasoning" and payload.get("kind") in {"delta", "content"}:
+                text = _trace_string(payload.get("text"))
+                if text:
+                    self._print_reasoning_text(text)
+            return
+        if event.event_type == "runtime.reasoning_part":
+            text = _trace_string(payload.get("text"))
+            if text:
+                self._print_reasoning_text(text)
             return
         if event.event_type == "graph.tool_request_created":
-            self._close_model_text()
+            self._close_open_streams()
             _print_trace_tool_request(payload)
             return
         if event.event_type == "runtime.tool_started":
-            self._close_model_text()
+            self._close_open_streams()
             _print_trace_tool_started(payload)
             return
         if event.event_type == "runtime.tool_progress":
-            self._close_model_text()
+            self._close_open_streams()
             _print_trace_tool_progress(payload)
             return
         if event.event_type == "runtime.tool_completed":
-            self._close_model_text()
+            self._close_open_streams()
             _print_trace_tool_completed(payload)
             return
         if event.event_type == "runtime.todo_updated":
-            self._close_model_text()
+            self._close_open_streams()
             _print_trace_todos(payload)
             return
         if event.event_type == "runtime.approval_requested":
-            self._close_model_text()
+            self._close_open_streams()
             tool = _trace_string(payload.get("tool")) or "tool"
             target = _trace_string(payload.get("target_summary"))
             suffix = f" for {target}" if target else ""
             print(f"\n⚠ Approval required: {tool}{suffix}", flush=True)
             return
         if event.event_type == "runtime.question_requested":
-            self._close_model_text()
+            self._close_open_streams()
             count = payload.get("question_count")
             print(f"\n? Question required: {count or 1} prompt(s)", flush=True)
             return
         if event.event_type == "runtime.failed":
-            self._close_model_text()
+            self._close_open_streams()
             error = _trace_string(payload.get("error")) or "runtime failed"
             print(f"\n✖ Failed: {error}", flush=True)
+
+    def _close_open_streams(self) -> None:
+        self._close_model_text()
+        self._close_reasoning_text()
 
     def _close_model_text(self) -> None:
         if self._model_text_open:
             print(flush=True)
             self._model_text_open = False
+
+    def _close_reasoning_text(self) -> None:
+        if self._reasoning_open:
+            print(flush=True)
+            self._reasoning_open = False
+
+    def _print_reasoning_text(self, text: str) -> None:
+        self._close_model_text()
+        if not self._reasoning_open:
+            print("[thinking] ", end="", flush=True)
+            self._reasoning_open = True
+        print(text, end="", flush=True)
 
 
 def _print_trace_tool_request(payload: dict[str, object]) -> None:
@@ -2463,6 +2493,7 @@ def tui(workspace: Path, approval_mode: str | None) -> int:
     "--agent",
     help="Select a top-level or local custom agent preset for this run.",
 )
+@click.option("--model", help="Override the provider/model for this run.")
 @click.option("--skills", multiple=True, help="Optional skill names applied for this run.")
 @click.option("--max-steps", type=int, help="Optional max graph steps override for this run.")
 @click.option(
@@ -2487,6 +2518,7 @@ def run(
     session_id: str | None,
     approval_mode: str | None,
     agent: str | None,
+    model: str | None,
     skills: tuple[str, ...],
     max_steps: int | None,
     reasoning_effort: str | None,
@@ -2504,6 +2536,7 @@ def run(
             session_id=session_id,
             approval_mode=approval_mode,
             agent=agent,
+            model=model,
             skills=list(skills),
             max_steps=max_steps,
             reasoning_effort=reasoning_effort,

--- a/src/voidcode/doctor/checker.py
+++ b/src/voidcode/doctor/checker.py
@@ -296,6 +296,18 @@ class McpServerChecker:
     def check(self) -> CapabilityCheckResult:
         """Check if the MCP server command is available."""
         command = self._config.command
+        if self._config.transport == "remote-http":
+            return CapabilityCheckResult(
+                status=CapabilityCheckStatus.READY,
+                name=f"mcp:{self._server_name}",
+                check_type=DoctorCheckType.MCP_SERVER.value,
+                details={
+                    "server_name": self._server_name,
+                    "transport": self._config.transport,
+                    "scope": getattr(self._config, "scope", "runtime"),
+                    "url": getattr(self._config, "url", None),
+                },
+            )
         if not command:
             return CapabilityCheckResult(
                 status=CapabilityCheckStatus.NOT_CONFIGURED,

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -610,6 +610,7 @@ def load_runtime_config(
     )
     resolved_tui = _resolve_tui_config(global_config.tui, repo_local.tui)
     resolved_lsp = repo_local.lsp or _derive_workspace_lsp_config(resolved_workspace)
+    resolved_mcp = repo_local.mcp or _derive_workspace_mcp_config()
     resolved_agent = _resolve_agent_config(repo_local.agent, agent_registry=agent_registry)
 
     env_providers = provider_configs_from_env(environment)
@@ -658,7 +659,7 @@ def load_runtime_config(
         context_window=repo_local.context_window,
         lsp=resolved_lsp,
         background_task=repo_local.background_task or RuntimeBackgroundTaskConfig(),
-        mcp=repo_local.mcp,
+        mcp=resolved_mcp,
         tui=resolved_tui,
         provider_fallback=repo_local.provider_fallback,
         providers=resolved_providers,
@@ -674,6 +675,21 @@ def _derive_workspace_lsp_config(workspace: Path) -> RuntimeLspConfig | None:
     if not derived_servers:
         return None
     return RuntimeLspConfig(enabled=True, servers=derived_servers)
+
+
+def _derive_workspace_mcp_config() -> RuntimeMcpConfig | None:
+    descriptor = get_builtin_mcp_descriptor("grep_app")
+    if descriptor is None or descriptor.url is None:
+        return None
+    return RuntimeMcpConfig(
+        enabled=True,
+        servers={
+            "grep_app": RuntimeMcpServerConfig(
+                transport="remote-http",
+                url=descriptor.url,
+            )
+        },
+    )
 
 
 def _discover_runtime_skill_names(

--- a/src/voidcode/tools/_pydantic_args.py
+++ b/src/voidcode/tools/_pydantic_args.py
@@ -67,13 +67,6 @@ class WriteFileArgs(BaseModel):
     path: str
     content: str
 
-    @field_validator("content", mode="after")
-    @classmethod
-    def _validate_content(cls, value: str) -> str:
-        if value == "":
-            raise ValueError("content must not be empty")
-        return value
-
 
 class GrepArgs(BaseModel):
     pattern: str

--- a/src/voidcode/tools/lsp.py
+++ b/src/voidcode/tools/lsp.py
@@ -39,15 +39,63 @@ class LspOperation(enum.Enum):
     OUTGOING_CALLS = "callHierarchy/outgoingCalls"
 
 
+_LSP_OPERATION_ALIASES: dict[str, LspOperation] = {
+    "gotodefinition": LspOperation.GO_TO_DEFINITION,
+    "definition": LspOperation.GO_TO_DEFINITION,
+    "findreferences": LspOperation.FIND_REFERENCES,
+    "references": LspOperation.FIND_REFERENCES,
+    "hover": LspOperation.HOVER,
+    "documentsymbol": LspOperation.DOCUMENT_SYMBOL,
+    "symbol": LspOperation.DOCUMENT_SYMBOL,
+    "workspacesymbol": LspOperation.WORKSPACE_SYMBOL,
+    "gotoimplementation": LspOperation.GO_TO_IMPLEMENTATION,
+    "implementation": LspOperation.GO_TO_IMPLEMENTATION,
+    "incomingcalls": LspOperation.INCOMING_CALLS,
+    "outgoingcalls": LspOperation.OUTGOING_CALLS,
+}
+
+
 class LspTool:
     definition: ClassVar[ToolDefinition] = ToolDefinition(
         name="lsp",
         description="LSP client for basic code intelligence lookups.",
         input_schema={
-            "operation": {"type": "string"},
-            "filePath": {"type": "string"},
-            "line": {"type": "integer"},
-            "character": {"type": "integer"},
+            "operation": {
+                "type": "string",
+                "description": (
+                    "LSP operation. Preferred names include goToDefinition, "
+                    "findReferences, hover, documentSymbol, workspaceSymbol, "
+                    "goToImplementation, incomingCalls, and outgoingCalls. "
+                    "Protocol method strings like textDocument/definition "
+                    "also work."
+                ),
+            },
+            "filePath": {
+                "type": "string",
+                "description": (
+                    "Workspace-relative file path used for target selection and server resolution."
+                ),
+            },
+            "line": {
+                "type": "integer",
+                "description": (
+                    "1-based line number as shown in editors. Required for "
+                    "position-based operations."
+                ),
+            },
+            "character": {
+                "type": "integer",
+                "description": (
+                    "1-based character number as shown in editors. Required "
+                    "for position-based operations."
+                ),
+            },
+            "query": {
+                "type": "string",
+                "description": (
+                    "Optional workspaceSymbol search query. Empty string requests all symbols."
+                ),
+            },
             "server": {"type": "string"},
         },
         read_only=True,
@@ -56,6 +104,26 @@ class LspTool:
     def __init__(self, *, requester: LspRequester) -> None:
         self._requester = requester
         self._converter = lsp_converters.get_converter()
+
+    @staticmethod
+    def _parse_operation(value: object) -> LspOperation:
+        if isinstance(value, LspOperation):
+            return value
+        if not isinstance(value, str):
+            raise ValueError(f"Unsupported LSP operation: {value}")
+        try:
+            return LspOperation(value)
+        except Exception:
+            pass
+        try:
+            return LspOperation[value]
+        except Exception:
+            pass
+        normalized = "".join(character for character in value if character.isalnum()).lower()
+        alias = _LSP_OPERATION_ALIASES.get(normalized)
+        if alias is not None:
+            return alias
+        raise ValueError(f"Unsupported LSP operation: {value}")
 
     @staticmethod
     def _invoke_requester(
@@ -85,10 +153,13 @@ class LspTool:
         file_path = call.arguments.get("filePath")
         line = call.arguments.get("line")
         character = call.arguments.get("character")
+        query = call.arguments.get("query")
         server = call.arguments.get("server")
 
         if server is not None and not isinstance(server, str):
             raise ValueError("lsp requires a string 'server' argument when provided")
+        if query is not None and not isinstance(query, str):
+            raise ValueError("lsp requires a string 'query' argument when provided")
         if not isinstance(file_path, str):
             raise ValueError("lsp requires a string 'filePath' argument")
         if isinstance(line, (int, float)):
@@ -101,26 +172,20 @@ class LspTool:
         else:
             character_value = None
 
-        if line_value is None or character_value is None:
-            raise ValueError("lsp requires numeric 'line' and 'character' arguments (1-based)")
-        if line_value < 1 or character_value < 1:
-            raise ValueError("lsp line and character must be >= 1")
         if op_value is None:
             raise ValueError("lsp invocation requires 'operation' argument")
 
-        try:
-            if isinstance(op_value, LspOperation):
-                operation = op_value
-            else:
-                operation = LspOperation(op_value)
-        except Exception:
-            if isinstance(op_value, str):
-                try:
-                    operation = LspOperation[op_value]
-                except Exception as exc:
-                    raise ValueError(f"Unsupported LSP operation: {op_value}") from exc
-            else:
-                raise ValueError(f"Unsupported LSP operation: {op_value}") from None
+        operation = self._parse_operation(op_value)
+        position_required = operation not in (
+            LspOperation.DOCUMENT_SYMBOL,
+            LspOperation.WORKSPACE_SYMBOL,
+        )
+        if position_required and (line_value is None or character_value is None):
+            raise ValueError("lsp requires numeric 'line' and 'character' arguments (1-based)")
+        if line_value is not None and line_value < 1:
+            raise ValueError("lsp line and character must be >= 1")
+        if character_value is not None and character_value < 1:
+            raise ValueError("lsp line and character must be >= 1")
 
         relative_path = Path(file_path)
         workspace_root = workspace.resolve()
@@ -130,19 +195,44 @@ class LspTool:
         if not candidate.is_file():
             raise ValueError(f"lsp target does not exist: {file_path}")
 
-        position = lsp_types.Position(line=line_value - 1, character=character_value - 1)
-        text_document = lsp_types.TextDocumentIdentifier(uri=candidate.as_uri())
-        params: dict[str, object] = self._converter.unstructure(
-            lsp_types.TextDocumentPositionParams(text_document=text_document, position=position),
-            unstructure_as=lsp_types.TextDocumentPositionParams,
+        position = (
+            lsp_types.Position(line=line_value - 1, character=character_value - 1)
+            if line_value is not None and character_value is not None
+            else None
         )
+        text_document = lsp_types.TextDocumentIdentifier(uri=candidate.as_uri())
+        params: dict[str, object]
+        if operation == LspOperation.DOCUMENT_SYMBOL:
+            params = cast(
+                dict[str, object],
+                self._converter.unstructure(
+                    lsp_types.DocumentSymbolParams(text_document=text_document),
+                    unstructure_as=lsp_types.DocumentSymbolParams,
+                ),
+            )
+        elif position is not None:
+            params = cast(
+                dict[str, object],
+                self._converter.unstructure(
+                    lsp_types.TextDocumentPositionParams(
+                        text_document=text_document, position=position
+                    ),
+                    unstructure_as=lsp_types.TextDocumentPositionParams,
+                ),
+            )
+        else:
+            params = cast(dict[str, object], {"textDocument": {"uri": candidate.as_uri()}})
         if operation == LspOperation.WORKSPACE_SYMBOL:
-            params = self._converter.unstructure(
-                lsp_types.WorkspaceSymbolParams(query=""),
-                unstructure_as=lsp_types.WorkspaceSymbolParams,
+            params = cast(
+                dict[str, object],
+                self._converter.unstructure(
+                    lsp_types.WorkspaceSymbolParams(query=query or ""),
+                    unstructure_as=lsp_types.WorkspaceSymbolParams,
+                ),
             )
 
         if operation in (LspOperation.INCOMING_CALLS, LspOperation.OUTGOING_CALLS):
+            assert position is not None
             prepare_result = self._invoke_requester(
                 self._requester,
                 server_name=server,
@@ -171,7 +261,7 @@ class LspTool:
                 item = cast(dict[str, object], prepare_payload)
             if item is None:
                 raise ValueError("LSP prepareCallHierarchy returned no item")
-            params = {"item": item}
+            params = cast(dict[str, object], {"item": item})
 
             response = self._invoke_requester(
                 self._requester,

--- a/tests/unit/doctor/test_checker.py
+++ b/tests/unit/doctor/test_checker.py
@@ -206,3 +206,19 @@ class TestMcpServerChecker:
 
         assert result.status == CapabilityCheckStatus.NOT_CONFIGURED
         assert result.error_message is not None
+
+    def test_check_with_remote_http_server(self) -> None:
+        """Remote HTTP MCP descriptors should not require a local executable."""
+        from voidcode.mcp.config import McpServerConfig
+
+        config = McpServerConfig(
+            command=(),
+            transport="remote-http",
+            url="https://mcp.grep.app",
+        )
+        checker = McpServerChecker("grep_app", config)
+        result = checker.check()
+
+        assert result.status == CapabilityCheckStatus.READY
+        assert result.details["transport"] == "remote-http"
+        assert result.details["url"] == "https://mcp.grep.app"

--- a/tests/unit/doctor/test_doctor.py
+++ b/tests/unit/doctor/test_doctor.py
@@ -105,6 +105,26 @@ class TestCreateDoctorForConfig:
         assert mcp_result.status == CapabilityCheckStatus.NOT_CONFIGURED
         assert mcp_result.details["configured_enabled"] is False
 
+    def test_reports_remote_http_mcp_server_as_ready(self) -> None:
+        config = RuntimeConfig(
+            mcp=RuntimeMcpConfig(
+                enabled=True,
+                servers={
+                    "grep_app": RuntimeMcpServerConfig(
+                        transport="remote-http",
+                        url="https://mcp.grep.app",
+                    )
+                },
+            )
+        )
+
+        doctor = create_doctor_for_config(Path("/tmp"), config)
+
+        mcp_result = next(result for result in doctor.results if result.name == "mcp:grep_app")
+        assert mcp_result.status == CapabilityCheckStatus.READY
+        assert mcp_result.details["transport"] == "remote-http"
+        assert mcp_result.details["url"] == "https://mcp.grep.app"
+
     def test_reports_disabled_mcp_configuration(self) -> None:
         config = RuntimeConfig(
             mcp=RuntimeMcpConfig(

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -916,7 +916,7 @@ def test_run_command_ctrl_c_cancels_active_runtime_session(capsys: Any) -> None:
     assert "Interrupted current run." in capsys.readouterr().err
 
 
-def test_run_command_accepts_agent_skills_max_steps_and_provider_stream_flags() -> None:
+def test_run_command_accepts_agent_skills_model_max_steps_and_provider_stream_flags() -> None:
     cli = importlib.import_module("voidcode.cli")
     workspace = Path("/tmp/demo-workspace")
     config = SimpleNamespace(approval_mode="allow")
@@ -929,7 +929,9 @@ def test_run_command_accepts_agent_skills_max_steps_and_provider_stream_flags() 
         _make_chunk(session_id="demo-session", status="completed", output="done\n"),
     )
 
-    with patch.object(cli, "load_runtime_config", autospec=True, return_value=config):
+    with patch.object(
+        cli, "load_runtime_config", autospec=True, return_value=config
+    ) as load_config:
         with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
             runtime_class.return_value.run_stream.return_value = iter(chunks)
             result = cli.main(
@@ -940,6 +942,8 @@ def test_run_command_accepts_agent_skills_max_steps_and_provider_stream_flags() 
                     str(workspace),
                     "--agent",
                     "product",
+                    "--model",
+                    "deepseek/deepseek-v4-pro",
                     "--skills",
                     "demo",
                     "review",
@@ -950,6 +954,12 @@ def test_run_command_accepts_agent_skills_max_steps_and_provider_stream_flags() 
             )
 
     assert result == 0
+    load_config.assert_called_once_with(
+        workspace,
+        approval_mode=None,
+        model="deepseek/deepseek-v4-pro",
+        reasoning_effort=None,
+    )
     runtime_class.return_value.run_stream.assert_called_once()
     request = runtime_class.return_value.run_stream.call_args.args[0]
     assert request.prompt == "read README.md"
@@ -1103,6 +1113,28 @@ def test_run_trace_streams_model_text_todos_and_tool_output(capsys: Any) -> None
                 "graph.provider_stream",
                 source="graph",
                 kind="delta",
+                channel="reasoning",
+                text="Need to confirm ",
+            ),
+        ),
+        _make_chunk(
+            session_id="trace-session",
+            status="running",
+            event=_runtime_event(
+                "graph.provider_stream",
+                source="graph",
+                kind="delta",
+                channel="reasoning",
+                text="the environment first.",
+            ),
+        ),
+        _make_chunk(
+            session_id="trace-session",
+            status="running",
+            event=_runtime_event(
+                "graph.provider_stream",
+                source="graph",
+                kind="delta",
                 channel="text",
                 text="I will create the file.\n",
             ),
@@ -1155,7 +1187,9 @@ def test_run_trace_streams_model_text_todos_and_tool_output(capsys: Any) -> None
     with patch.object(cli, "load_runtime_config", autospec=True, return_value=config):
         with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
             runtime_class.return_value.run_stream.return_value = iter(chunks)
-            result = cli.main(["run", "write sample", "--workspace", str(workspace), "--trace"])
+            result = cli.main(
+                ["run", "write sample", "--workspace", str(workspace), "--trace", "--show-thinking"]
+            )
 
     captured = capsys.readouterr()
     request = runtime_class.return_value.run_stream.call_args.args[0]
@@ -1163,6 +1197,7 @@ def test_run_trace_streams_model_text_todos_and_tool_output(capsys: Any) -> None
     assert result == 0
     assert request.metadata["provider_stream"] is True
     assert "● Model turn 1: opencode-go · glm-5.1" in captured.out
+    assert "[thinking] Need to confirm the environment first." in captured.out
     assert "I will create the file." in captured.out
     assert "TODO" in captured.out
     assert "  [x] Create sample file" in captured.out
@@ -1174,6 +1209,100 @@ def test_run_trace_streams_model_text_todos_and_tool_output(capsys: Any) -> None
     assert "Result\ndone" in captured.out
     assert "EVENT graph.provider_stream" not in captured.out
     assert captured.err == ""
+
+
+def test_run_trace_hides_reasoning_without_show_thinking(capsys: Any) -> None:
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/demo-workspace")
+    config = SimpleNamespace(approval_mode="allow")
+    chunks = (
+        _make_chunk(
+            session_id="trace-session",
+            status="running",
+            event=_runtime_event(
+                "graph.model_turn",
+                source="graph",
+                turn=1,
+                provider="deepseek",
+                model="deepseek-v4-pro",
+            ),
+        ),
+        _make_chunk(
+            session_id="trace-session",
+            status="running",
+            event=_StubEvent(
+                sequence=1,
+                event_type="runtime.reasoning_part",
+                source="runtime",
+                payload={"type": "reasoning", "text_omitted": True, "visibility": "hidden"},
+            ),
+        ),
+        _make_chunk(session_id="trace-session", status="completed", output="done\n"),
+    )
+
+    with patch.object(cli, "load_runtime_config", autospec=True, return_value=config):
+        with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
+            runtime_class.return_value.run_stream.return_value = iter(chunks)
+            result = cli.main(["run", "think", "--workspace", str(workspace), "--trace"])
+
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert "[thinking]" not in captured.out
+    assert "text_omitted" not in captured.out
+
+
+def test_run_trace_shows_reasoning_with_show_thinking(capsys: Any) -> None:
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/demo-workspace")
+    config = SimpleNamespace(approval_mode="allow")
+    chunks = (
+        _make_chunk(
+            session_id="trace-session",
+            status="running",
+            event=_runtime_event(
+                "graph.model_turn",
+                source="graph",
+                turn=1,
+                provider="deepseek",
+                model="deepseek-v4-pro",
+            ),
+        ),
+        _make_chunk(
+            session_id="trace-session",
+            status="running",
+            event=_StubEvent(
+                sequence=1,
+                event_type="runtime.reasoning_part",
+                source="runtime",
+                payload=runtime_reasoning_part_payload(text="Check SDL3 and "),
+            ),
+        ),
+        _make_chunk(
+            session_id="trace-session",
+            status="running",
+            event=_StubEvent(
+                sequence=2,
+                event_type="runtime.reasoning_part",
+                source="runtime",
+                payload=runtime_reasoning_part_payload(text="Vulkan availability."),
+            ),
+        ),
+        _make_chunk(session_id="trace-session", status="completed", output="done\n"),
+    )
+
+    with patch.object(cli, "load_runtime_config", autospec=True, return_value=config):
+        with patch.object(cli, "VoidCodeRuntime", autospec=True) as runtime_class:
+            runtime_class.return_value.run_stream.return_value = iter(chunks)
+            result = cli.main(
+                ["run", "think", "--workspace", str(workspace), "--trace", "--show-thinking"]
+            )
+
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert "[thinking] Check SDL3 and Vulkan availability." in captured.out
+    assert "[thinking] Check SDL3 and \n" not in captured.out
 
 
 def test_run_trace_respects_explicit_no_provider_stream() -> None:

--- a/tests/unit/runtime/test_lsp.py
+++ b/tests/unit/runtime/test_lsp.py
@@ -1001,3 +1001,131 @@ def test_lsp_tool_builds_same_text_document_position_wire_shape(tmp_path: Path) 
         "textDocument": {"uri": sample_file.resolve().as_uri()},
         "position": {"line": 1, "character": 2},
     }
+
+
+def test_lsp_tool_accepts_opencode_style_operation_aliases(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.py"
+    sample_file.write_text("x = 1\n", encoding="utf-8")
+
+    class _StubResponse:
+        def __init__(self, response: dict[str, object]) -> None:
+            self.response = response
+
+    captured: dict[str, object] = {}
+
+    def _requester(
+        *,
+        server_name: str | None,
+        method: str,
+        params: dict[str, object],
+        workspace: Path,
+    ) -> _StubResponse:
+        captured["server_name"] = server_name
+        captured["method"] = method
+        captured["params"] = params
+        captured["workspace"] = workspace
+        return _StubResponse({"result": {"ok": True}})
+
+    tool_module = import_module("voidcode.tools.lsp")
+    tool = tool_module.LspTool(requester=_requester)
+
+    result = tool.invoke(
+        ToolCall(
+            tool_name="lsp",
+            arguments={
+                "operation": "goToDefinition",
+                "filePath": "sample.py",
+                "line": 1,
+                "character": 1,
+            },
+        ),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert captured["method"] == "textDocument/definition"
+
+
+def test_lsp_tool_accepts_workspace_symbol_query_without_position(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.py"
+    sample_file.write_text("x = 1\n", encoding="utf-8")
+
+    class _StubResponse:
+        def __init__(self, response: dict[str, object]) -> None:
+            self.response = response
+
+    captured: dict[str, object] = {}
+
+    def _requester(
+        *,
+        server_name: str | None,
+        method: str,
+        params: dict[str, object],
+        workspace: Path,
+    ) -> _StubResponse:
+        captured["method"] = method
+        captured["params"] = params
+        captured["workspace"] = workspace
+        return _StubResponse({"result": {"ok": True}})
+
+    tool_module = import_module("voidcode.tools.lsp")
+    tool = tool_module.LspTool(requester=_requester)
+
+    result = tool.invoke(
+        ToolCall(
+            tool_name="lsp",
+            arguments={
+                "operation": "workspaceSymbol",
+                "filePath": "sample.py",
+                "query": "Sample",
+            },
+        ),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert captured["method"] == "workspace/symbol"
+    assert captured["workspace"] == tmp_path.resolve()
+    assert captured["params"] == {"query": "Sample"}
+
+
+def test_lsp_tool_accepts_document_symbol_without_position(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.py"
+    sample_file.write_text("x = 1\n", encoding="utf-8")
+
+    class _StubResponse:
+        def __init__(self, response: dict[str, object]) -> None:
+            self.response = response
+
+    captured: dict[str, object] = {}
+
+    def _requester(
+        *,
+        server_name: str | None,
+        method: str,
+        params: dict[str, object],
+        workspace: Path,
+    ) -> _StubResponse:
+        captured["method"] = method
+        captured["params"] = params
+        return _StubResponse({"result": {"ok": True}})
+
+    tool_module = import_module("voidcode.tools.lsp")
+    tool = tool_module.LspTool(requester=_requester)
+
+    result = tool.invoke(
+        ToolCall(
+            tool_name="lsp",
+            arguments={
+                "operation": "documentSymbol",
+                "filePath": "sample.py",
+            },
+        ),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert captured["method"] == "textDocument/documentSymbol"
+    assert captured["params"] == {
+        "textDocument": {"uri": sample_file.resolve().as_uri()},
+    }

--- a/tests/unit/runtime/test_mcp_config.py
+++ b/tests/unit/runtime/test_mcp_config.py
@@ -302,6 +302,20 @@ def test_runtime_config_expands_builtin_mcp_server_shorthand(tmp_path: Path) -> 
     )
 
 
+def test_runtime_config_derives_default_grep_app_mcp_when_unconfigured(tmp_path: Path) -> None:
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.mcp == RuntimeMcpConfig(
+        enabled=True,
+        servers={
+            "grep_app": RuntimeMcpServerConfig(
+                transport="remote-http",
+                url="https://mcp.grep.app",
+            )
+        },
+    )
+
+
 def test_runtime_config_rejects_missing_mcp_url_for_remote_http(tmp_path: Path) -> None:
     (tmp_path / ".voidcode.json").write_text(
         json.dumps(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -988,7 +988,10 @@ class _EmptyWriteThenResultAwareTurnProvider:
                     arguments={"path": "shader.frag", "content": ""},
                 )
             )
-        return ProviderTurnResult(output="recovered from validation error")
+        last_result = turn_request.tool_results[-1]
+        if last_result.status == "ok" and last_result.data.get("byte_count") == 0:
+            return ProviderTurnResult(output="empty write succeeded")
+        return ProviderTurnResult(output="unexpected result")
 
     def stream_turn(self, request: object):
         result = self.propose_turn(request)
@@ -2936,7 +2939,9 @@ def test_runtime_does_not_wait_on_failed_question_tool_result(
     assert tool_completed.payload["error"] == "question requires a non-empty questions array"
 
 
-def test_runtime_tool_validation_error_includes_actionable_content(tmp_path: Path) -> None:
+def test_runtime_write_file_allows_empty_content_and_returns_success_payload(
+    tmp_path: Path,
+) -> None:
     created_providers: list[_EmptyWriteThenResultAwareTurnProvider] = []
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
@@ -2955,44 +2960,20 @@ def test_runtime_tool_validation_error_includes_actionable_content(tmp_path: Pat
     response = runtime.run(RuntimeRequest(prompt="empty write", session_id="empty-write"))
 
     assert response.session.status == "completed"
-    assert response.output == "recovered from validation error"
-    assert (tmp_path / "shader.frag").exists() is False
+    assert response.output == "empty write succeeded"
+    assert (tmp_path / "shader.frag").read_text(encoding="utf-8") == ""
     tool_completed = next(
         event for event in response.events if event.event_type == "runtime.tool_completed"
     )
-    assert tool_completed.payload["status"] == "error"
-    assert tool_completed.payload["error"] == (
-        "write_file Validation error: content: Value error, content must not be empty "
-        "(received str). Please retry with corrected arguments that satisfy the tool schema."
-    )
-    assert tool_completed.payload["error_summary"] == (
-        "write_file Validation error: content: Value error, content must not be empty "
-        "(received str). Please retry with corrected arguments that satisfy the tool schema."
-    )
-    assert tool_completed.payload["error_details"] == {
-        "tool_name": "write_file",
-        "message": (
-            "write_file Validation error: content: Value error, content must not be empty "
-            "(received str). Please retry with corrected arguments that satisfy the tool schema."
-        ),
-        "summary": (
-            "write_file Validation error: content: Value error, content must not be empty "
-            "(received str). Please retry with corrected arguments that satisfy the tool schema."
-        ),
-    }
-    assert tool_completed.payload["retry_guidance"] == (
-        "Retry with corrected arguments that satisfy the tool schema."
-    )
-    assert tool_completed.payload["content"] == (
-        "write_file failed: write_file Validation error: content: Value error, content must not "
-        "be empty (received str). Please retry with corrected arguments that satisfy the tool "
-        "schema.. Please correct the tool arguments and retry."
-    )
-    failed_tool_result = created_providers[-1].requests[-1].tool_results[-1]
-    assert failed_tool_result.content == tool_completed.payload["content"]
-    assert failed_tool_result.error_summary == tool_completed.payload["error_summary"]
-    assert failed_tool_result.error_details == tool_completed.payload["error_details"]
-    assert failed_tool_result.retry_guidance == tool_completed.payload["retry_guidance"]
+    assert tool_completed.payload["status"] == "ok"
+    assert tool_completed.payload["tool"] == "write_file"
+    assert tool_completed.payload["path"] == "shader.frag"
+    assert tool_completed.payload["content"] == "Wrote file successfully: shader.frag"
+    successful_tool_result = created_providers[-1].requests[-1].tool_results[-1]
+    assert successful_tool_result.content == tool_completed.payload["content"]
+    assert successful_tool_result.data["path"] == "shader.frag"
+    assert successful_tool_result.data["byte_count"] == 0
+    assert successful_tool_result.data["diff"] == ""
 
 
 def test_runtime_tool_diagnostic_error_propagates_structured_payload(tmp_path: Path) -> None:

--- a/tests/unit/tools/test_write_file_tool.py
+++ b/tests/unit/tools/test_write_file_tool.py
@@ -77,23 +77,35 @@ def test_write_file_tool_rejects_non_string_arguments(tmp_path: Path) -> None:
         )
 
 
-def test_write_file_tool_rejects_empty_content(tmp_path: Path) -> None:
+def test_write_file_tool_allows_empty_content_for_new_file(tmp_path: Path) -> None:
     tool = WriteFileTool()
 
-    with pytest.raises(
-        ValueError,
-        match=(
-            r"write_file Validation error: content: Value error, content must not be empty "
-            r"\(received str\)\. "
-            r"Please retry with corrected arguments that satisfy the tool schema\."
-        ),
-    ):
-        tool.invoke(
-            ToolCall(tool_name="write_file", arguments={"path": "shader.frag", "content": ""}),
-            workspace=tmp_path,
-        )
+    result = tool.invoke(
+        ToolCall(tool_name="write_file", arguments={"path": "shader.frag", "content": ""}),
+        workspace=tmp_path,
+    )
 
-    assert (tmp_path / "shader.frag").exists() is False
+    assert (tmp_path / "shader.frag").read_text(encoding="utf-8") == ""
+    assert result.status == "ok"
+    assert result.content == "Wrote file successfully: shader.frag"
+    assert result.data == {"path": "shader.frag", "byte_count": 0, "diff": ""}
+
+
+def test_write_file_tool_allows_empty_content_for_existing_file(tmp_path: Path) -> None:
+    (tmp_path / "shader.frag").write_text("void main() {}\n", encoding="utf-8")
+    tool = WriteFileTool()
+
+    result = tool.invoke(
+        ToolCall(tool_name="write_file", arguments={"path": "shader.frag", "content": ""}),
+        workspace=tmp_path,
+    )
+
+    assert (tmp_path / "shader.frag").read_text(encoding="utf-8") == ""
+    assert result.status == "ok"
+    assert result.data["byte_count"] == 0
+    assert result.data["diff"] == (
+        "--- a/shader.frag\n+++ b/shader.frag\n@@ -1 +0,0 @@\n-void main() {}\n"
+    )
 
 
 def test_write_file_tool_allows_absolute_paths_outside_workspace(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- allow empty `write_file` content, add `voidcode run --model`, and render continuous reasoning output in CLI trace mode
- accept model-friendly LSP operation names like `goToDefinition` and `workspaceSymbol` while keeping protocol-string compatibility
- derive a default remote `grep_app` MCP config and mark remote-http MCP servers ready in doctor output so MCP works out of the box

## Verification
- `uv run pytest tests/unit/tools/test_write_file_tool.py tests/unit/runtime/test_runtime_service_extensions.py -q -k \"write_file_tool or empty_content_and_returns_success_payload\"`
- `uv run pytest tests/unit/interface/test_cli_smoke.py -q -k \"trace_streams_model_text_todos_and_tool_output or trace_hides_reasoning_without_show_thinking or trace_shows_reasoning_with_show_thinking or run_command_accepts_agent_skills_model_max_steps_and_provider_stream_flags\"`
- `uv run pytest tests/unit/runtime/test_lsp.py tests/unit/runtime/test_mcp_config.py tests/unit/doctor/test_doctor.py tests/unit/doctor/test_checker.py -q`
- manual CLI QA via `uv run voidcode doctor --workspace /home/hunter/Workspace/voidcode --json`, `uv run voidcode mcp list --workspace /home/hunter/Workspace/voidcode --json`, and a live `voidcode run --trace --show-thinking` session that successfully surfaced MCP tools and completed an `lsp` `goToDefinition` call