### PR TITLE
feat(runtime): add scoped transform policy

### DIFF
--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -33,6 +33,7 @@ from ..lsp import derive_workspace_lsp_defaults, has_builtin_lsp_server_preset
 from ..mcp.builtin import get_builtin_mcp_descriptor
 from ..provider import config as provider_config
 from ..skills import SkillRegistry, list_builtin_skills
+from .context_transforms import validate_runtime_context_transform_refs
 from .permission import (
     ExternalDirectoryPermissionConfig,
     ExternalDirectoryPolicy,
@@ -199,6 +200,7 @@ _AGENT_CONFIG_KEYS = frozenset(
         "manifest_skill_refs",
         "manifest_hook_refs",
         "hook_refs",
+        "context_transform_refs",
         "model",
         "tools",
         "skills",
@@ -442,6 +444,7 @@ class RuntimeAgentConfig:
     manifest_skill_refs: tuple[str, ...] = field(default=(), compare=False)
     manifest_hook_refs: tuple[str, ...] = field(default=(), compare=False)
     hook_refs: tuple[str, ...] = ()
+    context_transform_refs: tuple[str, ...] = ()
     model: str | None = None
     execution_engine: ExecutionEngineName | None = None
     tools: RuntimeToolsConfig | None = None
@@ -2481,6 +2484,9 @@ def _parse_agent_config(
             normalized_prompt_source = "builtin"
 
     hook_refs = _parse_agent_hook_refs(payload.get("hook_refs"), hooks=hooks)
+    context_transform_refs = _parse_agent_context_transform_refs(
+        payload.get("context_transform_refs")
+    )
 
     model = payload.get("model")
     if model is not None and (not isinstance(model, str) or not model.strip()):
@@ -2526,6 +2532,7 @@ def _parse_agent_config(
             field_path="agent.manifest_hook_refs",
         ),
         hook_refs=hook_refs,
+        context_transform_refs=context_transform_refs,
         model=model.strip() if isinstance(model, str) else None,
         execution_engine=execution_engine,
         tools=_parse_tools_config(
@@ -2590,6 +2597,7 @@ def _resolve_agent_config(
             manifest_skill_refs=agent.manifest_skill_refs or manifest.skill_refs,
             manifest_hook_refs=agent.manifest_hook_refs or manifest.preset_hook_refs,
             hook_refs=agent.hook_refs,
+            context_transform_refs=agent.context_transform_refs,
             model=model,
             execution_engine=agent.execution_engine or manifest.execution_engine,
             tools=agent.tools,
@@ -2751,6 +2759,16 @@ def _parse_agent_hook_refs(
         return ()
     _ = hooks
     return validate_hook_preset_refs(hook_refs, field_path="runtime config field 'agent.hook_refs'")
+
+
+def _parse_agent_context_transform_refs(raw_refs: object) -> tuple[str, ...]:
+    refs = _parse_string_list(raw_refs, field_path="agent.context_transform_refs")
+    if not refs:
+        return ()
+    return validate_runtime_context_transform_refs(
+        refs,
+        field_path="runtime config field 'agent.context_transform_refs'",
+    )
 
 
 def _parse_agent_provider_fallback_config(
@@ -3119,6 +3137,8 @@ def serialize_runtime_agent_config(agent: RuntimeAgentConfig | None) -> dict[str
         payload["manifest_hook_refs"] = list(agent.manifest_hook_refs)
     if agent.hook_refs:
         payload["hook_refs"] = list(agent.hook_refs)
+    if agent.context_transform_refs:
+        payload["context_transform_refs"] = list(agent.context_transform_refs)
     if agent.model is not None:
         payload["model"] = agent.model
     if agent.tools is not None:

--- a/src/voidcode/runtime/config_schema.py
+++ b/src/voidcode/runtime/config_schema.py
@@ -529,6 +529,11 @@ def runtime_config_json_schema() -> dict[str, object]:
                         "items": {"type": "string", "minLength": 1},
                     },
                     "hook_refs": {"type": "array", "items": {"type": "string"}},
+                    "context_transform_refs": {
+                        "type": "array",
+                        "items": {"type": "string", "minLength": 1},
+                        "uniqueItems": True,
+                    },
                     "model": {"type": "string", "minLength": 1},
                     "tools": {"$ref": "#/$defs/agentToolsConfig"},
                     "skills": {"$ref": "#/$defs/skillsConfig"},
@@ -587,6 +592,11 @@ def runtime_config_json_schema() -> dict[str, object]:
                         "uniqueItems": True,
                     },
                     "hook_preset_refs": {
+                        "type": "array",
+                        "items": {"type": "string", "minLength": 1},
+                        "uniqueItems": True,
+                    },
+                    "context_transform_refs": {
                         "type": "array",
                         "items": {"type": "string", "minLength": 1},
                         "uniqueItems": True,

--- a/src/voidcode/runtime/context_transforms.py
+++ b/src/voidcode/runtime/context_transforms.py
@@ -8,6 +8,8 @@ from typing import Protocol, cast
 from ..tools.contracts import ToolResult
 from .context_rules import runtime_file_rule_contexts
 
+type RuntimeContextTransformProviderId = str
+
 
 @dataclass(frozen=True, slots=True)
 class RuntimeContextTransformInjection:
@@ -136,6 +138,22 @@ class RuntimeFileRulesTransformProvider:
 class RuntimeContextTransformRegistry:
     providers: tuple[RuntimeContextTransformProvider, ...] = ()
 
+    def filtered(
+        self,
+        provider_ids: tuple[RuntimeContextTransformProviderId, ...],
+    ) -> RuntimeContextTransformRegistry:
+        if not provider_ids:
+            return self
+        allowed = frozenset(provider_ids)
+        return RuntimeContextTransformRegistry(
+            providers=tuple(
+                provider for provider in self.providers if provider.provider_id in allowed
+            )
+        )
+
+    def provider_ids(self) -> tuple[RuntimeContextTransformProviderId, ...]:
+        return tuple(provider.provider_id for provider in self.providers)
+
     def build_result(
         self,
         request: RuntimeContextTransformRequest,
@@ -188,3 +206,25 @@ def context_transform_metadata_from_payload(
     if not isinstance(applied, list):
         return None
     return typed_payload
+
+
+def validate_runtime_context_transform_refs(
+    refs: tuple[str, ...],
+    *,
+    field_path: str,
+    registry: RuntimeContextTransformRegistry | None = None,
+) -> tuple[str, ...]:
+    if not refs:
+        return ()
+    active_registry = registry or default_runtime_context_transform_registry()
+    valid_refs = frozenset(active_registry.provider_ids())
+    for ref in refs:
+        if not ref.strip():
+            raise ValueError(f"{field_path} entries must be non-empty strings")
+        if ref not in valid_refs:
+            allowed = ", ".join(sorted(valid_refs))
+            raise ValueError(
+                f"{field_path} references unknown context transform provider: {ref}; "
+                f"valid providers are: {allowed}"
+            )
+    return refs

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -1036,6 +1036,8 @@ class VoidCodeRuntime:
             raw_agent["prompt_append"] = preset.prompt_append
         if preset.hook_preset_refs:
             raw_agent["hook_refs"] = list(preset.hook_preset_refs)
+        if preset.context_transform_refs:
+            raw_agent["context_transform_refs"] = list(preset.context_transform_refs)
         return self._config_with_request_agent_override(
             resolved,
             raw_agent,
@@ -1070,6 +1072,7 @@ class VoidCodeRuntime:
             "skill_refs": list(preset.skill_refs),
             "force_load_skills": list(preset.force_load_skills),
             "hook_preset_refs": list(preset.hook_preset_refs),
+            "context_transform_refs": list(preset.context_transform_refs),
             "mcp_binding_intents": self._workflow_mcp_binding_intent_snapshots(preset),
             "materialization": "runtime_policy_enforced",
             "governance": (
@@ -6040,7 +6043,7 @@ class VoidCodeRuntime:
             workspace=self._workspace,
             tool_results=tool_results,
             hook_preset_context=hook_preset_context,
-            registry=self._context_transform_registry,
+            registry=self._context_transform_registry_for_agent(effective_config.agent),
         )
         return assemble_provider_context(
             prompt=prompt,
@@ -6567,6 +6570,13 @@ class VoidCodeRuntime:
         if snapshot is None:
             snapshot = self._build_hook_preset_snapshot(agent)
         return snapshot.guidance_context()
+
+    def _context_transform_registry_for_agent(
+        self,
+        agent: RuntimeAgentConfig | None,
+    ) -> RuntimeContextTransformRegistry:
+        refs = agent.context_transform_refs if agent is not None else ()
+        return self._context_transform_registry.filtered(refs)
 
     @staticmethod
     def _force_loaded_skill_payloads(

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -6801,6 +6801,13 @@ class VoidCodeRuntime:
                 if resolved.agent is not None
                 else ()
             ),
+            context_transform_refs=(
+                agent.context_transform_refs
+                if agent.context_transform_refs
+                else resolved.agent.context_transform_refs
+                if resolved.agent is not None
+                else ()
+            ),
             model=model,
             execution_engine=execution_engine,
             tools=(

--- a/src/voidcode/runtime/workflow.py
+++ b/src/voidcode/runtime/workflow.py
@@ -9,6 +9,7 @@ from typing import Literal, cast
 from ..agent.builtin import get_builtin_agent_manifest
 from ..hook.presets import validate_hook_preset_refs
 from ..skills.builtin import list_builtin_skills
+from .context_transforms import validate_runtime_context_transform_refs
 
 type WorkflowPresetId = Literal["research", "implementation", "frontend", "review", "git"]
 type WorkflowPresetKey = WorkflowPresetId | str
@@ -215,6 +216,10 @@ def validate_workflow_presets(
                     f"workflow preset '{preset.id}' skill_refs references missing skill: "
                     f"{skill_name}"
                 )
+        validate_runtime_context_transform_refs(
+            preset.context_transform_refs,
+            field_path=f"workflow preset '{preset.id}' context_transform_refs",
+        )
         for binding in preset.mcp_binding_intents:
             _validate_mcp_binding_availability(
                 preset,

--- a/src/voidcode/runtime/workflow.py
+++ b/src/voidcode/runtime/workflow.py
@@ -23,6 +23,7 @@ _WORKFLOW_PRESET_FIELDS = frozenset(
         "skill_refs",
         "force_load_skills",
         "hook_preset_refs",
+        "context_transform_refs",
         "mcp_binding_intents",
         "tool_policy_ref",
         "permission_policy_ref",
@@ -75,6 +76,7 @@ class WorkflowPreset:
     skill_refs: tuple[str, ...] = ()
     force_load_skills: tuple[str, ...] = ()
     hook_preset_refs: tuple[str, ...] = ()
+    context_transform_refs: tuple[str, ...] = ()
     mcp_binding_intents: tuple[WorkflowMcpBindingIntent, ...] = ()
     tool_policy_ref: str | None = None
     permission_policy_ref: str | None = None
@@ -107,6 +109,11 @@ class WorkflowPreset:
             field_path=f"workflow preset '{self.id}' hook_preset_refs",
             allow_empty=True,
         )
+        _validate_string_tuple(
+            self.context_transform_refs,
+            field_path=f"workflow preset '{self.id}' context_transform_refs",
+            allow_empty=True,
+        )
         validate_hook_preset_refs(
             self.hook_preset_refs,
             field_path=f"workflow preset '{self.id}' hook_preset_refs",
@@ -133,6 +140,8 @@ class WorkflowPreset:
             payload["force_load_skills"] = list(self.force_load_skills)
         if self.hook_preset_refs:
             payload["hook_preset_refs"] = list(self.hook_preset_refs)
+        if self.context_transform_refs:
+            payload["context_transform_refs"] = list(self.context_transform_refs)
         if self.mcp_binding_intents:
             payload["mcp_binding_intents"] = [
                 binding.to_payload() for binding in self.mcp_binding_intents
@@ -241,6 +250,10 @@ def workflow_preset_from_payload(
         hook_preset_refs=_string_list(
             payload.get("hook_preset_refs"),
             field_path=f"{field_path}.hook_preset_refs",
+        ),
+        context_transform_refs=_string_list(
+            payload.get("context_transform_refs"),
+            field_path=f"{field_path}.context_transform_refs",
         ),
         mcp_binding_intents=_mcp_binding_intent_list(
             payload.get("mcp_binding_intents"),

--- a/tests/unit/runtime/test_config_schema.py
+++ b/tests/unit/runtime/test_config_schema.py
@@ -467,3 +467,28 @@ def test_runtime_config_rejects_workflow_missing_skill_ref(tmp_path: Path) -> No
 
     with pytest.raises(ValueError, match="skill_refs references missing skill: missing"):
         _ = load_runtime_config(tmp_path, env={})
+
+
+def test_runtime_config_rejects_workflow_unknown_context_transform_ref(tmp_path: Path) -> None:
+    config_path = tmp_path / ".voidcode.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "workflows": {
+                    "custom": {
+                        "id": "custom",
+                        "default_agent": "leader",
+                        "category": "implementation",
+                        "context_transform_refs": ["missing"],
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=("context_transform_refs references unknown context transform provider"),
+    ):
+        _ = load_runtime_config(tmp_path, env={})

--- a/tests/unit/runtime/test_config_schema.py
+++ b/tests/unit/runtime/test_config_schema.py
@@ -100,6 +100,7 @@ def test_runtime_config_json_schema_exposes_core_fields() -> None:
         "skill_refs",
         "force_load_skills",
         "hook_preset_refs",
+        "context_transform_refs",
         "mcp_binding_intents",
         "tool_policy_ref",
         "permission_policy_ref",

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -1479,6 +1479,26 @@ def test_runtime_agent_payload_parses_prompt_and_hook_references() -> None:
     )
 
 
+def test_runtime_agent_payload_parses_context_transform_references() -> None:
+    agent = parse_runtime_agent_payload(
+        {
+            "preset": "leader",
+            "context_transform_refs": [
+                "hook_preset_guidance",
+                "runtime_file_rules",
+            ],
+        },
+        source="test payload",
+    )
+
+    assert agent == RuntimeAgentConfig(
+        preset="leader",
+        prompt_profile="leader",
+        context_transform_refs=("hook_preset_guidance", "runtime_file_rules"),
+        execution_engine="provider",
+    )
+
+
 def test_runtime_agent_payload_applies_explicit_prompt_override() -> None:
     agent = parse_runtime_agent_payload(
         {
@@ -1531,6 +1551,20 @@ def test_runtime_agent_payload_rejects_unknown_hook_reference() -> None:
     ):
         _ = parse_runtime_agent_payload(
             {"preset": "leader", "hook_refs": ["unknown"]},
+            source="test payload",
+        )
+
+
+def test_runtime_agent_payload_rejects_unknown_context_transform_reference() -> None:
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"runtime config field 'agent.context_transform_refs' references unknown "
+            r"context transform provider"
+        ),
+    ):
+        _ = parse_runtime_agent_payload(
+            {"preset": "leader", "context_transform_refs": ["unknown"]},
             source="test payload",
         )
 
@@ -1667,6 +1701,29 @@ def test_runtime_config_parses_agent_references_against_hook_preset_catalog(
         prompt_ref="researcher",
         prompt_source="builtin",
         hook_refs=("role_reminder",),
+        execution_engine="provider",
+    )
+
+
+def test_runtime_config_parses_agent_context_transform_refs(tmp_path: Path) -> None:
+    runtime_config_path(tmp_path).write_text(
+        json.dumps(
+            {
+                "agent": {
+                    "preset": "leader",
+                    "context_transform_refs": ["runtime_file_rules"],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_runtime_config(tmp_path, env={})
+
+    assert config.agent == RuntimeAgentConfig(
+        preset="leader",
+        prompt_profile="leader",
+        context_transform_refs=("runtime_file_rules",),
         execution_engine="provider",
     )
 

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -3000,6 +3000,50 @@ def test_runtime_materializes_explicit_agent_hook_refs_without_expanding_tools(
     }
 
 
+def test_runtime_agent_context_transform_refs_filter_provider_registry(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "AGENTS.md").write_text("Project rules", encoding="utf-8")
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_SkillCapturingStubGraph(),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            agent=RuntimeAgentConfig(
+                preset="leader",
+                context_transform_refs=("runtime_file_rules",),
+            ),
+        ),
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="hello", session_id="transform-filter"))
+    request = _SkillCapturingStubGraph.last_request
+
+    assert request is not None
+    system_sources = [
+        segment.metadata.get("source")
+        for segment in request.assembled_context.segments
+        if segment.role == "system" and segment.metadata is not None
+    ]
+    runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
+    runtime_agent = cast(dict[str, object], runtime_config["agent"])
+    assert "runtime_file_rules" in system_sources
+    assert "hook_preset_guidance" not in system_sources
+    assert request.assembled_context.metadata["context_transforms"] == {
+        "version": 1,
+        "applied": [
+            {
+                "provider_id": "runtime_file_rules",
+                "status": "ok",
+                "injection_count": 1,
+                "sources": ["runtime_file_rules"],
+            }
+        ],
+    }
+    assert runtime_agent["context_transform_refs"] == ["runtime_file_rules"]
+
+
 def test_runtime_resume_uses_persisted_hook_preset_snapshot(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -10047,6 +10047,64 @@ def test_runtime_required_workflow_mcp_intent_passes_when_configured(
     assert availability["missing_servers"] == []
 
 
+def test_runtime_workflow_context_transform_refs_filter_runtime_registry(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "AGENTS.md").write_text("Project rules", encoding="utf-8")
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_SkillCapturingStubGraph(),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            workflows=WorkflowPresetRegistry(
+                presets={
+                    "scoped": WorkflowPreset(
+                        id="scoped",
+                        default_agent="leader",
+                        category="implementation",
+                        context_transform_refs=("runtime_file_rules",),
+                    )
+                }
+            ),
+        ),
+    )
+
+    response = runtime.run(
+        RuntimeRequest(
+            prompt="hello",
+            session_id="workflow-transform-scope",
+            metadata={"workflow_preset": "scoped"},
+        )
+    )
+    request = _SkillCapturingStubGraph.last_request
+
+    assert request is not None
+    system_sources = [
+        segment.metadata.get("source")
+        for segment in request.assembled_context.segments
+        if segment.role == "system" and segment.metadata is not None
+    ]
+    workflow_snapshot = cast(dict[str, object], response.session.metadata["workflow"])
+    runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
+    runtime_agent = cast(dict[str, object], runtime_config["agent"])
+    assert workflow_snapshot["context_transform_refs"] == ["runtime_file_rules"]
+    assert runtime_agent["context_transform_refs"] == ["runtime_file_rules"]
+    assert "runtime_file_rules" in system_sources
+    assert "hook_preset_guidance" not in system_sources
+    assert request.assembled_context.metadata["context_transforms"] == {
+        "version": 1,
+        "applied": [
+            {
+                "provider_id": "runtime_file_rules",
+                "status": "ok",
+                "injection_count": 1,
+                "sources": ["runtime_file_rules"],
+            }
+        ],
+    }
+
+
 def test_runtime_workflow_resume_stable_debug_and_bundle_preserve_persisted_snapshot(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- Add scoped `context_transform_refs` policy for runtime agent and workflow surfaces so provider-context transforms can be narrowed instead of always running the full built-in registry.
- Validate and serialize transform policy through runtime config, workflow preset snapshots, and effective runtime metadata.
- Add runtime coverage proving scoped policy filters out hook guidance while preserving selected file-rule transforms.

## Verification
- `uv run pytest tests/unit/runtime/test_runtime_config.py tests/unit/runtime/test_config_schema.py tests/unit/runtime/test_runtime_service_extensions.py tests/unit/runtime/test_context_window.py -q`
- `uv run pytest tests/unit/hook/test_executor.py tests/unit/hook/test_presets.py tests/unit/runtime/test_context_rules.py tests/unit/runtime/test_context_window.py tests/unit/runtime/test_runtime_config.py tests/unit/runtime/test_config_schema.py tests/unit/runtime/test_runtime_service_extensions.py -q`
- Manual QA: run a provider-backed stub with `context_transform_refs=("runtime_file_rules",)` and verify `runtime_file_rules` remains while `hook_preset_guidance` is filtered out.