### PR TITLE
fix(runtime): close transform block bypass for off diagnostics

### DIFF
--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -4761,7 +4761,10 @@ class VoidCodeRuntime:
         if effective_config.execution_engine != "provider":
             return None
         context_window_config = effective_config.context_window or RuntimeContextWindowConfig()
-        if context_window_config.provider_context_diagnostics == "off":
+        if (
+            context_window_config.provider_context_diagnostics == "off"
+            and context_window_config.context_transform_failure_policy != "block"
+        ):
             return None
         snapshot = self._provider_context_snapshot_for_assembled_context(
             assembled_context=cast(RuntimeAssembledContext, graph_request.assembled_context),

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -12883,6 +12883,118 @@ def test_runtime_transform_failure_policy_block_overrides_warn_diagnostics_mode(
     assert "context_transform_trace" in cast(tuple[str, ...], policy["blocking_diagnostic_codes"])
 
 
+def test_runtime_transform_failure_policy_block_overrides_off_diagnostics_mode(
+    tmp_path: Path,
+) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("provider debug\n", encoding="utf-8")
+    created_providers: list[_ScriptedTurnProvider] = []
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderTurnResult(tool_call=ToolCall("read_file", {"filePath": "sample.txt"})),
+                    ProviderTurnResult(output="done"),
+                ),
+                created_providers=created_providers,
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_SkillCapturingStubGraph(),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                provider_context_diagnostics="off",
+                context_transform_failure_policy="block",
+            ),
+        ),
+        model_provider_registry=registry,
+        context_transform_registry=RuntimeContextTransformRegistry(
+            providers=(
+                HookPresetGuidanceTransformProvider(),
+                _FailingTransformProvider(),
+                RuntimeFileRulesTransformProvider(),
+            )
+        ),
+    )
+
+    response = runtime.run(
+        RuntimeRequest(prompt="read sample.txt", session_id="transform-block-off-mode")
+    )
+    assert response.session.status == "failed"
+    assert len(created_providers) == 0
+    failure = response.events[-1]
+    assert failure.event_type == "runtime.failed"
+    assert failure.payload["kind"] == "provider_context_policy_blocked"
+    policy = cast(dict[str, object], failure.payload["provider_context_policy"])
+    assert policy["mode"] == "off"
+    assert policy["action"] == "block"
+    assert policy["blocked"] is True
+    assert "context_transform_trace" in cast(tuple[str, ...], policy["blocking_diagnostic_codes"])
+
+
+def test_runtime_provider_context_diagnostics_off_with_block_transform_policy_no_failure(
+    tmp_path: Path,
+) -> None:
+    sample_file = tmp_path / "sample.txt"
+    sample_file.write_text("provider debug\n", encoding="utf-8")
+    created_providers: list[_ScriptedTurnProvider] = []
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _ScriptedModelProvider(
+                name="opencode",
+                outcomes=(
+                    ProviderTurnResult(tool_call=ToolCall("read_file", {"filePath": "sample.txt"})),
+                    ProviderTurnResult(output="done"),
+                ),
+                created_providers=created_providers,
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_SkillCapturingStubGraph(),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            context_window=RuntimeContextWindowConfig(
+                provider_context_diagnostics="off",
+                context_transform_failure_policy="block",
+            ),
+        ),
+        model_provider_registry=registry,
+        context_transform_registry=RuntimeContextTransformRegistry(
+            providers=(
+                HookPresetGuidanceTransformProvider(),
+                RuntimeFileRulesTransformProvider(),
+            )
+        ),
+    )
+
+    response = runtime.run(
+        RuntimeRequest(
+            prompt="read sample.txt",
+            session_id="transform-off-block-no-failure",
+        )
+    )
+    # status "completed" proves the off+block path did not block execution; combined with
+    # the policy_events check below it confirms the snapshot path stayed silent when no
+    # transform failed.
+    assert response.session.status == "completed"
+    assert all(event.event_type != "runtime.failed" for event in response.events)
+    policy_events = [
+        event for event in response.events if event.event_type == "runtime.provider_context_policy"
+    ]
+    # diagnostics="off" + failure_policy="block" runs the snapshot path so transform-failure
+    # enforcement remains active, but with no failing transforms evaluate_provider_context_policy
+    # returns action="ignored" (no warn event, no blocking).
+    assert policy_events == []
+
+
 def test_runtime_memory_refreshed_guard_suppresses_duplicate_anchor(tmp_path: Path) -> None:
     runtime = VoidCodeRuntime(workspace=tmp_path)
     coordinator = runtime._run_loop_coordinator


### PR DESCRIPTION
## Summary
- Enforce `context_transform_failure_policy=\"block\"` even when provider context diagnostics are disabled.
- Add coverage for `off` + `block` with both failing and non-failing transform paths.

## Verification
- `uv run pytest tests/unit/runtime/test_runtime_service_extensions.py -k "transform_failure_policy or provider_context_policy_off or provider_context_diagnostics_off" -v`
- pre-commit hooks during commit: trailing whitespace, EOF, large files, Ruff, Ruff format, ty check