### PR TITLE
feat(runtime): add context transform hooks

### DIFF
--- a/src/voidcode/runtime/context_transforms.py
+++ b/src/voidcode/runtime/context_transforms.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import cast
+
+from ..tools.contracts import ToolResult
+from .context_rules import runtime_file_rule_contexts
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeContextTransformInjection:
+    role: str
+    content: str
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeContextTransformTrace:
+    provider_id: str
+    status: str = "ok"
+    injection_count: int = 0
+    sources: tuple[str, ...] = ()
+    diagnostics: tuple[str, ...] = ()
+    error: str | None = None
+
+    def metadata_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "provider_id": self.provider_id,
+            "status": self.status,
+            "injection_count": self.injection_count,
+            "sources": list(self.sources),
+        }
+        if self.diagnostics:
+            payload["diagnostics"] = list(self.diagnostics)
+        if self.error is not None:
+            payload["error"] = self.error
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeContextTransformResult:
+    injections: tuple[RuntimeContextTransformInjection, ...] = ()
+    traces: tuple[RuntimeContextTransformTrace, ...] = ()
+
+    def metadata_payload(self) -> dict[str, object]:
+        return {
+            "version": 1,
+            "applied": [trace.metadata_payload() for trace in self.traces],
+        }
+
+
+def build_provider_context_transform_result(
+    *,
+    workspace: Path | None,
+    tool_results: tuple[ToolResult, ...],
+    hook_preset_context: str,
+) -> RuntimeContextTransformResult:
+    injections: list[RuntimeContextTransformInjection] = []
+    traces: list[RuntimeContextTransformTrace] = []
+
+    normalized_hook_preset_context = hook_preset_context.strip()
+    if normalized_hook_preset_context:
+        injections.append(
+            RuntimeContextTransformInjection(
+                role="system",
+                content=normalized_hook_preset_context,
+                metadata={"source": "hook_preset_guidance"},
+            )
+        )
+        traces.append(
+            RuntimeContextTransformTrace(
+                provider_id="hook_preset_guidance",
+                injection_count=1,
+                sources=("hook_preset_guidance",),
+            )
+        )
+
+    rule_segments: list[RuntimeContextTransformInjection] = []
+    for rule_context in runtime_file_rule_contexts(
+        workspace=workspace,
+        tool_results=tool_results,
+    ):
+        rule_segments.append(
+            RuntimeContextTransformInjection(
+                role="system",
+                content=(
+                    "Runtime file rules are active for touched workspace paths.\n"
+                    f"Rule file: {rule_context.path}\n"
+                    f"{rule_context.content}"
+                ).strip(),
+                metadata=rule_context.metadata_payload(),
+            )
+        )
+    injections.extend(rule_segments)
+    if rule_segments:
+        traces.append(
+            RuntimeContextTransformTrace(
+                provider_id="runtime_file_rules",
+                injection_count=len(rule_segments),
+                sources=("runtime_file_rules",),
+            )
+        )
+
+    return RuntimeContextTransformResult(injections=tuple(injections), traces=tuple(traces))
+
+
+def context_transform_metadata_from_payload(
+    payload: object,
+) -> Mapping[str, object] | None:
+    if not isinstance(payload, dict):
+        return None
+    typed_payload = cast(dict[str, object], payload)
+    applied = typed_payload.get("applied")
+    if not isinstance(applied, list):
+        return None
+    return typed_payload

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, Literal, NamedTuple, cast
 
 from ..tools.contracts import ToolResult
-from .context_rules import runtime_file_rule_contexts
+from .context_transforms import build_provider_context_transform_result
 from .continuity_distillation import (
     ContinuityDistillationRecord,
     build_distillation_input_envelope,
@@ -1892,29 +1892,24 @@ def assemble_provider_context(
         source="runtime_instruction_precedence",
     )
     _append_system_segment(agent_prompt_context, source="agent_prompt")
-    _append_system_segment(hook_preset_context, source="hook_preset_guidance")
     for segment_content in preserved_system_segments:
         _append_system_segment(segment_content, source="preserved_system_segment")
     _append_system_segment(skill_prompt_context, source="skill_prompt")
-    rule_contexts = runtime_file_rule_contexts(
+    transform_result = build_provider_context_transform_result(
         workspace=workspace,
         tool_results=tool_results,
+        hook_preset_context=hook_preset_context,
     )
-    for rule_context in rule_contexts:
-        rule_content = (
-            "Runtime file rules are active for touched workspace paths.\n"
-            f"Rule file: {rule_context.path}\n"
-            f"{rule_context.content}"
-        )
-        normalized = rule_content.strip()
+    for transform_injection in transform_result.injections:
+        normalized = transform_injection.content.strip()
         if not normalized or normalized in seen_system_contents:
             continue
         seen_system_contents.add(normalized)
         segments.append(
             RuntimeContextSegment(
-                role="system",
+                role=cast(Literal["system", "user", "assistant", "tool"], transform_injection.role),
                 content=normalized,
-                metadata=rule_context.metadata_payload(),
+                metadata=dict(transform_injection.metadata),
             )
         )
     pending_state_segment = _pending_state_segment(session_metadata)
@@ -1947,6 +1942,8 @@ def assemble_provider_context(
                 source="continuity_summary",
             )
         segments.extend(_artifact_reference_segments(continuity_state))
+    if transform_result.traces:
+        metadata_payload["context_transforms"] = transform_result.metadata_payload()
     segments.append(
         RuntimeContextSegment(
             role="user",

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -1094,6 +1094,14 @@ class RuntimeRunLoopCoordinator:
             for segment in current_segments:
                 if segment.role != "system" or not isinstance(segment.content, str):
                     continue
+                segment_source = (
+                    segment.metadata.get("source") if isinstance(segment.metadata, dict) else None
+                )
+                if segment_source in {
+                    "hook_preset_guidance",
+                    "runtime_file_rules",
+                }:
+                    continue
                 if segment.content.startswith("Runtime-managed todo state is active"):
                     continue
                 preserved_system_segments.append(segment.content)

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -266,6 +266,46 @@ def test_assemble_provider_context_injects_file_rules_from_tool_paths(tmp_path: 
     ]
     assert "Project rules" in (rule_segments[0].content or "")
     assert "Runtime rules" in (rule_segments[1].content or "")
+    assert assembled.metadata["context_transforms"] == {
+        "version": 1,
+        "applied": [
+            {
+                "provider_id": "runtime_file_rules",
+                "status": "ok",
+                "injection_count": 2,
+                "sources": ["runtime_file_rules"],
+            }
+        ],
+    }
+
+
+def test_assemble_provider_context_tracks_hook_preset_guidance_transform() -> None:
+    assembled = assemble_provider_context(
+        prompt="continue",
+        tool_results=(),
+        session_metadata={},
+        hook_preset_context="Resolved agent hook preset guidance.",
+        policy=ContextWindowPolicy(max_tool_results=4),
+    )
+
+    hook_segments = [
+        segment
+        for segment in assembled.segments
+        if segment.metadata is not None and segment.metadata.get("source") == "hook_preset_guidance"
+    ]
+    assert len(hook_segments) == 1
+    assert hook_segments[0].content == "Resolved agent hook preset guidance."
+    assert assembled.metadata["context_transforms"] == {
+        "version": 1,
+        "applied": [
+            {
+                "provider_id": "hook_preset_guidance",
+                "status": "ok",
+                "injection_count": 1,
+                "sources": ["hook_preset_guidance"],
+            }
+        ],
+    }
 
 
 def test_assemble_provider_context_uses_full_tool_history_for_rules_not_compacted_window(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -2951,6 +2951,17 @@ def test_runtime_materializes_leader_hook_preset_guidance_into_provider_context(
     assert len(hook_segments) == 1
     assert "active agent preset" in (hook_segments[0].content or "")
     assert "runtime-owned task routing" in (hook_segments[0].content or "")
+    assert request.assembled_context.metadata["context_transforms"] == {
+        "version": 1,
+        "applied": [
+            {
+                "provider_id": "hook_preset_guidance",
+                "status": "ok",
+                "injection_count": 1,
+                "sources": ["hook_preset_guidance"],
+            },
+        ],
+    }
 
 
 def test_runtime_materializes_explicit_agent_hook_refs_without_expanding_tools(
@@ -12284,6 +12295,17 @@ def test_runtime_provider_compaction_emits_continuity_state_and_persists_metadat
         "continuity_state": expected_continuity,
         "summary_anchor": summary_anchor,
         "summary_source": summary_source,
+        "context_transforms": {
+            "version": 1,
+            "applied": [
+                {
+                    "provider_id": "hook_preset_guidance",
+                    "status": "ok",
+                    "injection_count": 1,
+                    "sources": ["hook_preset_guidance"],
+                }
+            ],
+        },
         "estimated_context_tokens": response_context_window["estimated_context_tokens"],
         "estimated_context_token_source": "tiktoken:cl100k_base",
         "estimated_context_token_exact": True,


### PR DESCRIPTION
## Summary
- Add a runtime-owned `context_transforms` module that materializes provider-context transform results instead of keeping all injection logic hardcoded in one path.
- Route hook preset guidance and `AGENTS.md` file-rule injection through the shared transform surface while preserving runtime truth boundaries.
- Persist transform traces into provider-context metadata and cover the new behavior in runtime tests.

## Verification
- `uv run pytest tests/unit/runtime/test_context_window.py tests/unit/runtime/test_runtime_service_extensions.py -q`
- `uv run pytest tests/unit/hook/test_executor.py tests/unit/hook/test_presets.py tests/unit/runtime/test_context_rules.py tests/unit/runtime/test_context_window.py tests/unit/runtime/test_runtime_service_extensions.py -q`
- Manual QA: assemble provider context in an isolated temp workspace and verify `hook_preset_guidance` plus `runtime_file_rules` both appear in segments and in `context_transforms` metadata.