### PR TITLE
feat(command): add init slash command

### DIFF
--- a/src/voidcode/command/README.md
+++ b/src/voidcode/command/README.md
@@ -45,6 +45,7 @@ continuation loops.
 
 | Command              | Arguments                                                              | Execution mode                      | Default behavior                                   | Verification guidance                                                                   |
 | -------------------- | ---------------------------------------------------------------------- | ----------------------------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `/init [focus]`      | Optional focus notes for the project knowledge base                    | Default runtime prompt              | May write `AGENTS.md`                              | Inspect repo structure, generate/update structured project instructions, then read back |
 | `/review [target]`   | File, directory, PR/diff target, or empty for current changes          | Default runtime prompt              | Read-only                                          | Report missing/unreadable targets instead of generic reviews                            |
 | `/fix [problem]`     | Concrete failing test, lint/type error, review comment, or bug         | Default runtime prompt              | May edit                                           | Locate root cause, minimally edit, and run targeted checks                              |
 | `/explain [target]`  | File, module, stack trace, error, or behavior                          | Default runtime prompt              | Read-only                                          | State clearly when the target cannot be found or read                                   |
@@ -65,5 +66,7 @@ matches what actually ships.
 | `/continuation-loop`     | Start or continue a runtime-owned continuation loop on the session   |
 | `/intensive-loop`        | Start a higher-intensity continuation loop with verification state   |
 | `/cancel-continuation`   | Cancel the active continuation loop on the session                   |
+
+`/init` is intentionally a prompt command, not a separate CLI bootstrap flag: the active agent inspects the actual repository and writes a structured `AGENTS.md` with stable project knowledge. It should preserve useful existing guidance, avoid secrets and transient task state, and verify by reading the final file.
 
 Commands render templates into runtime prompts through `CommandRegistry` → `resolve_prompt_command()` → `render_command_template()`. The rendered prompt replaces the slash command line before graph or provider execution. Builtins are defined in `loader.py` as `_BUILTIN_COMMANDS` and can be overridden by project-local `commands/**/*.md` files.

--- a/src/voidcode/command/loader.py
+++ b/src/voidcode/command/loader.py
@@ -8,6 +8,24 @@ from .registry import CommandRegistry
 
 _BUILTIN_COMMANDS: tuple[CommandDefinition, ...] = (
     CommandDefinition(
+        name="init",
+        description="Generate or refresh a structured AGENTS.md project knowledge base.",
+        template=(
+            "Workflow: initialize durable project instructions by generating or refreshing "
+            "AGENTS.md at the workspace root. User focus notes: $ARGUMENTS. First inspect "
+            "the repository structure, existing AGENTS.md files, README/development docs, "
+            "runtime/config files, test/build commands, and notable conventions. Then write "
+            "or update AGENTS.md with stable, structured project knowledge only. Required "
+            "sections: PROJECT KNOWLEDGE BASE, OVERVIEW, STRUCTURE, WHERE TO LOOK, CODE MAP, "
+            "CONVENTIONS, ANTI-PATTERNS, UNIQUE STYLES, COMMANDS, and NOTES. Preserve useful "
+            "existing AGENTS.md content, remove stale or duplicate guidance, and do not store "
+            "secrets, transient task plans, chat history, or unverified guesses. Prefer concise "
+            "tables and bullets over prose. Verification: read the final AGENTS.md and confirm "
+            "it reflects the current repo surface without claiming unsupported capabilities."
+        ),
+        source="builtin",
+    ),
+    CommandDefinition(
         name="compact",
         description="Compact the current session into durable continuity guidance.",
         template=(

--- a/src/voidcode/runtime/context_rules.py
+++ b/src/voidcode/runtime/context_rules.py
@@ -33,6 +33,7 @@ def runtime_file_rule_contexts(
     tool_results: tuple[ToolResult, ...],
     max_rule_files: int = MAX_RULE_FILES,
     max_rule_file_chars: int = MAX_RULE_FILE_CHARS,
+    include_workspace_root: bool = True,
 ) -> tuple[RuntimeFileRuleContext, ...]:
     if workspace is None or max_rule_files < 1:
         return ()
@@ -41,6 +42,7 @@ def runtime_file_rule_contexts(
         workspace_root=workspace_root,
         touched_paths=_touched_paths_from_tool_results(tool_results),
         max_rule_files=max_rule_files,
+        include_workspace_root=include_workspace_root,
     )
     contexts: list[RuntimeFileRuleContext] = []
     for rule_path in rule_paths:
@@ -105,10 +107,20 @@ def _touched_paths_from_tool_results(tool_results: tuple[ToolResult, ...]) -> tu
 
 
 def _applicable_rule_paths(
-    *, workspace_root: Path, touched_paths: tuple[str, ...], max_rule_files: int
+    *,
+    workspace_root: Path,
+    touched_paths: tuple[str, ...],
+    max_rule_files: int,
+    include_workspace_root: bool,
 ) -> tuple[Path, ...]:
     ordered: list[Path] = []
     seen: set[Path] = set()
+
+    root_rule_path = workspace_root / RULE_FILE_NAME
+    if include_workspace_root and root_rule_path.is_file():
+        seen.add(root_rule_path)
+        ordered.append(root_rule_path)
+
     for raw_path in touched_paths:
         touched_path = _workspace_path(workspace_root=workspace_root, raw_path=raw_path)
         if touched_path is None:

--- a/tests/unit/command/test_command_registry.py
+++ b/tests/unit/command/test_command_registry.py
@@ -103,6 +103,7 @@ def test_template_rendering_does_not_rewrite_inserted_arguments_or_dollar_litera
 
 class TestBuiltinCommandDiscovery:
     _EXPECTED_NAMES = (
+        "init",
         "compact",
         "commit",
         "explain",
@@ -178,6 +179,22 @@ class TestBuiltinCommandRendering:
         assert "smallest safe code change" in rendered
         assert "run targeted tests" in rendered
         assert "$ARGUMENTS" not in rendered
+
+    def test_init_renders_agents_md_generation_guidance(self) -> None:
+        cmd = [c for c in builtin_commands() if c.name == "init"][0]
+        rendered = render_command_template(
+            cmd.template,
+            raw_arguments="focus on runtime boundaries",
+            arguments=split_command_arguments("focus on runtime boundaries"),
+        )
+
+        assert "focus on runtime boundaries" in rendered
+        assert "AGENTS.md at the workspace root" in rendered
+        assert "PROJECT KNOWLEDGE BASE" in rendered
+        assert "WHERE TO LOOK" in rendered
+        assert "CODE MAP" in rendered
+        assert "do not store secrets" in rendered
+        assert "read the final AGENTS.md" in rendered
 
     def test_explain_renders_read_only_guidance(self) -> None:
         cmd = [c for c in builtin_commands() if c.name == "explain"][0]
@@ -314,6 +331,7 @@ class TestBuiltinCommandProjectOverride:
         assert fix_cmd is not None
         assert fix_cmd.source == "project"
         for name in (
+            "init",
             "compact",
             "review",
             "explain",

--- a/tests/unit/runtime/test_command_resolution.py
+++ b/tests/unit/runtime/test_command_resolution.py
@@ -32,6 +32,7 @@ class _EchoPromptGraph:
         *,
         session: SessionState,
     ) -> _FinishedStep:
+        _ = tool_results, session
         return _FinishedStep(output=request.prompt)
 
 
@@ -122,6 +123,24 @@ def test_compact_command_renders_runtime_continuity_prompt(tmp_path: Path) -> No
     assert response.output is not None
     assert "runtime-owned continuity summary" in response.output
     assert "preserve test results" in response.output
+
+
+def test_init_command_renders_agents_md_generation_prompt(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path, graph=_EchoPromptGraph())
+
+    response = runtime.run(RuntimeRequest(prompt="/init focus on runtime boundaries"))
+
+    assert response.session.metadata.get("command") == {
+        "name": "init",
+        "source": "builtin",
+        "arguments": ["focus", "on", "runtime", "boundaries"],
+        "raw_arguments": "focus on runtime boundaries",
+        "original_prompt": "/init focus on runtime boundaries",
+    }
+    assert response.output is not None
+    assert "AGENTS.md at the workspace root" in response.output
+    assert "PROJECT KNOWLEDGE BASE" in response.output
+    assert "focus on runtime boundaries" in response.output
 
 
 def test_continuation_loop_command_creates_runtime_owned_loop(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_context_rules.py
+++ b/tests/unit/runtime/test_context_rules.py
@@ -49,7 +49,20 @@ def test_runtime_file_rule_contexts_ignore_external_paths(tmp_path: Path) -> Non
         ),
     )
 
-    assert contexts == ()
+    assert [(context.path, context.content) for context in contexts] == [
+        ("AGENTS.md", "Root rules")
+    ]
+
+
+def test_runtime_file_rule_contexts_load_root_rules_without_touched_paths(tmp_path: Path) -> None:
+    workspace = tmp_path
+    (workspace / "AGENTS.md").write_text("Root rules", encoding="utf-8")
+
+    contexts = runtime_file_rule_contexts(workspace=workspace, tool_results=())
+
+    assert [(context.path, context.content) for context in contexts] == [
+        ("AGENTS.md", "Root rules")
+    ]
 
 
 def test_runtime_file_rule_contexts_cap_preserves_nearest_rules(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add a builtin `/init` slash command that guides the agent to inspect the repository and generate or refresh a structured root `AGENTS.md`.
- Load the root `AGENTS.md` as runtime file-rule context even on the first provider turn before any tool has touched a path.
- Document the `/init` command surface and cover command rendering, runtime metadata, and root rule loading in tests.

## Verification
- `uv run pytest tests/unit/command/test_command_registry.py tests/unit/runtime/test_command_resolution.py tests/unit/runtime/test_context_rules.py tests/unit/runtime/test_context_window.py -q`
- `uv run pytest tests/unit/interface/test_cli_smoke.py -q -k "config_init or config_schema or commands_list or commands_show"`
- Manual QA: `VOIDCODE_EXECUTION_ENGINE=deterministic uv run voidcode run '/init focus on repo map' --workspace <tmp>` with isolated `XDG_STATE_HOME`, verified rendered prompt includes `AGENTS.md at the workspace root` and `PROJECT KNOWLEDGE BASE`.