### PR TITLE
feat(context): add readme context and write guards

### DIFF
--- a/src/voidcode/context/README.md
+++ b/src/voidcode/context/README.md
@@ -1,0 +1,25 @@
+# `voidcode.context`
+
+这里是 VoidCode 的上下文能力层。
+
+## 定位
+
+`voidcode.context` 承载与 provider context 组装相关的纯能力逻辑，例如目录级 README/规则发现与 context injection helper。
+
+## 负责什么
+
+- 目录级上下文文件发现
+- provider context injection 所需的纯 helper / provider 逻辑
+- 与上下文注入相关的有界截断与 metadata 生成
+
+## 不负责什么
+
+- session 生命周期与持久化
+- 审批与权限决策
+- runtime event 路由
+- provider 调用与 fallback
+
+## 边界关系
+
+`runtime/` 负责决定何时组装 context、如何持久化 metadata、以及何时把这些能力接入 execution path。
+`voidcode.context` 负责提供可复用、可测试的上下文能力实现。

--- a/src/voidcode/context/__init__.py
+++ b/src/voidcode/context/__init__.py
@@ -1,0 +1,3 @@
+from .readme import DirectoryReadmeContext, directory_readme_contexts
+
+__all__ = ["DirectoryReadmeContext", "directory_readme_contexts"]

--- a/src/voidcode/context/readme.py
+++ b/src/voidcode/context/readme.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol, cast
+
+
+class _ToolResultLike(Protocol):
+    data: dict[str, object]
+
+
+README_FILE_NAME = "README.md"
+MAX_README_FILES = 8
+MAX_README_FILE_CHARS = 12_000
+
+
+@dataclass(frozen=True, slots=True)
+class DirectoryReadmeContext:
+    path: str
+    content: str
+    truncated: bool = False
+
+    def metadata_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "source": "directory_readme_context",
+            "path": self.path,
+        }
+        if self.truncated:
+            payload["truncated"] = True
+        return payload
+
+
+def directory_readme_contexts(
+    *,
+    workspace: Path | None,
+    tool_results: tuple[_ToolResultLike, ...],
+    max_readme_files: int = MAX_README_FILES,
+    max_readme_file_chars: int = MAX_README_FILE_CHARS,
+    include_workspace_root: bool = True,
+) -> tuple[DirectoryReadmeContext, ...]:
+    if workspace is None or max_readme_files < 1:
+        return ()
+    workspace_root = workspace.resolve(strict=False)
+    readme_paths = _applicable_readme_paths(
+        workspace_root=workspace_root,
+        touched_paths=_touched_paths_from_tool_results(tool_results),
+        max_readme_files=max_readme_files,
+        include_workspace_root=include_workspace_root,
+    )
+    contexts: list[DirectoryReadmeContext] = []
+    for readme_path in readme_paths:
+        try:
+            content = readme_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        truncated = len(content) > max_readme_file_chars
+        if truncated:
+            content = content[:max_readme_file_chars].rstrip()
+            content = f"{content}\n[README context truncated by runtime context policy]"
+        contexts.append(
+            DirectoryReadmeContext(
+                path=readme_path.relative_to(workspace_root).as_posix(),
+                content=content.strip(),
+                truncated=truncated,
+            )
+        )
+    return tuple(contexts)
+
+
+def _touched_paths_from_tool_results(tool_results: tuple[_ToolResultLike, ...]) -> tuple[str, ...]:
+    paths: list[str] = []
+    seen: set[str] = set()
+
+    def append(value: object) -> None:
+        if not isinstance(value, str):
+            return
+        stripped = value.strip()
+        if not stripped:
+            return
+        if stripped in seen:
+            paths.remove(stripped)
+        else:
+            seen.add(stripped)
+        paths.append(stripped)
+
+    for result in tool_results:
+        append(result.data.get("path"))
+        append(result.data.get("output_path"))
+        raw_arguments = result.data.get("arguments")
+        if isinstance(raw_arguments, dict):
+            arguments = cast(dict[str, object], raw_arguments)
+            append(arguments.get("path"))
+            append(arguments.get("filePath"))
+        raw_matches = result.data.get("matches")
+        if isinstance(raw_matches, list | tuple):
+            for raw_match in raw_matches:
+                if not isinstance(raw_match, dict):
+                    continue
+                match = cast(dict[str, object], raw_match)
+                append(match.get("file"))
+                append(match.get("path"))
+        raw_changes = result.data.get("changes")
+        if isinstance(raw_changes, list | tuple):
+            for raw_change in raw_changes:
+                if not isinstance(raw_change, dict):
+                    continue
+                change = cast(dict[str, object], raw_change)
+                append(change.get("path"))
+    return tuple(paths)
+
+
+def _applicable_readme_paths(
+    *,
+    workspace_root: Path,
+    touched_paths: tuple[str, ...],
+    max_readme_files: int,
+    include_workspace_root: bool,
+) -> tuple[Path, ...]:
+    ordered: list[Path] = []
+    seen: set[Path] = set()
+
+    root_readme_path = workspace_root / README_FILE_NAME
+    if include_workspace_root and root_readme_path.is_file():
+        seen.add(root_readme_path)
+        ordered.append(root_readme_path)
+
+    for raw_path in touched_paths:
+        touched_path = _workspace_path(workspace_root=workspace_root, raw_path=raw_path)
+        if touched_path is None:
+            continue
+        for readme_path in _candidate_readme_paths(
+            workspace_root=workspace_root,
+            path=touched_path,
+        ):
+            if readme_path in seen or not readme_path.is_file():
+                continue
+            seen.add(readme_path)
+            ordered.append(readme_path)
+    if len(ordered) <= max_readme_files:
+        return tuple(ordered)
+    return tuple(ordered[-max_readme_files:])
+
+
+def _workspace_path(*, workspace_root: Path, raw_path: str) -> Path | None:
+    candidate = Path(raw_path).expanduser()
+    if not candidate.is_absolute():
+        candidate = workspace_root / candidate
+    resolved = candidate.resolve(strict=False)
+    try:
+        resolved.relative_to(workspace_root)
+    except ValueError:
+        return None
+    return resolved
+
+
+def _candidate_readme_paths(*, workspace_root: Path, path: Path) -> tuple[Path, ...]:
+    start = path if path.is_dir() else path.parent
+    directories: list[Path] = []
+    current = start
+    while True:
+        try:
+            current.relative_to(workspace_root)
+        except ValueError:
+            break
+        directories.append(current)
+        if current == workspace_root:
+            break
+        current = current.parent
+    return tuple(directory / README_FILE_NAME for directory in reversed(directories))

--- a/src/voidcode/runtime/context_transforms.py
+++ b/src/voidcode/runtime/context_transforms.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol, cast
 
+from ..context import directory_readme_contexts
 from ..tools.contracts import ToolResult
 from .context_rules import runtime_file_rule_contexts
 
@@ -149,6 +150,45 @@ class RuntimeFileRulesTransformProvider:
         )
 
 
+class DirectoryReadmeContextTransformProvider:
+    provider_id = "directory_readme_context"
+    priority = 250
+
+    def build_result(
+        self,
+        request: RuntimeContextTransformRequest,
+    ) -> RuntimeContextTransformResult:
+        readme_segments: list[RuntimeContextTransformInjection] = []
+        for readme_context in directory_readme_contexts(
+            workspace=request.workspace,
+            tool_results=request.tool_results,
+        ):
+            readme_segments.append(
+                RuntimeContextTransformInjection(
+                    role="system",
+                    content=(
+                        "Directory README context is active for touched workspace paths.\n"
+                        f"README file: {readme_context.path}\n"
+                        f"{readme_context.content}"
+                    ).strip(),
+                    metadata=readme_context.metadata_payload(),
+                )
+            )
+        if not readme_segments:
+            return RuntimeContextTransformResult()
+        return RuntimeContextTransformResult(
+            injections=tuple(readme_segments),
+            traces=(
+                RuntimeContextTransformTrace(
+                    provider_id=self.provider_id,
+                    priority=self.priority,
+                    injection_count=len(readme_segments),
+                    sources=(self.provider_id,),
+                ),
+            ),
+        )
+
+
 @dataclass(frozen=True, slots=True)
 class RuntimeContextTransformRegistry:
     providers: tuple[RuntimeContextTransformProvider, ...] = ()
@@ -230,6 +270,7 @@ def default_runtime_context_transform_registry() -> RuntimeContextTransformRegis
         providers=(
             HookPresetGuidanceTransformProvider(),
             RuntimeFileRulesTransformProvider(),
+            DirectoryReadmeContextTransformProvider(),
         )
     )
 

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -512,7 +512,7 @@ class RuntimeRunLoopCoordinator:
         tool: Any,
         tool_call: ToolCall,
         workspace: Any,
-        read_paths: frozenset[str],
+        read_paths: frozenset[str] = frozenset(),
         tool_timeout: int | None,
         session: SessionState,
         start_sequence: int,

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -33,6 +33,7 @@ from ..tools.contracts import (
     ToolErrorDetails,
     ToolResult,
 )
+from ..tools.guards import read_paths_for_tool_results
 from ..tools.output import (
     cap_tool_result_output,
     sanitize_tool_arguments,
@@ -511,6 +512,7 @@ class RuntimeRunLoopCoordinator:
         tool: Any,
         tool_call: ToolCall,
         workspace: Any,
+        read_paths: frozenset[str],
         tool_timeout: int | None,
         session: SessionState,
         start_sequence: int,
@@ -543,6 +545,7 @@ class RuntimeRunLoopCoordinator:
                         parent_session_id=parent_session_id,
                         delegation_depth=delegation_depth,
                         remaining_spawn_budget=remaining_spawn_budget,
+                        read_paths=read_paths,
                         abort_signal=abort_signal,
                         emit_tool_progress=emit_tool_progress,
                     )
@@ -754,6 +757,10 @@ class RuntimeRunLoopCoordinator:
                     tool=tool,
                     tool_call=tool_call,
                     workspace=runtime._workspace,
+                    read_paths=read_paths_for_tool_results(
+                        tool_results=tuple(tool_results),
+                        workspace=runtime._workspace,
+                    ),
                     tool_timeout=tool_timeout,
                     session=session,
                     start_sequence=sequence + 1,
@@ -769,6 +776,10 @@ class RuntimeRunLoopCoordinator:
                     raise tool_outcome
                 tool_result = tool_outcome
             else:
+                read_paths = read_paths_for_tool_results(
+                    tool_results=tuple(tool_results),
+                    workspace=runtime._workspace,
+                )
                 with bind_runtime_tool_context(
                     RuntimeToolInvocationContext(
                         session_id=session.session.id,
@@ -777,6 +788,7 @@ class RuntimeRunLoopCoordinator:
                         remaining_spawn_budget=runtime._remaining_spawn_budget_from_metadata(
                             session.metadata
                         ),
+                        read_paths=read_paths,
                         abort_signal=abort_signal,
                     )
                 ):
@@ -1228,6 +1240,7 @@ class RuntimeRunLoopCoordinator:
                 if segment_source in {
                     "hook_preset_guidance",
                     "runtime_file_rules",
+                    "directory_readme_context",
                 }:
                     continue
                 if segment.content.startswith("Runtime-managed todo state is active"):
@@ -2142,6 +2155,10 @@ class RuntimeRunLoopCoordinator:
                         tool=tool,
                         tool_call=plan_tool_call,
                         workspace=runtime._workspace,
+                        read_paths=read_paths_for_tool_results(
+                            tool_results=tuple(tool_results),
+                            workspace=runtime._workspace,
+                        ),
                         tool_timeout=tool_timeout,
                         session=session,
                         start_sequence=sequence + 1,
@@ -2157,6 +2174,10 @@ class RuntimeRunLoopCoordinator:
                         raise tool_outcome
                     tool_result = tool_outcome
                 else:
+                    read_paths = read_paths_for_tool_results(
+                        tool_results=tuple(tool_results),
+                        workspace=runtime._workspace,
+                    )
                     with bind_runtime_tool_context(
                         RuntimeToolInvocationContext(
                             session_id=session.session.id,
@@ -2167,6 +2188,7 @@ class RuntimeRunLoopCoordinator:
                             remaining_spawn_budget=runtime._remaining_spawn_budget_from_metadata(
                                 session.metadata
                             ),
+                            read_paths=read_paths,
                             abort_signal=active_graph_request.abort_signal,
                         )
                     ):

--- a/src/voidcode/tools/apply_patch.py
+++ b/src/voidcode/tools/apply_patch.py
@@ -643,6 +643,30 @@ def _with_formatter_feedback(
     )
 
 
+def _guard_changes_before_write(
+    changes: list[dict[str, object]],
+    *,
+    workspace: Path,
+    tool_name: str,
+) -> None:
+    for change in changes:
+        status = change.get("status")
+        if status == "A":
+            continue
+        guard_path = change.get("old_path") if status == "R" else change.get("path")
+        if not isinstance(guard_path, str):
+            continue
+        _assert_within_workspace(workspace, Path(guard_path))
+        enforce_read_before_write(
+            tool_name=tool_name,
+            workspace=workspace.resolve(),
+            raw_path=guard_path,
+            candidate=(workspace / guard_path).resolve(),
+            display_path=guard_path,
+            is_external=False,
+        )
+
+
 def _looks_like_mode_only_patch(patch_text: str) -> bool:
     inside_diff = False
     current_block_is_mode_only = False
@@ -818,6 +842,12 @@ class ApplyPatchTool:
             )
 
         normalized_patch = _normalize_patch_text(patch_text)
+        changes = _changes_from_patch(patch_text)
+        _guard_changes_before_write(
+            changes,
+            workspace=workspace,
+            tool_name=self.definition.name,
+        )
         patch_path = workspace / ".voidcode_apply_patch.patch"
         patch_path.write_text(normalized_patch, encoding="utf-8", newline="\n")
         try:
@@ -825,7 +855,6 @@ class ApplyPatchTool:
             if check.returncode != 0:
                 error = check.stdout or "Patch check failed"
                 if _looks_like_mode_only_patch(patch_text):
-                    changes = _changes_from_patch(patch_text)
                     content = "\n".join(
                         f"M {c['path']}"
                         if c.get("status") != "R"
@@ -845,7 +874,6 @@ class ApplyPatchTool:
             if apply.returncode != 0:
                 error = apply.stdout or "Patch apply failed"
                 if _looks_like_mode_only_patch(patch_text):
-                    changes = _changes_from_patch(patch_text)
                     content = "\n".join(
                         f"M {c['path']}"
                         if c.get("status") != "R"
@@ -859,25 +887,6 @@ class ApplyPatchTool:
                         data={"changes": changes, "count": len(changes)},
                     )
                 raise ValueError(_format_patch_error(error, normalized_patch))
-
-            changes = _changes_from_patch(patch_text)
-
-            for c in changes:
-                status = c.get("status")
-                if status == "A":
-                    continue
-                guard_path = c.get("old_path") if status == "R" else c.get("path")
-                if not isinstance(guard_path, str):
-                    continue
-                _assert_within_workspace(workspace, Path(guard_path))
-                enforce_read_before_write(
-                    tool_name=self.definition.name,
-                    workspace=workspace.resolve(),
-                    raw_path=guard_path,
-                    candidate=(workspace / guard_path).resolve(),
-                    display_path=guard_path,
-                    is_external=False,
-                )
 
             summary_lines: list[str] = []
             for c in changes:

--- a/src/voidcode/tools/apply_patch.py
+++ b/src/voidcode/tools/apply_patch.py
@@ -16,6 +16,7 @@ from ..hook.config import RuntimeHooksConfig
 from ..security.path_policy import resolve_workspace_path
 from ._repair import format_text_repair_hints, raise_tool_diagnostic
 from .contracts import ToolCall, ToolDefinition, ToolResult
+from .guards import enforce_read_before_write
 
 
 @dataclass(frozen=True)
@@ -379,6 +380,20 @@ def _apply_marker_patch(patch_text: str, *, workspace: Path) -> ToolResult:
                         old_path=hunk.path,
                     )
                 )
+
+    for change in prepared:
+        if change.status == "A":
+            continue
+        guard_path = change.old_path or change.path
+        target = workspace / guard_path
+        enforce_read_before_write(
+            tool_name="apply_patch",
+            workspace=workspace,
+            raw_path=guard_path,
+            candidate=target,
+            display_path=guard_path,
+            is_external=False,
+        )
 
     for change in prepared:
         target = workspace / change.path
@@ -846,6 +861,23 @@ class ApplyPatchTool:
                 raise ValueError(_format_patch_error(error, normalized_patch))
 
             changes = _changes_from_patch(patch_text)
+
+            for c in changes:
+                status = c.get("status")
+                if status == "A":
+                    continue
+                guard_path = c.get("old_path") if status == "R" else c.get("path")
+                if not isinstance(guard_path, str):
+                    continue
+                _assert_within_workspace(workspace, Path(guard_path))
+                enforce_read_before_write(
+                    tool_name=self.definition.name,
+                    workspace=workspace.resolve(),
+                    raw_path=guard_path,
+                    candidate=(workspace / guard_path).resolve(),
+                    display_path=guard_path,
+                    is_external=False,
+                )
 
             summary_lines: list[str] = []
             for c in changes:

--- a/src/voidcode/tools/edit.py
+++ b/src/voidcode/tools/edit.py
@@ -23,6 +23,7 @@ from ._repair import (
     raise_tool_diagnostic,
 )
 from .contracts import ToolCall, ToolDefinition, ToolResult
+from .guards import enforce_read_before_write
 
 
 def _normalize_line_endings(text: str) -> str:
@@ -594,6 +595,20 @@ class EditTool:
         if not candidate.is_file():
             raise ValueError(f"edit target is not a file: {path_value}")
 
+        display_path = (
+            str(candidate.resolve())
+            if resolution.is_external
+            else candidate.relative_to(workspace_root).as_posix()
+        )
+        enforce_read_before_write(
+            tool_name=self.definition.name,
+            workspace=workspace_root,
+            raw_path=path_value,
+            candidate=candidate,
+            display_path=display_path,
+            is_external=resolution.is_external,
+        )
+
         content_old = read_utf8_text(candidate)
 
         ending = _detect_line_ending(content_old)
@@ -630,12 +645,6 @@ class EditTool:
             output += f" ({match_count} occurrences replaced)"
         if diagnostics:
             output += f" Formatter warning: {diagnostics[0]['message']}"
-
-        display_path = (
-            str(candidate.resolve())
-            if resolution.is_external
-            else candidate.relative_to(workspace_root).as_posix()
-        )
 
         data: dict[str, object] = {
             "path": display_path,

--- a/src/voidcode/tools/guards.py
+++ b/src/voidcode/tools/guards.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from ..security.path_policy import resolve_workspace_path
+from ._repair import raise_tool_diagnostic
+from .contracts import ToolResult
+from .runtime_context import current_runtime_tool_context
+
+
+def read_paths_for_tool_results(
+    *,
+    tool_results: tuple[ToolResult, ...],
+    workspace: Path,
+) -> frozenset[str]:
+    resolved_paths: set[str] = set()
+    for result in tool_results:
+        if result.tool_name != "read_file" or result.status != "ok":
+            continue
+        candidate = _resolve_internal_workspace_path(
+            workspace=workspace,
+            raw_path=_read_result_path(result),
+        )
+        if candidate is not None:
+            resolved_paths.add(candidate.as_posix())
+    return frozenset(resolved_paths)
+
+
+def enforce_read_before_write(
+    *,
+    tool_name: str,
+    workspace: Path,
+    raw_path: str,
+    candidate: Path,
+    display_path: str,
+    is_external: bool,
+) -> None:
+    if is_external or not candidate.exists() or not candidate.is_file():
+        return
+    context = current_runtime_tool_context()
+    if context is None:
+        return
+    if candidate.resolve().as_posix() in context.read_paths:
+        return
+    raise_tool_diagnostic(
+        message=(
+            f"{tool_name} requires reading the current file before modifying it: {display_path}"
+        ),
+        error_kind="tool_input_mismatch",
+        reason="write_without_read",
+        retry_guidance=(
+            "Use read_file on the target path first, review the current content, "
+            "then retry the change."
+        ),
+        details={"path": display_path, "raw_path": raw_path},
+    )
+
+
+def _read_result_path(result: ToolResult) -> str | None:
+    raw_arguments = result.data.get("arguments")
+    if isinstance(raw_arguments, dict):
+        arguments = cast(dict[str, object], raw_arguments)
+        raw_file_path = arguments.get("filePath")
+        if isinstance(raw_file_path, str) and raw_file_path.strip():
+            return raw_file_path
+        raw_path = arguments.get("path")
+        if isinstance(raw_path, str) and raw_path.strip():
+            return raw_path
+    raw_path = result.data.get("path")
+    if isinstance(raw_path, str) and raw_path.strip():
+        return raw_path
+    return None
+
+
+def _resolve_internal_workspace_path(*, workspace: Path, raw_path: str | None) -> Path | None:
+    if raw_path is None or not raw_path.strip():
+        return None
+    resolution = resolve_workspace_path(
+        workspace=workspace,
+        raw_path=raw_path,
+        allow_outside_workspace=True,
+    )
+    if resolution.is_external:
+        return None
+    return resolution.candidate.resolve()
+
+
+__all__ = ["enforce_read_before_write", "read_paths_for_tool_results"]

--- a/src/voidcode/tools/runtime_context.py
+++ b/src/voidcode/tools/runtime_context.py
@@ -4,8 +4,12 @@ from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-from ..provider.protocol import ProviderAbortSignal
+if TYPE_CHECKING:
+    from ..provider.protocol import ProviderAbortSignal
+else:
+    ProviderAbortSignal = object
 
 
 @dataclass(frozen=True, slots=True)
@@ -14,6 +18,7 @@ class RuntimeToolInvocationContext:
     parent_session_id: str | None = None
     delegation_depth: int = 0
     remaining_spawn_budget: int | None = None
+    read_paths: frozenset[str] = frozenset()
     abort_signal: ProviderAbortSignal | None = None
     emit_tool_progress: Callable[[Mapping[str, object]], None] | None = None
 

--- a/src/voidcode/tools/write_file.py
+++ b/src/voidcode/tools/write_file.py
@@ -11,6 +11,7 @@ from ..hook.config import RuntimeHooksConfig
 from ..security.path_policy import resolve_workspace_path
 from ._pydantic_args import WriteFileArgs, format_validation_error
 from .contracts import ToolCall, ToolDefinition, ToolResult
+from .guards import enforce_read_before_write
 
 
 @final
@@ -44,6 +45,18 @@ class WriteFileTool:
         )
         workspace_root = resolution.workspace_root
         candidate = resolution.candidate
+        display_path = (
+            str(candidate.resolve()) if resolution.is_external else resolution.relative_path
+        )
+
+        enforce_read_before_write(
+            tool_name=self.definition.name,
+            workspace=workspace_root,
+            raw_path=args.path,
+            candidate=candidate,
+            display_path=display_path,
+            is_external=resolution.is_external,
+        )
 
         candidate.parent.mkdir(parents=True, exist_ok=True)
         old_content = candidate.read_text(encoding="utf-8") if candidate.exists() else ""
@@ -54,9 +67,6 @@ class WriteFileTool:
             formatter_result = FormatterExecutor(self._hooks_config, workspace_root).run(candidate)
 
         diagnostics = formatter_diagnostics(formatter_result)
-        display_path = (
-            str(candidate.resolve()) if resolution.is_external else resolution.relative_path
-        )
         content = f"Wrote file successfully: {display_path}"
         if diagnostics:
             content += f" Formatter warning: {diagnostics[0]['message']}"

--- a/tests/unit/context/test_readme.py
+++ b/tests/unit/context/test_readme.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from voidcode.context import directory_readme_contexts
+from voidcode.tools.contracts import ToolResult
+
+
+def test_directory_readme_contexts_load_root_and_nearest_readmes(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text("Project readme", encoding="utf-8")
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "README.md").write_text("Src readme", encoding="utf-8")
+
+    contexts = directory_readme_contexts(
+        workspace=tmp_path,
+        tool_results=(
+            ToolResult(
+                tool_name="read_file",
+                status="ok",
+                content="content",
+                data={"path": "src/app.py", "arguments": {"filePath": "src/app.py"}},
+            ),
+        ),
+    )
+
+    assert [context.path for context in contexts] == ["README.md", "src/README.md"]
+    assert contexts[0].content == "Project readme"
+    assert contexts[1].content == "Src readme"
+
+
+def test_directory_readme_contexts_ignore_external_paths(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text("Project readme", encoding="utf-8")
+
+    contexts = directory_readme_contexts(
+        workspace=tmp_path,
+        tool_results=(
+            ToolResult(
+                tool_name="read_file",
+                status="ok",
+                content="content",
+                data={
+                    "path": str((tmp_path.parent / "outside" / "secret.txt").resolve()),
+                    "arguments": {
+                        "filePath": str((tmp_path.parent / "outside" / "secret.txt").resolve())
+                    },
+                },
+            ),
+        ),
+    )
+
+    assert [context.path for context in contexts] == ["README.md"]

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -282,7 +282,11 @@ def test_assemble_provider_context_injects_file_rules_from_tool_paths(tmp_path: 
                 "priority": 200,
                 "execution_index": 2,
                 "injection_count": 2,
-                "provider_order": ["hook_preset_guidance", "runtime_file_rules"],
+                "provider_order": [
+                    "hook_preset_guidance",
+                    "runtime_file_rules",
+                    "directory_readme_context",
+                ],
                 "sources": ["runtime_file_rules"],
             }
         ],
@@ -315,7 +319,11 @@ def test_assemble_provider_context_tracks_hook_preset_guidance_transform() -> No
                 "priority": 100,
                 "execution_index": 1,
                 "injection_count": 1,
-                "provider_order": ["hook_preset_guidance", "runtime_file_rules"],
+                "provider_order": [
+                    "hook_preset_guidance",
+                    "runtime_file_rules",
+                    "directory_readme_context",
+                ],
                 "sources": ["hook_preset_guidance"],
             }
         ],

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -1502,6 +1502,23 @@ def test_runtime_agent_payload_parses_context_transform_references() -> None:
     )
 
 
+def test_runtime_agent_payload_parses_directory_readme_context_reference() -> None:
+    agent = parse_runtime_agent_payload(
+        {
+            "preset": "leader",
+            "context_transform_refs": ["directory_readme_context"],
+        },
+        source="test payload",
+    )
+
+    assert agent == RuntimeAgentConfig(
+        preset="leader",
+        prompt_profile="leader",
+        context_transform_refs=("directory_readme_context",),
+        execution_engine="provider",
+    )
+
+
 def test_runtime_agent_payload_applies_explicit_prompt_override() -> None:
     agent = parse_runtime_agent_payload(
         {

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1218,6 +1218,59 @@ class _DeniedWriteThenReadModelProvider:
         return provider
 
 
+class _UnreadWriteThenReadTurnProvider:
+    def __init__(self, *, name: str) -> None:
+        self.name = name
+        self.requests: list[ProviderTurnRequest] = []
+
+    def propose_turn(self, request: object) -> ProviderTurnResult:
+        turn_request = cast(ProviderTurnRequest, request)
+        self.requests.append(turn_request)
+        if not turn_request.tool_results:
+            return ProviderTurnResult(
+                tool_call=ToolCall(
+                    tool_name="write_file",
+                    arguments={"path": "safe.txt", "content": "updated"},
+                )
+            )
+        last_result = turn_request.tool_results[-1]
+        error_details = last_result.error_details or {}
+        if error_details.get("reason") == "write_without_read":
+            return ProviderTurnResult(
+                tool_call=ToolCall(tool_name="read_file", arguments={"filePath": "safe.txt"})
+            )
+        if last_result.tool_name == "read_file" and last_result.status == "ok":
+            return ProviderTurnResult(
+                tool_call=ToolCall(
+                    tool_name="write_file",
+                    arguments={"path": "safe.txt", "content": "updated"},
+                )
+            )
+        return ProviderTurnResult(output="recovered from unread write")
+
+    def stream_turn(self, request: object):
+        result = self.propose_turn(request)
+        if result.output is not None:
+            return iter(
+                (
+                    ProviderStreamEvent(kind="delta", channel="text", text=result.output),
+                    ProviderStreamEvent(kind="done", done_reason="completed"),
+                )
+            )
+        return iter((ProviderStreamEvent(kind="done", done_reason="completed"),))
+
+
+@dataclass(frozen=True, slots=True)
+class _UnreadWriteThenReadModelProvider:
+    name: str
+    created_providers: list[_UnreadWriteThenReadTurnProvider]
+
+    def turn_provider(self) -> _UnreadWriteThenReadTurnProvider:
+        provider = _UnreadWriteThenReadTurnProvider(name=self.name)
+        self.created_providers.append(provider)
+        return provider
+
+
 class _AlwaysFailingModelProvider:
     _error_kind: ProviderErrorKind
 
@@ -3003,7 +3056,11 @@ def test_runtime_materializes_leader_hook_preset_guidance_into_provider_context(
                 "priority": 100,
                 "execution_index": 1,
                 "injection_count": 1,
-                "provider_order": ["hook_preset_guidance", "runtime_file_rules"],
+                "provider_order": [
+                    "hook_preset_guidance",
+                    "runtime_file_rules",
+                    "directory_readme_context",
+                ],
                 "sources": ["hook_preset_guidance"],
             },
         ],
@@ -3092,6 +3149,53 @@ def test_runtime_agent_context_transform_refs_filter_provider_registry(
         ],
     }
     assert runtime_agent["context_transform_refs"] == ["runtime_file_rules"]
+
+
+def test_runtime_agent_context_transform_refs_filter_directory_readme_provider(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "README.md").write_text("Workspace readme", encoding="utf-8")
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_SkillCapturingStubGraph(),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            agent=RuntimeAgentConfig(
+                preset="leader",
+                context_transform_refs=("directory_readme_context",),
+            ),
+        ),
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="hello", session_id="readme-transform-filter"))
+    request = _SkillCapturingStubGraph.last_request
+
+    assert request is not None
+    system_sources = [
+        segment.metadata.get("source")
+        for segment in request.assembled_context.segments
+        if segment.role == "system" and segment.metadata is not None
+    ]
+    runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
+    runtime_agent = cast(dict[str, object], runtime_config["agent"])
+    assert "directory_readme_context" in system_sources
+    assert request.assembled_context.metadata["context_transforms"] == {
+        "version": 1,
+        "failure_policy": "warn",
+        "applied": [
+            {
+                "provider_id": "directory_readme_context",
+                "status": "ok",
+                "priority": 250,
+                "execution_index": 1,
+                "injection_count": 1,
+                "provider_order": ["directory_readme_context"],
+                "sources": ["directory_readme_context"],
+            }
+        ],
+    }
+    assert runtime_agent["context_transform_refs"] == ["directory_readme_context"]
 
 
 def test_runtime_resume_uses_persisted_hook_preset_snapshot(
@@ -3504,6 +3608,56 @@ def test_runtime_provider_recovers_after_permission_denial_feedback(tmp_path: Pa
     denied_tool_result = created_providers[-1].requests[1].tool_results[-1]
     assert denied_tool_result.status == "error"
     assert denied_tool_result.data["permission_denied"] is True
+
+
+def test_runtime_provider_recovers_after_read_before_write_feedback(tmp_path: Path) -> None:
+    (tmp_path / "safe.txt").write_text("safe context\n", encoding="utf-8")
+    created_providers: list[_UnreadWriteThenReadTurnProvider] = []
+    registry = ModelProviderRegistry(
+        providers={
+            "opencode": _UnreadWriteThenReadModelProvider(
+                name="opencode",
+                created_providers=created_providers,
+            )
+        }
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            approval_mode="allow",
+        ),
+        permission_policy=PermissionPolicy(mode="allow"),
+        model_provider_registry=registry,
+    )
+
+    response = runtime.run(
+        RuntimeRequest(
+            prompt="write then recover",
+            session_id="read-before-write-recover",
+        )
+    )
+
+    assert response.session.status == "completed"
+    assert response.output == "recovered from unread write"
+    assert (tmp_path / "safe.txt").read_text(encoding="utf-8") == "updated"
+    feedback = next(
+        event
+        for event in response.events
+        if event.event_type == "runtime.tool_completed"
+        and event.payload.get("tool") == "write_file"
+        and event.payload.get("status") == "error"
+    )
+    assert feedback.payload["error_kind"] == "tool_input_mismatch"
+    error_details = cast(dict[str, object], feedback.payload["error_details"])
+    assert error_details["reason"] == "write_without_read"
+    read_feedback = next(
+        event
+        for event in response.events
+        if event.event_type == "runtime.tool_completed" and event.payload.get("tool") == "read_file"
+    )
+    assert read_feedback.payload["status"] == "ok"
 
 
 def test_runtime_provider_executes_batched_tool_calls_before_next_model_turn(
@@ -12545,7 +12699,11 @@ def test_runtime_provider_compaction_emits_continuity_state_and_persists_metadat
                     "priority": 100,
                     "execution_index": 1,
                     "injection_count": 1,
-                    "provider_order": ["hook_preset_guidance", "runtime_file_rules"],
+                    "provider_order": [
+                        "hook_preset_guidance",
+                        "runtime_file_rules",
+                        "directory_readme_context",
+                    ],
                     "sources": ["hook_preset_guidance"],
                 }
             ],
@@ -13043,7 +13201,11 @@ def test_runtime_emits_context_transform_applied_event_for_runtime_file_rules(
         "priority": 200,
         "execution_index": 2,
         "injection_count": 1,
-        "provider_order": ["hook_preset_guidance", "runtime_file_rules"],
+        "provider_order": [
+            "hook_preset_guidance",
+            "runtime_file_rules",
+            "directory_readme_context",
+        ],
         "sources": ["runtime_file_rules"],
     }
     assert "Project rules" not in repr(transform_events[0].payload)

--- a/tests/unit/tools/test_apply_patch_tool.py
+++ b/tests/unit/tools/test_apply_patch_tool.py
@@ -10,6 +10,7 @@ import pytest
 from voidcode.formatter import RuntimeFormatterPresetConfig
 from voidcode.hook.config import RuntimeHooksConfig
 from voidcode.tools import ApplyPatchTool, ToolCall
+from voidcode.tools.runtime_context import RuntimeToolInvocationContext, bind_runtime_tool_context
 
 
 def _init_git_repo(path: Path) -> None:
@@ -56,6 +57,93 @@ def test_apply_patch_updates_file_with_valid_patch(tmp_path: Path) -> None:
     assert result.data["count"] == 1
     assert result.data["changes"] == [{"path": "sample.txt", "status": "M"}]
     assert result.content == "M sample.txt"
+
+
+def test_apply_patch_rejects_unified_diff_update_without_prior_read_side_effects(
+    tmp_path: Path,
+) -> None:
+    _init_git_repo(tmp_path)
+    target = tmp_path / "sample.txt"
+    target.write_text("line-1\nline-2\n", encoding="utf-8")
+    _commit_all(tmp_path, "baseline")
+    old = target.read_text(encoding="utf-8").splitlines(keepends=True)
+    new = ["patched-1\n", "line-2\n"]
+    patch_text = "".join(
+        difflib.unified_diff(old, new, fromfile="a/sample.txt", tofile="b/sample.txt")
+    )
+
+    with bind_runtime_tool_context(RuntimeToolInvocationContext(session_id="test")):
+        with pytest.raises(
+            ValueError, match="requires reading the current file before modifying it"
+        ):
+            ApplyPatchTool().invoke(
+                ToolCall(tool_name="apply_patch", arguments={"patch": patch_text}),
+                workspace=tmp_path,
+            )
+
+    assert target.read_text(encoding="utf-8") == "line-1\nline-2\n"
+
+
+def test_apply_patch_rejects_unified_diff_delete_without_prior_read_side_effects(
+    tmp_path: Path,
+) -> None:
+    _init_git_repo(tmp_path)
+    target = tmp_path / "sample.txt"
+    target.write_text("line-1\n", encoding="utf-8")
+    _commit_all(tmp_path, "baseline")
+    patch_text = "\n".join(
+        [
+            "diff --git a/sample.txt b/sample.txt",
+            "deleted file mode 100644",
+            "--- a/sample.txt",
+            "+++ /dev/null",
+            "@@ -1 +0,0 @@",
+            "-line-1",
+            "",
+        ]
+    )
+
+    with bind_runtime_tool_context(RuntimeToolInvocationContext(session_id="test")):
+        with pytest.raises(
+            ValueError, match="requires reading the current file before modifying it"
+        ):
+            ApplyPatchTool().invoke(
+                ToolCall(tool_name="apply_patch", arguments={"patch": patch_text}),
+                workspace=tmp_path,
+            )
+
+    assert target.exists()
+    assert target.read_text(encoding="utf-8") == "line-1\n"
+
+
+def test_apply_patch_rejects_unified_diff_rename_without_prior_read_side_effects(
+    tmp_path: Path,
+) -> None:
+    _init_git_repo(tmp_path)
+    source = tmp_path / "old.txt"
+    source.write_text("line-1\n", encoding="utf-8")
+    _commit_all(tmp_path, "baseline")
+    patch_text = "\n".join(
+        [
+            "diff --git a/old.txt b/new.txt",
+            "similarity index 100%",
+            "rename from old.txt",
+            "rename to new.txt",
+            "",
+        ]
+    )
+
+    with bind_runtime_tool_context(RuntimeToolInvocationContext(session_id="test")):
+        with pytest.raises(
+            ValueError, match="requires reading the current file before modifying it"
+        ):
+            ApplyPatchTool().invoke(
+                ToolCall(tool_name="apply_patch", arguments={"patch": patch_text}),
+                workspace=tmp_path,
+            )
+
+    assert source.exists()
+    assert not (tmp_path / "new.txt").exists()
 
 
 def test_apply_patch_allows_external_target_file(tmp_path: Path) -> None:

--- a/tests/unit/tools/test_write_before_read_guard.py
+++ b/tests/unit/tools/test_write_before_read_guard.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from voidcode.tools import ApplyPatchTool, EditTool, MultiEditTool, ToolCall, WriteFileTool
+from voidcode.tools.contracts import ToolResult
+from voidcode.tools.guards import read_paths_for_tool_results
+from voidcode.tools.runtime_context import RuntimeToolInvocationContext, bind_runtime_tool_context
+
+
+def test_read_paths_for_tool_results_collects_successful_workspace_reads(tmp_path: Path) -> None:
+    target = tmp_path / "sample.txt"
+    target.write_text("sample", encoding="utf-8")
+
+    paths = read_paths_for_tool_results(
+        tool_results=(
+            ToolResult(
+                tool_name="read_file",
+                status="ok",
+                content="sample",
+                data={"path": "sample.txt", "arguments": {"filePath": "sample.txt"}},
+            ),
+        ),
+        workspace=tmp_path,
+    )
+
+    assert paths == frozenset({target.resolve().as_posix()})
+
+
+def test_write_file_tool_rejects_overwrite_without_prior_read(tmp_path: Path) -> None:
+    target = tmp_path / "sample.txt"
+    target.write_text("old", encoding="utf-8")
+    tool = WriteFileTool()
+
+    with bind_runtime_tool_context(RuntimeToolInvocationContext(session_id="test")):
+        with pytest.raises(
+            ValueError, match="requires reading the current file before modifying it"
+        ):
+            tool.invoke(
+                ToolCall(
+                    tool_name="write_file", arguments={"path": "sample.txt", "content": "new"}
+                ),
+                workspace=tmp_path,
+            )
+
+
+def test_write_file_tool_allows_overwrite_after_prior_read(tmp_path: Path) -> None:
+    target = tmp_path / "sample.txt"
+    target.write_text("old", encoding="utf-8")
+    tool = WriteFileTool()
+    read_paths = frozenset({target.resolve().as_posix()})
+
+    with bind_runtime_tool_context(
+        RuntimeToolInvocationContext(session_id="test", read_paths=read_paths)
+    ):
+        result = tool.invoke(
+            ToolCall(tool_name="write_file", arguments={"path": "sample.txt", "content": "new"}),
+            workspace=tmp_path,
+        )
+
+    assert result.status == "ok"
+    assert target.read_text(encoding="utf-8") == "new"
+
+
+def test_edit_tool_rejects_modify_without_prior_read(tmp_path: Path) -> None:
+    target = tmp_path / "sample.txt"
+    target.write_text("old", encoding="utf-8")
+    tool = EditTool()
+
+    with bind_runtime_tool_context(RuntimeToolInvocationContext(session_id="test")):
+        with pytest.raises(
+            ValueError, match="requires reading the current file before modifying it"
+        ):
+            tool.invoke(
+                ToolCall(
+                    tool_name="edit",
+                    arguments={"path": "sample.txt", "oldString": "old", "newString": "new"},
+                ),
+                workspace=tmp_path,
+            )
+
+
+def test_multi_edit_rejects_modify_without_prior_read(tmp_path: Path) -> None:
+    target = tmp_path / "sample.txt"
+    target.write_text("old", encoding="utf-8")
+    tool = MultiEditTool()
+
+    with bind_runtime_tool_context(RuntimeToolInvocationContext(session_id="test")):
+        with pytest.raises(
+            ValueError, match="requires reading the current file before modifying it"
+        ):
+            tool.invoke(
+                ToolCall(
+                    tool_name="multi_edit",
+                    arguments={
+                        "path": "sample.txt",
+                        "edits": [{"oldString": "old", "newString": "new"}],
+                    },
+                ),
+                workspace=tmp_path,
+            )
+
+
+def test_apply_patch_rejects_modify_without_prior_read(tmp_path: Path) -> None:
+    target = tmp_path / "sample.txt"
+    target.write_text("old\n", encoding="utf-8")
+    tool = ApplyPatchTool()
+    patch = "\n".join(
+        [
+            "*** Begin Patch",
+            "*** Update File: sample.txt",
+            "@@",
+            "-old",
+            "+new",
+            "*** End Patch",
+        ]
+    )
+
+    with bind_runtime_tool_context(RuntimeToolInvocationContext(session_id="test")):
+        with pytest.raises(
+            ValueError, match="requires reading the current file before modifying it"
+        ):
+            tool.invoke(
+                ToolCall(tool_name="apply_patch", arguments={"patch": patch}), workspace=tmp_path
+            )


### PR DESCRIPTION
## Summary
- add a non-runtime `directory_readme_context` transform capability under `src/voidcode/context/` and wire it into the existing context transform registry
- add tool-layer read-before-write guards for existing files across `write_file`, `edit`, `multi_edit`, and `apply_patch`, using runtime-supplied read history
- add runtime/provider and unit coverage for README transform selection and write-after-read recovery

## Verification
- `uv run pytest tests/unit/context/test_readme.py tests/unit/tools/test_write_before_read_guard.py tests/unit/runtime/test_context_window.py tests/unit/runtime/test_runtime_config.py tests/unit/runtime/test_runtime_service_extensions.py -k "readme or write_before_read or context_transform_refs or transform_filter or recovers_after_read_before_write_feedback or context_transform_applied" -v`
- `uv run pytest tests/unit/tools/test_write_file_tool.py tests/unit/tools/test_edit_tool.py tests/unit/tools/test_apply_patch_tool.py -k "writes_utf8 or returns_diff or updates_file_with_valid_patch or accepts_structured_add_file_patch" -v`
- manual QA: README transform produced `readme_sources= ['runtime_instruction_precedence', 'agent_prompt', 'directory_readme_context']`
- manual QA: write-before-read recovery produced `guard_status= completed`, `guard_output= recovered`, `safe_txt= updated`