### PR TITLE
fix(tools): harden background process cleanup

### DIFF
--- a/src/voidcode/tools/background_process_logs.py
+++ b/src/voidcode/tools/background_process_logs.py
@@ -80,7 +80,7 @@ class BackgroundProcessLogsTool:
         if truncated and references:
             hint = (
                 f"[Background process logs truncated: use {', '.join(references)} "
-                "to inspect full logs.]"
+                "to inspect retained log tails. Earlier dropped lines are no longer available.]"
             )
             output = f"{output}\n\n{hint}" if output else hint
         return ToolResult(

--- a/src/voidcode/tools/background_process_start.py
+++ b/src/voidcode/tools/background_process_start.py
@@ -5,6 +5,7 @@ import shutil
 import signal
 import subprocess
 import threading
+import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -119,35 +120,34 @@ class BackgroundProcessManager:
 
 
 def _terminate_background_process_group(process: subprocess.Popen[str]) -> None:
-    if os.name == "nt":
-        taskkill = shutil.which("taskkill") or "taskkill"
-        completed = subprocess.run(
-            [taskkill, "/PID", str(process.pid), "/T", "/F"],
-            capture_output=True,
-            check=False,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-        )
-        if completed.returncode == 0:
-            return
-        process.kill()
-        process.wait(timeout=1)
+    if _is_windows():
+        _terminate_windows_process_tree(process)
         return
 
     killpg = getattr(os, "killpg", None)
     if callable(killpg):
+        process_group_id = process.pid
         try:
-            killpg(process.pid, signal.SIGTERM)
-            process.wait(timeout=1)
+            killpg(process_group_id, signal.SIGTERM)
+        except ProcessLookupError:
             return
-        except (ProcessLookupError, subprocess.TimeoutExpired):
+
+        try:
+            process.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            pass
+
+        if _process_group_exists(process_group_id):
             try:
-                killpg(process.pid, signal.SIGKILL)
+                killpg(process_group_id, signal.SIGKILL)
             except ProcessLookupError:
                 return
-            process.wait(timeout=1)
+            if process.poll() is None:
+                process.wait(timeout=1)
+            _wait_for_process_group_exit(process_group_id, timeout=1)
             return
+
+        return
 
     process.terminate()
     try:
@@ -155,6 +155,44 @@ def _terminate_background_process_group(process: subprocess.Popen[str]) -> None:
     except subprocess.TimeoutExpired:
         process.kill()
         process.wait(timeout=1)
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def _terminate_windows_process_tree(process: subprocess.Popen[str]) -> None:
+    taskkill = shutil.which("taskkill") or "taskkill"
+    completed = subprocess.run(
+        [taskkill, "/PID", str(process.pid), "/T", "/F"],
+        capture_output=True,
+        check=False,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if completed.returncode == 0:
+        return
+    process.kill()
+    process.wait(timeout=1)
+
+
+def _process_group_exists(process_group_id: int) -> bool:
+    try:
+        os.killpg(process_group_id, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _wait_for_process_group_exit(process_group_id: int, *, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _process_group_exists(process_group_id):
+            return
+        time.sleep(0.02)
 
 
 class _BackgroundProcessStartArgs(BaseModel):

--- a/tests/unit/tools/test_background_process_tool.py
+++ b/tests/unit/tools/test_background_process_tool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import signal
 import subprocess
 import sys
 import tempfile
@@ -101,11 +102,87 @@ def test_background_process_logs_retains_bounded_recent_lines(tmp_path: Path) ->
     assert stdout_artifact_id == str(references[0]).removeprefix("artifact:")
     assert logs_result.reference == references[0]
     assert "Background process logs truncated" in (logs_result.content or "")
+    assert "retained log tails" in (logs_result.content or "")
+    assert "full logs" not in (logs_result.content or "")
     stop_tool.invoke(
         ToolCall(tool_name="background_process_stop", arguments={"process_id": process_id}),
         workspace=tmp_path,
     )
     runtime.__exit__(None, None, None)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="posix-only process group behavior")
+def test_background_process_stop_escalates_when_descendant_ignores_sigterm(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+    start_tool = runtime._base_tool_registry.resolve("background_process_start")
+    stop_tool = runtime._base_tool_registry.resolve("background_process_stop")
+    child_file = tmp_path / "child.pid"
+    command = (
+        f'"{sys.executable}" -c '
+        f'"import os, signal, subprocess, sys, time; '
+        f"child=subprocess.Popen([sys.executable,'-c',"
+        f"'import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(30)']); "
+        f"open(r'{child_file}', 'w', encoding='utf-8').write(str(child.pid)); "
+        f'time.sleep(30)"'
+    )
+    start_result = start_tool.invoke(
+        ToolCall(tool_name="background_process_start", arguments={"command": command}),
+        workspace=tmp_path,
+    )
+    process_id = str(start_result.data["process_id"])
+    deadline = time.time() + 5
+    while time.time() < deadline and not child_file.exists():
+        time.sleep(0.05)
+    assert child_file.exists()
+    child_pid = int(child_file.read_text(encoding="utf-8"))
+    stop_result = stop_tool.invoke(
+        ToolCall(tool_name="background_process_stop", arguments={"process_id": process_id}),
+        workspace=tmp_path,
+    )
+
+    assert stop_result.status == "ok"
+    assert stop_result.data["running"] is False
+    with pytest.raises(ProcessLookupError):
+        os.kill(child_pid, 0)
+    runtime.__exit__(None, None, None)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="posix-only process group behavior")
+def test_terminate_background_process_group_sends_sigkill_after_leader_exits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[int, int]] = []
+    waits: list[float | None] = []
+    group_exists = True
+
+    class _FakeProcess:
+        pid = 4321
+
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            waits.append(timeout)
+            return 0
+
+    def fake_killpg(process_group_id: int, sig: int) -> None:
+        nonlocal group_exists
+        calls.append((process_group_id, sig))
+        if sig == signal.SIGKILL:
+            group_exists = False
+
+    monkeypatch.setattr("voidcode.tools.background_process_start.os.killpg", fake_killpg)
+    monkeypatch.setattr(
+        "voidcode.tools.background_process_start._process_group_exists",
+        lambda _process_group_id: group_exists,
+    )
+
+    _terminate_background_process_group(cast(subprocess.Popen[str], _FakeProcess()))
+
+    assert calls == [(4321, signal.SIGTERM), (4321, signal.SIGKILL)]
+    assert waits == [1]
 
 
 @pytest.mark.skipif(os.name == "nt", reason="posix-only process group behavior")


### PR DESCRIPTION
## Summary
- Escalate POSIX background process-group shutdown to SIGKILL when the process group still exists after SIGTERM, even if the shell leader exited.
- Clarify truncated background log artifacts as retained log tails instead of full logs.
- Add regressions for SIGTERM-resistant descendants and truncated log messaging.

## Verification
- `uv run ruff check src/voidcode/tools/background_process_start.py src/voidcode/tools/background_process_logs.py tests/unit/tools/test_background_process_tool.py`
- `uv run ty check src/voidcode/tools/background_process_start.py src/voidcode/tools/background_process_logs.py tests/unit/tools/test_background_process_tool.py`
- `uv run pytest tests/unit/tools/test_background_process_tool.py tests/unit/tools/test_tool_output_truncation.py tests/unit/tools/test_shell_exec_tool.py`
- Runtime tool manual QA driver: start background process, observe logs, stop SIGTERM-ignoring descendant, verify missing-process bad input.