### PR TITLE
feat(runtime): add transform ordering diagnostics

### DIFF
--- a/src/voidcode/runtime/context_transforms.py
+++ b/src/voidcode/runtime/context_transforms.py
@@ -22,7 +22,10 @@ class RuntimeContextTransformInjection:
 class RuntimeContextTransformTrace:
     provider_id: str
     status: str = "ok"
+    priority: int = 100
+    execution_index: int = 0
     injection_count: int = 0
+    provider_order: tuple[str, ...] = ()
     sources: tuple[str, ...] = ()
     diagnostics: tuple[str, ...] = ()
     error: str | None = None
@@ -31,7 +34,10 @@ class RuntimeContextTransformTrace:
         payload: dict[str, object] = {
             "provider_id": self.provider_id,
             "status": self.status,
+            "priority": self.priority,
+            "execution_index": self.execution_index,
             "injection_count": self.injection_count,
+            "provider_order": list(self.provider_order),
             "sources": list(self.sources),
         }
         if self.diagnostics:
@@ -62,6 +68,7 @@ class RuntimeContextTransformRequest:
 
 class RuntimeContextTransformProvider(Protocol):
     provider_id: str
+    priority: int
 
     def build_result(
         self,
@@ -71,6 +78,7 @@ class RuntimeContextTransformProvider(Protocol):
 
 class HookPresetGuidanceTransformProvider:
     provider_id = "hook_preset_guidance"
+    priority = 100
 
     def build_result(
         self,
@@ -90,6 +98,7 @@ class HookPresetGuidanceTransformProvider:
             traces=(
                 RuntimeContextTransformTrace(
                     provider_id=self.provider_id,
+                    priority=self.priority,
                     injection_count=1,
                     sources=(self.provider_id,),
                 ),
@@ -99,6 +108,7 @@ class HookPresetGuidanceTransformProvider:
 
 class RuntimeFileRulesTransformProvider:
     provider_id = "runtime_file_rules"
+    priority = 200
 
     def build_result(
         self,
@@ -127,6 +137,7 @@ class RuntimeFileRulesTransformProvider:
             traces=(
                 RuntimeContextTransformTrace(
                     provider_id=self.provider_id,
+                    priority=self.priority,
                     injection_count=len(rule_segments),
                     sources=(self.provider_id,),
                 ),
@@ -137,6 +148,14 @@ class RuntimeFileRulesTransformProvider:
 @dataclass(frozen=True, slots=True)
 class RuntimeContextTransformRegistry:
     providers: tuple[RuntimeContextTransformProvider, ...] = ()
+
+    def ordered_providers(self) -> tuple[RuntimeContextTransformProvider, ...]:
+        return tuple(
+            sorted(
+                self.providers,
+                key=lambda provider: (provider.priority, provider.provider_id),
+            )
+        )
 
     def filtered(
         self,
@@ -152,7 +171,7 @@ class RuntimeContextTransformRegistry:
         )
 
     def provider_ids(self) -> tuple[RuntimeContextTransformProviderId, ...]:
-        return tuple(provider.provider_id for provider in self.providers)
+        return tuple(provider.provider_id for provider in self.ordered_providers())
 
     def build_result(
         self,
@@ -160,10 +179,25 @@ class RuntimeContextTransformRegistry:
     ) -> RuntimeContextTransformResult:
         injections: list[RuntimeContextTransformInjection] = []
         traces: list[RuntimeContextTransformTrace] = []
-        for provider in self.providers:
+        ordered_providers = self.ordered_providers()
+        ordered_provider_ids = tuple(provider.provider_id for provider in ordered_providers)
+        for execution_index, provider in enumerate(ordered_providers, start=1):
             result = provider.build_result(request)
             injections.extend(result.injections)
-            traces.extend(result.traces)
+            traces.extend(
+                RuntimeContextTransformTrace(
+                    provider_id=trace.provider_id,
+                    status=trace.status,
+                    priority=trace.priority,
+                    execution_index=execution_index,
+                    injection_count=trace.injection_count,
+                    provider_order=ordered_provider_ids,
+                    sources=trace.sources,
+                    diagnostics=trace.diagnostics,
+                    error=trace.error,
+                )
+                for trace in result.traces
+            )
         return RuntimeContextTransformResult(
             injections=tuple(injections),
             traces=tuple(traces),

--- a/src/voidcode/runtime/provider_context.py
+++ b/src/voidcode/runtime/provider_context.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import re
 from collections import defaultdict
-from typing import cast
+from typing import Literal, cast
 
 from ..provider.model_catalog import ToolFeedbackMode
 from ..tools.output import (
@@ -84,6 +84,8 @@ def inspect_provider_context(
             oversized_tool_feedback_chars=oversized_tool_feedback_chars,
         )
     )
+    transform_diagnostics = _transform_diagnostics(dict(assembled_context.metadata))
+    diagnostics = (*diagnostics, *transform_diagnostics)
     policy_decision = (
         evaluate_provider_context_policy(diagnostics, mode=diagnostic_policy_mode)
         if diagnostic_policy_mode is not None
@@ -191,6 +193,63 @@ def _diagnostic_with_policy_metadata(
         policy_action=action,
         policy_blocking=blocking,
     )
+
+
+def _transform_diagnostics(
+    context_metadata: dict[str, object],
+) -> tuple[RuntimeProviderContextDiagnostic, ...]:
+    raw_transforms = context_metadata.get("context_transforms")
+    if not isinstance(raw_transforms, dict):
+        return ()
+    transform_payload = cast(dict[str, object], raw_transforms)
+    applied = transform_payload.get("applied")
+    if not isinstance(applied, list):
+        return ()
+    diagnostics: list[RuntimeProviderContextDiagnostic] = []
+    for raw_trace in cast(list[object], applied):
+        if not isinstance(raw_trace, dict):
+            continue
+        trace = cast(dict[str, object], raw_trace)
+        provider_id = trace.get("provider_id")
+        status = trace.get("status")
+        if not isinstance(provider_id, str) or not provider_id:
+            continue
+        if not isinstance(status, str) or not status:
+            continue
+        severity: Literal["info", "warning", "error"] = "info"
+        if status == "error":
+            severity = "error"
+        elif trace.get("diagnostics"):
+            severity = "warning"
+        execution_index = trace.get("execution_index")
+        priority = trace.get("priority")
+        injection_count = trace.get("injection_count")
+        details: dict[str, object] = {
+            "status": status,
+            "sources": trace.get("sources", []),
+        }
+        if isinstance(execution_index, int):
+            details["execution_index"] = execution_index
+        if isinstance(priority, int):
+            details["priority"] = priority
+        if isinstance(injection_count, int):
+            details["injection_count"] = injection_count
+        if isinstance(trace.get("diagnostics"), list):
+            details["diagnostics"] = trace["diagnostics"]
+        if isinstance(trace.get("error"), str):
+            details["error"] = trace["error"]
+        diagnostics.append(
+            RuntimeProviderContextDiagnostic(
+                severity=severity,
+                code="context_transform_trace",
+                message=(
+                    f"Context transform provider '{provider_id}' executed with status '{status}'."
+                ),
+                source=provider_id,
+                details=details,
+            )
+        )
+    return tuple(diagnostics)
 
 
 def _source_from_metadata(segment: RuntimeContextSegment) -> str:

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -4687,6 +4687,24 @@ class VoidCodeRuntime:
             session_metadata=result.session.metadata,
             skill_prompt_context=self._debug_skill_prompt_context(result.session.metadata),
         )
+        context_window_metadata = result.session.metadata.get("context_window")
+        if isinstance(context_window_metadata, dict):
+            typed_context_window_metadata = cast(dict[str, object], context_window_metadata)
+            preserved_transform_metadata = typed_context_window_metadata.get("context_transforms")
+            if isinstance(preserved_transform_metadata, dict):
+                assembled_context = RuntimeAssembledContext(
+                    prompt=assembled_context.prompt,
+                    tool_results=assembled_context.tool_results,
+                    continuity_state=assembled_context.continuity_state,
+                    segments=assembled_context.segments,
+                    metadata={
+                        **assembled_context.metadata,
+                        "context_transforms": dict(
+                            cast(dict[str, object], preserved_transform_metadata)
+                        ),
+                    },
+                    loaded_skills=assembled_context.loaded_skills,
+                )
         effective_config = self._effective_runtime_config_from_metadata(result.session.metadata)
         return self._provider_context_snapshot_for_assembled_context(
             assembled_context=assembled_context,

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -278,7 +278,10 @@ def test_assemble_provider_context_injects_file_rules_from_tool_paths(tmp_path: 
             {
                 "provider_id": "runtime_file_rules",
                 "status": "ok",
+                "priority": 200,
+                "execution_index": 2,
                 "injection_count": 2,
+                "provider_order": ["hook_preset_guidance", "runtime_file_rules"],
                 "sources": ["runtime_file_rules"],
             }
         ],
@@ -307,7 +310,10 @@ def test_assemble_provider_context_tracks_hook_preset_guidance_transform() -> No
             {
                 "provider_id": "hook_preset_guidance",
                 "status": "ok",
+                "priority": 100,
+                "execution_index": 1,
                 "injection_count": 1,
+                "provider_order": ["hook_preset_guidance", "runtime_file_rules"],
                 "sources": ["hook_preset_guidance"],
             }
         ],
@@ -342,17 +348,52 @@ def test_context_transform_registry_combines_multiple_providers(tmp_path: Path) 
             {
                 "provider_id": "hook_preset_guidance",
                 "status": "ok",
+                "priority": 100,
+                "execution_index": 1,
                 "injection_count": 1,
+                "provider_order": ["hook_preset_guidance", "runtime_file_rules"],
                 "sources": ["hook_preset_guidance"],
             },
             {
                 "provider_id": "runtime_file_rules",
                 "status": "ok",
+                "priority": 200,
+                "execution_index": 2,
                 "injection_count": 1,
+                "provider_order": ["hook_preset_guidance", "runtime_file_rules"],
                 "sources": ["runtime_file_rules"],
             },
         ],
     }
+
+
+def test_context_transform_registry_orders_providers_by_priority(tmp_path: Path) -> None:
+    class HighPriorityRulesProvider(RuntimeFileRulesTransformProvider):
+        priority = 50
+
+    workspace = tmp_path
+    (workspace / "AGENTS.md").write_text("Project rules", encoding="utf-8")
+    registry = RuntimeContextTransformRegistry(
+        providers=(
+            HookPresetGuidanceTransformProvider(),
+            HighPriorityRulesProvider(),
+        )
+    )
+
+    result = registry.build_result(
+        RuntimeContextTransformRequest(
+            workspace=workspace,
+            tool_results=(),
+            hook_preset_context="Resolved agent hook preset guidance.",
+        )
+    )
+
+    assert [trace.provider_id for trace in result.traces] == [
+        "runtime_file_rules",
+        "hook_preset_guidance",
+    ]
+    assert [trace.execution_index for trace in result.traces] == [1, 2]
+    assert [trace.priority for trace in result.traces] == [50, 100]
 
 
 def test_assemble_provider_context_uses_full_tool_history_for_rules_not_compacted_window(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -2635,6 +2635,7 @@ def test_runtime_session_debug_snapshot_includes_provider_context(tmp_path: Path
         diagnostic.code not in {"missing_tool_result", "orphan_tool_result"}
         for diagnostic in provider_context.diagnostics
     )
+    assert "context_transforms" not in provider_context.context_window
 
 
 def test_runtime_session_debug_snapshot_uses_model_tool_feedback_mode(
@@ -2957,7 +2958,10 @@ def test_runtime_materializes_leader_hook_preset_guidance_into_provider_context(
             {
                 "provider_id": "hook_preset_guidance",
                 "status": "ok",
+                "priority": 100,
+                "execution_index": 1,
                 "injection_count": 1,
+                "provider_order": ["hook_preset_guidance", "runtime_file_rules"],
                 "sources": ["hook_preset_guidance"],
             },
         ],
@@ -3036,7 +3040,10 @@ def test_runtime_agent_context_transform_refs_filter_provider_registry(
             {
                 "provider_id": "runtime_file_rules",
                 "status": "ok",
+                "priority": 200,
+                "execution_index": 1,
                 "injection_count": 1,
+                "provider_order": ["runtime_file_rules"],
                 "sources": ["runtime_file_rules"],
             }
         ],
@@ -10098,7 +10105,10 @@ def test_runtime_workflow_context_transform_refs_filter_runtime_registry(
             {
                 "provider_id": "runtime_file_rules",
                 "status": "ok",
+                "priority": 200,
+                "execution_index": 1,
                 "injection_count": 1,
+                "provider_order": ["runtime_file_rules"],
                 "sources": ["runtime_file_rules"],
             }
         ],
@@ -10153,7 +10163,10 @@ def test_runtime_request_context_transform_refs_narrow_agent_scope(
             {
                 "provider_id": "runtime_file_rules",
                 "status": "ok",
+                "priority": 200,
+                "execution_index": 1,
                 "injection_count": 1,
+                "provider_order": ["runtime_file_rules"],
                 "sources": ["runtime_file_rules"],
             }
         ],
@@ -12483,7 +12496,10 @@ def test_runtime_provider_compaction_emits_continuity_state_and_persists_metadat
                 {
                     "provider_id": "hook_preset_guidance",
                     "status": "ok",
+                    "priority": 100,
+                    "execution_index": 1,
                     "injection_count": 1,
+                    "provider_order": ["hook_preset_guidance", "runtime_file_rules"],
                     "sources": ["hook_preset_guidance"],
                 }
             ],


### PR DESCRIPTION
## Summary
- Add explicit transform provider ordering metadata (`priority`, `execution_index`, `provider_order`) to context transform traces.
- Surface context transform traces as structured provider-context diagnostics for runtime debug inspection.
- Add direct runtime tests and manual QA proving deterministic provider ordering and debug-visible transform trace metadata.

## Verification
- `uv run pytest tests/unit/runtime/test_context_window.py tests/unit/runtime/test_runtime_service_extensions.py tests/unit/runtime/test_single_agent_provider.py -q`
- `uv run pytest tests/unit/runtime/test_context_window.py tests/unit/runtime/test_runtime_service_extensions.py tests/unit/runtime/test_single_agent_provider.py tests/unit/hook/test_executor.py tests/unit/hook/test_presets.py tests/unit/runtime/test_context_rules.py -q`
- Manual QA: build a transform registry with a higher-priority file-rules provider and verify trace ordering and `provider_order` metadata.