### PR TITLE
feat(runtime): add transform failure policy

### DIFF
--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -72,6 +72,7 @@ _VALID_TUI_COMMANDS = ("command_palette", "session_new", "session_resume")
 type ExecutionEngineName = Literal["deterministic", "provider"]
 DEFAULT_EXECUTION_ENGINE: ExecutionEngineName = "provider"
 type RuntimeProviderContextDiagnosticMode = Literal["off", "warn", "block"]
+type RuntimeContextTransformFailureMode = Literal["ignore", "warn", "block"]
 type RuntimeAgentPresetId = str
 type RuntimeAgentPromptSource = Literal["builtin", "custom_markdown"]
 
@@ -159,6 +160,7 @@ _CONTEXT_WINDOW_CONFIG_KEYS = frozenset(
         "context_pressure_cooldown_steps",
         "provider_context_diagnostics",
         "provider_context_oversized_feedback_chars",
+        "context_transform_failure_policy",
         "continuity_distillation_enabled",
         "continuity_distillation_max_input_items",
         "continuity_distillation_max_input_chars",
@@ -341,6 +343,7 @@ class RuntimeContextWindowConfig:
     context_pressure_cooldown_steps: int = 3
     provider_context_diagnostics: RuntimeProviderContextDiagnosticMode = "warn"
     provider_context_oversized_feedback_chars: int = 8_000
+    context_transform_failure_policy: RuntimeContextTransformFailureMode = "warn"
     continuity_distillation_enabled: bool = True
     continuity_distillation_max_input_items: int = 12
     continuity_distillation_max_input_chars: int = 4000
@@ -1301,6 +1304,23 @@ def _parse_provider_context_diagnostic_mode(
     )
 
 
+def _parse_context_transform_failure_mode(
+    value: object,
+) -> RuntimeContextTransformFailureMode:
+    if value is None:
+        return "warn"
+    if value == "ignore":
+        return "ignore"
+    if value == "warn":
+        return "warn"
+    if value == "block":
+        return "block"
+    raise ValueError(
+        "runtime config field 'context_window.context_transform_failure_policy' must be one "
+        "of: ignore, warn, block"
+    )
+
+
 def _parse_runtime_mcp_server_scope(value: object, *, field_path: str) -> RuntimeMcpServerScope:
     if value is None:
         return "runtime"
@@ -1570,6 +1590,7 @@ class _RuntimeContextWindowValidationModel(BaseModel):
     context_pressure_cooldown_steps: int = 3
     provider_context_diagnostics: RuntimeProviderContextDiagnosticMode = "warn"
     provider_context_oversized_feedback_chars: int = 8_000
+    context_transform_failure_policy: RuntimeContextTransformFailureMode = "warn"
     continuity_distillation_enabled: bool = True
     continuity_distillation_max_input_items: int = 12
     continuity_distillation_max_input_chars: int = 4000
@@ -1747,6 +1768,13 @@ class _RuntimeContextWindowValidationModel(BaseModel):
             )
         return value
 
+    @field_validator("context_transform_failure_policy", mode="before")
+    @classmethod
+    def _validate_context_transform_failure_policy(
+        cls, value: object
+    ) -> RuntimeContextTransformFailureMode:
+        return _parse_context_transform_failure_mode(value)
+
     @field_validator("per_tool_result_tokens", mode="before")
     @classmethod
     def _validate_per_tool_result_tokens(cls, value: object) -> dict[str, int]:
@@ -1802,6 +1830,7 @@ class _RuntimeContextWindowValidationModel(BaseModel):
             context_pressure_cooldown_steps=self.context_pressure_cooldown_steps,
             provider_context_diagnostics=self.provider_context_diagnostics,
             provider_context_oversized_feedback_chars=self.provider_context_oversized_feedback_chars,
+            context_transform_failure_policy=self.context_transform_failure_policy,
             continuity_distillation_enabled=self.continuity_distillation_enabled,
             continuity_distillation_max_input_items=self.continuity_distillation_max_input_items,
             continuity_distillation_max_input_chars=self.continuity_distillation_max_input_chars,
@@ -3041,6 +3070,7 @@ def serialize_runtime_context_window_config(
         "provider_context_oversized_feedback_chars": (
             context_window.provider_context_oversized_feedback_chars
         ),
+        "context_transform_failure_policy": context_window.context_transform_failure_policy,
     }
     if context_window.max_tool_result_tokens is not None:
         payload["max_tool_result_tokens"] = context_window.max_tool_result_tokens

--- a/src/voidcode/runtime/config_schema.py
+++ b/src/voidcode/runtime/config_schema.py
@@ -442,6 +442,18 @@ def runtime_config_json_schema() -> dict[str, object]:
                             "Character threshold for oversized retained tool feedback diagnostics."
                         ),
                     },
+                    "context_transform_failure_policy": {
+                        "type": "string",
+                        "enum": ["ignore", "warn", "block"],
+                        "description": (
+                            "Policy for failed context transform providers. "
+                            "'ignore' keeps failures as debug metadata only, "
+                            "'warn' surfaces warning diagnostics without "
+                            "blocking provider execution, "
+                            "and 'block' turns transform failures into "
+                            "blocking provider-context diagnostics."
+                        ),
+                    },
                 },
             },
             "lspServerConfig": {

--- a/src/voidcode/runtime/context_transforms.py
+++ b/src/voidcode/runtime/context_transforms.py
@@ -9,6 +9,7 @@ from ..tools.contracts import ToolResult
 from .context_rules import runtime_file_rule_contexts
 
 type RuntimeContextTransformProviderId = str
+type RuntimeContextTransformFailurePolicy = str
 
 
 @dataclass(frozen=True, slots=True)
@@ -51,10 +52,12 @@ class RuntimeContextTransformTrace:
 class RuntimeContextTransformResult:
     injections: tuple[RuntimeContextTransformInjection, ...] = ()
     traces: tuple[RuntimeContextTransformTrace, ...] = ()
+    failure_policy: RuntimeContextTransformFailurePolicy = "warn"
 
     def metadata_payload(self) -> dict[str, object]:
         return {
             "version": 1,
+            "failure_policy": self.failure_policy,
             "applied": [trace.metadata_payload() for trace in self.traces],
         }
 
@@ -64,6 +67,7 @@ class RuntimeContextTransformRequest:
     workspace: Path | None
     tool_results: tuple[ToolResult, ...]
     hook_preset_context: str
+    failure_policy: RuntimeContextTransformFailurePolicy = "warn"
 
 
 class RuntimeContextTransformProvider(Protocol):
@@ -182,7 +186,23 @@ class RuntimeContextTransformRegistry:
         ordered_providers = self.ordered_providers()
         ordered_provider_ids = tuple(provider.provider_id for provider in ordered_providers)
         for execution_index, provider in enumerate(ordered_providers, start=1):
-            result = provider.build_result(request)
+            try:
+                result = provider.build_result(request)
+            except Exception as exc:
+                result = RuntimeContextTransformResult(
+                    failure_policy=request.failure_policy,
+                    traces=(
+                        RuntimeContextTransformTrace(
+                            provider_id=provider.provider_id,
+                            status="error",
+                            priority=provider.priority,
+                            diagnostics=(
+                                f"context transform provider '{provider.provider_id}' failed",
+                            ),
+                            error=str(exc),
+                        ),
+                    ),
+                )
             injections.extend(result.injections)
             traces.extend(
                 RuntimeContextTransformTrace(
@@ -201,6 +221,7 @@ class RuntimeContextTransformRegistry:
         return RuntimeContextTransformResult(
             injections=tuple(injections),
             traces=tuple(traces),
+            failure_policy=request.failure_policy,
         )
 
 
@@ -218,6 +239,7 @@ def build_provider_context_transform_result(
     workspace: Path | None,
     tool_results: tuple[ToolResult, ...],
     hook_preset_context: str,
+    failure_policy: RuntimeContextTransformFailurePolicy = "warn",
     registry: RuntimeContextTransformRegistry | None = None,
 ) -> RuntimeContextTransformResult:
     active_registry = registry or default_runtime_context_transform_registry()
@@ -226,6 +248,7 @@ def build_provider_context_transform_result(
             workspace=workspace,
             tool_results=tool_results,
             hook_preset_context=hook_preset_context,
+            failure_policy=failure_policy,
         )
     )
 

--- a/src/voidcode/runtime/provider_context.py
+++ b/src/voidcode/runtime/provider_context.py
@@ -202,6 +202,7 @@ def _transform_diagnostics(
     if not isinstance(raw_transforms, dict):
         return ()
     transform_payload = cast(dict[str, object], raw_transforms)
+    failure_policy = transform_payload.get("failure_policy")
     applied = transform_payload.get("applied")
     if not isinstance(applied, list):
         return ()
@@ -218,7 +219,9 @@ def _transform_diagnostics(
             continue
         severity: Literal["info", "warning", "error"] = "info"
         if status == "error":
-            severity = "error"
+            severity = "info" if failure_policy == "ignore" else "warning"
+            if failure_policy == "block":
+                severity = "error"
         elif trace.get("diagnostics"):
             severity = "warning"
         execution_index = trace.get("execution_index")
@@ -227,6 +230,7 @@ def _transform_diagnostics(
         details: dict[str, object] = {
             "status": status,
             "sources": trace.get("sources", []),
+            "failure_policy": failure_policy,
         }
         if isinstance(execution_index, int):
             details["execution_index"] = execution_index

--- a/src/voidcode/runtime/provider_context.py
+++ b/src/voidcode/runtime/provider_context.py
@@ -115,6 +115,13 @@ def evaluate_provider_context_policy(
     *,
     mode: RuntimeProviderContextDiagnosticPolicyMode,
 ) -> RuntimeProviderContextPolicyDecision:
+    transform_failures = tuple(
+        diagnostic
+        for diagnostic in diagnostics
+        if diagnostic.code == "context_transform_trace"
+        and diagnostic.details.get("failure_policy") == "block"
+        and diagnostic.severity == "error"
+    )
     actionable = tuple(
         diagnostic for diagnostic in diagnostics if diagnostic.severity in {"warning", "error"}
     )
@@ -125,7 +132,19 @@ def evaluate_provider_context_policy(
         or diagnostic.code in _PROVIDER_CONTEXT_POLICY_BLOCKING_CODES
     )
     diagnostic_codes = tuple(diagnostic.code for diagnostic in actionable)
-    blocking_codes = tuple(diagnostic.code for diagnostic in blocking)
+    blocking_codes_base = tuple(diagnostic.code for diagnostic in blocking)
+    transform_blocking_codes = tuple(diagnostic.code for diagnostic in transform_failures)
+    blocking_codes = tuple(dict.fromkeys((*blocking_codes_base, *transform_blocking_codes)))
+    if transform_failures:
+        return RuntimeProviderContextPolicyDecision(
+            mode=mode,
+            action="block",
+            blocked=True,
+            diagnostic_count=len(actionable),
+            diagnostic_codes=diagnostic_codes,
+            blocking_diagnostic_codes=blocking_codes,
+            message="Provider execution blocked by context transform failure policy.",
+        )
     if mode == "off":
         return RuntimeProviderContextPolicyDecision(
             mode=mode,

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -6111,6 +6111,9 @@ class VoidCodeRuntime:
             workspace=self._workspace,
             tool_results=tool_results,
             hook_preset_context=hook_preset_context,
+            failure_policy=effective_config.context_window.context_transform_failure_policy
+            if effective_config.context_window is not None
+            else "warn",
             registry=self._context_transform_registry_for_agent(effective_config.agent),
         )
         return assemble_provider_context(

--- a/tests/unit/runtime/test_config_schema.py
+++ b/tests/unit/runtime/test_config_schema.py
@@ -214,6 +214,10 @@ def test_runtime_config_json_schema_exposes_core_fields() -> None:
         dict[str, object], context_window_properties["provider_context_diagnostics"]
     )
     assert provider_context_diagnostics["enum"] == ["off", "warn", "block"]
+    transform_failure_policy = cast(
+        dict[str, object], context_window_properties["context_transform_failure_policy"]
+    )
+    assert transform_failure_policy["enum"] == ["ignore", "warn", "block"]
     provider_context_threshold = cast(
         dict[str, object], context_window_properties["provider_context_oversized_feedback_chars"]
     )

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -274,6 +274,7 @@ def test_assemble_provider_context_injects_file_rules_from_tool_paths(tmp_path: 
     assert "Runtime rules" in (rule_segments[1].content or "")
     assert assembled.metadata["context_transforms"] == {
         "version": 1,
+        "failure_policy": "warn",
         "applied": [
             {
                 "provider_id": "runtime_file_rules",
@@ -306,6 +307,7 @@ def test_assemble_provider_context_tracks_hook_preset_guidance_transform() -> No
     assert hook_segments[0].content == "Resolved agent hook preset guidance."
     assert assembled.metadata["context_transforms"] == {
         "version": 1,
+        "failure_policy": "warn",
         "applied": [
             {
                 "provider_id": "hook_preset_guidance",
@@ -344,6 +346,7 @@ def test_context_transform_registry_combines_multiple_providers(tmp_path: Path) 
     ]
     assert result.metadata_payload() == {
         "version": 1,
+        "failure_policy": "warn",
         "applied": [
             {
                 "provider_id": "hook_preset_guidance",

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -286,6 +286,7 @@ def test_runtime_config_loads_context_window_policy_from_repo_file(tmp_path: Pat
                     "context_pressure_cooldown_steps": 5,
                     "provider_context_diagnostics": "block",
                     "provider_context_oversized_feedback_chars": 16_000,
+                    "context_transform_failure_policy": "block",
                 }
             }
         ),
@@ -316,6 +317,7 @@ def test_runtime_config_loads_context_window_policy_from_repo_file(tmp_path: Pat
         context_pressure_cooldown_steps=5,
         provider_context_diagnostics="block",
         provider_context_oversized_feedback_chars=16_000,
+        context_transform_failure_policy="block",
     )
 
 
@@ -349,6 +351,7 @@ def test_runtime_context_window_config_serializes_for_session_resume() -> None:
         context_pressure_cooldown_steps=4,
         provider_context_diagnostics="block",
         provider_context_oversized_feedback_chars=12_000,
+        context_transform_failure_policy="ignore",
     )
 
     payload = serialize_runtime_context_window_config(config)

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -12829,6 +12829,60 @@ def test_runtime_transform_failure_policy_block_stops_provider_call(tmp_path: Pa
     assert "context_transform_trace" in cast(tuple[str, ...], policy["blocking_diagnostic_codes"])
 
 
+def test_runtime_transform_failure_policy_block_overrides_warn_diagnostics_mode(
+    tmp_path: Path,
+) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("provider debug\n", encoding="utf-8")
+    created_providers: list[_ScriptedTurnProvider] = []
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderTurnResult(tool_call=ToolCall("read_file", {"filePath": "sample.txt"})),
+                    ProviderTurnResult(output="done"),
+                ),
+                created_providers=created_providers,
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_SkillCapturingStubGraph(),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                provider_context_diagnostics="warn",
+                context_transform_failure_policy="block",
+            ),
+        ),
+        model_provider_registry=registry,
+        context_transform_registry=RuntimeContextTransformRegistry(
+            providers=(
+                HookPresetGuidanceTransformProvider(),
+                _FailingTransformProvider(),
+                RuntimeFileRulesTransformProvider(),
+            )
+        ),
+    )
+
+    response = runtime.run(
+        RuntimeRequest(prompt="read sample.txt", session_id="transform-block-warn-mode")
+    )
+    assert response.session.status == "failed"
+    assert len(created_providers) == 0
+    failure = response.events[-1]
+    assert failure.event_type == "runtime.failed"
+    assert failure.payload["kind"] == "provider_context_policy_blocked"
+    policy = cast(dict[str, object], failure.payload["provider_context_policy"])
+    assert policy["mode"] == "warn"
+    assert policy["action"] == "block"
+    assert policy["blocked"] is True
+    assert "context_transform_trace" in cast(tuple[str, ...], policy["blocking_diagnostic_codes"])
+
+
 def test_runtime_memory_refreshed_guard_suppresses_duplicate_anchor(tmp_path: Path) -> None:
     runtime = VoidCodeRuntime(workspace=tmp_path)
     coordinator = runtime._run_loop_coordinator

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -67,6 +67,11 @@ from voidcode.runtime.config import (
     RuntimeToolsBuiltinConfig,
     RuntimeToolsConfig,
 )
+from voidcode.runtime.context_transforms import (
+    HookPresetGuidanceTransformProvider,
+    RuntimeContextTransformRegistry,
+    RuntimeFileRulesTransformProvider,
+)
 from voidcode.runtime.context_window import (
     ContextWindowPolicy,
     RuntimeContextWindow,
@@ -781,6 +786,15 @@ class _FailingProviderGraph:
     ) -> _StubStep:
         _ = request, tool_results, session
         raise ValueError("provider context window exceeded")
+
+
+class _FailingTransformProvider:
+    provider_id = "failing_transform"
+    priority = 150
+
+    def build_result(self, request: object):
+        _ = request
+        raise RuntimeError("transform provider failed")
 
 
 class _ScriptedTurnProvider:
@@ -2954,6 +2968,7 @@ def test_runtime_materializes_leader_hook_preset_guidance_into_provider_context(
     assert "runtime-owned task routing" in (hook_segments[0].content or "")
     assert request.assembled_context.metadata["context_transforms"] == {
         "version": 1,
+        "failure_policy": "warn",
         "applied": [
             {
                 "provider_id": "hook_preset_guidance",
@@ -3036,6 +3051,7 @@ def test_runtime_agent_context_transform_refs_filter_provider_registry(
     assert "hook_preset_guidance" not in system_sources
     assert request.assembled_context.metadata["context_transforms"] == {
         "version": 1,
+        "failure_policy": "warn",
         "applied": [
             {
                 "provider_id": "runtime_file_rules",
@@ -10101,6 +10117,7 @@ def test_runtime_workflow_context_transform_refs_filter_runtime_registry(
     assert "hook_preset_guidance" not in system_sources
     assert request.assembled_context.metadata["context_transforms"] == {
         "version": 1,
+        "failure_policy": "warn",
         "applied": [
             {
                 "provider_id": "runtime_file_rules",
@@ -10159,6 +10176,7 @@ def test_runtime_request_context_transform_refs_narrow_agent_scope(
     assert "hook_preset_guidance" not in system_sources
     assert request.assembled_context.metadata["context_transforms"] == {
         "version": 1,
+        "failure_policy": "warn",
         "applied": [
             {
                 "provider_id": "runtime_file_rules",
@@ -12492,6 +12510,7 @@ def test_runtime_provider_compaction_emits_continuity_state_and_persists_metadat
         "summary_source": summary_source,
         "context_transforms": {
             "version": 1,
+            "failure_policy": "warn",
             "applied": [
                 {
                     "provider_id": "hook_preset_guidance",
@@ -12664,6 +12683,150 @@ def test_runtime_provider_context_policy_off_preserves_provider_execution(
     assert len(created_providers) == 1
     assert len(created_providers[0].requests) == 2
     assert policy_events == []
+
+
+def test_runtime_transform_failure_policy_ignore_keeps_debug_only_trace(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("provider debug\n", encoding="utf-8")
+    created_providers: list[_ScriptedTurnProvider] = []
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderTurnResult(tool_call=ToolCall("read_file", {"filePath": "sample.txt"})),
+                    ProviderTurnResult(output="done"),
+                ),
+                created_providers=created_providers,
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_SkillCapturingStubGraph(),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                provider_context_diagnostics="off",
+                context_transform_failure_policy="ignore",
+            ),
+        ),
+        model_provider_registry=registry,
+        context_transform_registry=RuntimeContextTransformRegistry(
+            providers=(
+                HookPresetGuidanceTransformProvider(),
+                _FailingTransformProvider(),
+                RuntimeFileRulesTransformProvider(),
+            )
+        ),
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="read sample.txt", session_id="transform-ignore"))
+    assert response.session.status == "completed"
+    context_window = cast(dict[str, object], response.session.metadata["context_window"])
+    transforms = cast(dict[str, object], context_window["context_transforms"])
+    applied = cast(list[dict[str, object]], transforms["applied"])
+    failing = next(item for item in applied if item["provider_id"] == "failing_transform")
+    assert failing["status"] == "error"
+    assert failing["error"] == "transform provider failed"
+    assert transforms["failure_policy"] == "ignore"
+
+
+def test_runtime_transform_failure_policy_warn_emits_policy_warning(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("provider debug\n", encoding="utf-8")
+    created_providers: list[_ScriptedTurnProvider] = []
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderTurnResult(tool_call=ToolCall("read_file", {"filePath": "sample.txt"})),
+                    ProviderTurnResult(output="done"),
+                ),
+                created_providers=created_providers,
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_SkillCapturingStubGraph(),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                provider_context_diagnostics="warn",
+                context_transform_failure_policy="warn",
+            ),
+        ),
+        model_provider_registry=registry,
+        context_transform_registry=RuntimeContextTransformRegistry(
+            providers=(
+                HookPresetGuidanceTransformProvider(),
+                _FailingTransformProvider(),
+                RuntimeFileRulesTransformProvider(),
+            )
+        ),
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="read sample.txt", session_id="transform-warn"))
+    policy_events = [
+        event for event in response.events if event.event_type == "runtime.provider_context_policy"
+    ]
+    assert response.session.status == "completed"
+    assert policy_events
+    assert policy_events[0].payload["action"] == "warn"
+    diagnostic_codes = cast(tuple[str, ...], policy_events[0].payload["diagnostic_codes"])
+    assert "context_transform_trace" in diagnostic_codes
+
+
+def test_runtime_transform_failure_policy_block_stops_provider_call(tmp_path: Path) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("provider debug\n", encoding="utf-8")
+    created_providers: list[_ScriptedTurnProvider] = []
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderTurnResult(tool_call=ToolCall("read_file", {"filePath": "sample.txt"})),
+                    ProviderTurnResult(output="done"),
+                ),
+                created_providers=created_providers,
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_SkillCapturingStubGraph(),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                provider_context_diagnostics="block",
+                context_transform_failure_policy="block",
+            ),
+        ),
+        model_provider_registry=registry,
+        context_transform_registry=RuntimeContextTransformRegistry(
+            providers=(
+                HookPresetGuidanceTransformProvider(),
+                _FailingTransformProvider(),
+                RuntimeFileRulesTransformProvider(),
+            )
+        ),
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="read sample.txt", session_id="transform-block"))
+    assert response.session.status == "failed"
+    assert len(created_providers) == 0
+    failure = response.events[-1]
+    assert failure.event_type == "runtime.failed"
+    assert failure.payload["kind"] == "provider_context_policy_blocked"
+    policy = cast(dict[str, object], failure.payload["provider_context_policy"])
+    assert policy["action"] == "block"
+    assert "context_transform_trace" in cast(tuple[str, ...], policy["blocking_diagnostic_codes"])
 
 
 def test_runtime_memory_refreshed_guard_suppresses_duplicate_anchor(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add `context_transform_failure_policy` to runtime context-window config with `ignore`, `warn`, and `block` modes.
- Capture transform provider exceptions as error traces instead of crashing the transform pipeline, and surface them through provider-context diagnostics.
- Block provider execution only when failure policy is `block`; otherwise preserve execution while keeping failure traces observable in metadata and debug surfaces.

## Verification
- `uv run pytest tests/unit/runtime/test_runtime_service_extensions.py -q -k "transform_failure_policy or provider_context_policy_"`
- `uv run pytest tests/unit/runtime/test_runtime_service_extensions.py tests/unit/runtime/test_context_window.py tests/unit/runtime/test_runtime_config.py tests/unit/runtime/test_config_schema.py tests/unit/hook/test_executor.py tests/unit/hook/test_presets.py tests/unit/runtime/test_context_rules.py -q`
- Manual QA: execute a registry with a failing transform provider under `ignore`, `warn`, and `block` and verify trace status/error plus blocking behavior only in `block` mode.