### PR TITLE
fix(build): honor verifier timeout for silent web launchers

### DIFF
--- a/scripts/verify_packaged_web_bundle.py
+++ b/scripts/verify_packaged_web_bundle.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import io
 import os
-import selectors
+import queue
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import urllib.request
 import venv
@@ -46,31 +47,44 @@ def _wait_for_url_from_stream(
     poll_fn = poll
     if not callable(poll_fn):
         raise TypeError("poll must be callable")
-    with selectors.DefaultSelector() as selector:
-        selector.register(stdout, selectors.EVENT_READ)
-        while time.monotonic() < deadline:
-            remaining = max(deadline - time.monotonic(), 0.0)
-            ready = selector.select(timeout=min(remaining, 0.1))
-            if not ready:
-                if poll_fn() is not None:
-                    output = "".join(buffered_lines).strip()
-                    raise SystemExit(
-                        "packaged launcher exited before printing its local URL"
-                        + (f"\nlauncher output:\n{output}" if output else "")
-                    )
-                continue
+    line_queue: queue.Queue[str | None] = queue.Queue()
+
+    def _read_stdout() -> None:
+        while True:
             line = stdout.readline()
-            if not line:
-                if poll_fn() is not None:
-                    output = "".join(buffered_lines).strip()
-                    raise SystemExit(
-                        "packaged launcher exited before printing its local URL"
-                        + (f"\nlauncher output:\n{output}" if output else "")
-                    )
-                continue
-            buffered_lines.append(line)
-            if "Local server running at:" in line:
-                return line.split("Local server running at:", 1)[1].strip()
+            if line == "":
+                line_queue.put(None)
+                return
+            line_queue.put(line)
+
+    reader = threading.Thread(target=_read_stdout, daemon=True)
+    reader.start()
+
+    while time.monotonic() < deadline:
+        remaining = max(deadline - time.monotonic(), 0.0)
+        try:
+            item = line_queue.get(timeout=min(remaining, 0.1))
+        except queue.Empty:
+            if poll_fn() is not None:
+                output = "".join(buffered_lines).strip()
+                raise SystemExit(
+                    "packaged launcher exited before printing its local URL"
+                    + (f"\nlauncher output:\n{output}" if output else "")
+                ) from None
+            continue
+
+        if item is None:
+            if poll_fn() is not None:
+                output = "".join(buffered_lines).strip()
+                raise SystemExit(
+                    "packaged launcher exited before printing its local URL"
+                    + (f"\nlauncher output:\n{output}" if output else "")
+                )
+            continue
+
+        buffered_lines.append(item)
+        if "Local server running at:" in item:
+            return item.split("Local server running at:", 1)[1].strip()
     raise SystemExit("timed out waiting for packaged launcher URL")
 
 

--- a/scripts/verify_packaged_web_bundle.py
+++ b/scripts/verify_packaged_web_bundle.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import io
 import os
+import selectors
 import subprocess
 import sys
 import tempfile
@@ -27,25 +29,48 @@ def _assert_wheel_contains_web_bundle(wheel_path: Path) -> None:
 
 
 def _wait_for_url(process: subprocess.Popen[str]) -> str:
-    deadline = time.monotonic() + 30.0
     stdout = process.stdout
     if stdout is None:
         raise SystemExit("packaged launcher stdout pipe is unavailable")
+    return _wait_for_url_from_stream(stdout=stdout, poll=process.poll, timeout_seconds=30.0)
+
+
+def _wait_for_url_from_stream(
+    *,
+    stdout: io.TextIOBase,
+    poll: object,
+    timeout_seconds: float,
+) -> str:
     buffered_lines: list[str] = []
-    while time.monotonic() < deadline:
-        line = stdout.readline()
-        if not line:
-            if process.poll() is not None:
-                output = "".join(buffered_lines).strip()
-                raise SystemExit(
-                    "packaged launcher exited before printing its local URL"
-                    + (f"\nlauncher output:\n{output}" if output else "")
-                )
-            time.sleep(0.1)
-            continue
-        buffered_lines.append(line)
-        if "Local server running at:" in line:
-            return line.split("Local server running at:", 1)[1].strip()
+    deadline = time.monotonic() + timeout_seconds
+    poll_fn = poll
+    if not callable(poll_fn):
+        raise TypeError("poll must be callable")
+    with selectors.DefaultSelector() as selector:
+        selector.register(stdout, selectors.EVENT_READ)
+        while time.monotonic() < deadline:
+            remaining = max(deadline - time.monotonic(), 0.0)
+            ready = selector.select(timeout=min(remaining, 0.1))
+            if not ready:
+                if poll_fn() is not None:
+                    output = "".join(buffered_lines).strip()
+                    raise SystemExit(
+                        "packaged launcher exited before printing its local URL"
+                        + (f"\nlauncher output:\n{output}" if output else "")
+                    )
+                continue
+            line = stdout.readline()
+            if not line:
+                if poll_fn() is not None:
+                    output = "".join(buffered_lines).strip()
+                    raise SystemExit(
+                        "packaged launcher exited before printing its local URL"
+                        + (f"\nlauncher output:\n{output}" if output else "")
+                    )
+                continue
+            buffered_lines.append(line)
+            if "Local server running at:" in line:
+                return line.split("Local server running at:", 1)[1].strip()
     raise SystemExit("timed out waiting for packaged launcher URL")
 
 

--- a/tests/unit/project/test_verify_packaged_web_bundle.py
+++ b/tests/unit/project/test_verify_packaged_web_bundle.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import queue
 from pathlib import Path
 
 import pytest
@@ -26,6 +27,16 @@ class _SilentStdout(io.TextIOBase):
         raise AssertionError("readline should not be called when selector reports no data")
 
 
+class _BlockingStdout(io.TextIOBase):
+    def fileno(self) -> int:
+        return 0
+
+    def readline(self, size: int = -1) -> str:
+        _ = size
+        while True:
+            pass
+
+
 def test_wait_for_url_from_stream_times_out_for_silent_alive_process(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -36,22 +47,17 @@ def test_wait_for_url_from_stream_times_out_for_silent_alive_process(
 
     monkeypatch.setattr(verify_packaged_web_bundle.time, "monotonic", fake_monotonic)
 
-    class _Selector:
-        def __enter__(self) -> _Selector:
-            return self
-
-        def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
-            _ = (exc_type, exc, tb)
-            return None
-
-        def register(self, fileobj: object, events: object) -> None:
-            _ = (fileobj, events)
-
-        def select(self, timeout: float | None = None) -> list[tuple[object, object]]:
+    class _Queue:
+        def get(self, timeout: float | None = None) -> str | None:
             _ = timeout
-            return []
+            raise queue.Empty
 
-    monkeypatch.setattr(verify_packaged_web_bundle.selectors, "DefaultSelector", _Selector)
+    monkeypatch.setattr(verify_packaged_web_bundle.queue, "Queue", lambda: _Queue())
+    monkeypatch.setattr(
+        verify_packaged_web_bundle.threading,
+        "Thread",
+        lambda *args, **kwargs: type("T", (), {"start": lambda self: None})(),
+    )
 
     stdout = _SilentStdout()
     with pytest.raises(SystemExit, match="timed out waiting for packaged launcher URL"):
@@ -71,22 +77,20 @@ def test_wait_for_url_from_stream_surfaces_launcher_output_on_early_exit(
         def fileno(self) -> int:
             return 0
 
-    class _Selector:
-        def __enter__(self) -> _Selector:
-            return self
+    class _Queue:
+        def __init__(self) -> None:
+            self._values = iter(["starting up\n", None])
 
-        def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
-            _ = (exc_type, exc, tb)
-            return None
-
-        def register(self, fileobj: object, events: object) -> None:
-            _ = (fileobj, events)
-
-        def select(self, timeout: float | None = None) -> list[tuple[object, object]]:
+        def get(self, timeout: float | None = None) -> str | None:
             _ = timeout
-            return [(object(), object())]
+            return next(self._values)
 
-    monkeypatch.setattr(verify_packaged_web_bundle.selectors, "DefaultSelector", _Selector)
+    monkeypatch.setattr(verify_packaged_web_bundle.queue, "Queue", _Queue)
+    monkeypatch.setattr(
+        verify_packaged_web_bundle.threading,
+        "Thread",
+        lambda *args, **kwargs: type("T", (), {"start": lambda self: None})(),
+    )
 
     stdout = _ReadableStdout("starting up\n")
     poll_results = iter([1])
@@ -96,4 +100,34 @@ def test_wait_for_url_from_stream_surfaces_launcher_output_on_early_exit(
             stdout=stdout,
             poll=lambda: next(poll_results),
             timeout_seconds=30.0,
+        )
+
+
+def test_wait_for_url_from_stream_does_not_require_selector_compatible_handles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    time_values = iter([0.0, 0.0, 0.2, 0.4, 0.6, 0.6])
+
+    def fake_monotonic() -> float:
+        return next(time_values)
+
+    monkeypatch.setattr(verify_packaged_web_bundle.time, "monotonic", fake_monotonic)
+
+    class _Queue:
+        def get(self, timeout: float | None = None) -> str | None:
+            _ = timeout
+            raise queue.Empty
+
+    monkeypatch.setattr(verify_packaged_web_bundle.queue, "Queue", lambda: _Queue())
+    monkeypatch.setattr(
+        verify_packaged_web_bundle.threading,
+        "Thread",
+        lambda *args, **kwargs: type("T", (), {"start": lambda self: None})(),
+    )
+
+    with pytest.raises(SystemExit, match="timed out waiting for packaged launcher URL"):
+        verify_packaged_web_bundle._wait_for_url_from_stream(
+            stdout=_BlockingStdout(),
+            poll=lambda: None,
+            timeout_seconds=0.5,
         )

--- a/tests/unit/project/test_verify_packaged_web_bundle.py
+++ b/tests/unit/project/test_verify_packaged_web_bundle.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+from pathlib import Path
+
+import pytest
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent.parent.parent
+    / "scripts"
+    / "verify_packaged_web_bundle.py"
+)
+_SPEC = importlib.util.spec_from_file_location("verify_packaged_web_bundle", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+verify_packaged_web_bundle = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(verify_packaged_web_bundle)
+
+
+class _SilentStdout(io.TextIOBase):
+    def fileno(self) -> int:
+        return 0
+
+    def readline(self, size: int = -1) -> str:
+        _ = size
+        raise AssertionError("readline should not be called when selector reports no data")
+
+
+def test_wait_for_url_from_stream_times_out_for_silent_alive_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    time_values = iter([0.0, 0.0, 0.2, 0.4, 0.6, 0.6])
+
+    def fake_monotonic() -> float:
+        return next(time_values)
+
+    monkeypatch.setattr(verify_packaged_web_bundle.time, "monotonic", fake_monotonic)
+
+    class _Selector:
+        def __enter__(self) -> _Selector:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+            _ = (exc_type, exc, tb)
+            return None
+
+        def register(self, fileobj: object, events: object) -> None:
+            _ = (fileobj, events)
+
+        def select(self, timeout: float | None = None) -> list[tuple[object, object]]:
+            _ = timeout
+            return []
+
+    monkeypatch.setattr(verify_packaged_web_bundle.selectors, "DefaultSelector", _Selector)
+
+    stdout = _SilentStdout()
+    with pytest.raises(SystemExit, match="timed out waiting for packaged launcher URL"):
+        verify_packaged_web_bundle._wait_for_url_from_stream(
+            stdout=stdout,
+            poll=lambda: None,
+            timeout_seconds=0.5,
+        )
+
+
+def test_wait_for_url_from_stream_surfaces_launcher_output_on_early_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(verify_packaged_web_bundle.time, "monotonic", lambda: 0.0)
+
+    class _ReadableStdout(io.StringIO):
+        def fileno(self) -> int:
+            return 0
+
+    class _Selector:
+        def __enter__(self) -> _Selector:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+            _ = (exc_type, exc, tb)
+            return None
+
+        def register(self, fileobj: object, events: object) -> None:
+            _ = (fileobj, events)
+
+        def select(self, timeout: float | None = None) -> list[tuple[object, object]]:
+            _ = timeout
+            return [(object(), object())]
+
+    monkeypatch.setattr(verify_packaged_web_bundle.selectors, "DefaultSelector", _Selector)
+
+    stdout = _ReadableStdout("starting up\n")
+    poll_results = iter([1])
+
+    with pytest.raises(SystemExit, match="launcher output:\nstarting up"):
+        verify_packaged_web_bundle._wait_for_url_from_stream(
+            stdout=stdout,
+            poll=lambda: next(poll_results),
+            timeout_seconds=30.0,
+        )


### PR DESCRIPTION
## Summary
- replace the blocking `stdout.readline()` wait loop in `scripts/verify_packaged_web_bundle.py` with a selector-based timeout loop
- preserve the existing early-exit diagnostics by surfacing buffered launcher output when the subprocess exits before printing its URL
- add regression tests for a silent-but-alive launcher timeout and an early-exit launcher that prints partial output

## Verification
- `uv run pytest tests/unit/project/test_verify_packaged_web_bundle.py`