### PR TITLE
fix: keep MCP disabled unless configured

### DIFF
--- a/src/voidcode/cli/app.py
+++ b/src/voidcode/cli/app.py
@@ -7,7 +7,7 @@ import shlex
 import sys
 from collections.abc import Callable, Iterator, Sequence
 from pathlib import Path
-from typing import Protocol, TypeGuard, cast
+from typing import Protocol, TypedDict, TypeGuard, cast
 
 import click
 
@@ -95,6 +95,12 @@ class _CliUsageError(Exception):
     def __init__(self, message: str, *, exit_code: int = 2) -> None:
         super().__init__(message)
         self.exit_code = exit_code
+
+
+class _RunCommandConfigKwargs(TypedDict, total=False):
+    approval_mode: PermissionDecision | None
+    model: str
+    reasoning_effort: str | None
 
 
 def _namespace(**values: object) -> argparse.Namespace:
@@ -201,12 +207,14 @@ def _handle_run_command(args: argparse.Namespace) -> int:
     show_thinking = cast(bool, getattr(args, "show_thinking", False))
     cli_reasoning_effort = cast(str | None, getattr(args, "reasoning_effort", None))
     cli_model = cast(str | None, getattr(args, "model", None))
-    config = load_runtime_config(
-        workspace,
-        approval_mode=cast(PermissionDecision | None, getattr(args, "approval_mode", None)),
-        model=cli_model,
-        reasoning_effort=cli_reasoning_effort,
-    )
+    approval_mode = cast(PermissionDecision | None, getattr(args, "approval_mode", None))
+    config_kwargs: _RunCommandConfigKwargs = {
+        "approval_mode": approval_mode,
+        "reasoning_effort": cli_reasoning_effort,
+    }
+    if cli_model is not None:
+        config_kwargs["model"] = cli_model
+    config = load_runtime_config(workspace, **config_kwargs)
     runtime = VoidCodeRuntime(workspace=workspace, config=config)
     try:
         metadata: dict[str, object] = {}

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -610,7 +610,7 @@ def load_runtime_config(
     )
     resolved_tui = _resolve_tui_config(global_config.tui, repo_local.tui)
     resolved_lsp = repo_local.lsp or _derive_workspace_lsp_config(resolved_workspace)
-    resolved_mcp = repo_local.mcp or _derive_workspace_mcp_config()
+    resolved_mcp = repo_local.mcp
     resolved_agent = _resolve_agent_config(repo_local.agent, agent_registry=agent_registry)
 
     env_providers = provider_configs_from_env(environment)
@@ -675,21 +675,6 @@ def _derive_workspace_lsp_config(workspace: Path) -> RuntimeLspConfig | None:
     if not derived_servers:
         return None
     return RuntimeLspConfig(enabled=True, servers=derived_servers)
-
-
-def _derive_workspace_mcp_config() -> RuntimeMcpConfig | None:
-    descriptor = get_builtin_mcp_descriptor("grep_app")
-    if descriptor is None or descriptor.url is None:
-        return None
-    return RuntimeMcpConfig(
-        enabled=True,
-        servers={
-            "grep_app": RuntimeMcpServerConfig(
-                transport="remote-http",
-                url=descriptor.url,
-            )
-        },
-    )
 
 
 def _discover_runtime_skill_names(

--- a/tests/unit/runtime/test_mcp_config.py
+++ b/tests/unit/runtime/test_mcp_config.py
@@ -302,18 +302,10 @@ def test_runtime_config_expands_builtin_mcp_server_shorthand(tmp_path: Path) -> 
     )
 
 
-def test_runtime_config_derives_default_grep_app_mcp_when_unconfigured(tmp_path: Path) -> None:
+def test_runtime_config_keeps_mcp_disabled_when_unconfigured(tmp_path: Path) -> None:
     config = load_runtime_config(tmp_path, env={})
 
-    assert config.mcp == RuntimeMcpConfig(
-        enabled=True,
-        servers={
-            "grep_app": RuntimeMcpServerConfig(
-                transport="remote-http",
-                url="https://mcp.grep.app",
-            )
-        },
-    )
+    assert config.mcp is None
 
 
 def test_runtime_config_rejects_missing_mcp_url_for_remote_http(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- stop `load_runtime_config()` from synthesizing a default remote `grep_app` MCP config when the workspace has no explicit `mcp` block
- restore unit coverage to assert that unconfigured workspaces keep MCP disabled by default, preserving the previous runtime startup behavior
- avoid pre-model managed MCP tool discovery on ordinary runs in offline or air-gapped environments unless the user explicitly opts into MCP

## Verification
- `uv run pytest tests/unit/runtime/test_mcp_config.py tests/unit/runtime/test_runtime_config.py`
- `mise run test` *(repo has 3 pre-existing unrelated failures: `tests/integration/test_http_transport.py::test_transport_status_preserves_mcp_failed_state_across_fresh_requests`, `tests/unit/interface/test_cli_smoke.py::test_run_command_loads_config_and_forwards_it_to_runtime`, `tests/unit/interface/test_cli_smoke.py::test_run_command_forwards_reasoning_effort_flag_to_metadata_and_config`)*
- manual CLI smoke via `uv run voidcode run \"read README.md\" --workspace /tmp/voidcode-mcp-smoke --approval-mode allow`, `uv run voidcode --help`, and invalid-command path `uv run voidcode definitely-not-a-command`