### PR TITLE
feat(runtime): add context transform registry

### DIFF
--- a/src/voidcode/runtime/context_transforms.py
+++ b/src/voidcode/runtime/context_transforms.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import cast
+from typing import Protocol, cast
 
 from ..tools.contracts import ToolResult
 from .context_rules import runtime_file_rule_contexts
@@ -51,59 +51,131 @@ class RuntimeContextTransformResult:
         }
 
 
+@dataclass(frozen=True, slots=True)
+class RuntimeContextTransformRequest:
+    workspace: Path | None
+    tool_results: tuple[ToolResult, ...]
+    hook_preset_context: str
+
+
+class RuntimeContextTransformProvider(Protocol):
+    provider_id: str
+
+    def build_result(
+        self,
+        request: RuntimeContextTransformRequest,
+    ) -> RuntimeContextTransformResult: ...
+
+
+class HookPresetGuidanceTransformProvider:
+    provider_id = "hook_preset_guidance"
+
+    def build_result(
+        self,
+        request: RuntimeContextTransformRequest,
+    ) -> RuntimeContextTransformResult:
+        normalized_hook_preset_context = request.hook_preset_context.strip()
+        if not normalized_hook_preset_context:
+            return RuntimeContextTransformResult()
+        return RuntimeContextTransformResult(
+            injections=(
+                RuntimeContextTransformInjection(
+                    role="system",
+                    content=normalized_hook_preset_context,
+                    metadata={"source": self.provider_id},
+                ),
+            ),
+            traces=(
+                RuntimeContextTransformTrace(
+                    provider_id=self.provider_id,
+                    injection_count=1,
+                    sources=(self.provider_id,),
+                ),
+            ),
+        )
+
+
+class RuntimeFileRulesTransformProvider:
+    provider_id = "runtime_file_rules"
+
+    def build_result(
+        self,
+        request: RuntimeContextTransformRequest,
+    ) -> RuntimeContextTransformResult:
+        rule_segments: list[RuntimeContextTransformInjection] = []
+        for rule_context in runtime_file_rule_contexts(
+            workspace=request.workspace,
+            tool_results=request.tool_results,
+        ):
+            rule_segments.append(
+                RuntimeContextTransformInjection(
+                    role="system",
+                    content=(
+                        "Runtime file rules are active for touched workspace paths.\n"
+                        f"Rule file: {rule_context.path}\n"
+                        f"{rule_context.content}"
+                    ).strip(),
+                    metadata=rule_context.metadata_payload(),
+                )
+            )
+        if not rule_segments:
+            return RuntimeContextTransformResult()
+        return RuntimeContextTransformResult(
+            injections=tuple(rule_segments),
+            traces=(
+                RuntimeContextTransformTrace(
+                    provider_id=self.provider_id,
+                    injection_count=len(rule_segments),
+                    sources=(self.provider_id,),
+                ),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeContextTransformRegistry:
+    providers: tuple[RuntimeContextTransformProvider, ...] = ()
+
+    def build_result(
+        self,
+        request: RuntimeContextTransformRequest,
+    ) -> RuntimeContextTransformResult:
+        injections: list[RuntimeContextTransformInjection] = []
+        traces: list[RuntimeContextTransformTrace] = []
+        for provider in self.providers:
+            result = provider.build_result(request)
+            injections.extend(result.injections)
+            traces.extend(result.traces)
+        return RuntimeContextTransformResult(
+            injections=tuple(injections),
+            traces=tuple(traces),
+        )
+
+
+def default_runtime_context_transform_registry() -> RuntimeContextTransformRegistry:
+    return RuntimeContextTransformRegistry(
+        providers=(
+            HookPresetGuidanceTransformProvider(),
+            RuntimeFileRulesTransformProvider(),
+        )
+    )
+
+
 def build_provider_context_transform_result(
     *,
     workspace: Path | None,
     tool_results: tuple[ToolResult, ...],
     hook_preset_context: str,
+    registry: RuntimeContextTransformRegistry | None = None,
 ) -> RuntimeContextTransformResult:
-    injections: list[RuntimeContextTransformInjection] = []
-    traces: list[RuntimeContextTransformTrace] = []
-
-    normalized_hook_preset_context = hook_preset_context.strip()
-    if normalized_hook_preset_context:
-        injections.append(
-            RuntimeContextTransformInjection(
-                role="system",
-                content=normalized_hook_preset_context,
-                metadata={"source": "hook_preset_guidance"},
-            )
+    active_registry = registry or default_runtime_context_transform_registry()
+    return active_registry.build_result(
+        RuntimeContextTransformRequest(
+            workspace=workspace,
+            tool_results=tool_results,
+            hook_preset_context=hook_preset_context,
         )
-        traces.append(
-            RuntimeContextTransformTrace(
-                provider_id="hook_preset_guidance",
-                injection_count=1,
-                sources=("hook_preset_guidance",),
-            )
-        )
-
-    rule_segments: list[RuntimeContextTransformInjection] = []
-    for rule_context in runtime_file_rule_contexts(
-        workspace=workspace,
-        tool_results=tool_results,
-    ):
-        rule_segments.append(
-            RuntimeContextTransformInjection(
-                role="system",
-                content=(
-                    "Runtime file rules are active for touched workspace paths.\n"
-                    f"Rule file: {rule_context.path}\n"
-                    f"{rule_context.content}"
-                ).strip(),
-                metadata=rule_context.metadata_payload(),
-            )
-        )
-    injections.extend(rule_segments)
-    if rule_segments:
-        traces.append(
-            RuntimeContextTransformTrace(
-                provider_id="runtime_file_rules",
-                injection_count=len(rule_segments),
-                sources=("runtime_file_rules",),
-            )
-        )
-
-    return RuntimeContextTransformResult(injections=tuple(injections), traces=tuple(traces))
+    )
 
 
 def context_transform_metadata_from_payload(

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -10,7 +10,10 @@ from pathlib import Path
 from typing import Any, Literal, NamedTuple, cast
 
 from ..tools.contracts import ToolResult
-from .context_transforms import build_provider_context_transform_result
+from .context_transforms import (
+    RuntimeContextTransformResult,
+    build_provider_context_transform_result,
+)
 from .continuity_distillation import (
     ContinuityDistillationRecord,
     build_distillation_input_envelope,
@@ -1853,6 +1856,7 @@ def assemble_provider_context(
     skill_prompt_context: str = "",
     agent_prompt_context: str = "",
     hook_preset_context: str = "",
+    context_transform_result: RuntimeContextTransformResult | None = None,
     preserved_system_segments: tuple[str, ...] = (),
     loaded_skills: tuple[dict[str, object], ...] = (),
     preserved_continuity_state: RuntimeContinuityState | None = None,
@@ -1895,7 +1899,7 @@ def assemble_provider_context(
     for segment_content in preserved_system_segments:
         _append_system_segment(segment_content, source="preserved_system_segment")
     _append_system_segment(skill_prompt_context, source="skill_prompt")
-    transform_result = build_provider_context_transform_result(
+    transform_result = context_transform_result or build_provider_context_transform_result(
         workspace=workspace,
         tool_results=tool_results,
         hook_preset_context=hook_preset_context,

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -152,6 +152,11 @@ from .config import (
     serialize_runtime_context_window_config,
     serialize_runtime_tools_config,
 )
+from .context_transforms import (
+    RuntimeContextTransformRegistry,
+    build_provider_context_transform_result,
+    default_runtime_context_transform_registry,
+)
 from .context_window import (
     ContextWindowPolicy,
     RuntimeAssembledContext,
@@ -515,6 +520,7 @@ class VoidCodeRuntime:
     _run_loop_coordinator: RuntimeRunLoopCoordinator
     _resume_coordinator: RuntimeResumeCoordinator
     _background_task_supervisor: RuntimeBackgroundTaskSupervisor
+    _context_transform_registry: RuntimeContextTransformRegistry
     _hook_recursion_env_var = "VOIDCODE_RUNNING_TOOL_HOOK"
     _default_context_window_policy = ContextWindowPolicy()
 
@@ -533,6 +539,7 @@ class VoidCodeRuntime:
         mcp_manager: McpManager | None = None,
         acp_adapter: AcpAdapter | None = None,
         context_window_policy: ContextWindowPolicy | None = None,
+        context_transform_registry: RuntimeContextTransformRegistry | None = None,
     ) -> None:
         self._workspace = workspace.resolve()
         self._permission_context_resolver = RuntimePermissionContextResolver(
@@ -623,6 +630,9 @@ class VoidCodeRuntime:
         )
         self._session_store = session_store or SqliteSessionStore()
         self._acp_adapter = acp_adapter or build_acp_adapter(self._config.acp)
+        self._context_transform_registry = (
+            context_transform_registry or default_runtime_context_transform_registry()
+        )
         self._default_context_window_policy = self._context_window_policy_from_config(
             initial_context_window,
             resolved_provider=None,
@@ -6026,6 +6036,12 @@ class VoidCodeRuntime:
             session_metadata,
             agent=effective_config.agent,
         )
+        context_transform_result = build_provider_context_transform_result(
+            workspace=self._workspace,
+            tool_results=tool_results,
+            hook_preset_context=hook_preset_context,
+            registry=self._context_transform_registry,
+        )
         return assemble_provider_context(
             prompt=prompt,
             tool_results=tool_results,
@@ -6033,6 +6049,7 @@ class VoidCodeRuntime:
             policy=policy or self._default_context_window_policy,
             agent_prompt_context=agent_prompt_context,
             hook_preset_context=hook_preset_context,
+            context_transform_result=context_transform_result,
             skill_prompt_context=skill_prompt_context,
             preserved_system_segments=preserved_system_segments,
             loaded_skills=loaded_skills,

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -7,6 +7,12 @@ from types import ModuleType
 from typing import Any, Literal, cast
 from unittest.mock import patch
 
+from voidcode.runtime.context_transforms import (
+    HookPresetGuidanceTransformProvider,
+    RuntimeContextTransformRegistry,
+    RuntimeContextTransformRequest,
+    RuntimeFileRulesTransformProvider,
+)
 from voidcode.runtime.context_window import (
     ContextWindowPolicy,
     DroppedToolResultDiagnostic,
@@ -304,6 +310,47 @@ def test_assemble_provider_context_tracks_hook_preset_guidance_transform() -> No
                 "injection_count": 1,
                 "sources": ["hook_preset_guidance"],
             }
+        ],
+    }
+
+
+def test_context_transform_registry_combines_multiple_providers(tmp_path: Path) -> None:
+    workspace = tmp_path
+    (workspace / "AGENTS.md").write_text("Project rules", encoding="utf-8")
+    registry = RuntimeContextTransformRegistry(
+        providers=(
+            HookPresetGuidanceTransformProvider(),
+            RuntimeFileRulesTransformProvider(),
+        )
+    )
+
+    result = registry.build_result(
+        RuntimeContextTransformRequest(
+            workspace=workspace,
+            tool_results=(),
+            hook_preset_context="Resolved agent hook preset guidance.",
+        )
+    )
+
+    assert [injection.metadata["source"] for injection in result.injections] == [
+        "hook_preset_guidance",
+        "runtime_file_rules",
+    ]
+    assert result.metadata_payload() == {
+        "version": 1,
+        "applied": [
+            {
+                "provider_id": "hook_preset_guidance",
+                "status": "ok",
+                "injection_count": 1,
+                "sources": ["hook_preset_guidance"],
+            },
+            {
+                "provider_id": "runtime_file_rules",
+                "status": "ok",
+                "injection_count": 1,
+                "sources": ["runtime_file_rules"],
+            },
         ],
     }
 


### PR DESCRIPTION
## Summary
- Refactor provider-context transforms into a typed in-process registry with explicit providers and request/result models.
- Move runtime ownership of transform selection into `VoidCodeRuntime` while keeping `assemble_provider_context()` backward-compatible for direct callers.
- Add focused runtime tests covering registry ordering, metadata shape, and compatibility with existing transform injection behavior.

## Verification
- `uv run pytest tests/unit/runtime/test_context_window.py tests/unit/runtime/test_runtime_service_extensions.py -q`
- `uv run pytest tests/unit/hook/test_executor.py tests/unit/hook/test_presets.py tests/unit/runtime/test_context_rules.py tests/unit/runtime/test_context_window.py tests/unit/runtime/test_runtime_service_extensions.py -q`
- Manual QA: construct a `RuntimeContextTransformRegistry` with hook guidance + file rules providers and verify ordered injections plus trace metadata.