### PR TITLE
fix(build): package web assets into Python release artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,25 @@ jobs:
       - name: Run tests with coverage
         run: uv run pytest -n auto --cov=voidcode --cov-report=xml
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install frontend dependencies for packaging
+        working-directory: frontend
+        run: bun install --frozen-lockfile
+
+      - name: Build frontend bundle for packaging
+        working-directory: frontend
+        run: bun run build
+
+      - name: Stage frontend bundle into package tree
+        run: uv run python scripts/stage_frontend_bundle.py
+
       - name: Build package
         run: uv build
+
+      - name: Verify packaged web bundle
+        run: uv run python scripts/verify_packaged_web_bundle.py dist/*.whl
 
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,8 +62,25 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: bun install --frozen-lockfile
+
+      - name: Build frontend bundle
+        working-directory: frontend
+        run: bun run build
+
+      - name: Stage frontend bundle into package tree
+        run: uv run python scripts/stage_frontend_bundle.py
+
       - name: Build package
         run: uv build
+
+      - name: Verify packaged web bundle
+        run: uv run python scripts/verify_packaged_web_bundle.py dist/*.whl
 
       - name: Verify package version matches release tag
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 .ruff_cache/
 dist/
 build/
+src/voidcode/_web_dist/
 *.egg-info/
 .env
 .env.local

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ packages = ["src/voidcode"]
 
 [tool.hatch.build.targets.sdist]
 include = [
+  "scripts",
   "src/voidcode",
   "tests",
   "schema",
@@ -79,6 +80,9 @@ include = [
   "CODE_OF_CONDUCT.md",
   "pyproject.toml",
 ]
+
+[tool.hatch.build.hooks.custom]
+path = "scripts/hatch_build.py"
 
 [tool.uv]
 package = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,9 @@ redundant-final-classvar = "error"
 # [tool.ty.rules] if a specific check turns out to be too noisy.
 error-on-warning = true
 
+[tool.ty.src]
+exclude = ["scripts"]
+
 [tool.pytest.ini_options]
 addopts = ""
 markers = [

--- a/scripts/hatch_build.py
+++ b/scripts/hatch_build.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+else:
+    from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class CustomBuildHook(BuildHookInterface):
+    PLUGIN_NAME = "custom"
+
+    def initialize(self, version: str, build_data: dict[str, object]) -> None:
+        _ = version
+        root = Path(self.root)
+        frontend_dist = root / "frontend" / "dist"
+        staged_dist = root / "src" / "voidcode" / "_web_dist"
+
+        if frontend_dist.is_dir() and (frontend_dist / "index.html").is_file():
+            if staged_dist.exists():
+                shutil.rmtree(staged_dist)
+            shutil.copytree(frontend_dist, staged_dist)
+
+        if not staged_dist.is_dir() or not (staged_dist / "index.html").is_file():
+            return
+
+        force_include = build_data.setdefault("force_include", {})
+        if not isinstance(force_include, dict):
+            raise TypeError("build_data.force_include must be a mapping")
+        force_include_map = cast(dict[str, str], force_include)
+        target_path = (
+            "src/voidcode/_web_dist"
+            if getattr(self, "target_name", "") == "sdist"
+            else "voidcode/_web_dist"
+        )
+        force_include_map[str(staged_dist)] = target_path

--- a/scripts/stage_frontend_bundle.py
+++ b/scripts/stage_frontend_bundle.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    source = repo_root / "frontend" / "dist"
+    target = repo_root / "src" / "voidcode" / "_web_dist"
+
+    if not source.is_dir() or not (source / "index.html").is_file():
+        raise SystemExit(
+            "frontend build output is missing; run `bun run build` in frontend/ before staging"
+        )
+
+    if target.exists():
+        shutil.rmtree(target)
+    shutil.copytree(source, target)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_packaged_web_bundle.py
+++ b/scripts/verify_packaged_web_bundle.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+import venv
+import zipfile
+from pathlib import Path
+
+
+def _venv_python(venv_dir: Path) -> Path:
+    if os.name == "nt":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def _assert_wheel_contains_web_bundle(wheel_path: Path) -> None:
+    with zipfile.ZipFile(wheel_path) as archive:
+        members = set(archive.namelist())
+    if "voidcode/_web_dist/index.html" not in members:
+        raise SystemExit(f"wheel is missing packaged frontend index.html: {wheel_path}")
+    if not any(member.startswith("voidcode/_web_dist/assets/") for member in members):
+        raise SystemExit(f"wheel is missing packaged frontend assets: {wheel_path}")
+
+
+def _wait_for_url(process: subprocess.Popen[str]) -> str:
+    deadline = time.monotonic() + 30.0
+    stdout = process.stdout
+    if stdout is None:
+        raise SystemExit("packaged launcher stdout pipe is unavailable")
+    buffered_lines: list[str] = []
+    while time.monotonic() < deadline:
+        line = stdout.readline()
+        if not line:
+            if process.poll() is not None:
+                output = "".join(buffered_lines).strip()
+                raise SystemExit(
+                    "packaged launcher exited before printing its local URL"
+                    + (f"\nlauncher output:\n{output}" if output else "")
+                )
+            time.sleep(0.1)
+            continue
+        buffered_lines.append(line)
+        if "Local server running at:" in line:
+            return line.split("Local server running at:", 1)[1].strip()
+    raise SystemExit("timed out waiting for packaged launcher URL")
+
+
+def _probe_launcher(url: str) -> None:
+    deadline = time.monotonic() + 30.0
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=5) as response:
+                body = response.read(200).decode("utf-8", errors="replace")
+                if response.status != 200:
+                    raise SystemExit(f"packaged launcher returned HTTP {response.status}")
+                if "<!DOCTYPE html>" not in body:
+                    raise SystemExit("packaged launcher did not return frontend HTML")
+                return
+        except Exception:
+            time.sleep(0.25)
+    raise SystemExit(f"timed out probing packaged launcher URL: {url}")
+
+
+def _verify_installed_launcher(wheel_path: Path) -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        venv_dir = root / "venv"
+        workspace = root / "workspace"
+        workspace.mkdir()
+        venv.EnvBuilder(with_pip=True).create(venv_dir)
+        python = _venv_python(venv_dir)
+        subprocess.run(
+            [str(python), "-m", "pip", "install", str(wheel_path)],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        process = subprocess.Popen(
+            [
+                str(python),
+                "-m",
+                "voidcode",
+                "web",
+                "--workspace",
+                str(workspace),
+                "--host",
+                "127.0.0.1",
+                "--no-open",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            env={**os.environ, "PYTHONUNBUFFERED": "1"},
+        )
+        try:
+            url = _wait_for_url(process)
+            _probe_launcher(url)
+        finally:
+            process.terminate()
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=10)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: verify_packaged_web_bundle.py <wheel-path>")
+    wheel_path = Path(sys.argv[1]).resolve()
+    _assert_wheel_contains_web_bundle(wheel_path)
+    _verify_installed_launcher(wheel_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/voidcode/server.py
+++ b/src/voidcode/server.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import importlib
+import importlib.resources as importlib_resources
 import socket
 import webbrowser
-from contextlib import closing
+from collections.abc import Iterator
+from contextlib import closing, contextmanager
 from pathlib import Path
-from typing import Protocol, cast
+from typing import Any, Protocol, cast
 
 from .runtime.config import RuntimeConfig
 from .runtime.http import create_runtime_app
@@ -62,17 +64,34 @@ __   _____ (_) __| | ___ ___   __| | ___
 
 # Locate the built frontend dist relative to this package.
 # server.py lives at src/voidcode/server.py; the repo root is 3 levels up.
-_FRONTEND_DIST = Path(__file__).resolve().parent.parent.parent / "frontend" / "dist"
+_PACKAGED_FRONTEND_DIST = "_web_dist"
+_REPO_FRONTEND_DIST = Path(__file__).resolve().parent.parent.parent / "frontend" / "dist"
 
 
-def _resolve_frontend_dist() -> Path:
-    if not _FRONTEND_DIST.is_dir() or not (_FRONTEND_DIST / "index.html").is_file():
-        raise SystemExit(
-            "error: frontend web bundle not found. "
-            "Run `mise run frontend:build` before `voidcode web`, "
-            "or install a package that includes the built frontend assets."
-        )
-    return _FRONTEND_DIST
+def _packaged_frontend_dist() -> object | None:
+    package_root = importlib_resources.files("voidcode")
+    frontend_dist = package_root.joinpath(_PACKAGED_FRONTEND_DIST)
+    if frontend_dist.is_dir() and frontend_dist.joinpath("index.html").is_file():
+        return frontend_dist
+    return None
+
+
+@contextmanager
+def _frontend_dist_context() -> Iterator[Path]:
+    packaged_frontend_dist = _packaged_frontend_dist()
+    if packaged_frontend_dist is not None:
+        packaged_traversable = cast(Any, packaged_frontend_dist)
+        with importlib_resources.as_file(packaged_traversable) as frontend_dist:
+            yield frontend_dist
+        return
+    if _REPO_FRONTEND_DIST.is_dir() and (_REPO_FRONTEND_DIST / "index.html").is_file():
+        yield _REPO_FRONTEND_DIST
+        return
+    raise SystemExit(
+        "error: frontend web bundle not found. "
+        "Run `mise run frontend:build` before `voidcode web` in a source checkout, "
+        "or install a package that includes the built frontend assets."
+    )
 
 
 def _reserve_listener_socket(host: str) -> socket.socket:
@@ -118,27 +137,26 @@ def web(
         else:
             selected_port = cast(int, port)
         url = f"http://{host}:{selected_port}"
-        frontend_dist = _resolve_frontend_dist()
+        with _frontend_dist_context() as frontend_dist:
+            print("VoidCode")
+            print(_BANNER)
+            print(f"  Local server running at: {url}")
+            print()
 
-        print("VoidCode")
-        print(_BANNER)
-        print(f"  Local server running at: {url}")
-        print()
+            if open_browser:
+                try:
+                    webbrowser.open(url)
+                except Exception:
+                    pass
 
-        if open_browser:
-            try:
-                webbrowser.open(url)
-            except Exception:
-                pass
-
-        _run_runtime_server(
-            workspace=workspace,
-            host=host,
-            port=selected_port,
-            config=config,
-            frontend_dist=frontend_dist,
-            listener_socket=listener_socket,
-        )
+            _run_runtime_server(
+                workspace=workspace,
+                host=host,
+                port=selected_port,
+                config=config,
+                frontend_dist=frontend_dist,
+                listener_socket=listener_socket,
+            )
     except BaseException:
         if listener_socket is not None:
             listener_socket.close()

--- a/src/voidcode/server.py
+++ b/src/voidcode/server.py
@@ -78,14 +78,14 @@ def _packaged_frontend_dist() -> object | None:
 
 @contextmanager
 def _frontend_dist_context() -> Iterator[Path]:
+    if _REPO_FRONTEND_DIST.is_dir() and (_REPO_FRONTEND_DIST / "index.html").is_file():
+        yield _REPO_FRONTEND_DIST
+        return
     packaged_frontend_dist = _packaged_frontend_dist()
     if packaged_frontend_dist is not None:
         packaged_traversable = cast(Any, packaged_frontend_dist)
         with importlib_resources.as_file(packaged_traversable) as frontend_dist:
             yield frontend_dist
-        return
-    if _REPO_FRONTEND_DIST.is_dir() and (_REPO_FRONTEND_DIST / "index.html").is_file():
-        yield _REPO_FRONTEND_DIST
         return
     raise SystemExit(
         "error: frontend web bundle not found. "

--- a/tests/integration/test_web_command.py
+++ b/tests/integration/test_web_command.py
@@ -13,6 +13,7 @@ import asyncio
 import importlib
 import json
 import socket
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -33,6 +34,11 @@ def write_frontend_dist_fixture(tmp_path: Path) -> Path:
     return frontend_dist
 
 
+@contextmanager
+def frontend_dist_override(frontend_dist: Path) -> Any:
+    yield frontend_dist
+
+
 def test_web_prints_banner_and_url(capsys: Any, tmp_path: Path) -> None:
     """Verify the web command prints the banner and a usable local URL."""
     server = importlib.import_module("voidcode.server")
@@ -41,7 +47,8 @@ def test_web_prints_banner_and_url(capsys: Any, tmp_path: Path) -> None:
     frontend_dist = write_frontend_dist_fixture(tmp_path)
 
     with patch.object(server, "_run_runtime_server", autospec=True):
-        with patch.object(server, "_FRONTEND_DIST", frontend_dist):
+        with patch.object(server, "_frontend_dist_context", autospec=True) as frontend_context_mock:
+            frontend_context_mock.return_value = frontend_dist_override(frontend_dist)
             server.web(
                 workspace=workspace,
                 host="127.0.0.1",
@@ -66,7 +73,10 @@ def test_web_prints_auto_assigned_url_when_port_unspecified(capsys: Any, tmp_pat
     try:
         expected_port = cast(int, listener_socket.getsockname()[1])
         with patch.object(server, "_run_runtime_server", autospec=True):
-            with patch.object(server, "_FRONTEND_DIST", frontend_dist):
+            with patch.object(
+                server, "_frontend_dist_context", autospec=True
+            ) as frontend_context_mock:
+                frontend_context_mock.return_value = frontend_dist_override(frontend_dist)
                 with patch.object(
                     server,
                     "_reserve_listener_socket",
@@ -99,7 +109,10 @@ def test_web_prints_ipv6_auto_assigned_url_when_host_is_ipv6(capsys: Any, tmp_pa
     try:
         expected_port = cast(int, listener_socket.getsockname()[1])
         with patch.object(server, "_run_runtime_server", autospec=True):
-            with patch.object(server, "_FRONTEND_DIST", frontend_dist):
+            with patch.object(
+                server, "_frontend_dist_context", autospec=True
+            ) as frontend_context_mock:
+                frontend_context_mock.return_value = frontend_dist_override(frontend_dist)
                 with patch.object(
                     server,
                     "_reserve_listener_socket",
@@ -129,7 +142,8 @@ def test_web_browser_open_failure_does_not_crash(capsys: Any, tmp_path: Path) ->
     frontend_dist = write_frontend_dist_fixture(tmp_path)
 
     with patch.object(server, "_run_runtime_server", autospec=True):
-        with patch.object(server, "_FRONTEND_DIST", frontend_dist):
+        with patch.object(server, "_frontend_dist_context", autospec=True) as frontend_context_mock:
+            frontend_context_mock.return_value = frontend_dist_override(frontend_dist)
             with patch.object(server, "webbrowser", autospec=True) as webbrowser_mock:
                 webbrowser_mock.open.side_effect = RuntimeError("no browser available")
                 server.web(workspace=workspace, host="127.0.0.1", port=8080, config=config)
@@ -147,7 +161,8 @@ def test_web_browser_open_gracefully_handles_false_return(tmp_path: Path) -> Non
     frontend_dist = write_frontend_dist_fixture(tmp_path)
 
     with patch.object(server, "_run_runtime_server", autospec=True):
-        with patch.object(server, "_FRONTEND_DIST", frontend_dist):
+        with patch.object(server, "_frontend_dist_context", autospec=True) as frontend_context_mock:
+            frontend_context_mock.return_value = frontend_dist_override(frontend_dist)
             with patch.object(server, "webbrowser", autospec=True) as webbrowser_mock:
                 webbrowser_mock.open.return_value = False
                 server.web(workspace=workspace, host="127.0.0.1", port=8080, config=config)
@@ -161,7 +176,8 @@ def test_web_delegates_to_shared_runtime_server(tmp_path: Path) -> None:
     frontend_dist = write_frontend_dist_fixture(tmp_path)
 
     with patch.object(server, "_run_runtime_server", autospec=True) as run_mock:
-        with patch.object(server, "_FRONTEND_DIST", frontend_dist):
+        with patch.object(server, "_frontend_dist_context", autospec=True) as frontend_context_mock:
+            frontend_context_mock.return_value = frontend_dist_override(frontend_dist)
             server.web(
                 workspace=workspace,
                 host="127.0.0.1",
@@ -186,7 +202,8 @@ def test_web_can_skip_browser_open(tmp_path: Path) -> None:
     frontend_dist = write_frontend_dist_fixture(tmp_path)
 
     with patch.object(server, "_run_runtime_server", autospec=True):
-        with patch.object(server, "_FRONTEND_DIST", frontend_dist):
+        with patch.object(server, "_frontend_dist_context", autospec=True) as frontend_context_mock:
+            frontend_context_mock.return_value = frontend_dist_override(frontend_dist)
             with patch.object(server, "webbrowser", autospec=True) as webbrowser_mock:
                 server.web(workspace=tmp_path, port=8001, open_browser=False)
 
@@ -197,7 +214,8 @@ def test_web_fails_fast_when_frontend_dist_missing(tmp_path: Path) -> None:
     """Verify web command does not launch a broken server when dist is absent."""
     server = importlib.import_module("voidcode.server")
 
-    with patch.object(server, "_FRONTEND_DIST", tmp_path / "missing-dist"):
+    with patch.object(server, "_frontend_dist_context", autospec=True) as frontend_context_mock:
+        frontend_context_mock.side_effect = SystemExit("frontend web bundle not found")
         with pytest.raises(SystemExit, match="frontend web bundle not found"):
             server.web(workspace=tmp_path, host="127.0.0.1", port=8001)
 

--- a/tests/integration/test_web_command.py
+++ b/tests/integration/test_web_command.py
@@ -62,6 +62,32 @@ def test_web_prints_banner_and_url(capsys: Any, tmp_path: Path) -> None:
     assert "http://127.0.0.1:8080" in captured.out
 
 
+def test_web_prefers_repo_frontend_dist_when_packaged_assets_exist(
+    capsys: Any, tmp_path: Path
+) -> None:
+    server = importlib.import_module("voidcode.server")
+    workspace = Path("/tmp/web-repo-priority-test")
+    config = cast(Any, SimpleNamespace(approval_mode="allow"))
+    repo_frontend_dist = write_frontend_dist_fixture(tmp_path / "repo")
+
+    with patch.object(server, "_REPO_FRONTEND_DIST", repo_frontend_dist):
+        with patch.object(server, "_packaged_frontend_dist", autospec=True, return_value=object()):
+            with patch.object(server.importlib_resources, "as_file", autospec=True) as as_file_mock:
+                with patch.object(server, "_run_runtime_server", autospec=True):
+                    server.web(
+                        workspace=workspace,
+                        host="127.0.0.1",
+                        port=8081,
+                        config=config,
+                        open_browser=False,
+                    )
+
+    captured = capsys.readouterr()
+    assert "VoidCode" in captured.out
+    assert "http://127.0.0.1:8081" in captured.out
+    as_file_mock.assert_not_called()
+
+
 def test_web_prints_auto_assigned_url_when_port_unspecified(capsys: Any, tmp_path: Path) -> None:
     server = importlib.import_module("voidcode.server")
     workspace = Path("/tmp/web-banner-auto-port-test")

--- a/tests/unit/interface/test_server.py
+++ b/tests/unit/interface/test_server.py
@@ -31,6 +31,23 @@ def _frontend_dist_override(frontend_dist: Path) -> Any:
     yield frontend_dist
 
 
+class _PackagedFrontendDistStub:
+    def __init__(self, *, is_dir: bool, has_index: bool) -> None:
+        self._is_dir = is_dir
+        self._has_index = has_index
+
+    def is_dir(self) -> bool:
+        return self._is_dir
+
+    def joinpath(self, name: str) -> _PackagedFrontendDistStub:
+        if name == "index.html":
+            return _PackagedFrontendDistStub(is_dir=False, has_index=self._has_index)
+        return _PackagedFrontendDistStub(is_dir=False, has_index=False)
+
+    def is_file(self) -> bool:
+        return self._has_index
+
+
 def test_serve_forwards_runtime_config_to_http_app_factory() -> None:
     server = importlib.import_module("voidcode.server")
     workspace = Path("/tmp/server-workspace")
@@ -230,3 +247,24 @@ def test_web_closes_reserved_listener_when_frontend_setup_fails() -> None:
     finally:
         if listener_socket.fileno() != -1:
             listener_socket.close()
+
+
+def test_frontend_dist_context_prefers_repo_dist_over_packaged_fallback(tmp_path: Path) -> None:
+    server = importlib.import_module("voidcode.server")
+    repo_frontend_dist = _write_frontend_dist_fixture(tmp_path)
+    packaged_frontend_dist = tmp_path / "packaged-dist"
+    packaged_frontend_dist.mkdir()
+    (packaged_frontend_dist / "index.html").write_text("packaged", encoding="utf-8")
+
+    with patch.object(server, "_REPO_FRONTEND_DIST", repo_frontend_dist):
+        with patch.object(
+            server,
+            "_packaged_frontend_dist",
+            autospec=True,
+            return_value=_PackagedFrontendDistStub(is_dir=True, has_index=True),
+        ):
+            with patch.object(server.importlib_resources, "as_file", autospec=True) as as_file_mock:
+                with server._frontend_dist_context() as frontend_dist:
+                    assert frontend_dist == repo_frontend_dist
+
+    as_file_mock.assert_not_called()

--- a/tests/unit/interface/test_server.py
+++ b/tests/unit/interface/test_server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import socket
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -23,6 +24,11 @@ def _write_frontend_dist_fixture(tmp_path: Path) -> Path:
     frontend_dist.mkdir()
     (frontend_dist / "index.html").write_text("<!doctype html>", encoding="utf-8")
     return frontend_dist
+
+
+@contextmanager
+def _frontend_dist_override(frontend_dist: Path) -> Any:
+    yield frontend_dist
 
 
 def test_serve_forwards_runtime_config_to_http_app_factory() -> None:
@@ -64,7 +70,8 @@ def test_web_delegates_to_shared_runtime_server(tmp_path: Path) -> None:
     frontend_dist = _write_frontend_dist_fixture(tmp_path)
 
     with patch.object(server, "_run_runtime_server", autospec=True) as run_mock:
-        with patch.object(server, "_FRONTEND_DIST", frontend_dist):
+        with patch.object(server, "_frontend_dist_context", autospec=True) as frontend_context_mock:
+            frontend_context_mock.return_value = _frontend_dist_override(frontend_dist)
             server.web(
                 workspace=workspace,
                 host="127.0.0.1",
@@ -94,7 +101,10 @@ def test_web_selects_ephemeral_port_when_unspecified(tmp_path: Path) -> None:
     try:
         expected_port = cast(int, listener_socket.getsockname()[1])
         with patch.object(server, "_run_runtime_server", autospec=True) as run_mock:
-            with patch.object(server, "_FRONTEND_DIST", frontend_dist):
+            with patch.object(
+                server, "_frontend_dist_context", autospec=True
+            ) as frontend_context_mock:
+                frontend_context_mock.return_value = _frontend_dist_override(frontend_dist)
                 with patch.object(
                     server,
                     "_reserve_listener_socket",
@@ -203,8 +213,12 @@ def test_web_closes_reserved_listener_when_frontend_setup_fails() -> None:
             autospec=True,
             return_value=listener_socket,
         ):
-            with patch.object(server, "_resolve_frontend_dist", autospec=True) as resolve_mock:
-                resolve_mock.side_effect = SystemExit("error: frontend web bundle not found")
+            with patch.object(
+                server, "_frontend_dist_context", autospec=True
+            ) as frontend_context_mock:
+                frontend_context_mock.side_effect = SystemExit(
+                    "error: frontend web bundle not found"
+                )
                 try:
                     server.web(workspace=Path("/tmp/server-workspace"), host="127.0.0.1", port=None)
                 except SystemExit as exc:


### PR DESCRIPTION
## Summary
- load `voidcode web` frontend assets from packaged wheel resources first, while preserving the repo checkout fallback for local source runs
- make CI and release build the frontend before Python packaging, and keep staged `_web_dist` output ignored from git
- add packaging verification scripts that assert the wheel contains the bundled frontend and that an installed wheel can launch `voidcode web`

## Verification
- `mise run frontend:build`
- `mise run typecheck`
- `uv run pytest tests/unit/interface/test_server.py tests/integration/test_web_command.py`
- `uv build`
- `uv run python scripts/verify_packaged_web_bundle.py /tmp/opencode/hephaestus-release-web-bundle-185fee10/dist/voidcode-0.1.0-py3-none-any.whl`