### PR TITLE
feat(runtime): phase 2 prompt assembly and context tier productization

### DIFF
--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -347,6 +347,27 @@ class RuntimeContextSegment:
     metadata: dict[str, object] | None = None
 
 
+def _context_tier_metadata(
+    segments: list[RuntimeContextSegment],
+) -> dict[str, object]:
+    order: list[str] = []
+    counts: dict[str, int] = {"instruction": 0, "workspace": 0, "task": 0, "recent": 0}
+    for segment in segments:
+        metadata = segment.metadata or {}
+        raw_tier = metadata.get("tier")
+        if raw_tier not in counts:
+            continue
+        tier = cast(Literal["instruction", "workspace", "task", "recent"], raw_tier)
+        counts[tier] += 1
+        if tier not in order:
+            order.append(tier)
+    return {
+        "version": 1,
+        "order": order,
+        "counts": counts,
+    }
+
+
 def estimate_provider_context_tokens(
     segments: tuple[RuntimeContextSegment, ...], *, tokenizer_model: str | None = None
 ) -> TokenCount:
@@ -1910,6 +1931,7 @@ def assemble_provider_context(
                         "runtime_context_artifact_reference",
                     ),
                 ),
+                tier="recent",
                 metadata={} if segment.metadata is None else dict(segment.metadata),
             )
             for segment in _artifact_reference_segments(continuity_state)
@@ -1942,6 +1964,7 @@ def assemble_provider_context(
                         "runtime_pending_state",
                     ),
                 ),
+                tier="task",
                 metadata=(
                     {}
                     if pending_state_segment.metadata is None
@@ -1959,7 +1982,11 @@ def assemble_provider_context(
         RuntimeContextSegment(
             role=section.role,
             content=section.content,
-            metadata={"source": section.source, **dict(section.metadata)},
+            metadata={
+                "source": section.source,
+                "tier": section.tier,
+                **dict(section.metadata),
+            },
         )
         for section in assembly_plan.sections
     ]
@@ -1985,7 +2012,7 @@ def assemble_provider_context(
                 tool_call_id=tool_call_id,
                 tool_name=result.tool_name,
                 tool_arguments=tool_arguments,
-                metadata={"source": "retained_tool_result"},
+                metadata={"source": "retained_tool_result", "tier": "recent"},
             )
         )
         segments.append(
@@ -1996,6 +2023,7 @@ def assemble_provider_context(
                 tool_name=result.tool_name,
                 metadata={
                     "source": "retained_tool_result",
+                    "tier": "recent",
                     "status": result.status,
                     "error": result.error,
                     "data": result.data,
@@ -2005,6 +2033,7 @@ def assemble_provider_context(
                 },
             )
         )
+    metadata_payload["context_tiers"] = _context_tier_metadata(segments)
     context_token_count = estimate_provider_context_tokens(
         tuple(segments), tokenizer_model=policy.tokenizer_model if policy is not None else None
     )

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -19,6 +19,10 @@ from .continuity_distillation import (
     build_distillation_input_envelope,
     distillation_record_from_payload,
 )
+from .prompt_assembly import (
+    PromptAssemblySection,
+    build_prompt_assembly_plan,
+)
 from .todos import render_provider_todo_state
 
 
@@ -1868,62 +1872,13 @@ def assemble_provider_context(
         session_metadata=session_metadata,
         policy=policy,
     )
-    segments: list[RuntimeContextSegment] = []
-    seen_system_contents: set[str] = set()
-
-    def _append_system_segment(content: str, *, source: str) -> None:
-        normalized = content.strip()
-        if not normalized or normalized in seen_system_contents:
-            return
-        seen_system_contents.add(normalized)
-        segments.append(
-            RuntimeContextSegment(
-                role="system",
-                content=normalized,
-                metadata={"source": source},
-            )
-        )
-
-    _append_system_segment(
-        (
-            "Runtime instruction precedence: active agent role and runtime enforcement "
-            "boundaries are authoritative. Tool allowlists, approvals, session truth, "
-            "and runtime safety policies outrank skill, todo, hook-preset, and "
-            "continuity guidance. Skill instructions may refine how to perform work, "
-            "but must not expand role scope, tool permissions, approval behavior, or "
-            "completion obligations."
-        ),
-        source="runtime_instruction_precedence",
-    )
-    _append_system_segment(agent_prompt_context, source="agent_prompt")
-    for segment_content in preserved_system_segments:
-        _append_system_segment(segment_content, source="preserved_system_segment")
-    _append_system_segment(skill_prompt_context, source="skill_prompt")
     transform_result = context_transform_result or build_provider_context_transform_result(
         workspace=workspace,
         tool_results=tool_results,
         hook_preset_context=hook_preset_context,
     )
-    for transform_injection in transform_result.injections:
-        normalized = transform_injection.content.strip()
-        if not normalized or normalized in seen_system_contents:
-            continue
-        seen_system_contents.add(normalized)
-        segments.append(
-            RuntimeContextSegment(
-                role=cast(Literal["system", "user", "assistant", "tool"], transform_injection.role),
-                content=normalized,
-                metadata=dict(transform_injection.metadata),
-            )
-        )
     pending_state_segment = _pending_state_segment(session_metadata)
-    if pending_state_segment is not None:
-        segments.append(pending_state_segment)
-        if isinstance(pending_state_segment.content, str):
-            seen_system_contents.add(pending_state_segment.content.strip())
     todo_prompt_context = render_provider_todo_state(session_metadata)
-    if todo_prompt_context is not None:
-        _append_system_segment(todo_prompt_context, source="runtime_todo_state")
     continuity_state = (
         preserved_continuity_state
         or context_window.continuity_state
@@ -1938,23 +1893,76 @@ def assemble_provider_context(
             metadata_payload["summary_anchor"] = summary_anchor
         if summary_source is not None:
             metadata_payload["summary_source"] = summary_source
+    continuity_summary = ""
+    artifact_reference_sections: tuple[PromptAssemblySection, ...] = ()
     if continuity_state is not None:
         summary_text = continuity_state.summary_text
         if isinstance(summary_text, str) and summary_text.strip():
-            _append_system_segment(
-                f"Runtime continuity summary:\n{summary_text.strip()}",
-                source="continuity_summary",
+            continuity_summary = f"Runtime continuity summary:\n{summary_text.strip()}"
+        artifact_reference_sections = tuple(
+            PromptAssemblySection(
+                role=segment.role,
+                content=segment.content or "",
+                source=cast(
+                    str,
+                    (segment.metadata or {}).get(
+                        "source",
+                        "runtime_context_artifact_reference",
+                    ),
+                ),
+                metadata={} if segment.metadata is None else dict(segment.metadata),
             )
-        segments.extend(_artifact_reference_segments(continuity_state))
+            for segment in _artifact_reference_segments(continuity_state)
+        )
     if transform_result.traces:
         metadata_payload["context_transforms"] = transform_result.metadata_payload()
-    segments.append(
-        RuntimeContextSegment(
-            role="user",
-            content=prompt,
-            metadata={"source": "current_user_prompt"},
-        )
+    runtime_instruction_precedence = (
+        "Runtime instruction precedence: active agent role and runtime enforcement "
+        "boundaries are authoritative. Tool allowlists, approvals, session truth, "
+        "and runtime safety policies outrank skill, todo, hook-preset, and "
+        "continuity guidance. Skill instructions may refine how to perform work, "
+        "but must not expand role scope, tool permissions, approval behavior, or "
+        "completion obligations."
     )
+    assembly_plan = build_prompt_assembly_plan(
+        prompt=prompt,
+        runtime_instruction_precedence=runtime_instruction_precedence,
+        agent_prompt_context=agent_prompt_context,
+        preserved_system_segments=preserved_system_segments,
+        skill_prompt_context=skill_prompt_context,
+        context_transform_result=transform_result,
+        pending_state_section=(
+            PromptAssemblySection(
+                role=pending_state_segment.role,
+                content=pending_state_segment.content or "",
+                source=cast(
+                    str,
+                    (pending_state_segment.metadata or {}).get(
+                        "source",
+                        "runtime_pending_state",
+                    ),
+                ),
+                metadata=(
+                    {}
+                    if pending_state_segment.metadata is None
+                    else dict(pending_state_segment.metadata)
+                ),
+            )
+            if pending_state_segment is not None
+            else None
+        ),
+        todo_prompt_context=todo_prompt_context or "",
+        continuity_summary=continuity_summary,
+        artifact_reference_sections=artifact_reference_sections,
+    )
+    segments: list[RuntimeContextSegment] = [
+        RuntimeContextSegment(
+            role=section.role,
+            content=section.content,
+            metadata={"source": section.source, **dict(section.metadata)},
+        )
+        for section in assembly_plan.sections
+    ]
     for index, result in enumerate(context_window.tool_results, start=1):
         if todo_prompt_context is not None and result.tool_name == "todo_write":
             continue

--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -178,6 +178,11 @@ class ContextWindowPolicy:
     continuity_distillation_max_input_items: int = 12
     continuity_distillation_max_input_chars: int = 4000
     importance_retention: bool = False
+    protected_context_tiers: tuple[str, ...] = (
+        "instruction",
+        "workspace",
+        "task",
+    )
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "per_tool_result_tokens", dict(self.per_tool_result_tokens))
@@ -218,6 +223,17 @@ class ContextWindowPolicy:
             raise ValueError("continuity_distillation_max_input_items must be >= 1")
         if self.continuity_distillation_max_input_chars < 64:
             raise ValueError("continuity_distillation_max_input_chars must be >= 64")
+        valid_tiers = {"instruction", "workspace", "task", "recent"}
+        normalized_tiers: list[str] = []
+        for tier in self.protected_context_tiers:
+            if tier not in valid_tiers:
+                raise ValueError(
+                    "protected_context_tiers must only contain: instruction, "
+                    "workspace, task, recent"
+                )
+            if tier not in normalized_tiers:
+                normalized_tiers.append(tier)
+        object.__setattr__(self, "protected_context_tiers", tuple(normalized_tiers))
 
     def metadata_payload(self) -> dict[str, object]:
         payload: dict[str, object] = {
@@ -255,6 +271,7 @@ class ContextWindowPolicy:
             self.continuity_distillation_max_input_chars
         )
         payload["importance_retention"] = self.importance_retention
+        payload["protected_context_tiers"] = list(self.protected_context_tiers)
         return payload
 
 
@@ -2034,6 +2051,11 @@ def assemble_provider_context(
             )
         )
     metadata_payload["context_tiers"] = _context_tier_metadata(segments)
+    metadata_payload["context_tier_policy"] = {
+        "version": 1,
+        "protected_tiers": list((policy or ContextWindowPolicy()).protected_context_tiers),
+        "compaction_target": "recent",
+    }
     context_token_count = estimate_provider_context_tokens(
         tuple(segments), tokenizer_model=policy.tokenizer_model if policy is not None else None
     )

--- a/src/voidcode/runtime/prompt_assembly.py
+++ b/src/voidcode/runtime/prompt_assembly.py
@@ -12,6 +12,7 @@ class PromptAssemblySection:
     role: Literal["system", "user", "assistant", "tool"]
     content: str
     source: str
+    tier: Literal["instruction", "workspace", "task", "recent"]
     metadata: Mapping[str, object] = field(default_factory=dict)
 
 
@@ -40,6 +41,7 @@ def build_prompt_assembly_plan(
         content: str,
         *,
         source: str,
+        tier: Literal["instruction", "workspace", "task", "recent"],
         metadata: Mapping[str, object] | None = None,
     ) -> None:
         normalized = content.strip()
@@ -51,6 +53,7 @@ def build_prompt_assembly_plan(
                 role="system",
                 content=normalized,
                 source=source,
+                tier=tier,
                 metadata={} if metadata is None else dict(metadata),
             )
         )
@@ -58,11 +61,16 @@ def build_prompt_assembly_plan(
     append_system(
         runtime_instruction_precedence,
         source="runtime_instruction_precedence",
+        tier="instruction",
     )
-    append_system(agent_prompt_context, source="agent_prompt")
+    append_system(agent_prompt_context, source="agent_prompt", tier="instruction")
     for segment_content in preserved_system_segments:
-        append_system(segment_content, source="preserved_system_segment")
-    append_system(skill_prompt_context, source="skill_prompt")
+        append_system(
+            segment_content,
+            source="preserved_system_segment",
+            tier="instruction",
+        )
+    append_system(skill_prompt_context, source="skill_prompt", tier="instruction")
 
     transform_result = context_transform_result
     if transform_result is not None:
@@ -74,6 +82,7 @@ def build_prompt_assembly_plan(
                 append_system(
                     normalized,
                     source=_metadata_source(injection.metadata, fallback="context_transform"),
+                    tier=_metadata_tier(injection.metadata, fallback="workspace"),
                     metadata=injection.metadata,
                 )
                 continue
@@ -82,6 +91,7 @@ def build_prompt_assembly_plan(
                     role=cast(Literal["system", "user", "assistant", "tool"], injection.role),
                     content=normalized,
                     source=_metadata_source(injection.metadata, fallback="context_transform"),
+                    tier=_metadata_tier(injection.metadata, fallback="workspace"),
                     metadata=dict(injection.metadata),
                 )
             )
@@ -91,19 +101,21 @@ def build_prompt_assembly_plan(
             append_system(
                 pending_state_section.content,
                 source=pending_state_section.source,
+                tier=pending_state_section.tier,
                 metadata=pending_state_section.metadata,
             )
         else:
             sections.append(pending_state_section)
 
-    append_system(todo_prompt_context, source="runtime_todo_state")
-    append_system(continuity_summary, source="continuity_summary")
+    append_system(todo_prompt_context, source="runtime_todo_state", tier="task")
+    append_system(continuity_summary, source="continuity_summary", tier="recent")
 
     for artifact_reference in artifact_reference_sections:
         if artifact_reference.role == "system":
             append_system(
                 artifact_reference.content,
                 source=artifact_reference.source,
+                tier=artifact_reference.tier,
                 metadata=artifact_reference.metadata,
             )
             continue
@@ -114,7 +126,8 @@ def build_prompt_assembly_plan(
             role="user",
             content=prompt,
             source="current_user_prompt",
-            metadata={"source": "current_user_prompt"},
+            tier="task",
+            metadata={"source": "current_user_prompt", "tier": "task"},
         )
     )
     return PromptAssemblyPlan(sections=tuple(sections))
@@ -123,6 +136,17 @@ def build_prompt_assembly_plan(
 def _metadata_source(metadata: Mapping[str, object], *, fallback: str) -> str:
     source = metadata.get("source")
     return source if isinstance(source, str) and source.strip() else fallback
+
+
+def _metadata_tier(
+    metadata: Mapping[str, object],
+    *,
+    fallback: Literal["instruction", "workspace", "task", "recent"],
+) -> Literal["instruction", "workspace", "task", "recent"]:
+    tier = metadata.get("tier")
+    if tier in {"instruction", "workspace", "task", "recent"}:
+        return cast(Literal["instruction", "workspace", "task", "recent"], tier)
+    return fallback
 
 
 __all__ = [

--- a/src/voidcode/runtime/prompt_assembly.py
+++ b/src/voidcode/runtime/prompt_assembly.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Literal, cast
+
+from .context_transforms import RuntimeContextTransformResult
+
+
+@dataclass(frozen=True, slots=True)
+class PromptAssemblySection:
+    role: Literal["system", "user", "assistant", "tool"]
+    content: str
+    source: str
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class PromptAssemblyPlan:
+    sections: tuple[PromptAssemblySection, ...] = ()
+
+
+def build_prompt_assembly_plan(
+    *,
+    prompt: str,
+    runtime_instruction_precedence: str,
+    agent_prompt_context: str = "",
+    preserved_system_segments: Iterable[str] = (),
+    skill_prompt_context: str = "",
+    context_transform_result: RuntimeContextTransformResult | None = None,
+    pending_state_section: PromptAssemblySection | None = None,
+    todo_prompt_context: str = "",
+    continuity_summary: str = "",
+    artifact_reference_sections: Iterable[PromptAssemblySection] = (),
+) -> PromptAssemblyPlan:
+    sections: list[PromptAssemblySection] = []
+    seen_system_contents: set[str] = set()
+
+    def append_system(
+        content: str,
+        *,
+        source: str,
+        metadata: Mapping[str, object] | None = None,
+    ) -> None:
+        normalized = content.strip()
+        if not normalized or normalized in seen_system_contents:
+            return
+        seen_system_contents.add(normalized)
+        sections.append(
+            PromptAssemblySection(
+                role="system",
+                content=normalized,
+                source=source,
+                metadata={} if metadata is None else dict(metadata),
+            )
+        )
+
+    append_system(
+        runtime_instruction_precedence,
+        source="runtime_instruction_precedence",
+    )
+    append_system(agent_prompt_context, source="agent_prompt")
+    for segment_content in preserved_system_segments:
+        append_system(segment_content, source="preserved_system_segment")
+    append_system(skill_prompt_context, source="skill_prompt")
+
+    transform_result = context_transform_result
+    if transform_result is not None:
+        for injection in transform_result.injections:
+            normalized = injection.content.strip()
+            if not normalized:
+                continue
+            if injection.role == "system":
+                append_system(
+                    normalized,
+                    source=_metadata_source(injection.metadata, fallback="context_transform"),
+                    metadata=injection.metadata,
+                )
+                continue
+            sections.append(
+                PromptAssemblySection(
+                    role=cast(Literal["system", "user", "assistant", "tool"], injection.role),
+                    content=normalized,
+                    source=_metadata_source(injection.metadata, fallback="context_transform"),
+                    metadata=dict(injection.metadata),
+                )
+            )
+
+    if pending_state_section is not None:
+        if pending_state_section.role == "system":
+            append_system(
+                pending_state_section.content,
+                source=pending_state_section.source,
+                metadata=pending_state_section.metadata,
+            )
+        else:
+            sections.append(pending_state_section)
+
+    append_system(todo_prompt_context, source="runtime_todo_state")
+    append_system(continuity_summary, source="continuity_summary")
+
+    for artifact_reference in artifact_reference_sections:
+        if artifact_reference.role == "system":
+            append_system(
+                artifact_reference.content,
+                source=artifact_reference.source,
+                metadata=artifact_reference.metadata,
+            )
+            continue
+        sections.append(artifact_reference)
+
+    sections.append(
+        PromptAssemblySection(
+            role="user",
+            content=prompt,
+            source="current_user_prompt",
+            metadata={"source": "current_user_prompt"},
+        )
+    )
+    return PromptAssemblyPlan(sections=tuple(sections))
+
+
+def _metadata_source(metadata: Mapping[str, object], *, fallback: str) -> str:
+    source = metadata.get("source")
+    return source if isinstance(source, str) and source.strip() else fallback
+
+
+__all__ = [
+    "PromptAssemblyPlan",
+    "PromptAssemblySection",
+    "build_prompt_assembly_plan",
+]

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -234,8 +234,58 @@ def test_assemble_provider_context_injects_active_runtime_todos() -> None:
         for content in system_segments
     )
     assert [segment.metadata for segment in assembled.segments if segment.role == "system"] == [
-        {"source": "runtime_instruction_precedence"},
-        {"source": "runtime_todo_state"},
+        {"source": "runtime_instruction_precedence", "tier": "instruction"},
+        {"source": "runtime_todo_state", "tier": "task"},
+    ]
+
+
+def test_assemble_provider_context_records_explicit_context_tiers() -> None:
+    assembled = assemble_provider_context(
+        prompt="continue",
+        tool_results=(
+            ToolResult(
+                tool_name="read_file",
+                status="ok",
+                content="alpha",
+                data={"tool_call_id": "call-1", "arguments": {"path": "src/app.py"}},
+            ),
+        ),
+        session_metadata={
+            "runtime_state": {
+                "todos": {
+                    "version": 1,
+                    "revision": 12,
+                    "todos": [
+                        {
+                            "content": "implement tiers",
+                            "status": "in_progress",
+                            "priority": "high",
+                            "position": 1,
+                            "updated_at": 12,
+                        }
+                    ],
+                }
+            }
+        },
+        skill_prompt_context="skill context",
+        policy=_legacy_context_window_policy(max_tool_results=4),
+    )
+
+    assert assembled.metadata["context_tiers"] == {
+        "version": 1,
+        "order": ["instruction", "task", "recent"],
+        "counts": {
+            "instruction": 2,
+            "workspace": 0,
+            "task": 2,
+            "recent": 2,
+        },
+    }
+    assert [(segment.metadata or {}).get("tier") for segment in assembled.segments[:4]] == [
+        "instruction",
+        "instruction",
+        "task",
+        "task",
     ]
 
 
@@ -534,6 +584,7 @@ def test_assemble_provider_context_injects_pending_approval_state() -> None:
     assert "runtime resume" in pending_segments[0].content
     assert pending_segments[0].metadata == {
         "source": "runtime_pending_state",
+        "tier": "task",
         "status": "waiting_approval",
         "blocked_tool": "write_file",
         "approval_request_id": "approval-123",
@@ -564,6 +615,12 @@ def test_assemble_provider_context_injects_pending_question_state() -> None:
     assert "waiting_question" in pending_segments[0].content
     assert "pending question" in pending_segments[0].content
     assert "question" in pending_segments[0].content
+    assert pending_segments[0].metadata == {
+        "source": "runtime_pending_state",
+        "tier": "task",
+        "status": "waiting_question",
+        "blocked_tool": "question",
+    }
 
 
 def test_provider_context_inspector_reports_synthetic_feedback_mode() -> None:
@@ -1970,7 +2027,7 @@ def test_assemble_provider_context_reconstructs_projection_metadata_from_prior_c
     continuity_segments = [
         segment
         for segment in assembled.segments
-        if segment.metadata == {"source": "continuity_summary"}
+        if segment.metadata is not None and segment.metadata.get("source") == "continuity_summary"
     ]
     assert len(continuity_segments) == 1
     assert "Prior compact projection only" in (continuity_segments[0].content or "")

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -7,6 +7,8 @@ from types import ModuleType
 from typing import Any, Literal, cast
 from unittest.mock import patch
 
+import pytest
+
 from voidcode.runtime.context_transforms import (
     HookPresetGuidanceTransformProvider,
     RuntimeContextTransformRegistry,
@@ -102,8 +104,22 @@ def test_context_window_policy_default_retains_more_tool_results_before_compacti
     assert policy.max_tool_results == 8
     assert policy.recent_tool_result_tokens == 3_000
     assert policy.default_tool_result_tokens == 1_500
+    assert policy.protected_context_tiers == ("instruction", "workspace", "task")
     assert context.compacted is False
     assert context.retained_tool_result_count == 7
+
+
+def test_context_window_policy_deduplicates_protected_tiers() -> None:
+    policy = _legacy_context_window_policy(
+        protected_context_tiers=("instruction", "task", "instruction", "recent")
+    )
+
+    assert policy.protected_context_tiers == ("instruction", "task", "recent")
+
+
+def test_context_window_policy_rejects_unknown_protected_tier() -> None:
+    with pytest.raises(ValueError, match="protected_context_tiers"):
+        _ = _legacy_context_window_policy(protected_context_tiers=("instruction", "weird"))
 
 
 def test_prepare_provider_context_default_policy_truncates_large_tool_results() -> None:
@@ -280,6 +296,11 @@ def test_assemble_provider_context_records_explicit_context_tiers() -> None:
             "task": 2,
             "recent": 2,
         },
+    }
+    assert assembled.metadata["context_tier_policy"] == {
+        "version": 1,
+        "protected_tiers": ["instruction", "workspace", "task"],
+        "compaction_target": "recent",
     }
     assert [(segment.metadata or {}).get("tier") for segment in assembled.segments[:4]] == [
         "instruction",

--- a/tests/unit/runtime/test_prompt_assembly.py
+++ b/tests/unit/runtime/test_prompt_assembly.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from voidcode.runtime.context_transforms import (
+    RuntimeContextTransformInjection,
+    RuntimeContextTransformResult,
+)
+from voidcode.runtime.prompt_assembly import (
+    PromptAssemblySection,
+    build_prompt_assembly_plan,
+)
+
+
+def test_build_prompt_assembly_plan_orders_core_sections() -> None:
+    plan = build_prompt_assembly_plan(
+        prompt="fix the failing test",
+        runtime_instruction_precedence="runtime first",
+        agent_prompt_context="agent prompt",
+        preserved_system_segments=("preserved-a",),
+        skill_prompt_context="skill context",
+        pending_state_section=PromptAssemblySection(
+            role="system",
+            content="waiting approval",
+            source="runtime_pending_state",
+            metadata={"status": "waiting_approval"},
+        ),
+        todo_prompt_context="active todo",
+        continuity_summary="continuity summary",
+        artifact_reference_sections=(
+            PromptAssemblySection(
+                role="system",
+                content="artifact ref",
+                source="runtime_context_artifact_reference",
+            ),
+        ),
+    )
+
+    assert [section.source for section in plan.sections] == [
+        "runtime_instruction_precedence",
+        "agent_prompt",
+        "preserved_system_segment",
+        "skill_prompt",
+        "runtime_pending_state",
+        "runtime_todo_state",
+        "continuity_summary",
+        "runtime_context_artifact_reference",
+        "current_user_prompt",
+    ]
+    assert plan.sections[-1].role == "user"
+    assert plan.sections[-1].content == "fix the failing test"
+
+
+def test_build_prompt_assembly_plan_deduplicates_system_text() -> None:
+    plan = build_prompt_assembly_plan(
+        prompt="continue",
+        runtime_instruction_precedence="same text",
+        agent_prompt_context="same text",
+        preserved_system_segments=("same text",),
+        skill_prompt_context="same text",
+    )
+
+    assert [section.source for section in plan.sections] == [
+        "runtime_instruction_precedence",
+        "current_user_prompt",
+    ]
+
+
+def test_build_prompt_assembly_plan_keeps_non_system_transform_roles() -> None:
+    plan = build_prompt_assembly_plan(
+        prompt="continue",
+        runtime_instruction_precedence="runtime first",
+        context_transform_result=RuntimeContextTransformResult(
+            injections=(
+                RuntimeContextTransformInjection(
+                    role="assistant",
+                    content="assistant injected note",
+                    metadata={"source": "transform_assistant"},
+                ),
+                RuntimeContextTransformInjection(
+                    role="system",
+                    content="system injected note",
+                    metadata={"source": "transform_system"},
+                ),
+            )
+        ),
+    )
+
+    assert [section.source for section in plan.sections] == [
+        "runtime_instruction_precedence",
+        "transform_assistant",
+        "transform_system",
+        "current_user_prompt",
+    ]
+    assistant_section = plan.sections[1]
+    assert assistant_section.role == "assistant"
+    assert assistant_section.content == "assistant injected note"
+
+
+def test_build_prompt_assembly_plan_preserves_pending_state_metadata() -> None:
+    pending = PromptAssemblySection(
+        role="system",
+        content="Runtime pending state: waiting_question.",
+        source="runtime_pending_state",
+        metadata={"status": "waiting_question", "blocked_tool": "question"},
+    )
+    plan = build_prompt_assembly_plan(
+        prompt="continue",
+        runtime_instruction_precedence="runtime first",
+        pending_state_section=pending,
+    )
+
+    pending_section = plan.sections[1]
+    assert pending_section.source == "runtime_pending_state"
+    assert pending_section.metadata == {
+        "status": "waiting_question",
+        "blocked_tool": "question",
+    }

--- a/tests/unit/runtime/test_prompt_assembly.py
+++ b/tests/unit/runtime/test_prompt_assembly.py
@@ -21,6 +21,7 @@ def test_build_prompt_assembly_plan_orders_core_sections() -> None:
             role="system",
             content="waiting approval",
             source="runtime_pending_state",
+            tier="task",
             metadata={"status": "waiting_approval"},
         ),
         todo_prompt_context="active todo",
@@ -30,6 +31,7 @@ def test_build_prompt_assembly_plan_orders_core_sections() -> None:
                 role="system",
                 content="artifact ref",
                 source="runtime_context_artifact_reference",
+                tier="recent",
             ),
         ),
     )
@@ -47,6 +49,17 @@ def test_build_prompt_assembly_plan_orders_core_sections() -> None:
     ]
     assert plan.sections[-1].role == "user"
     assert plan.sections[-1].content == "fix the failing test"
+    assert [section.tier for section in plan.sections] == [
+        "instruction",
+        "instruction",
+        "instruction",
+        "instruction",
+        "task",
+        "task",
+        "recent",
+        "recent",
+        "task",
+    ]
 
 
 def test_build_prompt_assembly_plan_deduplicates_system_text() -> None:
@@ -73,12 +86,12 @@ def test_build_prompt_assembly_plan_keeps_non_system_transform_roles() -> None:
                 RuntimeContextTransformInjection(
                     role="assistant",
                     content="assistant injected note",
-                    metadata={"source": "transform_assistant"},
+                    metadata={"source": "transform_assistant", "tier": "workspace"},
                 ),
                 RuntimeContextTransformInjection(
                     role="system",
                     content="system injected note",
-                    metadata={"source": "transform_system"},
+                    metadata={"source": "transform_system", "tier": "workspace"},
                 ),
             )
         ),
@@ -93,6 +106,7 @@ def test_build_prompt_assembly_plan_keeps_non_system_transform_roles() -> None:
     assistant_section = plan.sections[1]
     assert assistant_section.role == "assistant"
     assert assistant_section.content == "assistant injected note"
+    assert assistant_section.tier == "workspace"
 
 
 def test_build_prompt_assembly_plan_preserves_pending_state_metadata() -> None:
@@ -100,6 +114,7 @@ def test_build_prompt_assembly_plan_preserves_pending_state_metadata() -> None:
         role="system",
         content="Runtime pending state: waiting_question.",
         source="runtime_pending_state",
+        tier="task",
         metadata={"status": "waiting_question", "blocked_tool": "question"},
     )
     plan = build_prompt_assembly_plan(
@@ -114,3 +129,4 @@ def test_build_prompt_assembly_plan_preserves_pending_state_metadata() -> None:
         "status": "waiting_question",
         "blocked_tool": "question",
     }
+    assert pending_section.tier == "task"

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -2924,10 +2924,14 @@ def test_runtime_custom_primary_agent_summary_and_capability_snapshot(tmp_path: 
     agent_segments = [
         segment
         for segment in request.assembled_context.segments
-        if segment.role == "system" and segment.metadata == {"source": "agent_prompt"}
+        if segment.role == "system"
+        and segment.metadata is not None
+        and segment.metadata.get("source") == "agent_prompt"
     ]
     assert len(agent_segments) == 1
     assert agent_segments[0].content == "Custom planner prompt body."
+    assert agent_segments[0].metadata is not None
+    assert agent_segments[0].metadata.get("tier") == "instruction"
     capability_snapshot = cast(
         dict[str, object],
         response.session.metadata["agent_capability_snapshot"],
@@ -12708,6 +12712,16 @@ def test_runtime_provider_compaction_emits_continuity_state_and_persists_metadat
                 }
             ],
         },
+        "context_tiers": {
+            "version": 1,
+            "order": ["instruction", "workspace", "recent", "task"],
+            "counts": {
+                "instruction": 2,
+                "workspace": 1,
+                "task": 1,
+                "recent": 3,
+            },
+        },
         "estimated_context_tokens": response_context_window["estimated_context_tokens"],
         "estimated_context_token_source": "tiktoken:cl100k_base",
         "estimated_context_token_exact": True,
@@ -14691,10 +14705,14 @@ def test_runtime_preserved_prompt_materialization_reaches_render_agent_prompt(
     agent_segments = [
         segment
         for segment in request.assembled_context.segments
-        if segment.role == "system" and segment.metadata == {"source": "agent_prompt"}
+        if segment.role == "system"
+        and segment.metadata is not None
+        and segment.metadata.get("source") == "agent_prompt"
     ]
     assert len(agent_segments) == 1
     assert agent_segments[0].content == "Use only the custom leader prompt."
+    assert agent_segments[0].metadata is not None
+    assert agent_segments[0].metadata.get("tier") == "instruction"
     assert "Delegate when the task is multi-step" not in agent_segments[0].content
     runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
     agent_payload = cast(dict[str, object], runtime_config["agent"])
@@ -19550,7 +19568,8 @@ def test_runtime_context_window_resume_continuity_metadata_is_projection_only(
         "raw retained"
     ]
     assert any(
-        segment.metadata == {"source": "continuity_summary"}
+        segment.metadata is not None
+        and segment.metadata.get("source") == "continuity_summary"
         and segment.content is not None
         and "Prior compact summary is projection metadata" in segment.content
         for segment in assembled.segments

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -12722,6 +12722,11 @@ def test_runtime_provider_compaction_emits_continuity_state_and_persists_metadat
                 "recent": 3,
             },
         },
+        "context_tier_policy": {
+            "version": 1,
+            "protected_tiers": ["instruction", "workspace", "task"],
+            "compaction_target": "recent",
+        },
         "estimated_context_tokens": response_context_window["estimated_context_tokens"],
         "estimated_context_token_source": "tiktoken:cl100k_base",
         "estimated_context_token_exact": True,


### PR DESCRIPTION
## Summary

This PR starts **Phase 2** of the lightweight-harness roadmap by making the
runtime's prompt/context composition explicit and tier-aware, while keeping the
existing behavior stable.

It does **not** introduce RepoMap yet and does **not** rewrite the compaction
algorithm. Instead it lays the product boundaries that RepoMap or tier-specific
compaction can plug into later without reworking prompt assembly again.

### What ships in this PR

#### 1. Prompt Assembly Extraction
Commit: `2ed0f1d0`

- Add `src/voidcode/runtime/prompt_assembly.py`
- Introduce:
  - `PromptAssemblySection`
  - `PromptAssemblyPlan`
  - `build_prompt_assembly_plan()`
- Move section planning out of `context_window.assemble_provider_context()`
  while preserving current behavior.
- Make the following prompt sections explicit and testable:
  - runtime instruction precedence
  - agent prompt
  - preserved system segments
  - skill prompt
  - transform injections
  - pending state
  - todo state
  - continuity summary
  - artifact references
  - current user prompt

This is a structural extraction, not a semantic rewrite.

#### 2. Explicit Context Tiers
Commit: `c96907da`

- Productize the runtime's previously implicit context layering.
- Add explicit tiers to prompt sections / assembled segment metadata:
  - `instruction`
  - `workspace`
  - `task`
  - `recent`
- Persist tier info into `RuntimeContextSegment.metadata`.
- Add `assembled.metadata["context_tiers"]` with:
  - `version`
  - `order`
  - `counts`

This makes the assembled context layer-aware without changing existing prompt
source ordering.

#### 3. Tier-Aware Policy Metadata
Commit: `28a1dc2f`

- Extend `ContextWindowPolicy` with `protected_context_tiers`
- Default protected tiers:
  - `instruction`
  - `workspace`
  - `task`
- Treat `recent` as the current compaction target
- Expose `assembled.metadata["context_tier_policy"]`:
  - `version`
  - `protected_tiers`
  - `compaction_target`
- Add validation + deduplication for policy tiers

This still does **not** change the actual tool-result compaction algorithm. It
makes the policy surface explicit so future tier-specific compaction or a
workspace/project-map provider can target the right tier intentionally.

## Why this PR exists

Phase 1 gave VoidCode a more disciplined harness surface:
- plan/act execution modes
- lazy-skill contract lockdown
- disciplined `todo_write`

Phase 2 starts by making the runtime's prompt/context boundary more explicit:
- first extract section planning
- then make tiers explicit
- then surface the active tier policy

This is the minimum stable base needed before introducing either:
- tier-specific compaction, or
- a minimal workspace/project-map provider

## Verification

- `mise run lint` ✅
- `mise run typecheck` ✅
- `tests/unit/runtime/` ✅ `1165 passed`
- focused runtime regression suites updated and green:
  - `test_prompt_assembly.py`
  - `test_context_window.py`
  - `test_runtime_service_extensions.py`

## Important note about branch history

While developing this, one Phase 2 commit (`2ed0f1d0`) was accidentally created
on `master` before work continued on this feature branch. The author has
already acknowledged they plan to drop that stray commit manually. After that
history cleanup, this branch will likely need a small rebase to stay clean.

I am calling that out explicitly here so reviewers understand any temporary
history oddity is a workflow cleanup issue, not a code-integrity issue.

## Follow-ups intentionally left out

Not in this PR:
- RepoMap / project map provider
- graphify-style graph extraction
- tier-specific compaction of recent sections
- workspace-tier context providers
- config-surface expansion for tier policy

Those can now build on the product boundaries introduced here rather than
mixing new behavior into the old inline prompt assembly path.