### PR TITLE
feat(runtime): load project-local context transforms

### DIFF
--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -33,7 +33,10 @@ from ..lsp import derive_workspace_lsp_defaults, has_builtin_lsp_server_preset
 from ..mcp.builtin import get_builtin_mcp_descriptor
 from ..provider import config as provider_config
 from ..skills import SkillRegistry, list_builtin_skills
-from .context_transforms import validate_runtime_context_transform_refs
+from .context_transforms import (
+    RuntimeContextTransformRegistry,
+    validate_runtime_context_transform_refs,
+)
 from .permission import (
     ExternalDirectoryPermissionConfig,
     ExternalDirectoryPolicy,
@@ -609,6 +612,7 @@ def load_runtime_config(
     tool_timeout_seconds: int | None = None,
     reasoning_effort: str | None = None,
     env: Mapping[str, str] | None = None,
+    context_transform_registry: RuntimeContextTransformRegistry | None = None,
 ) -> RuntimeConfig:
     resolved_workspace = workspace.resolve()
     environment: Mapping[str, str] = os.environ if env is None else env
@@ -619,6 +623,7 @@ def load_runtime_config(
         resolved_workspace,
         env=environment,
         agent_registry=agent_registry,
+        context_transform_registry=context_transform_registry,
     )
     resolved_tui = _resolve_tui_config(global_config.tui, repo_local.tui)
     resolved_lsp = repo_local.lsp or _derive_workspace_lsp_config(resolved_workspace)
@@ -723,6 +728,7 @@ def _load_repo_local_config(
     *,
     env: Mapping[str, str],
     agent_registry: AgentManifestRegistry | None = None,
+    context_transform_registry: RuntimeContextTransformRegistry | None = None,
 ) -> RuntimeConfigOverrides:
     config_path = runtime_config_path(workspace)
     if not config_path.exists():
@@ -804,9 +810,19 @@ def _load_repo_local_config(
     providers = _parse_providers_config(raw_providers, env=env)
 
     raw_agent = payload.get("agent")
-    agent = _parse_agent_config(raw_agent, hooks=hooks, agent_registry=agent_registry)
+    agent = _parse_agent_config(
+        raw_agent,
+        hooks=hooks,
+        agent_registry=agent_registry,
+        context_transform_registry=context_transform_registry,
+    )
     raw_agents = payload.get("agents")
-    agents = _parse_agents_config(raw_agents, hooks=hooks, agent_registry=agent_registry)
+    agents = _parse_agents_config(
+        raw_agents,
+        hooks=hooks,
+        agent_registry=agent_registry,
+        context_transform_registry=context_transform_registry,
+    )
     raw_categories = payload.get("categories")
     categories = _parse_categories_config(raw_categories)
     raw_workflows = payload.get("workflows")
@@ -2438,6 +2454,7 @@ def _parse_agent_config(
     *,
     hooks: RuntimeHooksConfig | None = None,
     agent_registry: AgentManifestRegistry | None = None,
+    context_transform_registry: RuntimeContextTransformRegistry | None = None,
 ) -> RuntimeAgentConfig | None:
     if raw_agent is None:
         return None
@@ -2514,7 +2531,8 @@ def _parse_agent_config(
 
     hook_refs = _parse_agent_hook_refs(payload.get("hook_refs"), hooks=hooks)
     context_transform_refs = _parse_agent_context_transform_refs(
-        payload.get("context_transform_refs")
+        payload.get("context_transform_refs"),
+        registry=context_transform_registry,
     )
 
     model = payload.get("model")
@@ -2790,13 +2808,18 @@ def _parse_agent_hook_refs(
     return validate_hook_preset_refs(hook_refs, field_path="runtime config field 'agent.hook_refs'")
 
 
-def _parse_agent_context_transform_refs(raw_refs: object) -> tuple[str, ...]:
+def _parse_agent_context_transform_refs(
+    raw_refs: object,
+    *,
+    registry: RuntimeContextTransformRegistry | None = None,
+) -> tuple[str, ...]:
     refs = _parse_string_list(raw_refs, field_path="agent.context_transform_refs")
     if not refs:
         return ()
     return validate_runtime_context_transform_refs(
         refs,
         field_path="runtime config field 'agent.context_transform_refs'",
+        registry=registry,
     )
 
 
@@ -2830,6 +2853,7 @@ def _parse_agents_config(
     *,
     hooks: RuntimeHooksConfig | None = None,
     agent_registry: AgentManifestRegistry | None = None,
+    context_transform_registry: RuntimeContextTransformRegistry | None = None,
 ) -> Mapping[str, RuntimeAgentConfig] | None:
     if raw_agents is None:
         return None
@@ -2860,6 +2884,7 @@ def _parse_agents_config(
                 entry_payload,
                 hooks=hooks,
                 agent_registry=agent_registry,
+                context_transform_registry=context_transform_registry,
             )
         except ValueError as exc:
             message = (
@@ -2972,10 +2997,16 @@ def parse_runtime_agent_payload(
     source: str,
     hooks: RuntimeHooksConfig | None = None,
     agent_registry: AgentManifestRegistry | None = None,
+    context_transform_registry: RuntimeContextTransformRegistry | None = None,
 ) -> RuntimeAgentConfig | None:
     try:
         return _resolve_agent_config(
-            _parse_agent_config(raw_agent, hooks=hooks, agent_registry=agent_registry),
+            _parse_agent_config(
+                raw_agent,
+                hooks=hooks,
+                agent_registry=agent_registry,
+                context_transform_registry=context_transform_registry,
+            ),
             agent_registry=agent_registry,
         )
     except ValueError as exc:
@@ -2988,9 +3019,15 @@ def parse_runtime_agents_payload(
     source: str,
     hooks: RuntimeHooksConfig | None = None,
     agent_registry: AgentManifestRegistry | None = None,
+    context_transform_registry: RuntimeContextTransformRegistry | None = None,
 ) -> Mapping[str, RuntimeAgentConfig] | None:
     try:
-        return _parse_agents_config(raw_agents, hooks=hooks, agent_registry=agent_registry)
+        return _parse_agents_config(
+            raw_agents,
+            hooks=hooks,
+            agent_registry=agent_registry,
+            context_transform_registry=context_transform_registry,
+        )
     except ValueError as exc:
         raise ValueError(f"{source}: {exc}") from exc
 

--- a/src/voidcode/runtime/local_context_transforms.py
+++ b/src/voidcode/runtime/local_context_transforms.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast, final
+
+from .context_transforms import (
+    RuntimeContextTransformInjection,
+    RuntimeContextTransformProvider,
+    RuntimeContextTransformRegistry,
+    RuntimeContextTransformRequest,
+    RuntimeContextTransformResult,
+    RuntimeContextTransformTrace,
+)
+
+LOCAL_CONTEXT_TRANSFORM_DEFAULT_PATH = ".voidcode/context-transforms"
+LOCAL_CONTEXT_TRANSFORM_MANIFEST_SUFFIX = ".json"
+
+
+@dataclass(frozen=True, slots=True)
+class LocalContextTransformManifest:
+    provider_id: str
+    description: str
+    content: str
+    priority: int
+    manifest_path: Path
+
+
+def discover_local_context_transform_registry(workspace: Path) -> RuntimeContextTransformRegistry:
+    workspace_root = workspace.resolve()
+    root = (workspace_root / LOCAL_CONTEXT_TRANSFORM_DEFAULT_PATH).resolve()
+    try:
+        root.relative_to(workspace_root)
+    except ValueError as exc:
+        raise ValueError("local context transforms path must stay inside the workspace") from exc
+    if not root.exists():
+        return RuntimeContextTransformRegistry()
+    if not root.is_dir():
+        raise ValueError("local context transforms path is not a directory")
+
+    providers: list[RuntimeContextTransformProvider] = []
+    seen_ids: set[str] = set()
+    builtin_ids = {"hook_preset_guidance", "runtime_file_rules"}
+    for path in sorted(root.glob(f"*{LOCAL_CONTEXT_TRANSFORM_MANIFEST_SUFFIX}")):
+        if not path.is_file():
+            continue
+        manifest = _load_local_context_transform_manifest(path)
+        if manifest.provider_id in builtin_ids:
+            raise ValueError(
+                f"local context transform manifest {path} uses builtin id '{manifest.provider_id}'"
+            )
+        if manifest.provider_id in seen_ids:
+            raise ValueError(
+                f"duplicate local context transform provider id '{manifest.provider_id}' in {path}"
+            )
+        seen_ids.add(manifest.provider_id)
+        providers.append(LocalContextTransformProvider(manifest))
+    return RuntimeContextTransformRegistry(providers=tuple(providers))
+
+
+def merge_runtime_context_transform_registries(
+    base: RuntimeContextTransformRegistry,
+    extra: RuntimeContextTransformRegistry,
+) -> RuntimeContextTransformRegistry:
+    if not extra.providers:
+        return base
+    return RuntimeContextTransformRegistry(providers=(*base.providers, *extra.providers))
+
+
+def _load_local_context_transform_manifest(path: Path) -> LocalContextTransformManifest:
+    try:
+        raw_payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid local context transform manifest JSON at {path}") from exc
+    if not isinstance(raw_payload, dict):
+        raise ValueError(f"local context transform manifest must be an object: {path}")
+    payload = cast(dict[str, object], raw_payload)
+    allowed_keys = {"id", "description", "content", "priority", "enabled"}
+    unknown_keys = sorted(key for key in payload if key not in allowed_keys)
+    if unknown_keys:
+        raise ValueError(
+            f"local context transform manifest {path} has unsupported field: {unknown_keys[0]}"
+        )
+    enabled = payload.get("enabled", True)
+    if not isinstance(enabled, bool):
+        raise ValueError(f"local context transform manifest {path} enabled must be a boolean")
+    if enabled is not True:
+        raise ValueError(f"local context transform manifest {path} must be enabled to load")
+    provider_id = payload.get("id")
+    if not isinstance(provider_id, str) or not provider_id.strip():
+        raise ValueError(f"local context transform manifest {path} requires a non-empty id")
+    description = payload.get("description")
+    if not isinstance(description, str) or not description.strip():
+        raise ValueError(
+            f"local context transform manifest {path} requires a non-empty description"
+        )
+    content = payload.get("content")
+    if not isinstance(content, str) or not content.strip():
+        raise ValueError(f"local context transform manifest {path} requires non-empty content")
+    priority = payload.get("priority", 300)
+    if not isinstance(priority, int) or isinstance(priority, bool):
+        raise ValueError(f"local context transform manifest {path} priority must be an integer")
+    return LocalContextTransformManifest(
+        provider_id=provider_id.strip(),
+        description=description.strip(),
+        content=content.strip(),
+        priority=priority,
+        manifest_path=path,
+    )
+
+
+@final
+class LocalContextTransformProvider:
+    def __init__(self, manifest: LocalContextTransformManifest) -> None:
+        self._manifest = manifest
+
+    @property
+    def provider_id(self) -> str:
+        return self._manifest.provider_id
+
+    @property
+    def priority(self) -> int:
+        return self._manifest.priority
+
+    def build_result(
+        self,
+        request: RuntimeContextTransformRequest,
+    ) -> RuntimeContextTransformResult:
+        _ = request
+        return RuntimeContextTransformResult(
+            injections=(
+                RuntimeContextTransformInjection(
+                    role="system",
+                    content=self._manifest.content,
+                    metadata={
+                        "source": self._manifest.provider_id,
+                        "description": self._manifest.description,
+                        "manifest": str(self._manifest.manifest_path),
+                    },
+                ),
+            ),
+            traces=(
+                RuntimeContextTransformTrace(
+                    provider_id=self._manifest.provider_id,
+                    priority=self._manifest.priority,
+                    injection_count=1,
+                    sources=(self._manifest.provider_id,),
+                ),
+            ),
+            failure_policy=request.failure_policy,
+        )

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -1097,10 +1097,10 @@ class RuntimeRunLoopCoordinator:
                 segment_source = (
                     segment.metadata.get("source") if isinstance(segment.metadata, dict) else None
                 )
-                if segment_source in {
-                    "hook_preset_guidance",
-                    "runtime_file_rules",
-                }:
+                if (
+                    isinstance(segment_source, str)
+                    and segment_source in runtime._context_transform_registry.provider_ids()
+                ):
                     continue
                 if segment.content.startswith("Runtime-managed todo state is active"):
                     continue

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -250,6 +250,10 @@ from .hook_preset_metadata import (
     hook_preset_refs_for_agent,
     resolved_hook_preset_snapshot_from_session_metadata,
 )
+from .local_context_transforms import (
+    discover_local_context_transform_registry,
+    merge_runtime_context_transform_registries,
+)
 from .lsp import LspManager, LspManagerState, LspRequest, LspRequestResult, build_lsp_manager
 from .mcp import McpManager, build_mcp_manager
 from .paths import provider_catalog_cache_path
@@ -547,6 +551,16 @@ class VoidCodeRuntime:
             workspace=self._workspace
         )
         self._agent_registry = self._runtime_agent_registry()
+        base_context_transform_registry = (
+            context_transform_registry or default_runtime_context_transform_registry()
+        )
+        local_context_transform_registry = discover_local_context_transform_registry(
+            self._workspace
+        )
+        merged_context_transform_registry = merge_runtime_context_transform_registries(
+            base_context_transform_registry,
+            local_context_transform_registry,
+        )
         self._config = config or load_runtime_config(self._workspace)
         self._model_provider_registry = (
             model_provider_registry
@@ -562,6 +576,7 @@ class VoidCodeRuntime:
                 source="runtime config agent",
                 hooks=self._config.hooks,
                 agent_registry=self._agent_registry,
+                context_transform_registry=merged_context_transform_registry,
             )
             assert initial_agent is not None
             self._validate_runtime_agent_for_execution(
@@ -631,9 +646,7 @@ class VoidCodeRuntime:
         )
         self._session_store = session_store or SqliteSessionStore()
         self._acp_adapter = acp_adapter or build_acp_adapter(self._config.acp)
-        self._context_transform_registry = (
-            context_transform_registry or default_runtime_context_transform_registry()
-        )
+        self._context_transform_registry = merged_context_transform_registry
         self._default_context_window_policy = self._context_window_policy_from_config(
             initial_context_window,
             resolved_provider=None,
@@ -4556,6 +4569,7 @@ class VoidCodeRuntime:
                 source="runtime config agent",
                 hooks=self._config.hooks,
                 agent_registry=self._agent_registry,
+                context_transform_registry=self._context_transform_registry,
             )
             assert initial_agent is not None
             self._validate_runtime_agent_for_execution(
@@ -6794,6 +6808,7 @@ class VoidCodeRuntime:
             source="request metadata 'agent'",
             hooks=self._config.hooks,
             agent_registry=self._agent_registry,
+            context_transform_registry=self._context_transform_registry,
         )
         if agent is None:
             raise ValueError("request metadata 'agent' must be an object when provided")
@@ -7432,6 +7447,7 @@ class VoidCodeRuntime:
                 source="runtime config agent",
                 hooks=self._config.hooks,
                 agent_registry=self._agent_registry,
+                context_transform_registry=self._context_transform_registry,
             )
             assert agent is not None
             self._validate_runtime_agent_for_execution(
@@ -7444,6 +7460,7 @@ class VoidCodeRuntime:
                 source="runtime config agent",
                 hooks=self._config.hooks,
                 agent_registry=self._agent_registry,
+                context_transform_registry=self._context_transform_registry,
             )
             assert agent is not None
             self._validate_runtime_agent_for_execution(
@@ -7612,6 +7629,7 @@ class VoidCodeRuntime:
                 source="persisted runtime_config.agent",
                 hooks=self._config.hooks,
                 agent_registry=self._agent_registry,
+                context_transform_registry=self._context_transform_registry,
             )
             if agent is not None:
                 self._validate_runtime_agent_for_execution(

--- a/tests/unit/runtime/test_local_context_transforms.py
+++ b/tests/unit/runtime/test_local_context_transforms.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from voidcode.runtime.context_transforms import RuntimeContextTransformRequest
+from voidcode.runtime.local_context_transforms import (
+    discover_local_context_transform_registry,
+    merge_runtime_context_transform_registries,
+)
+
+
+def test_discover_local_context_transform_registry_loads_project_manifest(tmp_path: Path) -> None:
+    manifest_dir = tmp_path / ".voidcode" / "context-transforms"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "custom.json").write_text(
+        json.dumps(
+            {
+                "id": "project_custom",
+                "description": "Project custom guidance",
+                "content": "Custom transform guidance.",
+                "priority": 250,
+                "enabled": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    registry = discover_local_context_transform_registry(tmp_path)
+    result = registry.build_result(
+        RuntimeContextTransformRequest(
+            workspace=tmp_path,
+            tool_results=(),
+            hook_preset_context="",
+        )
+    )
+
+    assert registry.provider_ids() == ("project_custom",)
+    assert result.injections[0].metadata["source"] == "project_custom"
+    assert result.injections[0].metadata["manifest"] == str(manifest_dir / "custom.json")
+    assert result.traces[0].priority == 250
+
+
+def test_discover_local_context_transform_registry_rejects_builtin_id_collision(
+    tmp_path: Path,
+) -> None:
+    manifest_dir = tmp_path / ".voidcode" / "context-transforms"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "collision.json").write_text(
+        json.dumps(
+            {
+                "id": "runtime_file_rules",
+                "description": "Collision",
+                "content": "Bad",
+                "priority": 250,
+                "enabled": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="uses builtin id 'runtime_file_rules'"):
+        _ = discover_local_context_transform_registry(tmp_path)
+
+
+def test_merge_runtime_context_transform_registries_appends_custom_providers(
+    tmp_path: Path,
+) -> None:
+    manifest_dir = tmp_path / ".voidcode" / "context-transforms"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "custom.json").write_text(
+        json.dumps(
+            {
+                "id": "project_custom",
+                "description": "Project custom guidance",
+                "content": "Custom transform guidance.",
+                "priority": 250,
+                "enabled": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    builtins = discover_local_context_transform_registry(tmp_path)
+    merged = merge_runtime_context_transform_registries(builtins, builtins)
+    assert merged.provider_ids() == ("project_custom", "project_custom")

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -10191,6 +10191,70 @@ def test_runtime_request_context_transform_refs_narrow_agent_scope(
     }
 
 
+def test_runtime_loads_project_local_context_transform_provider(tmp_path: Path) -> None:
+    transforms_dir = tmp_path / ".voidcode" / "context-transforms"
+    transforms_dir.mkdir(parents=True)
+    manifest_path = transforms_dir / "custom.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "id": "project_custom",
+                "description": "Project custom guidance",
+                "content": "Custom transform guidance.",
+                "priority": 250,
+                "enabled": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_SkillCapturingStubGraph(),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            agent=RuntimeAgentConfig(
+                preset="leader",
+                context_transform_refs=("project_custom",),
+            ),
+        ),
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="hello", session_id="project-transform"))
+    request = _SkillCapturingStubGraph.last_request
+
+    assert request is not None
+    custom_segments = [
+        segment
+        for segment in request.assembled_context.segments
+        if segment.role == "system"
+        and segment.metadata is not None
+        and segment.metadata.get("source") == "project_custom"
+    ]
+    assert len(custom_segments) == 1
+    assert custom_segments[0].content == "Custom transform guidance."
+    custom_metadata = cast(dict[str, object], custom_segments[0].metadata)
+    assert custom_metadata["manifest"] == str(manifest_path)
+    runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
+    runtime_agent = cast(dict[str, object], runtime_config["agent"])
+    assert runtime_agent["context_transform_refs"] == ["project_custom"]
+    assert request.assembled_context.metadata["context_transforms"] == {
+        "version": 1,
+        "failure_policy": "warn",
+        "applied": [
+            {
+                "provider_id": "project_custom",
+                "status": "ok",
+                "priority": 250,
+                "execution_index": 1,
+                "injection_count": 1,
+                "provider_order": ["project_custom"],
+                "sources": ["project_custom"],
+            }
+        ],
+    }
+
+
 def test_runtime_request_context_transform_refs_reject_unknown_provider(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- Add a project-local `.voidcode/context-transforms/*.json` extension surface for custom runtime context transform providers.
- Merge discovered local providers into the runtime transform registry while preserving builtin-id collision safety and runtime provider ordering.
- Add unit and runtime tests proving local manifests are discovered, validated, and injectable via `context_transform_refs`.

## Verification
- `uv run pytest tests/unit/runtime/test_local_context_transforms.py tests/unit/runtime/test_runtime_service_extensions.py -q -k "project_local_context_transform_provider or local_context_transform"`
- `uv run pytest tests/unit/runtime/test_local_context_transforms.py tests/unit/runtime/test_context_window.py tests/unit/runtime/test_runtime_service_extensions.py tests/unit/runtime/test_runtime_config.py -q`
- Manual QA: place `project_custom` under `.voidcode/context-transforms/custom.json`, reference it from `context_transform_refs`, and verify the system segment and trace metadata appear in the assembled context.