### PR TITLE
feat(runtime): compact recent-tier context under pressure

### DIFF
--- a/src/voidcode/runtime/context_window.py
+++ b/src/voidcode/runtime/context_window.py
@@ -385,6 +385,52 @@ def _context_tier_metadata(
     }
 
 
+def _compact_recent_tier_segments(
+    segments: list[RuntimeContextSegment],
+) -> tuple[list[RuntimeContextSegment], dict[str, object]]:
+    compacted_segments: list[RuntimeContextSegment] = []
+    dropped_recent_segments = 0
+    dropped_sources: list[str] = []
+    skip_tool_call_ids: set[str] = set()
+
+    for segment in segments:
+        metadata = segment.metadata or {}
+        tier = metadata.get("tier")
+        source = metadata.get("source")
+        tool_call_id = segment.tool_call_id
+
+        drop_recent = False
+        if tier == "recent":
+            if source in {"continuity_summary", "runtime_context_artifact_reference"}:
+                drop_recent = True
+            elif source == "retained_tool_result" and tool_call_id is not None:
+                drop_recent = True
+
+        if drop_recent:
+            dropped_recent_segments += 1
+            if isinstance(source, str) and source not in dropped_sources:
+                dropped_sources.append(source)
+            if tool_call_id is not None:
+                skip_tool_call_ids.add(tool_call_id)
+            continue
+
+        if tool_call_id is not None and tool_call_id in skip_tool_call_ids:
+            dropped_recent_segments += 1
+            if isinstance(source, str) and source not in dropped_sources:
+                dropped_sources.append(source)
+            continue
+
+        compacted_segments.append(segment)
+
+    return compacted_segments, {
+        "version": 1,
+        "applied": dropped_recent_segments > 0,
+        "dropped_segment_count": dropped_recent_segments,
+        "dropped_sources": dropped_sources,
+        "target_tier": "recent",
+    }
+
+
 def estimate_provider_context_tokens(
     segments: tuple[RuntimeContextSegment, ...], *, tokenizer_model: str | None = None
 ) -> TokenCount:
@@ -2056,30 +2102,55 @@ def assemble_provider_context(
         "protected_tiers": list((policy or ContextWindowPolicy()).protected_context_tiers),
         "compaction_target": "recent",
     }
-    context_token_count = estimate_provider_context_tokens(
-        tuple(segments), tokenizer_model=policy.tokenizer_model if policy is not None else None
-    )
-    metadata_payload["estimated_context_tokens"] = context_token_count.tokens
-    metadata_payload["estimated_context_token_source"] = context_token_count.source
-    metadata_payload["estimated_context_token_exact"] = context_token_count.exact
-    # Final-context guard: compare the assembled context against the model window.
-    # Even after tool-result compaction, system segments (agent prompt, hook guidance,
-    # skills, todos, continuity summary) can push the prompt beyond the provider's
-    # input limit. We expose pressure ratio + overflow detection as metadata so the
-    # runtime can emit context_pressure events / overflow diagnostics without forcing
-    # a hard error here (callers may choose to surface or fail-fast).
     effective_policy_for_guard = policy or ContextWindowPolicy()
-    model_window_tokens = effective_policy_for_guard.model_context_window_tokens
-    if model_window_tokens is not None and model_window_tokens > 0:
-        pressure_ratio = context_token_count.tokens / model_window_tokens
-        metadata_payload["context_pressure_ratio"] = pressure_ratio
-        metadata_payload["context_pressure_threshold"] = (
-            effective_policy_for_guard.context_pressure_threshold
+
+    def _record_context_pressure(current_segments: list[RuntimeContextSegment]) -> TokenCount:
+        context_token_count = estimate_provider_context_tokens(
+            tuple(current_segments),
+            tokenizer_model=policy.tokenizer_model if policy is not None else None,
         )
-        metadata_payload["context_pressure_detected"] = (
-            pressure_ratio >= effective_policy_for_guard.context_pressure_threshold
-        )
-        metadata_payload["context_overflow_detected"] = pressure_ratio >= 1.0
+        metadata_payload["estimated_context_tokens"] = context_token_count.tokens
+        metadata_payload["estimated_context_token_source"] = context_token_count.source
+        metadata_payload["estimated_context_token_exact"] = context_token_count.exact
+        model_window_tokens = effective_policy_for_guard.model_context_window_tokens
+        if model_window_tokens is not None and model_window_tokens > 0:
+            pressure_ratio = context_token_count.tokens / model_window_tokens
+            metadata_payload["context_pressure_ratio"] = pressure_ratio
+            metadata_payload["context_pressure_threshold"] = (
+                effective_policy_for_guard.context_pressure_threshold
+            )
+            metadata_payload["context_pressure_detected"] = (
+                pressure_ratio >= effective_policy_for_guard.context_pressure_threshold
+            )
+            metadata_payload["context_overflow_detected"] = pressure_ratio >= 1.0
+        return context_token_count
+
+    _record_context_pressure(segments)
+    recent_tier_compaction = {
+        "version": 1,
+        "applied": False,
+        "dropped_segment_count": 0,
+        "dropped_sources": [],
+        "target_tier": "recent",
+    }
+    if metadata_payload.get("context_pressure_detected") is True:
+        pressure_before = metadata_payload.get("context_pressure_ratio")
+        overflow_before = metadata_payload.get("context_overflow_detected")
+        compacted_segments, compaction_metadata = _compact_recent_tier_segments(segments)
+        if compaction_metadata["applied"]:
+            segments = compacted_segments
+            metadata_payload["context_tiers"] = _context_tier_metadata(segments)
+            recent_tier_compaction = compaction_metadata
+            _record_context_pressure(segments)
+            recent_tier_compaction["pressure_ratio_before"] = pressure_before
+            recent_tier_compaction["pressure_ratio_after"] = metadata_payload.get(
+                "context_pressure_ratio"
+            )
+            recent_tier_compaction["overflow_before"] = overflow_before
+            recent_tier_compaction["overflow_after"] = metadata_payload.get(
+                "context_overflow_detected"
+            )
+    metadata_payload["recent_tier_compaction"] = recent_tier_compaction
     return RuntimeAssembledContext(
         prompt=prompt,
         tool_results=context_window.tool_results,

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -205,6 +205,101 @@ def test_assemble_provider_context_reports_full_context_pressure_and_overflow() 
     assert assembled.metadata["context_overflow_detected"] is True
     assert assembled.metadata["context_pressure_threshold"] == 0.5
     assert cast(float, assembled.metadata["context_pressure_ratio"]) >= 1.0
+    assert assembled.metadata["recent_tier_compaction"] == {
+        "version": 1,
+        "applied": False,
+        "dropped_segment_count": 0,
+        "dropped_sources": [],
+        "target_tier": "recent",
+    }
+
+
+def test_recent_tier_compaction_trims_recent_sections_under_pressure() -> None:
+    continuity = RuntimeContinuityState(
+        summary_text="recent summary " * 80,
+        dropped_tool_result_count=1,
+        retained_tool_result_count=1,
+        source="tool_result_window",
+    )
+    assembled = assemble_provider_context(
+        prompt="continue",
+        tool_results=(
+            ToolResult(
+                tool_name="read_file",
+                status="ok",
+                content="retained tool content " * 60,
+                data={"tool_call_id": "call-1", "arguments": {"path": "src/app.py"}},
+            ),
+        ),
+        session_metadata={},
+        preserved_continuity_state=continuity,
+        skill_prompt_context="task skill",
+        policy=_legacy_context_window_policy(
+            model_context_window_tokens=120,
+            context_pressure_threshold=0.3,
+            max_tool_results=4,
+        ),
+    )
+
+    recent_compaction = cast(dict[str, object], assembled.metadata["recent_tier_compaction"])
+    assert recent_compaction["version"] == 1
+    assert recent_compaction["applied"] is True
+    assert recent_compaction["dropped_segment_count"] == 3
+    assert recent_compaction["dropped_sources"] == [
+        "continuity_summary",
+        "retained_tool_result",
+    ]
+    assert recent_compaction["target_tier"] == "recent"
+    assert all(
+        segment.metadata is None
+        or segment.metadata.get("source") not in {"continuity_summary", "retained_tool_result"}
+        for segment in assembled.segments
+        if (segment.metadata or {}).get("tier") == "recent"
+    )
+    context_tiers = cast(dict[str, object], assembled.metadata["context_tiers"])
+    counts = cast(dict[str, int], context_tiers["counts"])
+    assert counts["recent"] == 0
+    pressure_before = cast(float, recent_compaction["pressure_ratio_before"])
+    pressure_after = cast(float, recent_compaction["pressure_ratio_after"])
+    assert pressure_after <= pressure_before
+
+
+def test_assemble_provider_context_second_stage_preserves_non_recent_tiers() -> None:
+    assembled = assemble_provider_context(
+        prompt="continue",
+        tool_results=(),
+        session_metadata={
+            "runtime_state": {
+                "todos": {
+                    "version": 1,
+                    "revision": 12,
+                    "todos": [
+                        {
+                            "content": "must survive compaction",
+                            "status": "in_progress",
+                            "priority": "high",
+                            "position": 1,
+                            "updated_at": 12,
+                        }
+                    ],
+                }
+            }
+        },
+        agent_prompt_context="A" * 400,
+        policy=_legacy_context_window_policy(
+            model_context_window_tokens=20,
+            context_pressure_threshold=0.5,
+        ),
+    )
+
+    assert any(
+        (segment.metadata or {}).get("source") == "runtime_todo_state"
+        for segment in assembled.segments
+    )
+    assert any(
+        (segment.metadata or {}).get("source") == "runtime_instruction_precedence"
+        for segment in assembled.segments
+    )
 
 
 def test_assemble_provider_context_injects_active_runtime_todos() -> None:

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -12727,6 +12727,13 @@ def test_runtime_provider_compaction_emits_continuity_state_and_persists_metadat
             "protected_tiers": ["instruction", "workspace", "task"],
             "compaction_target": "recent",
         },
+        "recent_tier_compaction": {
+            "version": 1,
+            "applied": False,
+            "dropped_segment_count": 0,
+            "dropped_sources": [],
+            "target_tier": "recent",
+        },
         "estimated_context_tokens": response_context_window["estimated_context_tokens"],
         "estimated_context_token_source": "tiktoken:cl100k_base",
         "estimated_context_token_exact": True,


### PR DESCRIPTION
## Summary

Follow-up to the Phase 2 prompt/context productization work in #468.

That PR made prompt assembly explicit, introduced context tiers, and surfaced
tier policy metadata. This PR is the first place where the runtime actually
**uses** that tier boundary at execution time.

When the assembled provider context still exceeds the configured pressure
threshold after the existing tool-result compaction pass, the runtime now runs a
**second-stage recent-tier compaction pass**. The key rule is simple:

- trim **only** `recent` tier context
- keep `instruction`, `workspace`, and `task` tiers protected

## What this PR changes

### Second-stage recent-tier compaction
In `src/voidcode/runtime/context_window.py`:

- After the normal assembled context is built, the runtime measures provider
  context pressure as before.
- If `context_pressure_detected` is still true, it compacts only the `recent`
  tier by removing:
  - `continuity_summary`
  - `runtime_context_artifact_reference`
  - retained `assistant` / `tool` pairs sourced from `retained_tool_result`
- The runtime then recalculates provider-context pressure on the compacted
  segment list.

This means the runtime now has a two-step strategy:
1. compact tool results into bounded retained history
2. if pressure still persists, shave off recent derived context before touching
   instructions, workspace context, or task-state guidance

### New metadata for observability
The assembled provider context now exposes:

```json
"recent_tier_compaction": {
  "version": 1,
  "applied": true|false,
  "dropped_segment_count": <int>,
  "dropped_sources": [...],
  "target_tier": "recent",
  "pressure_ratio_before": <float>,
  "pressure_ratio_after": <float>,
  "overflow_before": <bool>,
  "overflow_after": <bool>
}
```

This keeps the feature debuggable and gives future runtime policy work a stable
surface to build on.

## Behavioral intent

This PR deliberately does **not** attempt full tier-specific compaction for all
layers. It only answers one focused question:

> Once we know the runtime has a protected `instruction/workspace/task` core,
> can we safely trim `recent` derived context first?

The answer is now yes.

## Tests

Added / updated tests to cover:

- recent-tier compaction triggers under pressure
- non-recent tiers remain preserved
- before/after pressure metadata is recorded
- runtime service snapshot expectations include the new metadata shape
- full runtime unit suite remains green

## Verification

- `mise run lint` ✅
- `mise run typecheck` ✅
- `tests/unit/runtime/` ✅ (`1167 passed`)
- Manual QA driver confirmed:
  - compaction fires
  - recent-tier segments are removed
  - `context_tiers.counts.recent` drops to `0`
  - `pressure_ratio_after <= pressure_ratio_before`

## Why this matters

This is the first PR where context tiers stop being descriptive metadata and
start becoming a real runtime decision boundary.

It sets up the next logical follow-ups cleanly:
- more nuanced tier-specific compaction policy
- workspace-tier providers (e.g. minimal project map)
- better pressure handling before provider invocation