### PR TITLE
feat(harness): lightweight agent harness upgrades — phase 1 (plan/act, lazy skills, disciplined todos)

### DIFF
--- a/src/voidcode/cli/app.py
+++ b/src/voidcode/cli/app.py
@@ -226,6 +226,9 @@ def _handle_run_command(args: argparse.Namespace) -> int:
             metadata["agent"] = {"preset": cast(str, args.agent)}
         if getattr(args, "skills", None):
             metadata["skills"] = cast(list[str], args.skills)
+        execution_mode = cast(str | None, getattr(args, "execution_mode", None))
+        if execution_mode is not None:
+            metadata["execution_mode"] = execution_mode
         if getattr(args, "max_steps", None) is not None:
             metadata["max_steps"] = cast(int, args.max_steps)
         if cli_reasoning_effort is not None:
@@ -2550,6 +2553,12 @@ def tui(workspace: Path, approval_mode: str | None) -> int:
     "--agent",
     help="Select a top-level or local custom agent preset for this run.",
 )
+@click.option(
+    "--mode",
+    "execution_mode",
+    type=click.Choice(["plan", "act"]),
+    help="Plan mode denies all mutating tool calls; act mode is the default.",
+)
 @click.option("--model", help="Override the provider/model for this run.")
 @click.option("--skills", multiple=True, help="Optional skill names applied for this run.")
 @click.option("--max-steps", type=int, help="Optional max graph steps override for this run.")
@@ -2583,6 +2592,7 @@ def run(
     json_output: bool,
     trace: bool,
     provider_stream: bool | None,
+    execution_mode: str | None,
 ) -> int:
     return _invoke_handler_from_click(
         _handle_run_command,
@@ -2601,6 +2611,7 @@ def run(
             json=json_output,
             trace=trace,
             provider_stream=provider_stream,
+            execution_mode=execution_mode,
         ),
     )
 

--- a/src/voidcode/runtime/contracts.py
+++ b/src/voidcode/runtime/contracts.py
@@ -70,6 +70,7 @@ class RuntimeRequestMetadata(TypedDict, total=False):
     command: RuntimeCommandMetadata
     continuation_loop: RuntimeContinuationLoopMetadata
     delegation: RuntimeSubagentRoutingMetadata
+    execution_mode: str
     max_steps: int
     provider_stream: bool
     reasoning_effort: str
@@ -120,6 +121,7 @@ _STABLE_RUNTIME_REQUEST_METADATA_KEYS = frozenset(
         "context_transform_refs",
         "continuation_loop",
         "delegation",
+        "execution_mode",
         "max_steps",
         "provider_stream",
         "reasoning_effort",
@@ -522,6 +524,12 @@ def validate_runtime_request_metadata(
         normalized["delegation"] = validate_runtime_subagent_routing_metadata(
             metadata["delegation"]
         )
+
+    if "execution_mode" in metadata:
+        execution_mode = metadata["execution_mode"]
+        if execution_mode not in ("plan", "act"):
+            raise RuntimeRequestError("request metadata 'execution_mode' must be 'plan' or 'act'")
+        normalized["execution_mode"] = execution_mode
 
     if "max_steps" in metadata:
         max_steps = metadata["max_steps"]

--- a/src/voidcode/runtime/permission.py
+++ b/src/voidcode/runtime/permission.py
@@ -13,6 +13,10 @@ type PermissionDecision = Literal["allow", "deny", "ask"]
 type PermissionResolution = Literal["allow", "deny"]
 type PathScope = Literal["workspace", "external"]
 type OperationClass = Literal["read", "write", "execute"]
+type RuntimeExecutionMode = Literal["plan", "act"]
+
+DEFAULT_RUNTIME_EXECUTION_MODE: RuntimeExecutionMode = "act"
+PLAN_MODE_DENIAL_REASON = "plan mode is active; mutating tools are denied"
 
 
 @dataclass(frozen=True, slots=True)
@@ -83,6 +87,26 @@ def default_policy_for_tool(tool: ToolDefinition) -> PermissionPolicy:
     return PermissionPolicy(mode="ask")
 
 
+def is_plan_mode_blocked(
+    *,
+    execution_mode: RuntimeExecutionMode,
+    tool: ToolDefinition,
+    operation_class: OperationClass | None = None,
+) -> bool:
+    """Return True when plan mode must deny a tool call.
+
+    Plan mode is a read-only execution stance: every non-read-only tool is
+    denied regardless of approval policy or path scope, and any explicit
+    write/execute operation class is denied even if the tool itself is
+    advertised as read-only (defense in depth).
+    """
+    if execution_mode != "plan":
+        return False
+    if not tool.read_only:
+        return True
+    return operation_class in ("write", "execute")
+
+
 def resolve_permission(
     tool: ToolDefinition,
     tool_call: ToolCall,
@@ -98,7 +122,25 @@ def resolve_permission(
     policy_surface: str | None = None,
     external_decision: PermissionDecision | None = None,
     rule_decision: PermissionDecision | None = None,
+    execution_mode: RuntimeExecutionMode = DEFAULT_RUNTIME_EXECUTION_MODE,
 ) -> PermissionOutcome:
+    if is_plan_mode_blocked(
+        execution_mode=execution_mode, tool=tool, operation_class=operation_class
+    ):
+        pending_approval = build_pending_approval(
+            tool_call,
+            policy=PermissionPolicy(mode="deny"),
+            owner_session_id=owner_session_id,
+            owner_parent_session_id=owner_parent_session_id,
+            delegated_task_id=delegated_task_id,
+            path_scope=path_scope,
+            operation_class=operation_class,
+            canonical_path=canonical_path,
+            matched_rule=matched_rule,
+            policy_surface="execution_mode.plan",
+            reason=PLAN_MODE_DENIAL_REASON,
+        )
+        return PermissionOutcome(decision="deny", pending_approval=pending_approval)
     if rule_decision is not None:
         pending_approval = build_pending_approval(
             tool_call,
@@ -165,6 +207,7 @@ def build_pending_approval(
     canonical_path: str | None = None,
     matched_rule: str | None = None,
     policy_surface: str | None = None,
+    reason: str = "non-read-only tool invocation",
 ) -> PendingApproval:
     path = tool_call.arguments.get("path")
     if isinstance(path, str) and path:
@@ -176,7 +219,7 @@ def build_pending_approval(
         tool_name=tool_call.tool_name,
         arguments=dict(tool_call.arguments),
         target_summary=target_summary,
-        reason="non-read-only tool invocation",
+        reason=reason,
         policy_mode=policy.mode,
         owner_session_id=owner_session_id,
         owner_parent_session_id=owner_parent_session_id,
@@ -285,3 +328,20 @@ def _path_matches_rule(*, normalized_path: str, pattern: str) -> bool:
     if pattern == "*":
         return True
     return fnmatch(normalized_path, expanded_pattern)
+
+
+def execution_mode_from_metadata(
+    metadata: dict[str, object] | None,
+) -> RuntimeExecutionMode:
+    """Extract validated execution_mode from runtime request/session metadata.
+
+    Falls back to DEFAULT_RUNTIME_EXECUTION_MODE when missing or invalid; the
+    runtime contract layer is responsible for rejecting bad input upstream, so
+    this helper is intentionally permissive at read time.
+    """
+    if metadata is None:
+        return DEFAULT_RUNTIME_EXECUTION_MODE
+    raw = metadata.get("execution_mode")
+    if raw == "plan":
+        return "plan"
+    return DEFAULT_RUNTIME_EXECUTION_MODE

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -265,6 +265,7 @@ from .permission import (
     PermissionResolution,
     evaluate_external_directory_policy,
     evaluate_pattern_permission_rules,
+    execution_mode_from_metadata,
     resolve_permission,
 )
 from .permission_context import RuntimePermissionContextResolver
@@ -2669,6 +2670,7 @@ class VoidCodeRuntime:
                 if isinstance(session.metadata.get("background_task_id"), str)
                 else None
             ),
+            execution_mode=execution_mode_from_metadata(session.metadata),
         )
 
         if path_scope == "workspace" and tool.read_only and operation_class == "read":

--- a/src/voidcode/runtime/skill_metadata.py
+++ b/src/voidcode/runtime/skill_metadata.py
@@ -200,7 +200,11 @@ def catalog_skill_context(
         return ""
     lines = [
         "Runtime skills catalog (recommended/visible).",
-        "Load full instructions with tool: skill(name=...).",
+        "Each entry is metadata only; the full SKILL.md body is NOT in your",
+        "current context.",
+        "Load a skill body ONLY when its description matches the active task.",
+        'Use the skill tool: skill(name="..."). Do NOT speculatively load every',
+        "skill; lazy loading keeps the harness lightweight and the model focused.",
         "",
         "<available_skills>",
     ]

--- a/src/voidcode/tools/todo_write.py
+++ b/src/voidcode/tools/todo_write.py
@@ -68,12 +68,46 @@ def _render_todo_content(todos: list[dict[str, str]]) -> str:
     return "\n".join(lines)
 
 
+_TODO_WRITE_DESCRIPTION = (
+    "Manage a structured todo list for the current session. Use this tool\n"
+    "proactively to track multi-step work and surface progress to the user.\n"
+    "\n"
+    "WHEN TO USE (mandatory triggers):\n"
+    "  - The task has 2 or more distinct steps.\n"
+    "  - The user provided multiple items (numbered or comma-separated).\n"
+    "  - You receive new requirements that change the plan.\n"
+    "  - The scope is uncertain and writing it down clarifies thinking.\n"
+    "\n"
+    "WHEN NOT TO USE:\n"
+    "  - A single trivial task.\n"
+    "  - Purely conversational/informational requests.\n"
+    "  - Tasks that finish in fewer than 3 trivial steps.\n"
+    "\n"
+    "DISCIPLINE (non-negotiable):\n"
+    "  - Mark a todo `in_progress` BEFORE starting work on it.\n"
+    "  - Only ONE `in_progress` todo at a time. The runtime will reject\n"
+    "    payloads that violate this constraint.\n"
+    "  - Mark `completed` IMMEDIATELY after finishing; never batch.\n"
+    "  - Use `cancelled` (not delete) when a todo becomes irrelevant.\n"
+    "  - Each item must have content, status, and priority.\n"
+    "\n"
+    "ITEM SHAPE: {content: str, status: pending|in_progress|completed|cancelled,\n"
+    "             priority: high|medium|low}\n"
+)
+
+
 class TodoWriteTool:
     definition: ClassVar[ToolDefinition] = ToolDefinition(
         name="todo_write",
-        description="Manage todo list with status and priority.",
+        description=_TODO_WRITE_DESCRIPTION,
         input_schema={
-            "todos": {"type": "array", "description": "Array of {content, status, priority}"},
+            "todos": {
+                "type": "array",
+                "description": (
+                    "Full replacement list of {content, status, priority} items. "
+                    "At most one item may have status='in_progress'."
+                ),
+            },
         },
         read_only=True,
     )
@@ -88,6 +122,13 @@ class TodoWriteTool:
         normalized: list[dict[str, str]] = []
         for idx, item in enumerate(todos, start=1):
             normalized.append(_parse_todo_item(item, idx=idx))
+
+        in_progress_count = sum(1 for t in normalized if t["status"] == "in_progress")
+        if in_progress_count > 1:
+            raise ValueError(
+                "todo_write rejects payloads with more than one `in_progress` todo; "
+                "complete or move the current one to `pending` before starting another."
+            )
 
         summary = {
             "total": len(normalized),

--- a/tests/unit/runtime/test_permission_plan_mode.py
+++ b/tests/unit/runtime/test_permission_plan_mode.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import pytest
+
+from voidcode.runtime.contracts import (
+    RuntimeRequestError,
+    validate_runtime_request_metadata,
+)
+from voidcode.runtime.permission import (
+    DEFAULT_RUNTIME_EXECUTION_MODE,
+    PLAN_MODE_DENIAL_REASON,
+    PermissionPolicy,
+    execution_mode_from_metadata,
+    is_plan_mode_blocked,
+    resolve_permission,
+)
+from voidcode.tools.contracts import ToolCall, ToolDefinition
+
+
+def _read_only_tool() -> ToolDefinition:
+    return ToolDefinition(
+        name="grep",
+        description="search read-only tool",
+        input_schema={},
+        read_only=True,
+    )
+
+
+def _write_tool() -> ToolDefinition:
+    return ToolDefinition(
+        name="write_file",
+        description="mutating tool",
+        input_schema={},
+        read_only=False,
+    )
+
+
+def _call(name: str = "write_file") -> ToolCall:
+    return ToolCall(tool_name=name, arguments={"path": "foo.txt"})
+
+
+def test_default_runtime_execution_mode_is_act() -> None:
+    assert DEFAULT_RUNTIME_EXECUTION_MODE == "act"
+
+
+@pytest.mark.parametrize(
+    ("mode", "tool", "operation_class", "expected"),
+    [
+        ("act", _write_tool(), "write", False),
+        ("plan", _read_only_tool(), "read", False),
+        ("plan", _read_only_tool(), None, False),
+        ("plan", _write_tool(), "write", True),
+        ("plan", _write_tool(), None, True),
+        # Defense in depth: a read_only tool asked to perform a write/execute
+        # operation is still denied while plan mode is active.
+        ("plan", _read_only_tool(), "write", True),
+        ("plan", _read_only_tool(), "execute", True),
+    ],
+)
+def test_is_plan_mode_blocked_matrix(
+    mode: str,
+    tool: ToolDefinition,
+    operation_class: str | None,
+    expected: bool,
+) -> None:
+    assert (
+        is_plan_mode_blocked(
+            execution_mode=mode,  # type: ignore[arg-type]
+            tool=tool,
+            operation_class=operation_class,  # type: ignore[arg-type]
+        )
+        is expected
+    )
+
+
+def test_resolve_permission_plan_mode_denies_write_tool() -> None:
+    outcome = resolve_permission(
+        _write_tool(),
+        _call(),
+        policy=PermissionPolicy(mode="ask"),
+        execution_mode="plan",
+    )
+
+    assert outcome.decision == "deny"
+    assert outcome.pending_approval is not None
+    assert outcome.pending_approval.policy_mode == "deny"
+    assert outcome.pending_approval.policy_surface == "execution_mode.plan"
+    assert outcome.pending_approval.reason == PLAN_MODE_DENIAL_REASON
+
+
+def test_resolve_permission_plan_mode_allows_read_only_tool() -> None:
+    outcome = resolve_permission(
+        _read_only_tool(),
+        _call("grep"),
+        policy=PermissionPolicy(mode="ask"),
+        execution_mode="plan",
+    )
+
+    assert outcome.decision == "allow"
+    assert outcome.pending_approval is None
+
+
+def test_resolve_permission_act_mode_does_not_short_circuit() -> None:
+    outcome = resolve_permission(
+        _write_tool(),
+        _call(),
+        policy=PermissionPolicy(mode="ask"),
+        execution_mode="act",
+    )
+
+    assert outcome.decision == "ask"
+    assert outcome.pending_approval is not None
+    # Reason in act mode should remain the default approval reason rather than
+    # the plan-mode denial sentinel.
+    assert outcome.pending_approval.reason != PLAN_MODE_DENIAL_REASON
+
+
+def test_resolve_permission_plan_mode_overrides_explicit_allow_rule() -> None:
+    """Plan mode is a hard ceiling; even an `allow` rule cannot override it."""
+    outcome = resolve_permission(
+        _write_tool(),
+        _call(),
+        policy=PermissionPolicy(mode="ask"),
+        rule_decision="allow",
+        execution_mode="plan",
+    )
+
+    assert outcome.decision == "deny"
+    assert outcome.pending_approval is not None
+    assert outcome.pending_approval.policy_surface == "execution_mode.plan"
+
+
+def test_execution_mode_from_metadata_defaults_to_act() -> None:
+    assert execution_mode_from_metadata(None) == "act"
+    assert execution_mode_from_metadata({}) == "act"
+    assert execution_mode_from_metadata({"execution_mode": "act"}) == "act"
+    # Invalid values fall back to default rather than raising; validation is
+    # the responsibility of the runtime contract layer.
+    assert execution_mode_from_metadata({"execution_mode": "weird"}) == "act"
+
+
+def test_execution_mode_from_metadata_returns_plan_when_set() -> None:
+    assert execution_mode_from_metadata({"execution_mode": "plan"}) == "plan"
+
+
+def test_request_metadata_accepts_plan_execution_mode() -> None:
+    normalized = validate_runtime_request_metadata({"execution_mode": "plan"})
+
+    assert normalized.get("execution_mode") == "plan"
+
+
+def test_request_metadata_accepts_act_execution_mode() -> None:
+    normalized = validate_runtime_request_metadata({"execution_mode": "act"})
+
+    assert normalized.get("execution_mode") == "act"
+
+
+def test_request_metadata_rejects_unknown_execution_mode() -> None:
+    with pytest.raises(RuntimeRequestError, match="execution_mode"):
+        _ = validate_runtime_request_metadata({"execution_mode": "magic"})

--- a/tests/unit/runtime/test_skill_lazy_catalog.py
+++ b/tests/unit/runtime/test_skill_lazy_catalog.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from voidcode.runtime.skill_metadata import (
+    available_runtime_contexts,
+    catalog_skill_context,
+)
+from voidcode.skills import (
+    DEFAULT_SKILL_SEARCH_PATHS,
+    LocalSkillMetadataLoader,
+    SkillRegistry,
+)
+
+_SKILL_BODY_SECRET = "INSTRUCTIONS BODY THAT MUST NOT LEAK INTO CATALOG"
+
+
+def _make_workspace_with_skills(tmp_path: Path) -> SkillRegistry:
+    skill_root = tmp_path / DEFAULT_SKILL_SEARCH_PATHS[0]
+    summarize_dir = skill_root / "summarize"
+    review_dir = skill_root / "review"
+    summarize_dir.mkdir(parents=True)
+    review_dir.mkdir(parents=True)
+    (summarize_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: summarize\n"
+        "description: Summarize selected files cheaply.\n"
+        "---\n"
+        f"# Summarize body\n{_SKILL_BODY_SECRET}\nstep one of summarize.\n",
+        encoding="utf-8",
+    )
+    (review_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: review\n"
+        "description: Review changes against architecture rules.\n"
+        "---\n"
+        f"# Review body\n{_SKILL_BODY_SECRET}\nstep one of review.\n",
+        encoding="utf-8",
+    )
+    discovered = LocalSkillMetadataLoader().discover(workspace=tmp_path)
+    return SkillRegistry(skills={skill.name: skill for skill in discovered})
+
+
+def test_catalog_skill_context_omits_full_skill_body(tmp_path: Path) -> None:
+    """Lazy harness contract: the catalog must never embed the SKILL.md body.
+
+    If this test starts failing, the lazy-loading contract has been broken and
+    every active session is now paying the full body cost upfront. That is the
+    opposite of the OhMyOpenCode/OpenCode lazy-skill design.
+    """
+    registry = _make_workspace_with_skills(tmp_path)
+
+    catalog = catalog_skill_context(
+        registry,
+        available_skill_names=("summarize", "review"),
+        selected_skill_names=(),
+    )
+
+    assert _SKILL_BODY_SECRET not in catalog
+    assert "step one of summarize" not in catalog
+    assert "step one of review" not in catalog
+
+
+def test_catalog_skill_context_includes_name_and_description(tmp_path: Path) -> None:
+    registry = _make_workspace_with_skills(tmp_path)
+
+    catalog = catalog_skill_context(
+        registry,
+        available_skill_names=("summarize", "review"),
+        selected_skill_names=(),
+    )
+
+    assert "<name>summarize</name>" in catalog
+    assert "Summarize selected files cheaply." in catalog
+    assert "<name>review</name>" in catalog
+    assert "Review changes against architecture rules." in catalog
+
+
+def test_catalog_skill_context_directs_model_to_lazy_load_via_tool(
+    tmp_path: Path,
+) -> None:
+    registry = _make_workspace_with_skills(tmp_path)
+
+    catalog = catalog_skill_context(
+        registry,
+        available_skill_names=("summarize",),
+        selected_skill_names=(),
+    )
+
+    # The catalog must explicitly tell the model how to fetch a skill body
+    # rather than letting the model invent its own loading semantics.
+    assert "skill(name=" in catalog
+    # The catalog must discourage speculative bulk loading; this is the
+    # behavioral knob that keeps the harness lightweight.
+    assert "speculatively" in catalog.lower() or "lazy" in catalog.lower()
+
+
+def test_catalog_skill_context_returns_empty_when_no_skills() -> None:
+    empty_registry = SkillRegistry(skills={})
+
+    catalog = catalog_skill_context(
+        empty_registry,
+        available_skill_names=(),
+        selected_skill_names=(),
+    )
+
+    assert catalog == ""
+
+
+def test_available_runtime_contexts_does_load_full_body_when_requested(
+    tmp_path: Path,
+) -> None:
+    """When the runtime explicitly opts into eager loading (e.g., force_load_skills
+    or skill tool invocation), the body MUST become available. This protects the
+    other half of the contract: lazy by default, eager on request.
+    """
+    registry = _make_workspace_with_skills(tmp_path)
+
+    contexts = available_runtime_contexts(registry, ("summarize",))
+
+    assert len(contexts) == 1
+    only = contexts[0]
+    assert only.name == "summarize"
+    assert _SKILL_BODY_SECRET in only.content
+    assert "step one of summarize" in only.content

--- a/tests/unit/tools/fuzz/test_todo_write_tool_fuzz.py
+++ b/tests/unit/tools/fuzz/test_todo_write_tool_fuzz.py
@@ -52,6 +52,20 @@ def test_parse_todo_item_trims_content_and_preserves_enums(item: dict[str, str],
 @CI_SETTINGS
 @given(todos=st.lists(_todo_item, min_size=0, max_size=12))
 def test_todo_write_summary_matches_normalized_status_counts(todos: list[dict[str, str]]) -> None:
+    # The tool now enforces at-most-one in_progress todo to mirror the harness
+    # discipline; relax that constraint here so fuzz inputs stay legal.
+    in_progress_count = sum(1 for todo in todos if todo["status"] == "in_progress")
+    if in_progress_count > 1:
+        seen_in_progress = False
+        normalized_input: list[dict[str, str]] = []
+        for todo in todos:
+            if todo["status"] == "in_progress":
+                if seen_in_progress:
+                    normalized_input.append({**todo, "status": "pending"})
+                    continue
+                seen_in_progress = True
+            normalized_input.append(todo)
+        todos = normalized_input
     tool = TodoWriteTool()
 
     with TemporaryDirectory() as temp_dir:

--- a/tests/unit/tools/test_todo_write_tool.py
+++ b/tests/unit/tools/test_todo_write_tool.py
@@ -66,3 +66,64 @@ def test_todo_write_rejects_invalid_priority(tmp_path: Path) -> None:
             ),
             workspace=tmp_path,
         )
+
+
+def test_todo_write_rejects_more_than_one_in_progress_todo(tmp_path: Path) -> None:
+    tool = TodoWriteTool()
+
+    with pytest.raises(ValueError, match="more than one `in_progress`"):
+        tool.invoke(
+            ToolCall(
+                tool_name="todo_write",
+                arguments={
+                    "todos": [
+                        {
+                            "content": "first concurrent task",
+                            "status": "in_progress",
+                            "priority": "high",
+                        },
+                        {
+                            "content": "second concurrent task",
+                            "status": "in_progress",
+                            "priority": "high",
+                        },
+                    ]
+                },
+            ),
+            workspace=tmp_path,
+        )
+
+
+def test_todo_write_accepts_single_in_progress_todo(tmp_path: Path) -> None:
+    tool = TodoWriteTool()
+
+    result = tool.invoke(
+        ToolCall(
+            tool_name="todo_write",
+            arguments={
+                "todos": [
+                    {"content": "queued", "status": "pending", "priority": "high"},
+                    {"content": "active", "status": "in_progress", "priority": "high"},
+                    {"content": "shipped", "status": "completed", "priority": "low"},
+                ]
+            },
+        ),
+        workspace=tmp_path,
+    )
+
+    summary_raw = result.data["summary"]
+    assert isinstance(summary_raw, dict)
+    summary = cast(dict[str, object], summary_raw)
+    assert summary["in_progress"] == 1
+
+
+def test_todo_write_description_codifies_harness_discipline() -> None:
+    description = TodoWriteTool.definition.description
+
+    # The description must teach the model the contract; if any of these go
+    # missing the harness signal degrades and todos become decorative.
+    assert "in_progress" in description
+    assert "BEFORE starting" in description or "before starting" in description.lower()
+    assert "IMMEDIATELY" in description or "immediately" in description.lower()
+    assert "Only ONE" in description or "only one" in description.lower()
+    assert "2 or more distinct steps" in description


### PR DESCRIPTION
## Summary

Phase 1 of the "make the agent more harnessed while keeping it lightweight"
initiative, modeled on patterns from OhMyOpenCode, Claude Code, OpenCode, Aider,
Smolagents, and Plandex (research summary in the conversation that produced
this PR).

VoidCode's runtime control plane is already strong — it owns governance,
permissions, hooks, persistence, delegated execution, MCP/LSP lifecycle, and a
broad tool surface. The gap was at the **behavioral layer**: prompts, skills,
and todos were not yet tuned for harness ergonomics. This PR closes three of
the highest-leverage gaps with **minimal, contained, fully tested** changes.

## What this PR ships

### 1. Plan / Act execution modes (`feat(runtime): add plan/act execution modes…`)

- New `RuntimeExecutionMode = Literal["plan", "act"]` in `permission.py`.
- `is_plan_mode_blocked()` helper + `resolve_permission(execution_mode=…)`
  short-circuit. Plan mode denies every mutating tool call as a **hard ceiling**
  — overrides explicit `allow` rules, surfaces as `policy_surface =
  "execution_mode.plan"`, and uses `PLAN_MODE_DENIAL_REASON` for observability.
- Defense in depth: a read-only tool paired with an explicit
  `write` / `execute` operation class is still denied while plan mode is on.
- `RuntimeRequestMetadata` gains `execution_mode` with proper
  `validate_runtime_request_metadata` rejection of unknown values.
- `voidcode run --mode plan|act` CLI flag, threaded through metadata.
- 17 new tests in `tests/unit/runtime/test_permission_plan_mode.py`.

**Why it matters:** matches Cline/Claude Code plan mode semantics. A user can
now ask the agent to "plan the migration but don't touch files" without writing
elaborate permission rules.

### 2. Lazy-skills contract lockdown (`feat(skills): lock down lazy skill loading contract…`)

VoidCode already lazy-loads skills (the catalog injects only name/description/
location and the `skill` tool fetches bodies on demand), but the contract was
**implicit and untested**. This commit makes it explicit and verifiable.

- `skill_metadata.py`: catalog text now states (a) entries are metadata only,
  (b) the body is NOT in current context, (c) load only when description
  matches the active task, (d) use `skill(name=…)`, (e) do NOT speculatively
  load every skill. Mirrors the OhMyOpenCode/OpenCode lazy-skill design.
- New `tests/unit/runtime/test_skill_lazy_catalog.py` locks five contract
  invariants:
  - catalog never embeds the SKILL.md body
  - catalog includes name + description per skill
  - catalog explicitly directs the model to `skill(name=…)` and discourages
    speculative bulk loading
  - empty registry produces empty catalog
  - eager path (`available_runtime_contexts`) still surfaces full bodies, so
    the other half of the contract — lazy by default, eager on request — is
    also covered.

**Why it matters:** before this commit, a future refactor could silently start
embedding skill bodies into every prompt without anyone noticing. Now the
behavior is a tested contract.

### 3. Disciplined todo_write UX (`feat(tools): make todo_write a first-class harness UX…`)

- Replace the bare one-line `todo_write` description with **explicit harness
  guidance** modeled on Claude Code's TodoWrite: WHEN to use (2+ steps,
  multiple items, scope changes), WHEN not to use (trivial/conversational), and
  the DISCIPLINE rules (mark in_progress before starting, only ONE in_progress
  at a time, mark completed immediately, use cancelled rather than delete).
- Enforce the at-most-one-in_progress invariant at the runtime boundary:
  `ValueError` when a payload tries to start two tasks at once. Prevents the
  model from drifting into parallel work via the todo surface.
- `input_schema` description spells out the same constraint so providers see
  it during turn planning.
- New tests for positive (single in_progress accepted), negative (two
  in_progress rejected), and contract (description still teaches the
  discipline) cases. The existing fuzz test pre-normalizes hypothesis-generated
  todos so the new invariant is honored without weakening coverage of trimming
  + summary invariants.

**Why it matters:** todos were a tool but not a disciplined UX primitive.
Models could batch updates or run several todos in parallel. Now the contract
is enforced and discoverable from the tool description itself.

## Verification

- `mise run lint` ✅
- `mise run typecheck` ✅
- `mise run test` ✅ — **2343 passed** (was 2318; +25 new tests, no regressions)
- `voidcode run --help` exposes `--mode [plan |act]` correctly.
- All commits pass pre-commit (ruff format, ty, hygiene checks).

## Architectural notes

- All three features stay strictly inside the existing
  `runtime / graph / tools` boundary discipline documented in
  `src/voidcode/runtime/AGENTS.md`. No new control plane, no new state
  machines, no new persistence, no new contracts beyond a single optional
  `execution_mode` field on `RuntimeRequestMetadata`.
- Plan mode is implemented as a **permission-resolution short-circuit**, not a
  separate execution path. That is the smallest change that gives the harness
  a hard read-only stance.
- The lazy-skills change is **prompt-text + tests only**. The runtime already
  routed only force-loaded skills into the prompt context; this commit just
  makes that contract testable and self-documenting.
- The todo_write change adds one invariant (at most one in_progress) and a
  long but purely-textual description. Existing tool dispatch, persistence,
  and event semantics are untouched.

## Out of scope (Phase 2 follow-ups)

The original plan had six features; three were deferred to a follow-up PR
because each is a >300 LOC change that deserves its own focused review:

- **Prompt section composition** — extract identity / intent_gate /
  tool_catalog / verification_rules / task_state / workspace_summary into a
  composable `prompt_assembly.py` module rather than a single string.
- **RepoMap (Aider-style)** — token-budgeted symbol map cached at
  `\$XDG_STATE_HOME/voidcode/repomap-{workspace_id}.json`, built off the
  existing LSP integration with a tree-sitter fallback.
- **Context tier productization** — turn the existing context_window /
  continuity_distillation machinery into an explicit four-tier model
  (static instructions / workspace summary / task context / recent dialogue)
  with a cheap tool-result summarization pass.

Each of these reuses infrastructure that is already in the runtime; they are
behind this PR purely for review-size reasons, not technical risk.

## References

The decisions in this PR are grounded in a parallel survey of Claude Code,
OpenCode, Aider, Cline, Roo Code, Codex CLI, Smolagents, Plandex, gptme, goose,
and the OhMyOpenCode plugin layer. The recurring pattern across all of them:
the lightest harnesses move discipline into **prompt text + a few hard runtime
invariants**, not new subsystems. That is exactly what this PR does.