### PR TITLE
feat: add tmux-backed interactive shell tool

### DIFF
--- a/src/voidcode/runtime/tool_display.py
+++ b/src/voidcode/runtime/tool_display.py
@@ -144,6 +144,12 @@ def _build_copyable(
     """Build optional copyable payload for the tool."""
     payload: dict[str, object] = {}
 
+    if tool_name == "interactive_shell":
+        tmux_command = _first_primitive(arguments, "tmux_command")
+        if tmux_command:
+            payload["tmux_command"] = _truncate_arg(tmux_command)
+        return payload if payload else None
+
     if tool_name == "shell_exec":
         command = _first_primitive(arguments, "command")
         if command:

--- a/src/voidcode/runtime/tool_provider.py
+++ b/src/voidcode/runtime/tool_provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Callable, Iterable
 from fnmatch import fnmatchcase
 from pathlib import Path
@@ -11,6 +12,7 @@ from ..tools.contracts import Tool
 from ..tools.edit import EditTool
 from ..tools.glob import GlobTool
 from ..tools.grep import GrepTool
+from ..tools.interactive_shell import InteractiveShellTool
 from ..tools.local_custom import discover_local_custom_tools
 from ..tools.read_file import ReadFileTool
 from ..tools.shell_exec import ShellExecTool
@@ -32,6 +34,7 @@ BUILTIN_TOOL_NAMES = frozenset(
         "format_file",
         "glob",
         "grep",
+        "interactive_shell",
         "lsp",
         "multi_edit",
         "read_file",
@@ -228,6 +231,9 @@ class BuiltinToolProvider:
             WebSearchTool(),
             WriteFileTool(hooks_config=self._hooks_config),
         ]
+
+        if os.name != "nt":
+            tools.append(InteractiveShellTool())
 
         if self._lsp_tool is not None:
             tools.append(self._lsp_tool)

--- a/src/voidcode/tools/__init__.py
+++ b/src/voidcode/tools/__init__.py
@@ -8,6 +8,7 @@ from .edit import EditTool
 from .format_file import FormatTool
 from .glob import GlobTool
 from .grep import GrepTool
+from .interactive_shell import InteractiveShellTool
 from .local_custom import LocalCustomTool
 from .lsp import LspTool
 from .mcp import McpTool
@@ -45,6 +46,7 @@ __all__ = [
     "FormatTool",
     "GlobTool",
     "GrepTool",
+    "InteractiveShellTool",
     "LocalCustomTool",
     "ReadFileTool",
     "QuestionTool",

--- a/src/voidcode/tools/guidance.py
+++ b/src/voidcode/tools/guidance.py
@@ -19,6 +19,7 @@ _TOOL_GUIDANCE_FILES = {
     "format_file": "format_file.txt",
     "glob": "glob.txt",
     "grep": "grep.txt",
+    "interactive_shell": "interactive_shell.txt",
     "lsp": "lsp.txt",
     "multi_edit": "multi_edit.txt",
     "question": "question.txt",

--- a/src/voidcode/tools/interactive_shell.py
+++ b/src/voidcode/tools/interactive_shell.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+from typing import ClassVar, final
+
+from pydantic import BaseModel, ValidationError, field_validator
+
+from ._pydantic_args import format_validation_error
+from .contracts import ToolCall, ToolDefinition, ToolResult
+
+_BLOCKED_SUBCOMMANDS = frozenset(
+    {
+        "attach-session",
+        "attach",
+        "kill-pane",
+        "kill-server",
+        "kill-session",
+        "wait-for",
+    }
+)
+
+
+class InteractiveShellArgs(BaseModel):
+    tmux_command: str
+    description: str | None = None
+
+    @field_validator("tmux_command")
+    @classmethod
+    def _validate_tmux_command(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("tmux_command must not be empty")
+        return normalized
+
+    @field_validator("description")
+    @classmethod
+    def _validate_description(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("description must not be empty when provided")
+        return normalized
+
+
+@final
+class InteractiveShellTool:
+    definition: ClassVar[ToolDefinition] = ToolDefinition(
+        name="interactive_shell",
+        description="Execute a tmux subcommand for interactive terminal sessions.",
+        input_schema={
+            "tmux_command": {
+                "type": "string",
+                "description": "tmux subcommand and arguments, without the 'tmux' prefix",
+            },
+            "description": {
+                "type": "string",
+                "description": "Human-readable description of the tmux action",
+            },
+        },
+        read_only=False,
+    )
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        try:
+            args = InteractiveShellArgs.model_validate(
+                {
+                    "tmux_command": call.arguments.get("tmux_command"),
+                    "description": call.arguments.get("description"),
+                }
+            )
+        except ValidationError as exc:
+            raise ValueError(format_validation_error(self.definition.name, exc)) from exc
+
+        if os.name == "nt":
+            raise ValueError(
+                "interactive_shell currently requires tmux and is unsupported on Windows"
+            )
+
+        tmux_binary = shutil.which("tmux")
+        if tmux_binary is None:
+            raise ValueError("interactive_shell requires tmux to be installed and on PATH")
+
+        try:
+            command_parts = shlex.split(args.tmux_command)
+        except ValueError as exc:
+            raise ValueError(f"interactive_shell failed to parse tmux_command: {exc}") from exc
+        if not command_parts:
+            raise ValueError("interactive_shell tmux_command must not be empty")
+
+        subcommand = command_parts[0]
+        if subcommand in _BLOCKED_SUBCOMMANDS:
+            raise ValueError(f"interactive_shell blocks risky tmux subcommand '{subcommand}'")
+
+        completed = subprocess.run(
+            [tmux_binary, *command_parts],
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+        stdout = completed.stdout.replace("\r\n", "\n")
+        stderr = completed.stderr.replace("\r\n", "\n")
+        output = stdout if not stderr else f"{stdout}{stderr}" if stdout else stderr
+        status = "ok" if completed.returncode == 0 else "error"
+        error = (
+            None if status == "ok" else output or f"tmux exited with status {completed.returncode}"
+        )
+        return ToolResult(
+            tool_name=self.definition.name,
+            status=status,
+            content=output,
+            error=error,
+            data={
+                "tmux_command": args.tmux_command,
+                "subcommand": subcommand,
+                "exit_code": completed.returncode,
+                "stdout": stdout,
+                "stderr": stderr,
+                "cwd": str(workspace),
+            },
+        )

--- a/src/voidcode/tools/interactive_shell.txt
+++ b/src/voidcode/tools/interactive_shell.txt
@@ -1,0 +1,9 @@
+Execute a tmux subcommand for an interactive terminal session.
+
+Usage:
+- Pass tmux subcommands directly, without the `tmux` prefix.
+- Use this tool for interactive/session-oriented terminal control such as `new-session -d`, `split-window`, `send-keys`, `capture-pane`, `list-sessions`, or `list-panes`.
+- Prefer `shell_exec` for one-shot tests, builds, installs, and diagnostics.
+- This tool currently requires tmux and is unsupported on Windows.
+- Risky lifecycle commands such as `attach-session`, `kill-session`, `kill-pane`, `kill-server`, and `wait-for` are blocked.
+- Treat stdout, stderr, and exit_code as the source of truth.

--- a/tests/unit/runtime/test_tool_provider.py
+++ b/tests/unit/runtime/test_tool_provider.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 import textwrap
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -49,6 +50,7 @@ from voidcode.tools import (
     EditTool,
     GlobTool,
     GrepTool,
+    InteractiveShellTool,
     LocalCustomTool,
     McpTool,
     MultiEditTool,
@@ -241,8 +243,9 @@ def _write_local_tool_manifest(
 
 def test_builtin_tool_provider_returns_expected_builtin_tools() -> None:
     tools = BuiltinToolProvider().provide_tools()
+    tools_by_type = {type(tool) for tool in tools}
 
-    expected_tools = (
+    expected_tools: list[type[Any]] = [
         EditTool,
         GlobTool,
         GrepTool,
@@ -258,11 +261,12 @@ def test_builtin_tool_provider_returns_expected_builtin_tools() -> None:
         WriteFileTool,
         MultiEditTool,
         TodoWriteTool,
-    )
+    ]
+    if os.name != "nt":
+        expected_tools.append(InteractiveShellTool)
 
-    tool_types = tuple(type(tool) for tool in tools)
     for expected in expected_tools:
-        assert expected in tool_types, f"Missing tool: {expected.__name__}"
+        assert expected in tools_by_type, f"Missing tool: {expected.__name__}"
 
 
 def test_builtin_tool_provider_can_include_runtime_managed_mcp_tools() -> None:
@@ -620,6 +624,7 @@ def test_dynamic_mcp_tool_definitions_apply_server_safety_hints() -> None:
 
 def test_tool_registry_with_defaults_delegates_through_builtin_provider() -> None:
     provided_tools = BuiltinToolProvider().provide_tools()
+    provided_by_name = {tool.definition.name: tool for tool in provided_tools}
 
     with patch.object(
         BuiltinToolProvider,
@@ -643,9 +648,11 @@ def test_tool_registry_with_defaults_delegates_through_builtin_provider() -> Non
         "web_search",
         "write_file",
     ]
-    for i, tool_name in enumerate(core_tools):
+    if os.name != "nt":
+        core_tools.insert(3, "interactive_shell")
+    for tool_name in core_tools:
         assert tool_name in registry.tools, f"Missing core tool: {tool_name}"
-        assert registry.resolve(tool_name) is provided_tools[i]
+        assert registry.resolve(tool_name) is provided_by_name[tool_name]
 
     # Verify optional tools if present
     optional_tools = [

--- a/tests/unit/tools/test_interactive_shell_tool.py
+++ b/tests/unit/tools/test_interactive_shell_tool.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from voidcode.runtime.service import ToolRegistry
+from voidcode.tools import InteractiveShellTool, ToolCall
+
+
+def test_tools_package_and_default_registry_export_interactive_shell_tool() -> None:
+    registry = ToolRegistry.with_defaults()
+
+    assert "InteractiveShellTool" in __import__("voidcode.tools", fromlist=["__all__"]).__all__
+    if os.name == "nt":
+        assert "interactive_shell" not in registry.tools
+    else:
+        assert registry.resolve("interactive_shell").definition.name == "interactive_shell"
+        assert registry.resolve("interactive_shell").definition.read_only is False
+
+
+@pytest.mark.skipif(shutil.which("tmux") is None, reason="tmux unavailable")
+def test_interactive_shell_creates_and_captures_tmux_session(tmp_path: Path) -> None:
+    tool = InteractiveShellTool()
+    session_name = "vc-it-shell-test"
+    subprocess.run(["tmux", "kill-session", "-t", session_name], check=False, capture_output=True)
+    try:
+        create_result = tool.invoke(
+            ToolCall(
+                tool_name="interactive_shell",
+                arguments={"tmux_command": f"new-session -d -s {session_name}"},
+            ),
+            workspace=tmp_path,
+        )
+        assert create_result.status == "ok"
+
+        send_result = tool.invoke(
+            ToolCall(
+                tool_name="interactive_shell",
+                arguments={"tmux_command": f'send-keys -t {session_name} "printf hello" Enter'},
+            ),
+            workspace=tmp_path,
+        )
+        assert send_result.status == "ok"
+
+        capture_result = tool.invoke(
+            ToolCall(
+                tool_name="interactive_shell",
+                arguments={"tmux_command": f"capture-pane -p -t {session_name}"},
+            ),
+            workspace=tmp_path,
+        )
+        assert capture_result.status == "ok"
+        assert isinstance(capture_result.content, str)
+        assert "hello" in capture_result.content
+        assert capture_result.data["subcommand"] == "capture-pane"
+    finally:
+        subprocess.run(
+            ["tmux", "kill-session", "-t", session_name], check=False, capture_output=True
+        )
+
+
+def test_interactive_shell_blocks_risky_tmux_subcommands(tmp_path: Path) -> None:
+    tool = InteractiveShellTool()
+    with pytest.raises(ValueError, match="blocks risky tmux subcommand 'kill-session'"):
+        tool.invoke(
+            ToolCall(
+                tool_name="interactive_shell", arguments={"tmux_command": "kill-session -t demo"}
+            ),
+            workspace=tmp_path,
+        )
+
+
+@pytest.mark.skipif(os.name != "nt", reason="windows-only behavior")
+def test_interactive_shell_not_registered_on_windows() -> None:
+    registry = ToolRegistry.with_defaults()
+    assert "interactive_shell" not in registry.tools
+
+
+@pytest.mark.skipif(shutil.which("tmux") is None, reason="tmux unavailable")
+def test_interactive_shell_reports_tmux_failures(tmp_path: Path) -> None:
+    tool = InteractiveShellTool()
+    result = tool.invoke(
+        ToolCall(
+            tool_name="interactive_shell",
+            arguments={"tmux_command": "has-session -t definitely-missing-session"},
+        ),
+        workspace=tmp_path,
+    )
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.data["subcommand"] == "has-session"


### PR DESCRIPTION
## Summary
- add a new runtime-owned  tool for tmux-backed interactive terminal control
- keep  as the non-interactive command surface and hide  on Windows
- cover registration, blocking of risky tmux subcommands, and tmux-backed session capture with unit tests

## Verification
- ...s..............................................                       [100%]
49 passed, 1 skipped in 31.17s
- manual QA: created a tmux session, sent hello, and captured pane output through the new tool

## Follow-up
- consider a separate  tool for long-running non-interactive services like Vite or Uvicorn without overloading 
