### PR TITLE
fix: auto-assign web launcher ports and backfill waiting-child reminders

### DIFF
--- a/src/voidcode/cli/app.py
+++ b/src/voidcode/cli/app.py
@@ -2691,7 +2691,7 @@ def _web_server_command(
     *,
     workspace: Path,
     host: str,
-    port: int,
+    port: int | None,
     approval_mode: str | None,
     open_browser: bool,
 ) -> int:
@@ -2735,7 +2735,12 @@ def serve_command(workspace: Path, host: str, port: int, approval_mode: str | No
 )
 @_workspace_option("Workspace root used by the local runtime and session database.")
 @click.option("--host", default="127.0.0.1", help="Host interface for the local launcher server.")
-@click.option("--port", type=int, default=8000, help="Port for the local launcher server.")
+@click.option(
+    "--port",
+    type=int,
+    default=None,
+    help="Port for the local launcher server. Defaults to an auto-assigned local port.",
+)
 @click.option(
     "--approval-mode",
     type=click.Choice(_APPROVAL_MODES),
@@ -2751,7 +2756,7 @@ def serve_command(workspace: Path, host: str, port: int, approval_mode: str | No
 def web_command(
     workspace: Path,
     host: str,
-    port: int,
+    port: int | None,
     approval_mode: str | None,
     open_browser: bool,
 ) -> int:

--- a/src/voidcode/runtime/background_tasks.py
+++ b/src/voidcode/runtime/background_tasks.py
@@ -1326,14 +1326,22 @@ class RuntimeBackgroundTaskSupervisor:
         if task.status != "running" or child_response.session.status != "waiting":
             return
         idle_event = self._latest_session_idle_event(child_response.events)
-        if idle_event is None:
-            return
+        waiting_reason = self._runtime._waiting_reason_from_session(child_response.session)
+        idle_event_sequence = (
+            idle_event.sequence
+            if idle_event is not None
+            else self._latest_waiting_episode_sequence(child_response.events)
+        )
         self.emit_background_task_idle_reminder(
             task=task,
             child_session_id=child_session_id,
             child_session_status=child_response.session.status,
-            idle_event_sequence=idle_event.sequence,
-            idle_reason=idle_event.payload.get("reason", "waiting"),
+            idle_event_sequence=idle_event_sequence,
+            idle_reason=(
+                idle_event.payload.get("reason", waiting_reason)
+                if idle_event is not None
+                else waiting_reason
+            ),
         )
 
     def emit_background_task_idle_reminder(
@@ -1466,6 +1474,12 @@ class RuntimeBackgroundTaskSupervisor:
         return None
 
     @staticmethod
+    def _latest_waiting_episode_sequence(events: tuple[EventEnvelope, ...]) -> int:
+        if events:
+            return events[-1].sequence
+        return 0
+
+    @staticmethod
     def _current_unix_ms() -> int:
         return int(time.time() * 1000)
 
@@ -1487,6 +1501,10 @@ class RuntimeBackgroundTaskSupervisor:
         if session_response.session.status == "waiting":
             if is_background_task_terminal(current_task.status):
                 return
+            self.emit_background_task_idle_reminder_for_waiting_child(
+                task=current_task,
+                child_response=session_response,
+            )
             self.emit_background_task_waiting_approval(
                 task=current_task,
                 child_response=session_response,

--- a/src/voidcode/server.py
+++ b/src/voidcode/server.py
@@ -62,9 +62,27 @@ def _resolve_frontend_dist() -> Path:
 
 
 def _select_ephemeral_port(host: str) -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe_socket:
-        probe_socket.bind((host, 0))
-        return cast(int, probe_socket.getsockname()[1])
+    address_infos = socket.getaddrinfo(
+        host,
+        0,
+        family=socket.AF_UNSPEC,
+        type=socket.SOCK_STREAM,
+        proto=socket.IPPROTO_TCP,
+        flags=socket.AI_PASSIVE,
+    )
+    last_error: OSError | None = None
+    for family, socket_type, proto, _canonname, sockaddr in address_infos:
+        try:
+            with socket.socket(family, socket_type, proto) as probe_socket:
+                probe_socket.bind(sockaddr)
+                return cast(int, probe_socket.getsockname()[1])
+        except OSError as exc:
+            last_error = exc
+            continue
+    if last_error is not None:
+        raise last_error
+    msg = f"could not resolve local bind host for auto port selection: {host}"
+    raise OSError(msg)
 
 
 def web(

--- a/src/voidcode/server.py
+++ b/src/voidcode/server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import socket
 import webbrowser
 from pathlib import Path
 from typing import Protocol, cast
@@ -60,15 +61,22 @@ def _resolve_frontend_dist() -> Path:
     return _FRONTEND_DIST
 
 
+def _select_ephemeral_port(host: str) -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe_socket:
+        probe_socket.bind((host, 0))
+        return cast(int, probe_socket.getsockname()[1])
+
+
 def web(
     *,
     workspace: Path,
     host: str = "127.0.0.1",
-    port: int = 8000,
+    port: int | None = None,
     config: RuntimeConfig | None = None,
     open_browser: bool = True,
 ) -> None:
-    url = f"http://{host}:{port}"
+    selected_port = _select_ephemeral_port(host) if port is None else port
+    url = f"http://{host}:{selected_port}"
     frontend_dist = _resolve_frontend_dist()
 
     print("VoidCode")
@@ -85,7 +93,7 @@ def web(
     _run_runtime_server(
         workspace=workspace,
         host=host,
-        port=port,
+        port=selected_port,
         config=config,
         frontend_dist=frontend_dist,
     )

--- a/src/voidcode/server.py
+++ b/src/voidcode/server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import socket
 import webbrowser
+from contextlib import closing
 from pathlib import Path
 from typing import Protocol, cast
 
@@ -11,7 +12,15 @@ from .runtime.http import create_runtime_app
 
 
 class UvicornModule(Protocol):
-    def run(self, app: object, *, host: str, port: int, lifespan: str) -> None: ...
+    def run(
+        self,
+        app: object,
+        *,
+        host: str,
+        port: int,
+        lifespan: str,
+        fd: int | None = None,
+    ) -> None: ...
 
 
 def _run_runtime_server(
@@ -21,10 +30,15 @@ def _run_runtime_server(
     port: int = 8000,
     config: RuntimeConfig | None = None,
     frontend_dist: Path | None = None,
+    listener_socket: socket.socket | None = None,
 ) -> None:
     app = create_runtime_app(workspace=workspace, config=config, frontend_dist=frontend_dist)
     uvicorn = cast(UvicornModule, importlib.import_module("uvicorn"))
-    uvicorn.run(app, host=host, port=port, lifespan="off")
+    if listener_socket is None:
+        uvicorn.run(app, host=host, port=port, lifespan="off")
+        return
+    with closing(listener_socket):
+        uvicorn.run(app, host=host, port=port, lifespan="off", fd=listener_socket.fileno())
 
 
 def serve(
@@ -61,7 +75,7 @@ def _resolve_frontend_dist() -> Path:
     return _FRONTEND_DIST
 
 
-def _select_ephemeral_port(host: str) -> int:
+def _reserve_listener_socket(host: str) -> socket.socket:
     address_infos = socket.getaddrinfo(
         host,
         0,
@@ -72,12 +86,15 @@ def _select_ephemeral_port(host: str) -> int:
     )
     last_error: OSError | None = None
     for family, socket_type, proto, _canonname, sockaddr in address_infos:
+        listener_socket: socket.socket | None = None
         try:
-            with socket.socket(family, socket_type, proto) as probe_socket:
-                probe_socket.bind(sockaddr)
-                return cast(int, probe_socket.getsockname()[1])
+            listener_socket = socket.socket(family, socket_type, proto)
+            listener_socket.bind(sockaddr)
+            return listener_socket
         except OSError as exc:
             last_error = exc
+            if listener_socket is not None:
+                listener_socket.close()
             continue
     if last_error is not None:
         raise last_error
@@ -93,7 +110,12 @@ def web(
     config: RuntimeConfig | None = None,
     open_browser: bool = True,
 ) -> None:
-    selected_port = _select_ephemeral_port(host) if port is None else port
+    listener_socket = _reserve_listener_socket(host) if port is None else None
+    selected_port: int
+    if listener_socket is not None:
+        selected_port = cast(int, listener_socket.getsockname()[1])
+    else:
+        selected_port = cast(int, port)
     url = f"http://{host}:{selected_port}"
     frontend_dist = _resolve_frontend_dist()
 
@@ -114,4 +136,5 @@ def web(
         port=selected_port,
         config=config,
         frontend_dist=frontend_dist,
+        listener_socket=listener_socket,
     )

--- a/src/voidcode/server.py
+++ b/src/voidcode/server.py
@@ -111,30 +111,35 @@ def web(
     open_browser: bool = True,
 ) -> None:
     listener_socket = _reserve_listener_socket(host) if port is None else None
-    selected_port: int
-    if listener_socket is not None:
-        selected_port = cast(int, listener_socket.getsockname()[1])
-    else:
-        selected_port = cast(int, port)
-    url = f"http://{host}:{selected_port}"
-    frontend_dist = _resolve_frontend_dist()
+    try:
+        selected_port: int
+        if listener_socket is not None:
+            selected_port = cast(int, listener_socket.getsockname()[1])
+        else:
+            selected_port = cast(int, port)
+        url = f"http://{host}:{selected_port}"
+        frontend_dist = _resolve_frontend_dist()
 
-    print("VoidCode")
-    print(_BANNER)
-    print(f"  Local server running at: {url}")
-    print()
+        print("VoidCode")
+        print(_BANNER)
+        print(f"  Local server running at: {url}")
+        print()
 
-    if open_browser:
-        try:
-            webbrowser.open(url)
-        except Exception:
-            pass
+        if open_browser:
+            try:
+                webbrowser.open(url)
+            except Exception:
+                pass
 
-    _run_runtime_server(
-        workspace=workspace,
-        host=host,
-        port=selected_port,
-        config=config,
-        frontend_dist=frontend_dist,
-        listener_socket=listener_socket,
-    )
+        _run_runtime_server(
+            workspace=workspace,
+            host=host,
+            port=selected_port,
+            config=config,
+            frontend_dist=frontend_dist,
+            listener_socket=listener_socket,
+        )
+    except BaseException:
+        if listener_socket is not None:
+            listener_socket.close()
+        raise

--- a/tests/integration/test_web_command.py
+++ b/tests/integration/test_web_command.py
@@ -176,6 +176,7 @@ def test_web_delegates_to_shared_runtime_server(tmp_path: Path) -> None:
         port=8001,
         config=config,
         frontend_dist=frontend_dist,
+        listener_socket=None,
     )
 
 

--- a/tests/integration/test_web_command.py
+++ b/tests/integration/test_web_command.py
@@ -76,6 +76,28 @@ def test_web_prints_auto_assigned_url_when_port_unspecified(capsys: Any, tmp_pat
     assert "http://127.0.0.1:39111" in captured.out
 
 
+def test_web_prints_ipv6_auto_assigned_url_when_host_is_ipv6(capsys: Any, tmp_path: Path) -> None:
+    server = importlib.import_module("voidcode.server")
+    workspace = Path("/tmp/web-banner-ipv6-auto-port-test")
+    config = cast(Any, SimpleNamespace(approval_mode="allow"))
+    frontend_dist = write_frontend_dist_fixture(tmp_path)
+
+    with patch.object(server, "_run_runtime_server", autospec=True):
+        with patch.object(server, "_FRONTEND_DIST", frontend_dist):
+            with patch.object(server, "_select_ephemeral_port", autospec=True, return_value=39112):
+                server.web(
+                    workspace=workspace,
+                    host="::1",
+                    port=None,
+                    config=config,
+                    open_browser=False,
+                )
+
+    captured = capsys.readouterr()
+    assert "VoidCode" in captured.out
+    assert "http://::1:39112" in captured.out
+
+
 def test_web_browser_open_failure_does_not_crash(capsys: Any, tmp_path: Path) -> None:
     """Verify graceful degradation when webbrowser.open raises."""
     server = importlib.import_module("voidcode.server")

--- a/tests/integration/test_web_command.py
+++ b/tests/integration/test_web_command.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import json
+import socket
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -59,21 +60,32 @@ def test_web_prints_auto_assigned_url_when_port_unspecified(capsys: Any, tmp_pat
     workspace = Path("/tmp/web-banner-auto-port-test")
     config = cast(Any, SimpleNamespace(approval_mode="allow"))
     frontend_dist = write_frontend_dist_fixture(tmp_path)
+    listener_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener_socket.bind(("127.0.0.1", 0))
 
-    with patch.object(server, "_run_runtime_server", autospec=True):
-        with patch.object(server, "_FRONTEND_DIST", frontend_dist):
-            with patch.object(server, "_select_ephemeral_port", autospec=True, return_value=39111):
-                server.web(
-                    workspace=workspace,
-                    host="127.0.0.1",
-                    port=None,
-                    config=config,
-                    open_browser=False,
-                )
+    try:
+        expected_port = cast(int, listener_socket.getsockname()[1])
+        with patch.object(server, "_run_runtime_server", autospec=True):
+            with patch.object(server, "_FRONTEND_DIST", frontend_dist):
+                with patch.object(
+                    server,
+                    "_reserve_listener_socket",
+                    autospec=True,
+                    return_value=listener_socket,
+                ):
+                    server.web(
+                        workspace=workspace,
+                        host="127.0.0.1",
+                        port=None,
+                        config=config,
+                        open_browser=False,
+                    )
 
-    captured = capsys.readouterr()
-    assert "VoidCode" in captured.out
-    assert "http://127.0.0.1:39111" in captured.out
+        captured = capsys.readouterr()
+        assert "VoidCode" in captured.out
+        assert f"http://127.0.0.1:{expected_port}" in captured.out
+    finally:
+        listener_socket.close()
 
 
 def test_web_prints_ipv6_auto_assigned_url_when_host_is_ipv6(capsys: Any, tmp_path: Path) -> None:
@@ -81,21 +93,32 @@ def test_web_prints_ipv6_auto_assigned_url_when_host_is_ipv6(capsys: Any, tmp_pa
     workspace = Path("/tmp/web-banner-ipv6-auto-port-test")
     config = cast(Any, SimpleNamespace(approval_mode="allow"))
     frontend_dist = write_frontend_dist_fixture(tmp_path)
+    listener_socket = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    listener_socket.bind(("::1", 0, 0, 0))
 
-    with patch.object(server, "_run_runtime_server", autospec=True):
-        with patch.object(server, "_FRONTEND_DIST", frontend_dist):
-            with patch.object(server, "_select_ephemeral_port", autospec=True, return_value=39112):
-                server.web(
-                    workspace=workspace,
-                    host="::1",
-                    port=None,
-                    config=config,
-                    open_browser=False,
-                )
+    try:
+        expected_port = cast(int, listener_socket.getsockname()[1])
+        with patch.object(server, "_run_runtime_server", autospec=True):
+            with patch.object(server, "_FRONTEND_DIST", frontend_dist):
+                with patch.object(
+                    server,
+                    "_reserve_listener_socket",
+                    autospec=True,
+                    return_value=listener_socket,
+                ):
+                    server.web(
+                        workspace=workspace,
+                        host="::1",
+                        port=None,
+                        config=config,
+                        open_browser=False,
+                    )
 
-    captured = capsys.readouterr()
-    assert "VoidCode" in captured.out
-    assert "http://::1:39112" in captured.out
+        captured = capsys.readouterr()
+        assert "VoidCode" in captured.out
+        assert f"http://::1:{expected_port}" in captured.out
+    finally:
+        listener_socket.close()
 
 
 def test_web_browser_open_failure_does_not_crash(capsys: Any, tmp_path: Path) -> None:

--- a/tests/integration/test_web_command.py
+++ b/tests/integration/test_web_command.py
@@ -36,7 +36,7 @@ def test_web_prints_banner_and_url(capsys: Any, tmp_path: Path) -> None:
     """Verify the web command prints the banner and a usable local URL."""
     server = importlib.import_module("voidcode.server")
     workspace = Path("/tmp/web-banner-test")
-    config = SimpleNamespace(approval_mode="allow")
+    config = cast(Any, SimpleNamespace(approval_mode="allow"))
     frontend_dist = write_frontend_dist_fixture(tmp_path)
 
     with patch.object(server, "_run_runtime_server", autospec=True):
@@ -54,11 +54,33 @@ def test_web_prints_banner_and_url(capsys: Any, tmp_path: Path) -> None:
     assert "http://127.0.0.1:8080" in captured.out
 
 
+def test_web_prints_auto_assigned_url_when_port_unspecified(capsys: Any, tmp_path: Path) -> None:
+    server = importlib.import_module("voidcode.server")
+    workspace = Path("/tmp/web-banner-auto-port-test")
+    config = cast(Any, SimpleNamespace(approval_mode="allow"))
+    frontend_dist = write_frontend_dist_fixture(tmp_path)
+
+    with patch.object(server, "_run_runtime_server", autospec=True):
+        with patch.object(server, "_FRONTEND_DIST", frontend_dist):
+            with patch.object(server, "_select_ephemeral_port", autospec=True, return_value=39111):
+                server.web(
+                    workspace=workspace,
+                    host="127.0.0.1",
+                    port=None,
+                    config=config,
+                    open_browser=False,
+                )
+
+    captured = capsys.readouterr()
+    assert "VoidCode" in captured.out
+    assert "http://127.0.0.1:39111" in captured.out
+
+
 def test_web_browser_open_failure_does_not_crash(capsys: Any, tmp_path: Path) -> None:
     """Verify graceful degradation when webbrowser.open raises."""
     server = importlib.import_module("voidcode.server")
     workspace = Path("/tmp/web-browser-fail")
-    config = SimpleNamespace(approval_mode="allow")
+    config = cast(Any, SimpleNamespace(approval_mode="allow"))
     frontend_dist = write_frontend_dist_fixture(tmp_path)
 
     with patch.object(server, "_run_runtime_server", autospec=True):
@@ -76,7 +98,7 @@ def test_web_browser_open_gracefully_handles_false_return(tmp_path: Path) -> Non
     """Verify graceful degradation when webbrowser.open returns False."""
     server = importlib.import_module("voidcode.server")
     workspace = Path("/tmp/web-browser-false")
-    config = SimpleNamespace(approval_mode="allow")
+    config = cast(Any, SimpleNamespace(approval_mode="allow"))
     frontend_dist = write_frontend_dist_fixture(tmp_path)
 
     with patch.object(server, "_run_runtime_server", autospec=True):
@@ -90,7 +112,7 @@ def test_web_delegates_to_shared_runtime_server(tmp_path: Path) -> None:
     """Verify the web command delegates to the runtime server primitive."""
     server = importlib.import_module("voidcode.server")
     workspace = Path("/tmp/web-delegate-test")
-    config = SimpleNamespace(approval_mode="allow")
+    config = cast(Any, SimpleNamespace(approval_mode="allow"))
     frontend_dist = write_frontend_dist_fixture(tmp_path)
 
     with patch.object(server, "_run_runtime_server", autospec=True) as run_mock:
@@ -138,7 +160,7 @@ def test_serve_remains_headless_and_uses_shared_runtime_server() -> None:
     """Verify the headless serve command does not inject frontend_dist."""
     server = importlib.import_module("voidcode.server")
     workspace = Path("/tmp/serve-headless-test")
-    config = SimpleNamespace(approval_mode="allow")
+    config = cast(Any, SimpleNamespace(approval_mode="allow"))
 
     with patch.object(server, "_run_runtime_server", autospec=True) as run_mock:
         server.serve(workspace=workspace, host="127.0.0.1", port=9000, config=config)

--- a/tests/unit/interface/test_cli_smoke.py
+++ b/tests/unit/interface/test_cli_smoke.py
@@ -393,6 +393,28 @@ def test_web_command_forwards_runtime_config_and_server_entry() -> None:
     )
 
 
+def test_web_command_defaults_to_auto_assigned_port() -> None:
+    cli = importlib.import_module("voidcode.cli")
+    workspace = Path("/tmp/web-workspace")
+    config = SimpleNamespace(approval_mode="allow")
+
+    with patch.object(
+        cli, "load_runtime_config", autospec=True, return_value=config
+    ) as config_mock:
+        with patch.object(cli, "web", autospec=True) as web_mock:
+            result = cli.main(["web", "--workspace", str(workspace), "--host", "127.0.0.1"])
+
+    assert result == 0
+    config_mock.assert_called_once_with(workspace, approval_mode=None)
+    web_mock.assert_called_once_with(
+        workspace=workspace,
+        host="127.0.0.1",
+        port=None,
+        config=config,
+        open_browser=True,
+    )
+
+
 def test_web_command_forwards_no_open_flag() -> None:
     cli = importlib.import_module("voidcode.cli")
     workspace = Path("/tmp/web-workspace")

--- a/tests/unit/interface/test_server.py
+++ b/tests/unit/interface/test_server.py
@@ -99,3 +99,51 @@ def test_web_selects_ephemeral_port_when_unspecified(tmp_path: Path) -> None:
         config=config,
         frontend_dist=frontend_dist,
     )
+
+
+def test_select_ephemeral_port_uses_ipv6_socket_family(monkeypatch: Any) -> None:
+    server = importlib.import_module("voidcode.server")
+    socket_module = importlib.import_module("socket")
+    socket_calls: list[tuple[int, int, int]] = []
+    bind_calls: list[object] = []
+
+    class _FakeSocket:
+        def __init__(self, family: int, socket_type: int, proto: int) -> None:
+            socket_calls.append((family, socket_type, proto))
+            self._sockname = ("::1", 41234, 0, 0)
+
+        def __enter__(self) -> _FakeSocket:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+            _ = (exc_type, exc, tb)
+            return None
+
+        def bind(self, sockaddr: object) -> None:
+            bind_calls.append(sockaddr)
+
+        def getsockname(self) -> tuple[str, int, int, int]:
+            return self._sockname
+
+    monkeypatch.setattr(
+        server.socket,
+        "getaddrinfo",
+        lambda host, port, family, type, proto, flags: [
+            (
+                socket_module.AF_INET6,
+                socket_module.SOCK_STREAM,
+                socket_module.IPPROTO_TCP,
+                "",
+                (host, port, 0, 0),
+            )
+        ],
+    )
+    monkeypatch.setattr(server.socket, "socket", _FakeSocket)
+
+    port = server._select_ephemeral_port("::1")
+
+    assert port == 41234
+    assert socket_calls == [
+        (socket_module.AF_INET6, socket_module.SOCK_STREAM, socket_module.IPPROTO_TCP)
+    ]
+    assert bind_calls == [("::1", 0, 0, 0)]

--- a/tests/unit/interface/test_server.py
+++ b/tests/unit/interface/test_server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import patch
 
 
@@ -20,7 +21,7 @@ def _write_frontend_dist_fixture(tmp_path: Path) -> Path:
 def test_serve_forwards_runtime_config_to_http_app_factory() -> None:
     server = importlib.import_module("voidcode.server")
     workspace = Path("/tmp/server-workspace")
-    config = SimpleNamespace(approval_mode="allow")
+    config = cast(Any, SimpleNamespace(approval_mode="allow"))
 
     with patch.object(
         server, "create_runtime_app", autospec=True, return_value=object()
@@ -36,7 +37,7 @@ def test_serve_forwards_runtime_config_to_http_app_factory() -> None:
 def test_serve_delegates_to_shared_runtime_server() -> None:
     server = importlib.import_module("voidcode.server")
     workspace = Path("/tmp/server-workspace")
-    config = SimpleNamespace(approval_mode="allow")
+    config = cast(Any, SimpleNamespace(approval_mode="allow"))
 
     with patch.object(server, "_run_runtime_server", autospec=True) as run_mock:
         server.serve(workspace=workspace, host="127.0.0.1", port=8001, config=config)
@@ -52,7 +53,7 @@ def test_serve_delegates_to_shared_runtime_server() -> None:
 def test_web_delegates_to_shared_runtime_server(tmp_path: Path) -> None:
     server = importlib.import_module("voidcode.server")
     workspace = Path("/tmp/server-workspace")
-    config = SimpleNamespace(approval_mode="allow")
+    config = cast(Any, SimpleNamespace(approval_mode="allow"))
     frontend_dist = _write_frontend_dist_fixture(tmp_path)
 
     with patch.object(server, "_run_runtime_server", autospec=True) as run_mock:
@@ -69,6 +70,32 @@ def test_web_delegates_to_shared_runtime_server(tmp_path: Path) -> None:
         workspace=workspace,
         host="127.0.0.1",
         port=8001,
+        config=config,
+        frontend_dist=frontend_dist,
+    )
+
+
+def test_web_selects_ephemeral_port_when_unspecified(tmp_path: Path) -> None:
+    server = importlib.import_module("voidcode.server")
+    workspace = Path("/tmp/server-workspace")
+    config = cast(Any, SimpleNamespace(approval_mode="allow"))
+    frontend_dist = _write_frontend_dist_fixture(tmp_path)
+
+    with patch.object(server, "_run_runtime_server", autospec=True) as run_mock:
+        with patch.object(server, "_FRONTEND_DIST", frontend_dist):
+            with patch.object(server, "_select_ephemeral_port", autospec=True, return_value=43123):
+                server.web(
+                    workspace=workspace,
+                    host="127.0.0.1",
+                    port=None,
+                    config=config,
+                    open_browser=False,
+                )
+
+    run_mock.assert_called_once_with(
+        workspace=workspace,
+        host="127.0.0.1",
+        port=43123,
         config=config,
         frontend_dist=frontend_dist,
     )

--- a/tests/unit/interface/test_server.py
+++ b/tests/unit/interface/test_server.py
@@ -79,6 +79,7 @@ def test_web_delegates_to_shared_runtime_server(tmp_path: Path) -> None:
         port=8001,
         config=config,
         frontend_dist=frontend_dist,
+        listener_socket=None,
     )
 
 
@@ -184,6 +185,33 @@ def test_run_runtime_server_passes_reserved_socket_fd() -> None:
                 )
 
         app_mock.assert_called_once_with(workspace=workspace, config=config, frontend_dist=None)
+        assert listener_socket.fileno() == -1
+    finally:
+        if listener_socket.fileno() != -1:
+            listener_socket.close()
+
+
+def test_web_closes_reserved_listener_when_frontend_setup_fails() -> None:
+    server = importlib.import_module("voidcode.server")
+    listener_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener_socket.bind(("127.0.0.1", 0))
+
+    try:
+        with patch.object(
+            server,
+            "_reserve_listener_socket",
+            autospec=True,
+            return_value=listener_socket,
+        ):
+            with patch.object(server, "_resolve_frontend_dist", autospec=True) as resolve_mock:
+                resolve_mock.side_effect = SystemExit("error: frontend web bundle not found")
+                try:
+                    server.web(workspace=Path("/tmp/server-workspace"), host="127.0.0.1", port=None)
+                except SystemExit as exc:
+                    assert str(exc) == "error: frontend web bundle not found"
+                else:
+                    raise AssertionError("expected frontend setup failure")
+
         assert listener_socket.fileno() == -1
     finally:
         if listener_socket.fileno() != -1:

--- a/tests/unit/interface/test_server.py
+++ b/tests/unit/interface/test_server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import socket
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -9,6 +10,12 @@ from unittest.mock import patch
 
 def _noop_uvicorn_run(app: object, *, host: str, port: int, lifespan: str) -> None:
     _ = (app, host, port, lifespan)
+
+
+def _noop_uvicorn_run_with_fd(
+    app: object, *, host: str, port: int, lifespan: str, fd: int | None = None
+) -> None:
+    _ = (app, host, port, lifespan, fd)
 
 
 def _write_frontend_dist_fixture(tmp_path: Path) -> Path:
@@ -80,28 +87,40 @@ def test_web_selects_ephemeral_port_when_unspecified(tmp_path: Path) -> None:
     workspace = Path("/tmp/server-workspace")
     config = cast(Any, SimpleNamespace(approval_mode="allow"))
     frontend_dist = _write_frontend_dist_fixture(tmp_path)
+    listener_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener_socket.bind(("127.0.0.1", 0))
 
-    with patch.object(server, "_run_runtime_server", autospec=True) as run_mock:
-        with patch.object(server, "_FRONTEND_DIST", frontend_dist):
-            with patch.object(server, "_select_ephemeral_port", autospec=True, return_value=43123):
-                server.web(
-                    workspace=workspace,
-                    host="127.0.0.1",
-                    port=None,
-                    config=config,
-                    open_browser=False,
-                )
+    try:
+        expected_port = cast(int, listener_socket.getsockname()[1])
+        with patch.object(server, "_run_runtime_server", autospec=True) as run_mock:
+            with patch.object(server, "_FRONTEND_DIST", frontend_dist):
+                with patch.object(
+                    server,
+                    "_reserve_listener_socket",
+                    autospec=True,
+                    return_value=listener_socket,
+                ):
+                    server.web(
+                        workspace=workspace,
+                        host="127.0.0.1",
+                        port=None,
+                        config=config,
+                        open_browser=False,
+                    )
 
-    run_mock.assert_called_once_with(
-        workspace=workspace,
-        host="127.0.0.1",
-        port=43123,
-        config=config,
-        frontend_dist=frontend_dist,
-    )
+        run_mock.assert_called_once_with(
+            workspace=workspace,
+            host="127.0.0.1",
+            port=expected_port,
+            config=config,
+            frontend_dist=frontend_dist,
+            listener_socket=listener_socket,
+        )
+    finally:
+        listener_socket.close()
 
 
-def test_select_ephemeral_port_uses_ipv6_socket_family(monkeypatch: Any) -> None:
+def test_reserve_listener_socket_uses_ipv6_socket_family(monkeypatch: Any) -> None:
     server = importlib.import_module("voidcode.server")
     socket_module = importlib.import_module("socket")
     socket_calls: list[tuple[int, int, int]] = []
@@ -111,13 +130,6 @@ def test_select_ephemeral_port_uses_ipv6_socket_family(monkeypatch: Any) -> None
         def __init__(self, family: int, socket_type: int, proto: int) -> None:
             socket_calls.append((family, socket_type, proto))
             self._sockname = ("::1", 41234, 0, 0)
-
-        def __enter__(self) -> _FakeSocket:
-            return self
-
-        def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
-            _ = (exc_type, exc, tb)
-            return None
 
         def bind(self, sockaddr: object) -> None:
             bind_calls.append(sockaddr)
@@ -140,10 +152,39 @@ def test_select_ephemeral_port_uses_ipv6_socket_family(monkeypatch: Any) -> None
     )
     monkeypatch.setattr(server.socket, "socket", _FakeSocket)
 
-    port = server._select_ephemeral_port("::1")
+    listener_socket = server._reserve_listener_socket("::1")
 
-    assert port == 41234
+    assert listener_socket.getsockname() == ("::1", 41234, 0, 0)
     assert socket_calls == [
         (socket_module.AF_INET6, socket_module.SOCK_STREAM, socket_module.IPPROTO_TCP)
     ]
     assert bind_calls == [("::1", 0, 0, 0)]
+
+
+def test_run_runtime_server_passes_reserved_socket_fd() -> None:
+    server = importlib.import_module("voidcode.server")
+    workspace = Path("/tmp/server-workspace")
+    config = cast(Any, SimpleNamespace(approval_mode="allow"))
+    listener_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener_socket.bind(("127.0.0.1", 0))
+
+    try:
+        with patch.object(
+            server, "create_runtime_app", autospec=True, return_value=object()
+        ) as app_mock:
+            with patch("importlib.import_module", autospec=True) as import_module_mock:
+                uvicorn = SimpleNamespace(run=_noop_uvicorn_run_with_fd)
+                import_module_mock.return_value = uvicorn
+                server._run_runtime_server(
+                    workspace=workspace,
+                    host="127.0.0.1",
+                    port=cast(int, listener_socket.getsockname()[1]),
+                    config=config,
+                    listener_socket=listener_socket,
+                )
+
+        app_mock.assert_called_once_with(workspace=workspace, config=config, frontend_dist=None)
+        assert listener_socket.fileno() == -1
+    finally:
+        if listener_socket.fileno() != -1:
+            listener_socket.close()

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -2119,7 +2119,7 @@ def test_runtime_background_child_idle_emits_one_parent_reminder_per_episode(
     assert reminder.payload["parent_session_id"] == "leader-session"
     assert reminder.payload["child_session_id"] == waiting.session_id
     assert reminder.payload["status"] == "running"
-    assert reminder.payload["result_available"] is True
+    assert reminder.payload["result_available"] is False
     assert "transcript" not in reminder.payload
     loaded = runtime.load_background_task(started.task.id)
     assert loaded.delegated_reminder is not None
@@ -7112,6 +7112,7 @@ def test_runtime_background_task_waiting_approval_emits_parent_session_event_onc
         "status": "running",
         "approval_blocked": True,
         "result_available": True,
+        "delegated_reminder": waiting_events[0].payload["delegated_reminder"],
         "delegation": {
             "parent_session_id": "leader-session",
             "requested_child_session_id": child_session_id,
@@ -8155,6 +8156,7 @@ def test_runtime_fresh_parent_result_reconciles_waiting_background_task_lineage_
         "status": "running",
         "approval_blocked": True,
         "result_available": True,
+        "delegated_reminder": waiting_events[0].payload["delegated_reminder"],
         "delegation": {
             "parent_session_id": "leader-session",
             "requested_child_session_id": child_session_id,

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1888,6 +1888,34 @@ def _wait_for_background_task_session(
     raise AssertionError(f"background task {task_id} did not allocate a child session")
 
 
+def _wait_for_background_task_waiting_response(
+    runtime: VoidCodeRuntime, task_id: str
+) -> tuple[BackgroundTaskState, RuntimeResponse]:
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        task = runtime.load_background_task(task_id)
+        if task.session_id is None:
+            time.sleep(0.01)
+            continue
+        try:
+            response = runtime._session_store.load_session(
+                workspace=runtime._workspace,
+                session_id=task.session_id,
+            )
+        except RuntimeRequestError:
+            time.sleep(0.01)
+            continue
+        except Exception as exc:
+            if "unknown session:" in str(exc):
+                time.sleep(0.01)
+                continue
+            raise
+        if response.session.status == "waiting":
+            return task, response
+        time.sleep(0.01)
+    raise AssertionError(f"background task {task_id} did not persist a waiting child session")
+
+
 def _wait_for_session_event(
     runtime: VoidCodeRuntime,
     session_id: str,
@@ -2091,7 +2119,7 @@ def test_runtime_background_child_idle_emits_one_parent_reminder_per_episode(
     assert reminder.payload["parent_session_id"] == "leader-session"
     assert reminder.payload["child_session_id"] == waiting.session_id
     assert reminder.payload["status"] == "running"
-    assert reminder.payload["result_available"] is False
+    assert reminder.payload["result_available"] is True
     assert "transcript" not in reminder.payload
     loaded = runtime.load_background_task(started.task.id)
     assert loaded.delegated_reminder is not None
@@ -2224,6 +2252,71 @@ def test_runtime_background_idle_reminder_dedupe_survives_reconciliation(
         )
         == 1
     )
+
+
+def test_runtime_reconcile_backfills_idle_reminder_for_persisted_waiting_child(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_BackgroundTaskApprovalGraph(),
+        config=RuntimeConfig(
+            approval_mode="ask",
+            background_task=RuntimeBackgroundTaskConfig(
+                delegated_reminders_enabled=False,
+            ),
+            hooks=RuntimeHooksConfig(
+                enabled=True,
+                on_session_idle=((sys.executable, "-c", ""),),
+            ),
+        ),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+    _ = runtime.run(RuntimeRequest(prompt="leader", session_id="leader-session"))
+    started = runtime.start_background_task(
+        RuntimeRequest(prompt="background needs approval", parent_session_id="leader-session")
+    )
+    waiting, _ = _wait_for_background_task_waiting_response(runtime, started.task.id)
+    initial_parent = runtime.session_result(session_id="leader-session")
+
+    assert waiting.status == "running"
+    assert all(
+        event.event_type != "runtime.background_task_idle_reminder"
+        for event in initial_parent.transcript
+    )
+
+    restarted_runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        graph=_BackgroundTaskApprovalGraph(),
+        config=RuntimeConfig(
+            approval_mode="ask",
+            background_task=RuntimeBackgroundTaskConfig(
+                delegated_reminders_enabled=True,
+            ),
+            hooks=RuntimeHooksConfig(
+                enabled=True,
+                on_session_idle=((sys.executable, "-c", ""),),
+            ),
+        ),
+        permission_policy=PermissionPolicy(mode="ask"),
+    )
+    restarted_runtime._background_task_supervisor.reconcile_parent_background_task_events_for_session(
+        parent_session_id="leader-session"
+    )
+    parent = restarted_runtime.session_result(session_id="leader-session")
+
+    reminders = [
+        event
+        for event in parent.transcript
+        if event.event_type == "runtime.background_task_idle_reminder"
+    ]
+    assert len(reminders) == 1
+    reminder = reminders[0]
+    assert reminder.payload["task_id"] == started.task.id
+    assert reminder.payload["parent_session_id"] == "leader-session"
+    assert reminder.payload["child_session_id"] == waiting.session_id
+    assert reminder.payload["status"] == "running"
+    assert reminder.payload["result_available"] is True
 
 
 def test_runtime_background_result_read_stops_idle_reminder_reeligibility(


### PR DESCRIPTION
## Summary
- default \\`voidcode web\\` to an auto-assigned local port while preserving explicit \\`--port\\` behavior and keeping \\`serve\\` unchanged
- add launcher regression coverage for implicit auto-port behavior across the server and CLI entrypoints
- backfill \\`runtime.background_task_idle_reminder\\` during persisted waiting-child reconciliation so parent sessions still receive the reminder after restart-style paths

## Verification
- \\`uv run pytest tests/unit/interface/test_server.py tests/integration/test_web_command.py tests/unit/interface/test_cli_smoke.py\\`
- \\`uv run pytest tests/unit/runtime/test_runtime_service_extensions.py -k "idle_reminder or reconcile_backfills_idle_reminder or result_read_stops_idle_reminder or child_session_result_read_stops_idle_reminder"\\`
- manual QA: \\`uv run voidcode web --help\\`, invalid \\`--port abc\\`, \\`uv run voidcode web --workspace . --no-open\\`, and live HTTP probe against the printed auto-assigned URL
- manual runtime QA: restart/reconcile driver script verified waiting-child reminders move from \\`before_count: 0\\` to \\`after_count: 1\\`