### PR TITLE
feat(tools): add tool governance workflow guards

### DIFF
--- a/src/voidcode/security/shell_policy.py
+++ b/src/voidcode/security/shell_policy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shlex
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -12,11 +13,15 @@ class ShellExecutionPolicy:
     workspace_root: Path
     timeout_seconds: int
     runtime_timeout_selected: bool
+    non_interactive_blocked: bool = False
+    non_interactive_reason: str | None = None
+    retry_guidance: str | None = None
 
 
 def resolve_shell_execution_policy(
     *,
     workspace: Path,
+    command_text: str,
     timeout_argument: object,
     runtime_timeout_seconds: int | None,
 ) -> ShellExecutionPolicy:
@@ -35,16 +40,53 @@ def resolve_shell_execution_policy(
         timeout_seconds = runtime_timeout_seconds
         runtime_timeout_selected = True
 
+    blocked, reason, retry_guidance = classify_non_interactive_command(command_text)
     return ShellExecutionPolicy(
         workspace_root=workspace_root,
         timeout_seconds=timeout_seconds,
         runtime_timeout_selected=runtime_timeout_selected,
+        non_interactive_blocked=blocked,
+        non_interactive_reason=reason,
+        retry_guidance=retry_guidance,
     )
+
+
+def classify_non_interactive_command(command_text: str) -> tuple[bool, str | None, str | None]:
+    try:
+        tokens = shlex.split(command_text, posix=True)
+    except ValueError:
+        tokens = command_text.split()
+    if not tokens:
+        return False, None, None
+    executable = tokens[0]
+    if executable in {"vim", "vi", "nano", "less", "more", "man", "top", "htop", "watch"}:
+        return (
+            True,
+            "interactive_command",
+            "Use a non-interactive command or a file-oriented tool instead of "
+            "launching an interactive TUI.",
+        )
+    if executable in {"python", "python3"} and "-i" in tokens[1:]:
+        return (
+            True,
+            "interactive_command",
+            "Avoid interactive Python shells; run a non-interactive script or use a "
+            "file-oriented tool.",
+        )
+    if executable in {"bash", "sh", "zsh"} and all(token != "-c" for token in tokens[1:]):
+        return (
+            True,
+            "interactive_command",
+            "Provide a non-interactive shell command with -c, or use shell_exec for a "
+            "bounded one-shot command.",
+        )
+    return False, None, None
 
 
 __all__ = [
     "DEFAULT_TIMEOUT_SECONDS",
     "MAX_TIMEOUT_SECONDS",
     "ShellExecutionPolicy",
+    "classify_non_interactive_command",
     "resolve_shell_execution_policy",
 ]

--- a/src/voidcode/security/shell_policy.py
+++ b/src/voidcode/security/shell_policy.py
@@ -73,12 +73,22 @@ def classify_non_interactive_command(command_text: str) -> tuple[bool, str | Non
             "Avoid interactive Python shells; run a non-interactive script or use a "
             "file-oriented tool.",
         )
-    if executable in {"bash", "sh", "zsh"} and all(token != "-c" for token in tokens[1:]):
+    if executable in {"bash", "sh", "zsh"}:
+        shell_args = tokens[1:]
+        if not shell_args:
+            return (
+                True,
+                "interactive_command",
+                "Provide a shell command string with -c/-lc or invoke a script file explicitly.",
+            )
+        if any(token in {"-c", "-lc", "--version", "-n"} for token in shell_args):
+            return False, None, None
+        if any(not token.startswith("-") for token in shell_args):
+            return False, None, None
         return (
             True,
             "interactive_command",
-            "Provide a non-interactive shell command with -c, or use shell_exec for a "
-            "bounded one-shot command.",
+            "Provide a shell command string with -c/-lc or invoke a script file explicitly.",
         )
     return False, None, None
 

--- a/src/voidcode/tools/background_output.py
+++ b/src/voidcode/tools/background_output.py
@@ -126,16 +126,13 @@ class BackgroundOutputTool:
             not args.full_session
             and result.child_session_id is not None
             and result.status == "completed"
-            and not (result.summary_output or "").strip()
         ):
             try:
                 session_result = self._runtime.session_result(session_id=result.child_session_id)
             except UnknownSessionError:
                 session_result = None
             if session_result is not None:
-                empty_child_output = (
-                    session_result.status == "completed" and session_result.output == ""
-                )
+                empty_child_output = _session_result_has_empty_output(session_result)
 
         if args.full_session and result.child_session_id is not None:
             try:
@@ -143,9 +140,7 @@ class BackgroundOutputTool:
             except UnknownSessionError:
                 session_result = None
             if session_result is not None:
-                empty_child_output = (
-                    session_result.status == "completed" and session_result.output == ""
-                )
+                empty_child_output = _session_result_has_empty_output(session_result)
                 safe_summary = _background_session_safe_summary(
                     result=result,
                     session_result=session_result,
@@ -195,6 +190,7 @@ class BackgroundOutputTool:
                     transcript_truncated=len(session_result.transcript) > len(transcript),
                     output_available=output_available,
                     full_session_reference=full_session_reference,
+                    empty_child_output=empty_child_output,
                 )
 
         guidance = _background_output_guidance(
@@ -278,7 +274,13 @@ def _background_session_digest(
     transcript_truncated: bool,
     output_available: bool,
     full_session_reference: str,
+    empty_child_output: bool = False,
 ) -> str:
+    if empty_child_output:
+        return (
+            "The delegated child completed with empty output. Treat this as an empty result, "
+            "inspect full_session=true if needed, and continue without hidden retries."
+        )
     lines = [
         "Background task result digest:",
         f"- task_id: {result.task_id}",
@@ -299,6 +301,13 @@ def _background_session_digest(
         "into active provider context."
     )
     return "\n".join(lines)
+
+
+def _session_result_has_empty_output(session_result: RuntimeSessionResult) -> bool:
+    if session_result.status != "completed":
+        return False
+    output = session_result.output
+    return output is None or output == ""
 
 
 def _background_result_safe_summary(result: BackgroundTaskResult) -> str | None:

--- a/src/voidcode/tools/background_output.py
+++ b/src/voidcode/tools/background_output.py
@@ -122,6 +122,21 @@ class BackgroundOutputTool:
         )
         empty_child_output = False
 
+        if (
+            not args.full_session
+            and result.child_session_id is not None
+            and result.status == "completed"
+            and not (result.summary_output or "").strip()
+        ):
+            try:
+                session_result = self._runtime.session_result(session_id=result.child_session_id)
+            except UnknownSessionError:
+                session_result = None
+            if session_result is not None:
+                empty_child_output = (
+                    session_result.status == "completed" and session_result.output == ""
+                )
+
         if args.full_session and result.child_session_id is not None:
             try:
                 session_result = self._runtime.session_result(session_id=result.child_session_id)
@@ -188,6 +203,7 @@ class BackgroundOutputTool:
             empty_child_output=empty_child_output,
             block_timed_out=block_timed_out,
         )
+        payload["empty_child_output"] = empty_child_output
         if guidance is not None:
             payload["guidance"] = guidance
             content = f"{content}\n\nGuidance: {guidance}"

--- a/src/voidcode/tools/background_output.py
+++ b/src/voidcode/tools/background_output.py
@@ -122,18 +122,6 @@ class BackgroundOutputTool:
         )
         empty_child_output = False
 
-        if (
-            not args.full_session
-            and result.child_session_id is not None
-            and result.status == "completed"
-        ):
-            try:
-                session_result = self._runtime.session_result(session_id=result.child_session_id)
-            except UnknownSessionError:
-                session_result = None
-            if session_result is not None:
-                empty_child_output = _session_result_has_empty_output(session_result)
-
         if args.full_session and result.child_session_id is not None:
             try:
                 session_result = self._runtime.session_result(session_id=result.child_session_id)

--- a/src/voidcode/tools/output.py
+++ b/src/voidcode/tools/output.py
@@ -179,6 +179,25 @@ def _diagnostics_with(
     return [diagnostic]
 
 
+def _normalization_payload(
+    *,
+    kind: str,
+    artifact_id: str,
+    original_byte_count: int,
+    original_line_count: int,
+    max_bytes: int,
+    max_lines: int,
+) -> dict[str, object]:
+    return {
+        "kind": kind,
+        "artifact_id": artifact_id,
+        "original_byte_count": original_byte_count,
+        "original_line_count": original_line_count,
+        "max_bytes": max_bytes,
+        "max_lines": max_lines,
+    }
+
+
 def _user_cache_root() -> Path:
     if sys.platform == "win32":
         cache_home = os.environ.get("LOCALAPPDATA") or os.environ.get("APPDATA")
@@ -489,6 +508,14 @@ def cap_tool_result_output(
             data={
                 **result.data,
                 "truncated": True,
+                "normalization": _normalization_payload(
+                    kind="tool_error_truncated",
+                    artifact_id=cast(str, artifact["artifact_id"]),
+                    original_byte_count=error_size,
+                    original_line_count=error_lines,
+                    max_bytes=max_bytes,
+                    max_lines=max_lines,
+                ),
                 "diagnostics": _diagnostics_with(
                     result.data,
                     {
@@ -554,6 +581,14 @@ def cap_tool_result_output(
         data={
             **result.data,
             "truncated": True,
+            "normalization": _normalization_payload(
+                kind="tool_output_truncated",
+                artifact_id=cast(str, artifact["artifact_id"]),
+                original_byte_count=encoded_size,
+                original_line_count=line_count,
+                max_bytes=max_bytes,
+                max_lines=max_lines,
+            ),
             "diagnostics": _diagnostics_with(
                 result.data,
                 {

--- a/src/voidcode/tools/shell_exec.py
+++ b/src/voidcode/tools/shell_exec.py
@@ -17,6 +17,7 @@ from ..security.shell_policy import (
     resolve_shell_execution_policy,
 )
 from ._pydantic_args import ShellExecArgs, format_validation_error
+from ._repair import raise_tool_diagnostic
 from .contracts import RuntimeToolTimeoutError, ToolCall, ToolDefinition, ToolResult
 from .runtime_context import current_runtime_tool_context
 
@@ -192,11 +193,24 @@ class ShellExecTool:
         timeout_value = call.arguments.get("timeout", DEFAULT_TIMEOUT_SECONDS)
         policy = resolve_shell_execution_policy(
             workspace=workspace,
+            command_text=command_text,
             timeout_argument=timeout_value,
             runtime_timeout_seconds=runtime_timeout_seconds,
         )
         timeout_seconds = policy.timeout_seconds
         runtime_timeout_selected = policy.runtime_timeout_selected
+        if policy.non_interactive_blocked:
+            raise_tool_diagnostic(
+                message=(
+                    "shell_exec rejected a command that looks interactive in a "
+                    "non-interactive runtime: "
+                    f"{command_text}"
+                ),
+                error_kind="non_interactive_shell_denied",
+                reason=policy.non_interactive_reason or "interactive_command",
+                retry_guidance=policy.retry_guidance,
+                details={"command": command_text, "non_interactive": True},
+            )
 
         try:
             command_text = command_text.encode("utf-8", errors="replace").decode("utf-8")

--- a/tests/unit/tools/test_background_task_tools.py
+++ b/tests/unit/tools/test_background_task_tools.py
@@ -305,6 +305,28 @@ class _EmptyOutputBackgroundRuntime(_StubBackgroundRuntime):
         )
 
 
+class _SummaryPresentEmptyOutputBackgroundRuntime(_EmptyOutputBackgroundRuntime):
+    def load_background_task_result(
+        self,
+        task_id: str,
+        *,
+        emit_result_read_hook: bool = True,
+    ) -> BackgroundTaskResult:
+        _ = emit_result_read_hook
+        assert task_id == "task-1"
+        return BackgroundTaskResult(
+            task_id="task-1",
+            parent_session_id="leader-session",
+            child_session_id="child-session",
+            status="completed",
+            summary_output=(
+                "Completed child session child-session; full output is preserved outside "
+                "active context."
+            ),
+            result_available=True,
+        )
+
+
 class _MissingChildSessionBackgroundRuntime(_StubBackgroundRuntime):
     def session_result(self, *, session_id: str) -> RuntimeSessionResult:
         assert session_id == "child-session"
@@ -630,7 +652,7 @@ def test_background_output_tool_guides_empty_child_output(tmp_path: Path) -> Non
 def test_background_output_default_detects_empty_child_output_without_full_session(
     tmp_path: Path,
 ) -> None:
-    tool = BackgroundOutputTool(runtime=_EmptyOutputBackgroundRuntime())
+    tool = BackgroundOutputTool(runtime=_SummaryPresentEmptyOutputBackgroundRuntime())
 
     result = tool.invoke(
         ToolCall(tool_name="background_output", arguments={"task_id": "task-1"}),

--- a/tests/unit/tools/test_background_task_tools.py
+++ b/tests/unit/tools/test_background_task_tools.py
@@ -327,6 +327,33 @@ class _SummaryPresentEmptyOutputBackgroundRuntime(_EmptyOutputBackgroundRuntime)
         )
 
 
+class _SummaryPresentEmptyOutputNoSessionReadRuntime(_StubBackgroundRuntime):
+    def load_background_task_result(
+        self,
+        task_id: str,
+        *,
+        emit_result_read_hook: bool = True,
+    ) -> BackgroundTaskResult:
+        _ = emit_result_read_hook
+        assert task_id == "task-1"
+        return BackgroundTaskResult(
+            task_id="task-1",
+            parent_session_id="leader-session",
+            child_session_id="child-session",
+            status="completed",
+            summary_output=(
+                "Completed child session child-session; full output is preserved outside "
+                "active context."
+            ),
+            result_available=True,
+        )
+
+    def session_result(self, *, session_id: str) -> RuntimeSessionResult:
+        raise AssertionError(
+            f"session_result should not be called for default background_output: {session_id}"
+        )
+
+
 class _MissingChildSessionBackgroundRuntime(_StubBackgroundRuntime):
     def session_result(self, *, session_id: str) -> RuntimeSessionResult:
         assert session_id == "child-session"
@@ -649,10 +676,10 @@ def test_background_output_tool_guides_empty_child_output(tmp_path: Path) -> Non
     assert result.data["empty_child_output"] is True
 
 
-def test_background_output_default_detects_empty_child_output_without_full_session(
+def test_background_output_default_skips_full_session_fetch_when_full_session_false(
     tmp_path: Path,
 ) -> None:
-    tool = BackgroundOutputTool(runtime=_SummaryPresentEmptyOutputBackgroundRuntime())
+    tool = BackgroundOutputTool(runtime=_SummaryPresentEmptyOutputNoSessionReadRuntime())
 
     result = tool.invoke(
         ToolCall(tool_name="background_output", arguments={"task_id": "task-1"}),
@@ -660,8 +687,8 @@ def test_background_output_default_detects_empty_child_output_without_full_sessi
     )
 
     assert result.status == "ok"
-    assert result.data["empty_child_output"] is True
-    assert "completed with empty output" in str(result.data["guidance"])
+    assert result.data["empty_child_output"] is False
+    assert "guidance" not in result.data
 
 
 def test_background_output_full_session_falls_back_when_child_session_unavailable(

--- a/tests/unit/tools/test_background_task_tools.py
+++ b/tests/unit/tools/test_background_task_tools.py
@@ -271,6 +271,23 @@ class _TerminalAfterTimeoutBackgroundRuntime(_StubBackgroundRuntime):
 
 
 class _EmptyOutputBackgroundRuntime(_StubBackgroundRuntime):
+    def load_background_task_result(
+        self,
+        task_id: str,
+        *,
+        emit_result_read_hook: bool = True,
+    ) -> BackgroundTaskResult:
+        _ = emit_result_read_hook
+        assert task_id == "task-1"
+        return BackgroundTaskResult(
+            task_id="task-1",
+            parent_session_id="leader-session",
+            child_session_id="child-session",
+            status="completed",
+            summary_output="",
+            result_available=True,
+        )
+
     def session_result(self, *, session_id: str) -> RuntimeSessionResult:
         assert session_id == "child-session"
         return RuntimeSessionResult(
@@ -606,6 +623,22 @@ def test_background_output_tool_guides_empty_child_output(tmp_path: Path) -> Non
     assert result.status == "ok"
     assert result.content is not None
     assert "completed with empty output" in result.content
+    assert "completed with empty output" in str(result.data["guidance"])
+    assert result.data["empty_child_output"] is True
+
+
+def test_background_output_default_detects_empty_child_output_without_full_session(
+    tmp_path: Path,
+) -> None:
+    tool = BackgroundOutputTool(runtime=_EmptyOutputBackgroundRuntime())
+
+    result = tool.invoke(
+        ToolCall(tool_name="background_output", arguments={"task_id": "task-1"}),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert result.data["empty_child_output"] is True
     assert "completed with empty output" in str(result.data["guidance"])
 
 

--- a/tests/unit/tools/test_shell_exec_tool.py
+++ b/tests/unit/tools/test_shell_exec_tool.py
@@ -406,6 +406,34 @@ def test_shell_exec_rejects_shell_without_dash_c(tmp_path: Path) -> None:
         )
 
 
+def test_shell_exec_allows_bash_lc_command(tmp_path: Path) -> None:
+    tool = ShellExecTool()
+
+    result = tool.invoke(
+        ToolCall(tool_name="shell_exec", arguments={"command": "bash -lc 'printf ok'"}),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert result.content is not None
+    assert result.content.strip() == "ok"
+
+
+def test_shell_exec_allows_bash_script_invocation(tmp_path: Path) -> None:
+    tool = ShellExecTool()
+    script = tmp_path / "script.sh"
+    script.write_text("printf script-ok\n", encoding="utf-8")
+
+    result = tool.invoke(
+        ToolCall(tool_name="shell_exec", arguments={"command": f"bash {script.name}"}),
+        workspace=tmp_path,
+    )
+
+    assert result.status == "ok"
+    assert result.content is not None
+    assert result.content.strip() == "script-ok"
+
+
 # ── Target contract: ShellExecArgs.description ──────────────────────────
 # These tests encode the expected behaviour BEFORE the field exists.
 # They are expected to fail (RED) until T2 adds `description` support.

--- a/tests/unit/tools/test_shell_exec_tool.py
+++ b/tests/unit/tools/test_shell_exec_tool.py
@@ -386,6 +386,26 @@ def test_shell_exec_large_output_spills_full_payload_via_central_cap(tmp_path: P
     assert not (tmp_path / ".voidcode" / "tool-output").exists()
 
 
+def test_shell_exec_rejects_interactive_python_shell(tmp_path: Path) -> None:
+    tool = ShellExecTool()
+
+    with pytest.raises(ValueError, match="looks interactive in a non-interactive runtime"):
+        tool.invoke(
+            ToolCall(tool_name="shell_exec", arguments={"command": "python -i"}),
+            workspace=tmp_path,
+        )
+
+
+def test_shell_exec_rejects_shell_without_dash_c(tmp_path: Path) -> None:
+    tool = ShellExecTool()
+
+    with pytest.raises(ValueError, match="looks interactive in a non-interactive runtime"):
+        tool.invoke(
+            ToolCall(tool_name="shell_exec", arguments={"command": "bash"}),
+            workspace=tmp_path,
+        )
+
+
 # ── Target contract: ShellExecArgs.description ──────────────────────────
 # These tests encode the expected behaviour BEFORE the field exists.
 # They are expected to fail (RED) until T2 adds `description` support.

--- a/tests/unit/tools/test_tool_output_truncation.py
+++ b/tests/unit/tools/test_tool_output_truncation.py
@@ -47,9 +47,11 @@ def test_cap_tool_result_output_caps_by_line_count_and_saves_full_output(tmp_pat
     assert artifact["status"] == "available"
     assert artifact["producer"] == "voidcode.tool_output.v1"
     assert capped.data["artifact_id"] == artifact["artifact_id"]
+    normalization = cast(dict[str, object], capped.data["normalization"])
+    assert normalization["kind"] == "tool_output_truncated"
+    assert normalization["artifact_id"] == artifact["artifact_id"]
     assert "retry_guidance" in capped.data
-    diagnostics = capped.data["diagnostics"]
-    assert isinstance(diagnostics, list)
+    diagnostics = cast(list[dict[str, object]], capped.data["diagnostics"])
     assert diagnostics[-1]["reason"] == "tool_output_truncated"
     artifact_path = Path(cast(str, artifact["path"]))
     assert artifact_path.read_text(encoding="utf-8") == content
@@ -390,11 +392,13 @@ def test_cap_tool_result_output_caps_large_errors(tmp_path: Path) -> None:
     assert "error-4" not in capped.error
     assert "Tool error truncated" in capped.error
     assert capped.truncated is True
-    diagnostics = capped.data["diagnostics"]
-    assert isinstance(diagnostics, list)
+    diagnostics = cast(list[dict[str, object]], capped.data["diagnostics"])
     assert diagnostics[-1]["reason"] == "tool_error_truncated"
-    assert "full error" in diagnostics[-1]["retry_guidance"]
+    retry_guidance = cast(str, diagnostics[-1]["retry_guidance"])
+    assert "full error" in retry_guidance
     assert isinstance(capped.reference, str)
+    normalization = cast(dict[str, object], capped.data["normalization"])
+    assert normalization["kind"] == "tool_error_truncated"
     raw_artifact = capped.data["artifact"]
     assert isinstance(raw_artifact, dict)
     artifact = cast(dict[str, object], raw_artifact)


### PR DESCRIPTION
## Summary
- add normalization metadata for truncated tool output and tool errors
- surface completed-but-empty delegated child output explicitly in background_output
- reject obvious interactive shell commands before execution with structured diagnostics

## Verification
- `uv run pytest tests/unit/tools/test_tool_output_truncation.py -k "caps_by_line_count_and_saves_full_output or caps_large_errors" -v`
- `uv run pytest tests/unit/tools/test_background_task_tools.py -k "empty_child_output" -v`
- `uv run pytest tests/unit/tools/test_shell_exec_tool.py -k "interactive" -v`
- manual QA: `shell_exec` with `python -i` returns a structured guard error
- manual QA: `background_output` reports `empty_child_output=True` with guidance
- manual QA: `cap_tool_result_output(...)` returns `normalization={...}` metadata for truncated output