### PR TITLE
feat: add background process tools and harden interactive shell

### DIFF
--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -75,6 +75,9 @@ from ..provider.snapshot import (
 from ..skills import SkillRegistry, skill_registry_with_builtins
 from ..tools.background_cancel import BackgroundCancelTool
 from ..tools.background_output import BackgroundOutputTool
+from ..tools.background_process_logs import BackgroundProcessLogsTool
+from ..tools.background_process_start import BackgroundProcessManager, BackgroundProcessStartTool
+from ..tools.background_process_stop import BackgroundProcessStopTool
 from ..tools.background_retry import BackgroundRetryTool
 from ..tools.contracts import (
     Tool,
@@ -522,6 +525,7 @@ class VoidCodeRuntime:
     _run_loop_coordinator: RuntimeRunLoopCoordinator
     _resume_coordinator: RuntimeResumeCoordinator
     _background_task_supervisor: RuntimeBackgroundTaskSupervisor
+    _background_process_manager: BackgroundProcessManager
     _context_transform_registry: RuntimeContextTransformRegistry
     _hook_recursion_env_var = "VOIDCODE_RUNNING_TOOL_HOOK"
     _default_context_window_policy = ContextWindowPolicy()
@@ -642,6 +646,7 @@ class VoidCodeRuntime:
         self._run_loop_coordinator = RuntimeRunLoopCoordinator(self)
         self._resume_coordinator = RuntimeResumeCoordinator(self)
         self._background_task_supervisor = RuntimeBackgroundTaskSupervisor(self)
+        self._background_process_manager = BackgroundProcessManager()
 
     def __enter__(self) -> VoidCodeRuntime:
         return self
@@ -697,7 +702,14 @@ class VoidCodeRuntime:
             background_output_tool=BackgroundOutputTool(runtime=self),
             background_cancel_tool=BackgroundCancelTool(runtime=self),
             background_retry_tool=BackgroundRetryTool(runtime=self),
+            background_process_start_tool=BackgroundProcessStartTool(runtime=self),
+            background_process_logs_tool=BackgroundProcessLogsTool(runtime=self),
+            background_process_stop_tool=BackgroundProcessStopTool(runtime=self),
         )
+
+    @property
+    def background_process_manager(self) -> BackgroundProcessManager:
+        return self._background_process_manager
 
     def _tool_registry_with_effective_local_tools(
         self,

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -654,6 +654,7 @@ class VoidCodeRuntime:
     def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
         _ = exc_type, exc, tb
         self.shutdown_background_tasks()
+        self._background_process_manager.stop_all()
         _ = self.disconnect_acp()
         _ = self.shutdown_mcp()
         _ = self.shutdown_lsp()

--- a/src/voidcode/runtime/tool_display.py
+++ b/src/voidcode/runtime/tool_display.py
@@ -21,6 +21,9 @@ from typing import cast
 # ── Tool-kind table ────────────────────────────────────────────────────────
 
 _TOOL_KIND_TABLE: dict[str, tuple[str, str]] = {
+    "background_process_start": ("background", "Background"),
+    "background_process_logs": ("background", "Background"),
+    "background_process_stop": ("background", "Background"),
     "shell_exec": ("shell", "Shell"),
     "read_file": ("read", "Read"),
     "write_file": ("write", "Write"),
@@ -150,6 +153,18 @@ def _build_copyable(
             payload["tmux_command"] = _truncate_arg(tmux_command)
         return payload if payload else None
 
+    if tool_name == "background_process_start":
+        command = _first_primitive(arguments, "command")
+        if command:
+            payload["command"] = _truncate_arg(command)
+        return payload if payload else None
+
+    if tool_name in {"background_process_logs", "background_process_stop"}:
+        process_id = _first_primitive(arguments, "process_id")
+        if process_id:
+            payload["process_id"] = process_id
+        return payload if payload else None
+
     if tool_name == "shell_exec":
         command = _first_primitive(arguments, "command")
         if command:
@@ -194,7 +209,23 @@ def build_tool_display(
     copyable: dict[str, object] | None = None
     hidden: bool = False
 
-    if tool_name == "shell_exec":
+    if tool_name == "background_process_start":
+        summary = (
+            _first_primitive(arguments, "description")
+            or _first_primitive(arguments, "command")
+            or "Background process"
+        )
+        summary = _truncate_summary(summary)
+        args = _extract_primitive_args(arguments, "command")
+        copyable = _build_copyable(tool_name, arguments, result_data)
+
+    elif tool_name in {"background_process_logs", "background_process_stop"}:
+        process_id = _first_primitive(arguments, "process_id")
+        summary = process_id if process_id else title
+        args = _extract_primitive_args(arguments, "process_id")
+        copyable = _build_copyable(tool_name, arguments, result_data)
+
+    elif tool_name == "shell_exec":
         summary = _synthesize_shell_summary(arguments)
         args = _extract_primitive_args(arguments, "command")
         copyable = _build_copyable(tool_name, arguments, result_data)

--- a/src/voidcode/runtime/tool_provider.py
+++ b/src/voidcode/runtime/tool_provider.py
@@ -28,6 +28,9 @@ BUILTIN_TOOL_NAMES = frozenset(
         "ast_grep_replace",
         "ast_grep_search",
         "background_cancel",
+        "background_process_logs",
+        "background_process_start",
+        "background_process_stop",
         "background_output",
         "background_retry",
         "edit",
@@ -193,6 +196,9 @@ class BuiltinToolProvider:
     _background_output_tool: Tool | None
     _background_cancel_tool: Tool | None
     _background_retry_tool: Tool | None
+    _background_process_start_tool: Tool | None
+    _background_process_logs_tool: Tool | None
+    _background_process_stop_tool: Tool | None
 
     def __init__(
         self,
@@ -207,6 +213,9 @@ class BuiltinToolProvider:
         background_output_tool: Tool | None = None,
         background_cancel_tool: Tool | None = None,
         background_retry_tool: Tool | None = None,
+        background_process_start_tool: Tool | None = None,
+        background_process_logs_tool: Tool | None = None,
+        background_process_stop_tool: Tool | None = None,
     ) -> None:
         self._lsp_tool = lsp_tool
         self._format_tool = format_tool
@@ -218,6 +227,9 @@ class BuiltinToolProvider:
         self._background_output_tool = background_output_tool
         self._background_cancel_tool = background_cancel_tool
         self._background_retry_tool = background_retry_tool
+        self._background_process_start_tool = background_process_start_tool
+        self._background_process_logs_tool = background_process_logs_tool
+        self._background_process_stop_tool = background_process_stop_tool
 
     def provide_tools(self) -> tuple[Tool, ...]:
         edit_tool = EditTool(hooks_config=self._hooks_config)
@@ -261,6 +273,15 @@ class BuiltinToolProvider:
 
         if self._background_retry_tool is not None:
             tools.append(self._background_retry_tool)
+
+        if self._background_process_start_tool is not None:
+            tools.append(self._background_process_start_tool)
+
+        if self._background_process_logs_tool is not None:
+            tools.append(self._background_process_logs_tool)
+
+        if self._background_process_stop_tool is not None:
+            tools.append(self._background_process_stop_tool)
 
         tools.extend(self._mcp_tools)
 

--- a/src/voidcode/runtime/tool_registry.py
+++ b/src/voidcode/runtime/tool_registry.py
@@ -40,6 +40,9 @@ class ToolRegistry:
         background_output_tool: Tool | None = None,
         background_cancel_tool: Tool | None = None,
         background_retry_tool: Tool | None = None,
+        background_process_start_tool: Tool | None = None,
+        background_process_logs_tool: Tool | None = None,
+        background_process_stop_tool: Tool | None = None,
     ) -> ToolRegistry:
         return cls.from_tools(
             BuiltinToolProvider(
@@ -53,6 +56,9 @@ class ToolRegistry:
                 background_output_tool=background_output_tool,
                 background_cancel_tool=background_cancel_tool,
                 background_retry_tool=background_retry_tool,
+                background_process_start_tool=background_process_start_tool,
+                background_process_logs_tool=background_process_logs_tool,
+                background_process_stop_tool=background_process_stop_tool,
             ).provide_tools()
         )
 

--- a/src/voidcode/tools/__init__.py
+++ b/src/voidcode/tools/__init__.py
@@ -2,6 +2,9 @@ from .apply_patch import ApplyPatchTool
 from .ast_grep import AstGrepPreviewTool, AstGrepReplaceTool, AstGrepSearchTool
 from .background_cancel import BackgroundCancelTool
 from .background_output import BackgroundOutputTool
+from .background_process_logs import BackgroundProcessLogsTool
+from .background_process_start import BackgroundProcessManager, BackgroundProcessStartTool
+from .background_process_stop import BackgroundProcessStopTool
 from .background_retry import BackgroundRetryTool
 from .contracts import ToolCall, ToolDefinition, ToolResult, ToolResultStatus
 from .edit import EditTool
@@ -40,6 +43,10 @@ from .write_file import WriteFileTool
 
 __all__ = [
     "BackgroundCancelTool",
+    "BackgroundProcessLogsTool",
+    "BackgroundProcessManager",
+    "BackgroundProcessStartTool",
+    "BackgroundProcessStopTool",
     "BackgroundOutputTool",
     "BackgroundRetryTool",
     "EditTool",

--- a/src/voidcode/tools/background_process_logs.py
+++ b/src/voidcode/tools/background_process_logs.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ValidationError, field_validator
 from ._pydantic_args import format_validation_error
 from .background_process_start import BackgroundProcessManager
 from .contracts import ToolCall, ToolDefinition, ToolResult
+from .output import _artifact_metadata
 
 
 class _BackgroundProcessLogsArgs(BaseModel):
@@ -47,9 +48,41 @@ class BackgroundProcessLogsTool:
         state = self._runtime.background_process_manager.load(args.process_id)
         if state is None:
             raise ValueError(f"unknown background process: {args.process_id}")
+        stdout_artifact = getattr(state, "stdout_artifact", None)
+        stderr_artifact = getattr(state, "stderr_artifact", None)
+        if state.stdout_dropped_lines > 0 and stdout_artifact is None:
+            stdout_artifact = _artifact_metadata(
+                session_id=None,
+                tool_call_id=state.process_id,
+                tool_name=self.definition.name,
+                content="".join(state.stdout_chunks),
+                kind="content",
+            )
+            state.stdout_artifact = stdout_artifact
+        if state.stderr_dropped_lines > 0 and stderr_artifact is None:
+            stderr_artifact = _artifact_metadata(
+                session_id=None,
+                tool_call_id=state.process_id,
+                tool_name=self.definition.name,
+                content="".join(state.stderr_chunks),
+                kind="error",
+            )
+            state.stderr_artifact = stderr_artifact
         stdout = "".join(state.stdout_chunks)
         stderr = "".join(state.stderr_chunks)
         output = stdout if not stderr else f"{stdout}{stderr}" if stdout else stderr
+        truncated = state.stdout_dropped_lines > 0 or state.stderr_dropped_lines > 0
+        references: list[str] = []
+        if stdout_artifact is not None:
+            references.append(f"artifact:{stdout_artifact['artifact_id']}")
+        if stderr_artifact is not None:
+            references.append(f"artifact:{stderr_artifact['artifact_id']}")
+        if truncated and references:
+            hint = (
+                f"[Background process logs truncated: use {', '.join(references)} "
+                "to inspect full logs.]"
+            )
+            output = f"{output}\n\n{hint}" if output else hint
         return ToolResult(
             tool_name=self.definition.name,
             status="ok",
@@ -60,5 +93,16 @@ class BackgroundProcessLogsTool:
                 "exit_code": state.process.poll(),
                 "stdout": stdout,
                 "stderr": stderr,
+                "stdout_retained_lines": len(state.stdout_chunks),
+                "stderr_retained_lines": len(state.stderr_chunks),
+                "stdout_dropped_lines": state.stdout_dropped_lines,
+                "stderr_dropped_lines": state.stderr_dropped_lines,
+                "stdout_artifact": stdout_artifact,
+                "stderr_artifact": stderr_artifact,
+                "truncated": truncated,
+                "references": references,
             },
+            truncated=truncated,
+            partial=truncated,
+            reference=references[0] if references else None,
         )

--- a/src/voidcode/tools/background_process_logs.py
+++ b/src/voidcode/tools/background_process_logs.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+from pydantic import BaseModel, ValidationError, field_validator
+
+from ._pydantic_args import format_validation_error
+from .background_process_start import BackgroundProcessManager
+from .contracts import ToolCall, ToolDefinition, ToolResult
+
+
+class _BackgroundProcessLogsArgs(BaseModel):
+    process_id: str
+
+    @field_validator("process_id", mode="after")
+    @classmethod
+    def _validate_process_id(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("process_id must be a non-empty string")
+        return value
+
+
+class BackgroundProcessLogsRuntime(Protocol):
+    @property
+    def background_process_manager(self) -> BackgroundProcessManager: ...
+
+
+class BackgroundProcessLogsTool:
+    definition = ToolDefinition(
+        name="background_process_logs",
+        description="Read accumulated stdout/stderr from a background process.",
+        input_schema={"process_id": {"type": "string"}},
+        read_only=True,
+    )
+
+    def __init__(self, *, runtime: BackgroundProcessLogsRuntime) -> None:
+        self._runtime = runtime
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        _ = workspace
+        try:
+            args = _BackgroundProcessLogsArgs.model_validate(call.arguments)
+        except ValidationError as exc:
+            raise ValueError(format_validation_error(self.definition.name, exc)) from exc
+
+        state = self._runtime.background_process_manager.load(args.process_id)
+        if state is None:
+            raise ValueError(f"unknown background process: {args.process_id}")
+        stdout = "".join(state.stdout_chunks)
+        stderr = "".join(state.stderr_chunks)
+        output = stdout if not stderr else f"{stdout}{stderr}" if stdout else stderr
+        return ToolResult(
+            tool_name=self.definition.name,
+            status="ok",
+            content=output,
+            data={
+                "process_id": state.process_id,
+                "running": state.process.poll() is None,
+                "exit_code": state.process.poll(),
+                "stdout": stdout,
+                "stderr": stderr,
+            },
+        )

--- a/src/voidcode/tools/background_process_logs.txt
+++ b/src/voidcode/tools/background_process_logs.txt
@@ -1,0 +1,6 @@
+Read the accumulated stdout and stderr from a long-running background process.
+
+Usage:
+- Pass a process_id previously returned by `background_process_start`.
+- Use this tool to inspect whether a dev server or watcher has started successfully.
+- The output is observational; use `background_process_stop` to terminate the process.

--- a/src/voidcode/tools/background_process_start.py
+++ b/src/voidcode/tools/background_process_start.py
@@ -16,6 +16,8 @@ from ._pydantic_args import format_validation_error
 from .contracts import RuntimeToolTimeoutError, ToolCall, ToolDefinition, ToolResult
 from .runtime_context import current_runtime_tool_context
 
+_MAX_BACKGROUND_PROCESS_LOG_LINES = 500
+
 
 @dataclass(slots=True)
 class BackgroundProcessState:
@@ -25,6 +27,10 @@ class BackgroundProcessState:
     process: subprocess.Popen[str]
     stdout_chunks: list[str]
     stderr_chunks: list[str]
+    stdout_dropped_lines: int = 0
+    stderr_dropped_lines: int = 0
+    stdout_artifact: dict[str, object] | None = None
+    stderr_artifact: dict[str, object] | None = None
 
 
 class BackgroundProcessManager:
@@ -52,6 +58,8 @@ class BackgroundProcessManager:
             process=process,
             stdout_chunks=[],
             stderr_chunks=[],
+            stdout_dropped_lines=0,
+            stderr_dropped_lines=0,
         )
         with self._lock:
             self._processes[state.process_id] = state
@@ -94,8 +102,14 @@ class BackgroundProcessManager:
             for line in stream:
                 if stream_name == "stdout":
                     state.stdout_chunks.append(line)
+                    if len(state.stdout_chunks) > _MAX_BACKGROUND_PROCESS_LOG_LINES:
+                        state.stdout_chunks.pop(0)
+                        state.stdout_dropped_lines += 1
                 else:
                     state.stderr_chunks.append(line)
+                    if len(state.stderr_chunks) > _MAX_BACKGROUND_PROCESS_LOG_LINES:
+                        state.stderr_chunks.pop(0)
+                        state.stderr_dropped_lines += 1
 
         threading.Thread(
             target=_read,

--- a/src/voidcode/tools/background_process_start.py
+++ b/src/voidcode/tools/background_process_start.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import subprocess
+import threading
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from pydantic import BaseModel, ValidationError, field_validator
+
+from ._pydantic_args import format_validation_error
+from .contracts import RuntimeToolTimeoutError, ToolCall, ToolDefinition, ToolResult
+from .runtime_context import current_runtime_tool_context
+
+
+@dataclass(slots=True)
+class BackgroundProcessState:
+    process_id: str
+    command: str
+    cwd: str
+    process: subprocess.Popen[str]
+    stdout_chunks: list[str]
+    stderr_chunks: list[str]
+
+
+class BackgroundProcessManager:
+    def __init__(self) -> None:
+        self._processes: dict[str, BackgroundProcessState] = {}
+        self._lock = threading.RLock()
+
+    def start(self, *, command: str, workspace: Path) -> BackgroundProcessState:
+        process = subprocess.Popen(
+            command,
+            cwd=workspace,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            start_new_session=True,
+            creationflags=getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0),
+        )
+        state = BackgroundProcessState(
+            process_id=f"proc-{uuid.uuid4().hex}",
+            command=command,
+            cwd=str(workspace),
+            process=process,
+            stdout_chunks=[],
+            stderr_chunks=[],
+        )
+        with self._lock:
+            self._processes[state.process_id] = state
+        self._start_reader(state, stream_name="stdout")
+        self._start_reader(state, stream_name="stderr")
+        return state
+
+    def load(self, process_id: str) -> BackgroundProcessState | None:
+        with self._lock:
+            return self._processes.get(process_id)
+
+    def stop(self, process_id: str) -> BackgroundProcessState:
+        state = self._require(process_id)
+        if state.process.poll() is None:
+            state.process.terminate()
+            try:
+                state.process.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                state.process.kill()
+                state.process.wait(timeout=1)
+        return state
+
+    def stop_all(self) -> None:
+        with self._lock:
+            process_ids = tuple(self._processes)
+        for process_id in process_ids:
+            try:
+                self.stop(process_id)
+            except ValueError:
+                continue
+
+    def _require(self, process_id: str) -> BackgroundProcessState:
+        state = self.load(process_id)
+        if state is None:
+            raise ValueError(f"unknown background process: {process_id}")
+        return state
+
+    @staticmethod
+    def _start_reader(state: BackgroundProcessState, *, stream_name: str) -> None:
+        stream = state.process.stdout if stream_name == "stdout" else state.process.stderr
+
+        def _read() -> None:
+            if stream is None:
+                return
+            for line in stream:
+                if stream_name == "stdout":
+                    state.stdout_chunks.append(line)
+                else:
+                    state.stderr_chunks.append(line)
+
+        threading.Thread(
+            target=_read,
+            name=f"background-process-{stream_name}",
+            daemon=True,
+        ).start()
+
+
+class _BackgroundProcessStartArgs(BaseModel):
+    command: str
+    description: str | None = None
+
+    @field_validator("command", mode="after")
+    @classmethod
+    def _validate_command(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("command must not be empty")
+        return value
+
+    @field_validator("description", mode="after")
+    @classmethod
+    def _validate_description(cls, value: str | None) -> str | None:
+        if value is not None and not value.strip():
+            raise ValueError("description must not be empty when provided")
+        return value
+
+
+class BackgroundProcessStartRuntime(Protocol):
+    @property
+    def background_process_manager(self) -> BackgroundProcessManager: ...
+
+
+class BackgroundProcessStartTool:
+    definition = ToolDefinition(
+        name="background_process_start",
+        description=(
+            "Start a long-running non-interactive process without blocking the current turn."
+        ),
+        input_schema={
+            "command": {"type": "string"},
+            "description": {"type": "string"},
+        },
+        read_only=False,
+    )
+
+    def __init__(self, *, runtime: BackgroundProcessStartRuntime) -> None:
+        self._runtime = runtime
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        try:
+            args = _BackgroundProcessStartArgs.model_validate(call.arguments)
+        except ValidationError as exc:
+            raise ValueError(format_validation_error(self.definition.name, exc)) from exc
+
+        runtime_context = current_runtime_tool_context()
+        if runtime_context is not None and runtime_context.abort_signal is not None:
+            if runtime_context.abort_signal.cancelled:
+                raise RuntimeToolTimeoutError(
+                    "background_process_start aborted before launching process"
+                )
+
+        state = self._runtime.background_process_manager.start(
+            command=args.command, workspace=workspace
+        )
+        pid = state.process.pid
+        return ToolResult(
+            tool_name=self.definition.name,
+            status="ok",
+            content=(
+                f"Started background process {state.process_id} (pid={pid}) "
+                f"for command: {args.command}. "
+                f"Use background_process_logs(process_id='{state.process_id}') to inspect output."
+            ),
+            data={
+                "process_id": state.process_id,
+                "pid": pid,
+                "command": args.command,
+                "cwd": state.cwd,
+                "running": state.process.poll() is None,
+            },
+        )

--- a/src/voidcode/tools/background_process_start.py
+++ b/src/voidcode/tools/background_process_start.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+import shutil
+import signal
 import subprocess
 import threading
 import uuid
@@ -63,12 +66,7 @@ class BackgroundProcessManager:
     def stop(self, process_id: str) -> BackgroundProcessState:
         state = self._require(process_id)
         if state.process.poll() is None:
-            state.process.terminate()
-            try:
-                state.process.wait(timeout=1)
-            except subprocess.TimeoutExpired:
-                state.process.kill()
-                state.process.wait(timeout=1)
+            _terminate_background_process_group(state.process)
         return state
 
     def stop_all(self) -> None:
@@ -104,6 +102,45 @@ class BackgroundProcessManager:
             name=f"background-process-{stream_name}",
             daemon=True,
         ).start()
+
+
+def _terminate_background_process_group(process: subprocess.Popen[str]) -> None:
+    if os.name == "nt":
+        taskkill = shutil.which("taskkill") or "taskkill"
+        completed = subprocess.run(
+            [taskkill, "/PID", str(process.pid), "/T", "/F"],
+            capture_output=True,
+            check=False,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        if completed.returncode == 0:
+            return
+        process.kill()
+        process.wait(timeout=1)
+        return
+
+    killpg = getattr(os, "killpg", None)
+    if callable(killpg):
+        try:
+            killpg(process.pid, signal.SIGTERM)
+            process.wait(timeout=1)
+            return
+        except (ProcessLookupError, subprocess.TimeoutExpired):
+            try:
+                killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                return
+            process.wait(timeout=1)
+            return
+
+    process.terminate()
+    try:
+        process.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=1)
 
 
 class _BackgroundProcessStartArgs(BaseModel):

--- a/src/voidcode/tools/background_process_start.txt
+++ b/src/voidcode/tools/background_process_start.txt
@@ -1,0 +1,7 @@
+Start a long-running non-interactive background process in the workspace.
+
+Usage:
+- Use this tool for dev servers or watchers such as `npm run dev`, `vite`, or `uvicorn` when the agent must keep working without blocking.
+- Prefer `shell_exec` for one-shot commands that should finish inside the current turn.
+- Use `background_process_logs` to inspect output and `background_process_stop` to stop the process.
+- Treat process_id, running, and exit_code as the source of truth.

--- a/src/voidcode/tools/background_process_stop.py
+++ b/src/voidcode/tools/background_process_stop.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+from pydantic import BaseModel, ValidationError, field_validator
+
+from ._pydantic_args import format_validation_error
+from .background_process_start import BackgroundProcessManager
+from .contracts import ToolCall, ToolDefinition, ToolResult
+
+
+class _BackgroundProcessStopArgs(BaseModel):
+    process_id: str
+
+    @field_validator("process_id", mode="after")
+    @classmethod
+    def _validate_process_id(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("process_id must be a non-empty string")
+        return value
+
+
+class BackgroundProcessStopRuntime(Protocol):
+    @property
+    def background_process_manager(self) -> BackgroundProcessManager: ...
+
+
+class BackgroundProcessStopTool:
+    definition = ToolDefinition(
+        name="background_process_stop",
+        description="Stop a background process by id.",
+        input_schema={"process_id": {"type": "string"}},
+        read_only=False,
+    )
+
+    def __init__(self, *, runtime: BackgroundProcessStopRuntime) -> None:
+        self._runtime = runtime
+
+    def invoke(self, call: ToolCall, *, workspace: Path) -> ToolResult:
+        _ = workspace
+        try:
+            args = _BackgroundProcessStopArgs.model_validate(call.arguments)
+        except ValidationError as exc:
+            raise ValueError(format_validation_error(self.definition.name, exc)) from exc
+
+        state = self._runtime.background_process_manager.stop(args.process_id)
+        return ToolResult(
+            tool_name=self.definition.name,
+            status="ok",
+            content=f"Stopped background process {state.process_id}.",
+            data={
+                "process_id": state.process_id,
+                "exit_code": state.process.poll(),
+                "running": state.process.poll() is None,
+            },
+        )

--- a/src/voidcode/tools/background_process_stop.txt
+++ b/src/voidcode/tools/background_process_stop.txt
@@ -1,0 +1,6 @@
+Stop a long-running background process by id.
+
+Usage:
+- Pass a process_id previously returned by `background_process_start`.
+- Use this tool to shut down a background server or watcher when verification is complete.
+- Treat the returned running flag and exit_code as the source of truth.

--- a/src/voidcode/tools/guidance.py
+++ b/src/voidcode/tools/guidance.py
@@ -10,6 +10,9 @@ _GUIDANCE_SEPARATOR = "\n\nAgent usage guidance:\n"
 
 _TOOL_GUIDANCE_FILES = {
     "background_cancel": "background_cancel.txt",
+    "background_process_logs": "background_process_logs.txt",
+    "background_process_start": "background_process_start.txt",
+    "background_process_stop": "background_process_stop.txt",
     "background_output": "background_output.txt",
     "apply_patch": "apply_patch.txt",
     "ast_grep_preview": "ast_grep.txt",

--- a/tests/unit/tools/test_background_process_tool.py
+++ b/tests/unit/tools/test_background_process_tool.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from voidcode.runtime.service import VoidCodeRuntime
+from voidcode.tools import ToolCall
+
+
+def test_background_process_tools_are_registered() -> None:
+    runtime = VoidCodeRuntime(workspace=Path(tempfile.mkdtemp()))
+    registry = runtime._base_tool_registry
+    assert (
+        registry.resolve("background_process_start").definition.name == "background_process_start"
+    )
+    assert registry.resolve("background_process_logs").definition.name == "background_process_logs"
+    assert registry.resolve("background_process_stop").definition.name == "background_process_stop"
+    runtime.__exit__(None, None, None)
+
+
+def test_background_process_start_logs_and_stop(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+    start_tool = runtime._base_tool_registry.resolve("background_process_start")
+    logs_tool = runtime._base_tool_registry.resolve("background_process_logs")
+    stop_tool = runtime._base_tool_registry.resolve("background_process_stop")
+    command = f'"{sys.executable}" -c "import time; print(\'ready\', flush=True); time.sleep(5)"'
+    start_result = start_tool.invoke(
+        ToolCall(tool_name="background_process_start", arguments={"command": command}),
+        workspace=tmp_path,
+    )
+    process_id = str(start_result.data["process_id"])
+    assert start_result.status == "ok"
+    time.sleep(0.2)
+    logs_result = logs_tool.invoke(
+        ToolCall(tool_name="background_process_logs", arguments={"process_id": process_id}),
+        workspace=tmp_path,
+    )
+    assert logs_result.status == "ok"
+    assert isinstance(logs_result.content, str)
+    assert "ready" in logs_result.content
+    stop_result = stop_tool.invoke(
+        ToolCall(tool_name="background_process_stop", arguments={"process_id": process_id}),
+        workspace=tmp_path,
+    )
+    assert stop_result.status == "ok"
+    assert stop_result.data["running"] is False
+    runtime.__exit__(None, None, None)

--- a/tests/unit/tools/test_background_process_tool.py
+++ b/tests/unit/tools/test_background_process_tool.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import os
+import subprocess
 import sys
 import tempfile
 import time
 from pathlib import Path
+from typing import cast
+
+import pytest
 
 from voidcode.runtime.service import VoidCodeRuntime
 from voidcode.tools import ToolCall
+from voidcode.tools.background_process_start import _terminate_background_process_group
 
 
 def test_background_process_tools_are_registered() -> None:
@@ -47,3 +53,83 @@ def test_background_process_start_logs_and_stop(tmp_path: Path) -> None:
     assert stop_result.status == "ok"
     assert stop_result.data["running"] is False
     runtime.__exit__(None, None, None)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="posix-only process group behavior")
+def test_background_process_stop_terminates_spawned_children(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+    start_tool = runtime._base_tool_registry.resolve("background_process_start")
+    stop_tool = runtime._base_tool_registry.resolve("background_process_stop")
+    child_file = tmp_path / "child.pid"
+    command = (
+        f'"{sys.executable}" -c '
+        f'"import subprocess, sys, time; '
+        f"child=subprocess.Popen([sys.executable,'-c','import time; time.sleep(30)']); "
+        f"open(r'{child_file}', 'w', encoding='utf-8').write(str(child.pid)); "
+        f'time.sleep(30)"'
+    )
+    start_result = start_tool.invoke(
+        ToolCall(tool_name="background_process_start", arguments={"command": command}),
+        workspace=tmp_path,
+    )
+    process_id = str(start_result.data["process_id"])
+    deadline = time.time() + 5
+    while time.time() < deadline and not child_file.exists():
+        time.sleep(0.05)
+    assert child_file.exists()
+    child_pid = int(child_file.read_text(encoding="utf-8"))
+    stop_tool.invoke(
+        ToolCall(tool_name="background_process_stop", arguments={"process_id": process_id}),
+        workspace=tmp_path,
+    )
+    with pytest.raises(ProcessLookupError):
+        os.kill(child_pid, 0)
+    runtime.__exit__(None, None, None)
+
+
+def test_terminate_background_process_group_uses_taskkill_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+    killed = False
+
+    class _FakeProcess:
+        pid = 4321
+
+        def kill(self) -> None:
+            nonlocal killed
+            killed = True
+
+        def wait(self, timeout: float | None = None) -> None:
+            _ = timeout
+
+    def fake_run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr("voidcode.tools.background_process_start.os.name", "nt")
+    monkeypatch.setattr(
+        "voidcode.tools.background_process_start.shutil.which", lambda _name: "taskkill"
+    )
+    monkeypatch.setattr("voidcode.tools.background_process_start.subprocess.run", fake_run)
+
+    _terminate_background_process_group(cast(subprocess.Popen[str], _FakeProcess()))
+
+    assert calls == [["taskkill", "/PID", "4321", "/T", "/F"]]
+    assert killed is False
+
+
+def test_runtime_exit_stops_managed_background_processes(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+    start_tool = runtime._base_tool_registry.resolve("background_process_start")
+    command = f'"{sys.executable}" -c "import time; time.sleep(30)"'
+    started = start_tool.invoke(
+        ToolCall(tool_name="background_process_start", arguments={"command": command}),
+        workspace=tmp_path,
+    )
+    process_id = str(started.data["process_id"])
+    state = runtime.background_process_manager.load(process_id)
+    assert state is not None
+    assert state.process.poll() is None
+    runtime.__exit__(None, None, None)
+    assert state.process.poll() is not None

--- a/tests/unit/tools/test_background_process_tool.py
+++ b/tests/unit/tools/test_background_process_tool.py
@@ -12,7 +12,10 @@ import pytest
 
 from voidcode.runtime.service import VoidCodeRuntime
 from voidcode.tools import ToolCall
-from voidcode.tools.background_process_start import _terminate_background_process_group
+from voidcode.tools.background_process_start import (
+    _MAX_BACKGROUND_PROCESS_LOG_LINES,
+    _terminate_background_process_group,
+)
 
 
 def test_background_process_tools_are_registered() -> None:
@@ -52,6 +55,56 @@ def test_background_process_start_logs_and_stop(tmp_path: Path) -> None:
     )
     assert stop_result.status == "ok"
     assert stop_result.data["running"] is False
+    runtime.__exit__(None, None, None)
+
+
+def test_background_process_logs_retains_bounded_recent_lines(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+    start_tool = runtime._base_tool_registry.resolve("background_process_start")
+    logs_tool = runtime._base_tool_registry.resolve("background_process_logs")
+    stop_tool = runtime._base_tool_registry.resolve("background_process_stop")
+    line_count = _MAX_BACKGROUND_PROCESS_LOG_LINES + 25
+    command = (
+        f'"{sys.executable}" -c '
+        f"\"import sys; [sys.stdout.write('line-%d\\n' % i) for i in range({line_count})]\""
+    )
+    start_result = start_tool.invoke(
+        ToolCall(tool_name="background_process_start", arguments={"command": command}),
+        workspace=tmp_path,
+    )
+    process_id = str(start_result.data["process_id"])
+    deadline = time.time() + 5
+    logs_result = None
+    while time.time() < deadline:
+        logs_result = logs_tool.invoke(
+            ToolCall(tool_name="background_process_logs", arguments={"process_id": process_id}),
+            workspace=tmp_path,
+        )
+        if logs_result.data["running"] is False:
+            break
+        time.sleep(0.05)
+    assert logs_result is not None
+    assert logs_result.status == "ok"
+    stdout = str(logs_result.data["stdout"])
+    assert "line-0" not in stdout
+    assert f"line-{line_count - 1}" in stdout
+    assert logs_result.data["stdout_retained_lines"] == _MAX_BACKGROUND_PROCESS_LOG_LINES
+    assert logs_result.data["stdout_dropped_lines"] == 25
+    assert logs_result.data["truncated"] is True
+    references = logs_result.data["references"]
+    assert isinstance(references, list)
+    assert references
+    assert str(references[0]).startswith("artifact:")
+    stdout_artifact = cast(dict[str, object], logs_result.data["stdout_artifact"])
+    assert isinstance(stdout_artifact, dict)
+    stdout_artifact_id = str(stdout_artifact["artifact_id"])
+    assert stdout_artifact_id == str(references[0]).removeprefix("artifact:")
+    assert logs_result.reference == references[0]
+    assert "Background process logs truncated" in (logs_result.content or "")
+    stop_tool.invoke(
+        ToolCall(tool_name="background_process_stop", arguments={"process_id": process_id}),
+        workspace=tmp_path,
+    )
     runtime.__exit__(None, None, None)
 
 


### PR DESCRIPTION
## Summary
- harden the tmux-backed  surface by keeping it hidden on Windows and preparing follow-up room for stricter lifecycle handling
- add a minimal runtime-owned  tool family for long-running non-interactive commands (, , )
- wire the new tools into the runtime registry, display metadata, and guidance with targeted unit coverage

## Verification
- ...s................................................                     [100%]
51 passed, 1 skipped in 4.79s
- manual QA: started a background Python process, read logs, and stopped it through the new tools

## Notes
- this keeps  focused on one-shot commands and avoids overloading it with long-running server semantics
