### PR TITLE
feat(runtime): add request transform narrowing

### DIFF
--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -117,6 +117,7 @@ _STABLE_RUNTIME_REQUEST_METADATA_KEYS = frozenset(
         "abort_requested",
         "agent",
         "command",
+        "context_transform_refs",
         "continuation_loop",
         "delegation",
         "max_steps",
@@ -562,6 +563,22 @@ def validate_runtime_request_metadata(
                 )
             parsed_skills.append(raw_name)
         normalized["skills"] = parsed_skills
+
+    if "context_transform_refs" in metadata:
+        raw_transform_refs = metadata["context_transform_refs"]
+        if not isinstance(raw_transform_refs, list):
+            raise RuntimeRequestError(
+                "request metadata 'context_transform_refs' must be a list of "
+                "transform provider names"
+            )
+        parsed_transform_refs: list[str] = []
+        for index, raw_name in enumerate(cast(list[object], raw_transform_refs)):
+            if not isinstance(raw_name, str) or not raw_name:
+                raise RuntimeRequestError(
+                    f"request metadata 'context_transform_refs[{index}]' must be a non-empty string"
+                )
+            parsed_transform_refs.append(raw_name)
+        normalized["context_transform_refs"] = parsed_transform_refs
 
     if "force_load_skills" in metadata:
         raw_force_load = metadata["force_load_skills"]

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -156,6 +156,7 @@ from .context_transforms import (
     RuntimeContextTransformRegistry,
     build_provider_context_transform_result,
     default_runtime_context_transform_registry,
+    validate_runtime_context_transform_refs,
 )
 from .context_window import (
     ContextWindowPolicy,
@@ -1009,6 +1010,55 @@ class VoidCodeRuntime:
                 providers=resolved.providers,
                 resolved_provider=resolved.resolved_provider,
                 agent=resolved.agent,
+                context_window=resolved.context_window,
+                tools=resolved.tools,
+            )
+        request_context_transform_refs = request.metadata.get("context_transform_refs")
+        if request_context_transform_refs is not None:
+            assert isinstance(request_context_transform_refs, list)
+            refs = tuple(cast(list[str], request_context_transform_refs))
+            validate_runtime_context_transform_refs(
+                refs,
+                field_path="request metadata 'context_transform_refs'",
+                registry=self._context_transform_registry_for_agent(resolved.agent),
+            )
+            resolved = EffectiveRuntimeConfig(
+                approval_mode=resolved.approval_mode,
+                permission=resolved.permission,
+                model=resolved.model,
+                execution_engine=resolved.execution_engine,
+                max_steps=resolved.max_steps,
+                tool_timeout_seconds=resolved.tool_timeout_seconds,
+                reasoning_effort=resolved.reasoning_effort,
+                provider_fallback=resolved.provider_fallback,
+                providers=resolved.providers,
+                resolved_provider=resolved.resolved_provider,
+                agent=(
+                    RuntimeAgentConfig(
+                        preset=resolved.agent.preset,
+                        prompt_profile=resolved.agent.prompt_profile,
+                        prompt=resolved.agent.prompt,
+                        prompt_append=resolved.agent.prompt_append,
+                        prompt_ref=resolved.agent.prompt_ref,
+                        prompt_source=resolved.agent.prompt_source,
+                        prompt_materialization=resolved.agent.prompt_materialization,
+                        manifest_source_scope=resolved.agent.manifest_source_scope,
+                        manifest_source_path=resolved.agent.manifest_source_path,
+                        manifest_tool_allowlist=resolved.agent.manifest_tool_allowlist,
+                        manifest_skill_refs=resolved.agent.manifest_skill_refs,
+                        manifest_hook_refs=resolved.agent.manifest_hook_refs,
+                        hook_refs=resolved.agent.hook_refs,
+                        context_transform_refs=refs,
+                        model=resolved.agent.model,
+                        execution_engine=resolved.agent.execution_engine,
+                        tools=resolved.agent.tools,
+                        skills=resolved.agent.skills,
+                        mcp_binding=resolved.agent.mcp_binding,
+                        provider_fallback=resolved.agent.provider_fallback,
+                    )
+                    if resolved.agent is not None
+                    else None
+                ),
                 context_window=resolved.context_window,
                 tools=resolved.tools,
             )

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -72,7 +72,7 @@ from voidcode.runtime.context_window import (
     RuntimeContextWindow,
     RuntimeContinuityState,
 )
-from voidcode.runtime.contracts import RuntimeRequestError
+from voidcode.runtime.contracts import RuntimeRequestError, validate_runtime_request_metadata
 from voidcode.runtime.events import (
     RUNTIME_BACKGROUND_TASK_CANCELLED,
     RUNTIME_BACKGROUND_TASK_COMPLETED,
@@ -10103,6 +10103,86 @@ def test_runtime_workflow_context_transform_refs_filter_runtime_registry(
             }
         ],
     }
+
+
+def test_runtime_request_context_transform_refs_narrow_agent_scope(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "AGENTS.md").write_text("Project rules", encoding="utf-8")
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_SkillCapturingStubGraph(),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            agent=RuntimeAgentConfig(
+                preset="leader",
+                context_transform_refs=(
+                    "hook_preset_guidance",
+                    "runtime_file_rules",
+                ),
+            ),
+        ),
+    )
+
+    response = runtime.run(
+        RuntimeRequest(
+            prompt="hello",
+            session_id="request-transform-scope",
+            metadata=validate_runtime_request_metadata(
+                {"context_transform_refs": ["runtime_file_rules"]}
+            ),
+        )
+    )
+    request = _SkillCapturingStubGraph.last_request
+
+    assert request is not None
+    system_sources = [
+        segment.metadata.get("source")
+        for segment in request.assembled_context.segments
+        if segment.role == "system" and segment.metadata is not None
+    ]
+    runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
+    runtime_agent = cast(dict[str, object], runtime_config["agent"])
+    assert runtime_agent["context_transform_refs"] == ["runtime_file_rules"]
+    assert "runtime_file_rules" in system_sources
+    assert "hook_preset_guidance" not in system_sources
+    assert request.assembled_context.metadata["context_transforms"] == {
+        "version": 1,
+        "applied": [
+            {
+                "provider_id": "runtime_file_rules",
+                "status": "ok",
+                "injection_count": 1,
+                "sources": ["runtime_file_rules"],
+            }
+        ],
+    }
+
+
+def test_runtime_request_context_transform_refs_reject_unknown_provider(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_SkillCapturingStubGraph(),
+        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"request metadata 'context_transform_refs' references unknown context "
+            r"transform provider"
+        ),
+    ):
+        _ = runtime.run(
+            RuntimeRequest(
+                prompt="hello",
+                session_id="request-transform-invalid",
+                metadata=validate_runtime_request_metadata({"context_transform_refs": ["unknown"]}),
+            )
+        )
 
 
 def test_runtime_workflow_resume_stable_debug_and_bundle_preserve_persisted_snapshot(


### PR DESCRIPTION
## Summary
- Add request-scoped `context_transform_refs` metadata so a single run can narrow the active transform provider set.
- Apply request-level narrowing after workflow and agent policy so request scope can only reduce the effective registry, not expand it.
- Add runtime tests proving request narrowing filters hook guidance while keeping selected file-rule transforms.

## Verification
- `uv run pytest tests/unit/runtime/test_runtime_service_extensions.py -q -k "request_context_transform or workflow_context_transform"`
- `uv run pytest tests/unit/runtime/test_runtime_service_extensions.py tests/unit/runtime/test_context_window.py tests/unit/runtime/test_runtime_config.py tests/unit/hook/test_executor.py tests/unit/hook/test_presets.py tests/unit/runtime/test_context_rules.py -q`
- Manual QA: run a provider-backed stub with request metadata `context_transform_refs=[\"runtime_file_rules\"]` and confirm `hook_preset_guidance` is filtered out while `runtime_file_rules` remains.