### PR TITLE
feat(runtime): add intensive loop verification state

### DIFF
--- a/src/voidcode/command/loader.py
+++ b/src/voidcode/command/loader.py
@@ -97,10 +97,12 @@ _BUILTIN_COMMANDS: tuple[CommandDefinition, ...] = (
         template=(
             "Workflow: continue under the runtime-owned intensive continuation loop recorded for "
             "this request. Task: $ARGUMENTS. The runtime persists intensive=true before execution "
-            "to signal deeper exploration and stricter verification. Do not use external product "
-            "names for this mode. Preserve runtime session/storage ownership, avoid prompt-only "
-            "continuation hacks, and stop only after concrete verification passes or a runtime "
-            "terminal loop state is reached."
+            "to signal deeper exploration and stricter runtime verification. Completion is not "
+            "terminal when the normal promise is reached; the runtime keeps verification_status "
+            "pending until independent verification succeeds and the verification promise is met. "
+            "Do not use external product names for this mode. Preserve runtime session/storage "
+            "ownership, avoid prompt-only continuation hacks, and stop only after concrete "
+            "verification passes or a runtime terminal loop state is reached."
         ),
         source="builtin",
         workflow_preset="implementation",

--- a/src/voidcode/runtime/command_effects.py
+++ b/src/voidcode/runtime/command_effects.py
@@ -178,6 +178,8 @@ def continuation_loop_metadata(loop: ContinuationLoopState) -> dict[str, object]
         "iteration": loop.iteration,
         "intensive": loop.intensive,
         "strategy": loop.strategy,
+        "verification_status": loop.verification_status,
+        "verification_promise": loop.verification_promise,
         "created_at": loop.created_at,
         "updated_at": loop.updated_at,
         "finished_at": loop.finished_at,
@@ -193,8 +195,13 @@ def render_intensive_loop_prefix(loop: ContinuationLoopState) -> str:
             "Runtime continuation mode: intensive.",
             f"Iteration budget: {loop.max_iterations}.",
             f"Completion promise: {loop.completion_promise}.",
-            "Before declaring completion, verify the result with the strongest targeted "
-            "checks available and explicitly account for unresolved risks.",
+            f"Verification promise: {loop.verification_promise}.",
+            f"Verification status: {loop.verification_status}.",
+            "Before declaring completion, move through runtime verification: first produce "
+            f"the completion promise <promise>{loop.completion_promise}</promise>, then "
+            "perform the strongest targeted checks available, consult Oracle or an equivalent "
+            "independent verifier, and only finish after "
+            f"<promise>{loop.verification_promise}</promise>.",
         )
     )
 

--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -55,6 +55,8 @@ class RuntimeContinuationLoopMetadata(TypedDict, total=False):
     iteration: int
     intensive: bool
     strategy: str
+    verification_status: str
+    verification_promise: str
     created_at: int
     updated_at: int
     finished_at: int | None
@@ -224,6 +226,8 @@ def validate_runtime_continuation_loop_metadata(
         "iteration",
         "intensive",
         "strategy",
+        "verification_status",
+        "verification_promise",
         "created_at",
         "updated_at",
         "finished_at",
@@ -252,6 +256,14 @@ def validate_runtime_continuation_loop_metadata(
         ),
         "strategy": _validate_optional_runtime_metadata_string(
             loop_payload.get("strategy"), field_name="continuation_loop.strategy"
+        ),
+        "verification_status": _validate_optional_runtime_metadata_string(
+            loop_payload.get("verification_status"),
+            field_name="continuation_loop.verification_status",
+        ),
+        "verification_promise": _validate_optional_runtime_metadata_string(
+            loop_payload.get("verification_promise"),
+            field_name="continuation_loop.verification_promise",
         ),
     }
     optional_string_fields = ("session_id", "error")

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -3113,6 +3113,7 @@ class VoidCodeRuntime:
             max_iterations=max_iterations,
             intensive=intensive,
             strategy=strategy,
+            verification_status="pending" if intensive else "not_required",
         )
         self._session_store.create_continuation_loop(workspace=self._workspace, loop=loop)
         return self._session_store.load_continuation_loop(
@@ -3135,6 +3136,33 @@ class VoidCodeRuntime:
         return self._session_store.record_continuation_loop_iteration(
             workspace=self._workspace,
             loop_id=loop_id,
+        )
+
+    def mark_continuation_loop_verification_pending(self, loop_id: str) -> ContinuationLoopState:
+        validate_continuation_loop_id(loop_id)
+        return self._session_store.mark_continuation_loop_verification_pending(
+            workspace=self._workspace,
+            loop_id=loop_id,
+        )
+
+    def mark_continuation_loop_verified(self, loop_id: str) -> ContinuationLoopState:
+        validate_continuation_loop_id(loop_id)
+        return self._session_store.mark_continuation_loop_verified(
+            workspace=self._workspace,
+            loop_id=loop_id,
+        )
+
+    def mark_continuation_loop_verification_failed(
+        self,
+        loop_id: str,
+        *,
+        error: str | None = None,
+    ) -> ContinuationLoopState:
+        validate_continuation_loop_id(loop_id)
+        return self._session_store.mark_continuation_loop_verification_failed(
+            workspace=self._workspace,
+            loop_id=loop_id,
+            error=error,
         )
 
     def mark_continuation_loop_terminal(

--- a/src/voidcode/runtime/storage.py
+++ b/src/voidcode/runtime/storage.py
@@ -45,6 +45,7 @@ from .task import (
     is_continuation_loop_terminal,
     is_continuation_loop_transition_allowed,
     parse_continuation_loop_strategy,
+    parse_continuation_loop_verification_status,
     validate_background_task_id,
     validate_continuation_loop_id,
 )
@@ -218,6 +219,22 @@ class SessionStore(Protocol):
         self, *, workspace: Path, loop_id: str
     ) -> ContinuationLoopState: ...
 
+    def mark_continuation_loop_verification_pending(
+        self, *, workspace: Path, loop_id: str
+    ) -> ContinuationLoopState: ...
+
+    def mark_continuation_loop_verified(
+        self, *, workspace: Path, loop_id: str
+    ) -> ContinuationLoopState: ...
+
+    def mark_continuation_loop_verification_failed(
+        self,
+        *,
+        workspace: Path,
+        loop_id: str,
+        error: str | None = None,
+    ) -> ContinuationLoopState: ...
+
     def mark_continuation_loop_terminal(
         self,
         *,
@@ -270,7 +287,7 @@ class _SQLitePolicy:
 @final
 class SqliteSessionStore:
     _database_path: Path | None
-    _SCHEMA_VERSION = 3
+    _SCHEMA_VERSION = 4
     _RESUME_CHECKPOINT_KINDS = frozenset(
         {"approval_wait", "question_wait", "provider_failure_retryable", "terminal"}
     )
@@ -351,6 +368,8 @@ class SqliteSessionStore:
             ("iteration", "INTEGER", 1, None, 0),
             ("intensive", "INTEGER", 1, None, 0),
             ("strategy", "TEXT", 1, None, 0),
+            ("verification_status", "TEXT", 1, None, 0),
+            ("verification_promise", "TEXT", 1, None, 0),
             ("created_at", "INTEGER", 1, None, 0),
             ("updated_at", "INTEGER", 1, None, 0),
             ("finished_at", "INTEGER", 0, None, 0),
@@ -545,6 +564,8 @@ class SqliteSessionStore:
                 iteration INTEGER NOT NULL,
                 intensive INTEGER NOT NULL,
                 strategy TEXT NOT NULL,
+                verification_status TEXT NOT NULL,
+                verification_promise TEXT NOT NULL,
                 created_at INTEGER NOT NULL,
                 updated_at INTEGER NOT NULL,
                 finished_at INTEGER,
@@ -2653,15 +2674,27 @@ class SqliteSessionStore:
         if loop.iteration < 0:
             raise ValueError("continuation loop iteration must be non-negative")
         _ = parse_continuation_loop_strategy(loop.strategy)
+        _ = parse_continuation_loop_verification_status(loop.verification_status)
+        if loop.intensive and loop.verification_status == "not_required":
+            raise ValueError(
+                "intensive continuation loop verification_status must require verification"
+            )
+        if not loop.intensive and loop.verification_status != "not_required":
+            raise ValueError(
+                "non-intensive continuation loop verification_status must be not_required"
+            )
+        if not loop.verification_promise:
+            raise ValueError("continuation loop verification_promise must be non-empty")
         with self._write_connect(workspace) as connection:
             timestamp = self._next_continuation_loop_timestamp(connection=connection)
             _ = connection.execute(
                 """
                 INSERT INTO continuation_loops (
                     loop_id, workspace_id, status, prompt, session_id, completion_promise,
-                    max_iterations, iteration, intensive, strategy, created_at, updated_at,
-                    finished_at, cancel_requested_at, error
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    max_iterations, iteration, intensive, strategy, verification_status,
+                    verification_promise, created_at, updated_at, finished_at,
+                    cancel_requested_at, error
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     loop_id,
@@ -2674,6 +2707,8 @@ class SqliteSessionStore:
                     loop.iteration,
                     1 if loop.intensive else 0,
                     loop.strategy,
+                    loop.verification_status,
+                    loop.verification_promise,
                     timestamp,
                     timestamp,
                     loop.finished_at,
@@ -2702,7 +2737,8 @@ class SqliteSessionStore:
                 connection.execute(
                     """
                     SELECT loop_id, status, prompt, session_id, iteration, max_iterations,
-                           intensive, created_at, updated_at, error
+                           intensive, verification_status, verification_promise, created_at,
+                           updated_at, error
                     FROM continuation_loops
                     WHERE workspace_id = ?
                     ORDER BY updated_at DESC, created_at DESC, loop_id ASC
@@ -2728,8 +2764,12 @@ class SqliteSessionStore:
                 return self._continuation_loop_state_from_row(current)
             next_iteration = cast(int, current["iteration"]) + 1
             max_iterations = cast(int, current["max_iterations"])
+            intensive = bool(cast(int, current["intensive"]))
+            verification_status = parse_continuation_loop_verification_status(
+                cast(str, current["verification_status"])
+            )
             next_status: ContinuationLoopStatus = (
-                "exhausted" if next_iteration >= max_iterations else "active"
+                "exhausted" if next_iteration >= max_iterations and not intensive else "active"
             )
             updated_at = self._next_continuation_loop_timestamp(connection=connection)
             finished_at = updated_at if next_status == "exhausted" else None
@@ -2738,18 +2778,146 @@ class SqliteSessionStore:
                 if next_status == "exhausted"
                 else cast(str | None, current["error"])
             )
+            next_verification_status = (
+                "pending"
+                if (
+                    intensive
+                    and next_iteration >= max_iterations
+                    and verification_status != "verified"
+                )
+                else verification_status
+            )
+            if next_verification_status == "pending" and error is None:
+                error = "intensive continuation loop reached verification pending state"
             _ = connection.execute(
                 """
                 UPDATE continuation_loops
-                SET iteration = ?, status = ?, updated_at = ?, finished_at = ?, error = ?
+                SET iteration = ?, status = ?, verification_status = ?, updated_at = ?,
+                    finished_at = ?, error = ?
                 WHERE workspace_id = ? AND loop_id = ? AND status = 'active'
                 """,
                 (
                     next_iteration,
                     next_status,
+                    next_verification_status,
                     updated_at,
                     finished_at,
                     error,
+                    str(workspace),
+                    loop_id,
+                ),
+            )
+            updated_row = self._continuation_loop_row(
+                connection=connection,
+                workspace=workspace,
+                loop_id=loop_id,
+            )
+            connection.commit()
+        return self._continuation_loop_state_from_row(updated_row)
+
+    def mark_continuation_loop_verification_pending(
+        self, *, workspace: Path, loop_id: str
+    ) -> ContinuationLoopState:
+        loop_id = validate_continuation_loop_id(loop_id)
+        with self._write_connect(workspace) as connection:
+            current = self._continuation_loop_row(
+                connection=connection,
+                workspace=workspace,
+                loop_id=loop_id,
+            )
+            if not bool(cast(int, current["intensive"])):
+                raise ValueError("only intensive continuation loops can require verification")
+            current_status = self._parse_continuation_loop_status(cast(str, current["status"]))
+            current_verification_status = parse_continuation_loop_verification_status(
+                cast(str, current["verification_status"])
+            )
+            if current_status != "active" or current_verification_status == "verified":
+                connection.commit()
+                return self._continuation_loop_state_from_row(current)
+            updated_at = self._next_continuation_loop_timestamp(connection=connection)
+            error = cast(str | None, current["error"])
+            if error is None:
+                error = "intensive continuation loop awaiting verification"
+            _ = connection.execute(
+                """
+                UPDATE continuation_loops
+                SET verification_status = 'pending', error = ?, updated_at = ?
+                WHERE workspace_id = ? AND loop_id = ? AND status = 'active'
+                """,
+                (error, updated_at, str(workspace), loop_id),
+            )
+            updated_row = self._continuation_loop_row(
+                connection=connection,
+                workspace=workspace,
+                loop_id=loop_id,
+            )
+            connection.commit()
+        return self._continuation_loop_state_from_row(updated_row)
+
+    def mark_continuation_loop_verified(
+        self, *, workspace: Path, loop_id: str
+    ) -> ContinuationLoopState:
+        loop_id = validate_continuation_loop_id(loop_id)
+        with self._write_connect(workspace) as connection:
+            current = self._continuation_loop_row(
+                connection=connection,
+                workspace=workspace,
+                loop_id=loop_id,
+            )
+            if not bool(cast(int, current["intensive"])):
+                raise ValueError("only intensive continuation loops can be verified")
+            current_status = self._parse_continuation_loop_status(cast(str, current["status"]))
+            if current_status != "active":
+                connection.commit()
+                return self._continuation_loop_state_from_row(current)
+            updated_at = self._next_continuation_loop_timestamp(connection=connection)
+            _ = connection.execute(
+                """
+                UPDATE continuation_loops
+                SET status = 'completed', verification_status = 'verified', error = NULL,
+                    finished_at = ?, updated_at = ?
+                WHERE workspace_id = ? AND loop_id = ? AND status = 'active'
+                """,
+                (updated_at, updated_at, str(workspace), loop_id),
+            )
+            updated_row = self._continuation_loop_row(
+                connection=connection,
+                workspace=workspace,
+                loop_id=loop_id,
+            )
+            connection.commit()
+        return self._continuation_loop_state_from_row(updated_row)
+
+    def mark_continuation_loop_verification_failed(
+        self,
+        *,
+        workspace: Path,
+        loop_id: str,
+        error: str | None = None,
+    ) -> ContinuationLoopState:
+        loop_id = validate_continuation_loop_id(loop_id)
+        with self._write_connect(workspace) as connection:
+            current = self._continuation_loop_row(
+                connection=connection,
+                workspace=workspace,
+                loop_id=loop_id,
+            )
+            if not bool(cast(int, current["intensive"])):
+                raise ValueError("only intensive continuation loops can fail verification")
+            current_status = self._parse_continuation_loop_status(cast(str, current["status"]))
+            if current_status != "active":
+                connection.commit()
+                return self._continuation_loop_state_from_row(current)
+            updated_at = self._next_continuation_loop_timestamp(connection=connection)
+            _ = connection.execute(
+                """
+                UPDATE continuation_loops
+                SET verification_status = 'failed', error = ?, updated_at = ?
+                WHERE workspace_id = ? AND loop_id = ? AND status = 'active'
+                """,
+                (
+                    error or "intensive continuation loop verification failed",
+                    updated_at,
                     str(workspace),
                     loop_id,
                 ),
@@ -2788,6 +2956,35 @@ class SqliteSessionStore:
             ):
                 connection.commit()
                 return self._continuation_loop_state_from_row(current)
+            if (
+                bool(cast(int, current["intensive"]))
+                and status == "completed"
+                and parse_continuation_loop_verification_status(
+                    cast(str, current["verification_status"])
+                )
+                != "verified"
+            ):
+                updated_at = self._next_continuation_loop_timestamp(connection=connection)
+                _ = connection.execute(
+                    """
+                    UPDATE continuation_loops
+                    SET verification_status = 'pending', error = ?, updated_at = ?
+                    WHERE workspace_id = ? AND loop_id = ? AND status = 'active'
+                    """,
+                    (
+                        error or "intensive continuation loop awaiting verification",
+                        updated_at,
+                        str(workspace),
+                        loop_id,
+                    ),
+                )
+                updated_row = self._continuation_loop_row(
+                    connection=connection,
+                    workspace=workspace,
+                    loop_id=loop_id,
+                )
+                connection.commit()
+                return self._continuation_loop_state_from_row(updated_row)
             updated_at = self._next_continuation_loop_timestamp(connection=connection)
             _ = connection.execute(
                 """
@@ -3209,6 +3406,10 @@ class SqliteSessionStore:
             iteration=cast(int, row["iteration"]),
             intensive=bool(cast(int, row["intensive"])),
             strategy=parse_continuation_loop_strategy(cast(str, row["strategy"])),
+            verification_status=parse_continuation_loop_verification_status(
+                cast(str, row["verification_status"])
+            ),
+            verification_promise=cast(str, row["verification_promise"]),
             created_at=cast(int, row["created_at"]),
             updated_at=cast(int, row["updated_at"]),
             finished_at=cast(int | None, row["finished_at"]),
@@ -3227,6 +3428,10 @@ class SqliteSessionStore:
             iteration=cast(int, row["iteration"]),
             max_iterations=cast(int, row["max_iterations"]),
             intensive=bool(cast(int, row["intensive"])),
+            verification_status=parse_continuation_loop_verification_status(
+                cast(str, row["verification_status"])
+            ),
+            verification_promise=cast(str, row["verification_promise"]),
             created_at=cast(int, row["created_at"]),
             updated_at=cast(int, row["updated_at"]),
             error=cast(str | None, row["error"]),

--- a/src/voidcode/runtime/task.py
+++ b/src/voidcode/runtime/task.py
@@ -18,6 +18,12 @@ type ContinuationLoopStatus = Literal[
     "cancelled",
     "exhausted",
 ]
+type ContinuationLoopVerificationStatus = Literal[
+    "not_required",
+    "pending",
+    "verified",
+    "failed",
+]
 type ContinuationLoopStrategy = Literal["continue", "reset"]
 type SubagentExecutionMode = Literal["sync", "background"]
 type SubagentResultOwner = Literal["child_session"]
@@ -484,6 +490,8 @@ class ContinuationLoopState:
     iteration: int = 0
     intensive: bool = False
     strategy: ContinuationLoopStrategy = "continue"
+    verification_status: ContinuationLoopVerificationStatus = "not_required"
+    verification_promise: str = "VERIFIED"
     created_at: int = 0
     updated_at: int = 0
     finished_at: int | None = None
@@ -500,6 +508,8 @@ class StoredContinuationLoopSummary:
     iteration: int
     max_iterations: int
     intensive: bool
+    verification_status: ContinuationLoopVerificationStatus
+    verification_promise: str
     created_at: int
     updated_at: int
     error: str | None = None
@@ -527,3 +537,19 @@ def parse_continuation_loop_strategy(value: str) -> ContinuationLoopStrategy:
     if value == "reset":
         return "reset"
     raise ValueError("continuation loop strategy must be 'continue' or 'reset'")
+
+
+def parse_continuation_loop_verification_status(
+    value: str,
+) -> ContinuationLoopVerificationStatus:
+    if value == "not_required":
+        return "not_required"
+    if value == "pending":
+        return "pending"
+    if value == "verified":
+        return "verified"
+    if value == "failed":
+        return "failed"
+    raise ValueError(
+        "continuation loop verification_status must be not_required, pending, verified, or failed"
+    )

--- a/tests/unit/command/test_command_registry.py
+++ b/tests/unit/command/test_command_registry.py
@@ -151,6 +151,7 @@ class TestBuiltinCommandDiscovery:
         assert commands["cancel-continuation"].workflow_preset is None
         assert "runtime-owned" in commands["continuation-loop"].template
         assert "intensive=true" in commands["intensive-loop"].template
+        assert "verification_status" in commands["intensive-loop"].template
         assert "latest active loop" in commands["cancel-continuation"].template
 
     def test_commands_are_disabled_when_hidden_flag_set(self) -> None:

--- a/tests/unit/runtime/test_command_resolution.py
+++ b/tests/unit/runtime/test_command_resolution.py
@@ -91,6 +91,8 @@ def test_runtime_command_metadata_validates_continuation_loop_shape() -> None:
                 "iteration": 0,
                 "intensive": False,
                 "strategy": "continue",
+                "verification_status": "not_required",
+                "verification_promise": "VERIFIED",
                 "created_at": 1,
                 "updated_at": 1,
                 "finished_at": None,
@@ -123,8 +125,10 @@ def test_continuation_loop_command_creates_runtime_owned_loop(tmp_path: Path) ->
     assert loop_metadata["status"] == "active"
     assert loop_metadata["prompt"] == "finish the migration"
     assert loop_metadata["intensive"] is False
+    assert loop_metadata["verification_status"] == "not_required"
     assert persisted_loop.prompt == "finish the migration"
     assert persisted_loop.intensive is False
+    assert persisted_loop.verification_status == "not_required"
     assert persisted_loop.max_iterations == 100
     assert response.output is not None
     assert "Runtime continuation loop state:" in response.output
@@ -150,12 +154,17 @@ def test_intensive_loop_command_marks_runtime_loop_intensive(tmp_path: Path) -> 
     }
     assert loop_metadata["intensive"] is True
     assert loop_metadata["max_iterations"] == 500
+    assert loop_metadata["verification_status"] == "pending"
+    assert loop_metadata["verification_promise"] == "VERIFIED"
     assert persisted_loop.intensive is True
     assert persisted_loop.max_iterations == 500
+    assert persisted_loop.verification_status == "pending"
     assert response.output is not None
     assert "Runtime continuation mode: intensive." in response.output
     assert "Iteration budget: 500." in response.output
-    assert "strongest targeted checks" in response.output
+    assert "Verification status: pending." in response.output
+    assert "<promise>DONE</promise>" in response.output
+    assert "<promise>VERIFIED</promise>" in response.output
 
 
 def test_cancel_continuation_command_cancels_persisted_loop(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_continuation_loop_storage.py
+++ b/tests/unit/runtime/test_continuation_loop_storage.py
@@ -16,13 +16,15 @@ def _loop(
     *,
     loop_id: str = "loop-1",
     prompt: str = "finish the migration",
+    intensive: bool = True,
 ) -> ContinuationLoopState:
     return ContinuationLoopState(
         loop=ContinuationLoopRef(id=loop_id),
         prompt=prompt,
         completion_promise="DONE",
         max_iterations=3,
-        intensive=True,
+        intensive=intensive,
+        verification_status="pending" if intensive else "not_required",
     )
 
 
@@ -48,16 +50,35 @@ def test_continuation_loop_storage_create_load_and_list(tmp_path: Path) -> None:
     assert loaded.status == "active"
     assert loaded.max_iterations == 3
     assert loaded.intensive is True
+    assert loaded.verification_status == "pending"
+    assert loaded.verification_promise == "VERIFIED"
     assert loaded.created_at == 1
     assert loaded.updated_at == 1
     assert len(listed) == 1
     assert listed[0].loop.id == "loop-a"
     assert listed[0].iteration == 0
+    assert listed[0].verification_status == "pending"
+
+
+def test_non_intensive_loop_rejects_verification_status(tmp_path: Path) -> None:
+    store = SqliteSessionStore()
+    loop = ContinuationLoopState(
+        loop=ContinuationLoopRef(id="loop-invalid"),
+        prompt="finish the migration",
+        intensive=False,
+        verification_status="pending",
+    )
+
+    with pytest.raises(ValueError, match="must be not_required"):
+        store.create_continuation_loop(workspace=tmp_path, loop=loop)
 
 
 def test_continuation_loop_records_iterations_and_exhausts(tmp_path: Path) -> None:
     store = SqliteSessionStore()
-    store.create_continuation_loop(workspace=tmp_path, loop=_loop(loop_id="loop-iter"))
+    store.create_continuation_loop(
+        workspace=tmp_path,
+        loop=_loop(loop_id="loop-iter", intensive=False),
+    )
 
     first = store.record_continuation_loop_iteration(workspace=tmp_path, loop_id="loop-iter")
     second = store.record_continuation_loop_iteration(workspace=tmp_path, loop_id="loop-iter")
@@ -73,6 +94,62 @@ def test_continuation_loop_records_iterations_and_exhausts(tmp_path: Path) -> No
     assert third.finished_at == third.updated_at
     assert third.error == "continuation loop reached max iterations"
     assert fourth == third
+
+
+def test_intensive_loop_reaches_verification_pending_instead_of_exhausted(
+    tmp_path: Path,
+) -> None:
+    store = SqliteSessionStore()
+    store.create_continuation_loop(workspace=tmp_path, loop=_loop(loop_id="loop-verify"))
+
+    first = store.record_continuation_loop_iteration(workspace=tmp_path, loop_id="loop-verify")
+    second = store.record_continuation_loop_iteration(workspace=tmp_path, loop_id="loop-verify")
+    third = store.record_continuation_loop_iteration(workspace=tmp_path, loop_id="loop-verify")
+
+    assert first.status == "active"
+    assert second.status == "active"
+    assert third.status == "active"
+    assert third.iteration == 3
+    assert third.verification_status == "pending"
+    assert third.finished_at is None
+    assert third.error == "intensive continuation loop reached verification pending state"
+
+
+def test_intensive_loop_completion_requires_verification(tmp_path: Path) -> None:
+    store = SqliteSessionStore()
+    store.create_continuation_loop(workspace=tmp_path, loop=_loop(loop_id="loop-complete"))
+
+    pending = store.mark_continuation_loop_terminal(
+        workspace=tmp_path,
+        loop_id="loop-complete",
+        status="completed",
+    )
+    completed = store.mark_continuation_loop_verified(
+        workspace=tmp_path,
+        loop_id="loop-complete",
+    )
+
+    assert pending.status == "active"
+    assert pending.verification_status == "pending"
+    assert pending.finished_at is None
+    assert completed.status == "completed"
+    assert completed.verification_status == "verified"
+    assert completed.finished_at == completed.updated_at
+
+
+def test_intensive_loop_verification_failure_keeps_loop_active(tmp_path: Path) -> None:
+    store = SqliteSessionStore()
+    store.create_continuation_loop(workspace=tmp_path, loop=_loop(loop_id="loop-failed"))
+
+    failed = store.mark_continuation_loop_verification_failed(
+        workspace=tmp_path,
+        loop_id="loop-failed",
+        error="oracle found a regression",
+    )
+
+    assert failed.status == "active"
+    assert failed.verification_status == "failed"
+    assert failed.error == "oracle found a regression"
 
 
 def test_continuation_loop_cancel_is_terminal_and_idempotent(tmp_path: Path) -> None:
@@ -104,3 +181,4 @@ def test_continuation_loop_runtime_restart_loads_persisted_state(tmp_path: Path)
     assert loaded.loop.id == "loop-restart"
     assert loaded.iteration == 1
     assert loaded.status == "active"
+    assert loaded.verification_status == "pending"

--- a/tests/unit/runtime/test_session_storage.py
+++ b/tests/unit/runtime/test_session_storage.py
@@ -374,7 +374,7 @@ def test_session_storage_bootstraps_canonical_schema_for_fresh_database(tmp_path
         "updated_at",
     ]
     assert delivery_columns == ["workspace_id", "session_id", "dedupe_key", "delivered_at"]
-    assert schema_version == 3
+    assert schema_version == 4
     assert any(row[2] == 1 and row[3] == "u" for row in notification_indexes)
 
 
@@ -513,7 +513,7 @@ def test_session_storage_rejects_runtime_schema_version_mismatch(tmp_path: Path)
 
     with pytest.raises(
         RuntimeError,
-        match=r"schema version mismatch: expected 3 got 999.*future-runtime\.sqlite3",
+        match=r"schema version mismatch: expected 4 got 999.*future-runtime\.sqlite3",
     ):
         store.list_sessions(workspace=tmp_path)
 
@@ -523,7 +523,7 @@ def test_session_storage_rejects_non_canonical_schema_missing_runtime_columns(
 ) -> None:
     database_path = tmp_path / "invalid-sessions.sqlite3"
     with closing(sqlite3.connect(database_path)) as connection:
-        _ = connection.execute("PRAGMA user_version = 3")
+        _ = connection.execute("PRAGMA user_version = 4")
         _ = connection.execute(
             """
             CREATE TABLE sessions (
@@ -621,7 +621,7 @@ def test_session_storage_rejects_non_canonical_schema_with_wrong_existing_table_
 ) -> None:
     database_path = tmp_path / "wrong-table-shape.sqlite3"
     with closing(sqlite3.connect(database_path)) as connection:
-        _ = connection.execute("PRAGMA user_version = 3")
+        _ = connection.execute("PRAGMA user_version = 4")
         _ = connection.execute(
             """
             CREATE TABLE sessions (


### PR DESCRIPTION
## Summary
- Persist intensive continuation-loop verification state so DONE does not immediately become terminal completion.
- Add runtime transitions for pending, verified, and failed verification outcomes.
- Surface DONE -> independent verification -> VERIFIED guidance through intensive-loop command metadata/prompt projection.

## Verification
- uv run pytest tests/unit/runtime/test_continuation_loop_storage.py tests/unit/runtime/test_command_resolution.py tests/unit/command/test_command_registry.py tests/unit/runtime/test_session_storage.py
- MISE_TRUSTED_CONFIG_PATHS=/tmp/opencode/voidcode-ulw-loop/mise.toml mise run check