### PR TITLE
fix(tools): remove shell interactivity classifier

### DIFF
--- a/src/voidcode/security/shell_policy.py
+++ b/src/voidcode/security/shell_policy.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import shlex
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -13,15 +12,11 @@ class ShellExecutionPolicy:
     workspace_root: Path
     timeout_seconds: int
     runtime_timeout_selected: bool
-    non_interactive_blocked: bool = False
-    non_interactive_reason: str | None = None
-    retry_guidance: str | None = None
 
 
 def resolve_shell_execution_policy(
     *,
     workspace: Path,
-    command_text: str,
     timeout_argument: object,
     runtime_timeout_seconds: int | None,
 ) -> ShellExecutionPolicy:
@@ -40,63 +35,16 @@ def resolve_shell_execution_policy(
         timeout_seconds = runtime_timeout_seconds
         runtime_timeout_selected = True
 
-    blocked, reason, retry_guidance = classify_non_interactive_command(command_text)
     return ShellExecutionPolicy(
         workspace_root=workspace_root,
         timeout_seconds=timeout_seconds,
         runtime_timeout_selected=runtime_timeout_selected,
-        non_interactive_blocked=blocked,
-        non_interactive_reason=reason,
-        retry_guidance=retry_guidance,
     )
-
-
-def classify_non_interactive_command(command_text: str) -> tuple[bool, str | None, str | None]:
-    try:
-        tokens = shlex.split(command_text, posix=True)
-    except ValueError:
-        tokens = command_text.split()
-    if not tokens:
-        return False, None, None
-    executable = tokens[0]
-    if executable in {"vim", "vi", "nano", "less", "more", "man", "top", "htop", "watch"}:
-        return (
-            True,
-            "interactive_command",
-            "Use a non-interactive command or a file-oriented tool instead of "
-            "launching an interactive TUI.",
-        )
-    if executable in {"python", "python3"} and "-i" in tokens[1:]:
-        return (
-            True,
-            "interactive_command",
-            "Avoid interactive Python shells; run a non-interactive script or use a "
-            "file-oriented tool.",
-        )
-    if executable in {"bash", "sh", "zsh"}:
-        shell_args = tokens[1:]
-        if not shell_args:
-            return (
-                True,
-                "interactive_command",
-                "Provide a shell command string with -c/-lc or invoke a script file explicitly.",
-            )
-        if any(token in {"-c", "-lc", "--version", "-n"} for token in shell_args):
-            return False, None, None
-        if any(not token.startswith("-") for token in shell_args):
-            return False, None, None
-        return (
-            True,
-            "interactive_command",
-            "Provide a shell command string with -c/-lc or invoke a script file explicitly.",
-        )
-    return False, None, None
 
 
 __all__ = [
     "DEFAULT_TIMEOUT_SECONDS",
     "MAX_TIMEOUT_SECONDS",
     "ShellExecutionPolicy",
-    "classify_non_interactive_command",
     "resolve_shell_execution_policy",
 ]

--- a/src/voidcode/tools/shell_exec.py
+++ b/src/voidcode/tools/shell_exec.py
@@ -17,7 +17,6 @@ from ..security.shell_policy import (
     resolve_shell_execution_policy,
 )
 from ._pydantic_args import ShellExecArgs, format_validation_error
-from ._repair import raise_tool_diagnostic
 from .contracts import RuntimeToolTimeoutError, ToolCall, ToolDefinition, ToolResult
 from .runtime_context import current_runtime_tool_context
 
@@ -193,24 +192,11 @@ class ShellExecTool:
         timeout_value = call.arguments.get("timeout", DEFAULT_TIMEOUT_SECONDS)
         policy = resolve_shell_execution_policy(
             workspace=workspace,
-            command_text=command_text,
             timeout_argument=timeout_value,
             runtime_timeout_seconds=runtime_timeout_seconds,
         )
         timeout_seconds = policy.timeout_seconds
         runtime_timeout_selected = policy.runtime_timeout_selected
-        if policy.non_interactive_blocked:
-            raise_tool_diagnostic(
-                message=(
-                    "shell_exec rejected a command that looks interactive in a "
-                    "non-interactive runtime: "
-                    f"{command_text}"
-                ),
-                error_kind="non_interactive_shell_denied",
-                reason=policy.non_interactive_reason or "interactive_command",
-                retry_guidance=policy.retry_guidance,
-                details={"command": command_text, "non_interactive": True},
-            )
 
         try:
             command_text = command_text.encode("utf-8", errors="replace").decode("utf-8")

--- a/tests/unit/tools/test_shell_exec_tool.py
+++ b/tests/unit/tools/test_shell_exec_tool.py
@@ -386,54 +386,6 @@ def test_shell_exec_large_output_spills_full_payload_via_central_cap(tmp_path: P
     assert not (tmp_path / ".voidcode" / "tool-output").exists()
 
 
-def test_shell_exec_rejects_interactive_python_shell(tmp_path: Path) -> None:
-    tool = ShellExecTool()
-
-    with pytest.raises(ValueError, match="looks interactive in a non-interactive runtime"):
-        tool.invoke(
-            ToolCall(tool_name="shell_exec", arguments={"command": "python -i"}),
-            workspace=tmp_path,
-        )
-
-
-def test_shell_exec_rejects_shell_without_dash_c(tmp_path: Path) -> None:
-    tool = ShellExecTool()
-
-    with pytest.raises(ValueError, match="looks interactive in a non-interactive runtime"):
-        tool.invoke(
-            ToolCall(tool_name="shell_exec", arguments={"command": "bash"}),
-            workspace=tmp_path,
-        )
-
-
-def test_shell_exec_allows_bash_lc_command(tmp_path: Path) -> None:
-    tool = ShellExecTool()
-
-    result = tool.invoke(
-        ToolCall(tool_name="shell_exec", arguments={"command": "bash -lc 'printf ok'"}),
-        workspace=tmp_path,
-    )
-
-    assert result.status == "ok"
-    assert result.content is not None
-    assert result.content.strip() == "ok"
-
-
-def test_shell_exec_allows_bash_script_invocation(tmp_path: Path) -> None:
-    tool = ShellExecTool()
-    script = tmp_path / "script.sh"
-    script.write_text("printf script-ok\n", encoding="utf-8")
-
-    result = tool.invoke(
-        ToolCall(tool_name="shell_exec", arguments={"command": f"bash {script.name}"}),
-        workspace=tmp_path,
-    )
-
-    assert result.status == "ok"
-    assert result.content is not None
-    assert result.content.strip() == "script-ok"
-
-
 # ── Target contract: ShellExecArgs.description ──────────────────────────
 # These tests encode the expected behaviour BEFORE the field exists.
 # They are expected to fail (RED) until T2 adds `description` support.


### PR DESCRIPTION
## Summary
- remove the interactive-shell command classifier from `shell_policy.py`
- restore `shell_exec` to general-purpose command execution with only workspace/timeout governance
- drop the shell classifier-specific tests and keep the existing shell execution/timeout/progress coverage

## Verification
- `uv run pytest tests/unit/tools/test_shell_exec_tool.py -v`
- manual QA: `bash script.sh` executes successfully via `shell_exec`