### PR TITLE
fix: harden delegated child session frontend flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Web frontend delegated child sessions now expose an in-context return action,
+  keep replay run state aligned with running child sessions, and allow returning
+  to the parent session while the delegated child is still active.
+- Web runtime status surfaces no longer crash when partial status payloads omit
+  nested `git`, `lsp`, or `mcp` details.
+
 ## [0.1.0] - 2026-05-06
 
 First productionized release of the VoidCode runtime control plane.

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import App from "./App";
 import { useAppStore } from "./store";
+import type { RuntimeStatusSnapshot } from "./lib/runtime/types";
 import "./i18n";
 
 vi.mock("./store", () => ({
@@ -421,6 +422,28 @@ describe("App", () => {
     expect(screen.queryByText("Agent Idle")).not.toBeInTheDocument();
   });
 
+  it("renders when runtime status omits git details", () => {
+    (useAppStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      ...mockStore,
+      workspaces: {
+        current: {
+          path: "/workspace",
+          label: "workspace",
+          available: true,
+          current: true,
+          last_opened_at: 1,
+        },
+        recent: [],
+        candidates: [],
+      },
+      statusSnapshot: {} as RuntimeStatusSnapshot,
+    });
+
+    render(<App />);
+
+    expect(screen.getByText("New Chat")).toBeInTheDocument();
+  });
+
   it("shows delegated child session transcript and switches back to the parent session", () => {
     const loadBackgroundTaskOutput = vi.fn();
     const selectSession = vi.fn();
@@ -557,12 +580,13 @@ describe("App", () => {
     expect(screen.getByText("child output")).toBeInTheDocument();
     expect(screen.getByText("Subsession timeline")).toBeInTheDocument();
     expect(screen.getByText("你好")).toBeInTheDocument();
+    expect(screen.getByText("Back to parent")).toBeInTheDocument();
     expect(
       screen.getByText("Subagent is still working..."),
     ).toBeInTheDocument();
     expect(screen.queryByText("parent output")).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByText("Parent session"));
+    fireEvent.click(screen.getByText("Back to parent"));
 
     expect(selectSession).toHaveBeenCalledWith("parent-session");
     expect(loadBackgroundTaskOutput).not.toHaveBeenCalledWith(null);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,14 +23,27 @@ import { buildSessionDisplayTitle } from "./components/sessionTitle";
 
 function SubsessionTimelineHeader({
   childPrompt,
+  onReturn,
 }: {
   childPrompt: string | null;
+  onReturn: () => void;
 }) {
   const { t } = useTranslation();
   return (
     <div className="mx-auto max-w-[var(--vc-chat-content-width)] px-4 pt-4">
-      <div className="text-[11px] uppercase tracking-wide text-[var(--vc-text-subtle)]">
-        {t("subsession.timelineTitle")}
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-[11px] uppercase tracking-wide text-[var(--vc-text-subtle)]">
+          {t("subsession.timelineTitle")}
+        </div>
+        <ControlButton
+          compact
+          variant="ghost"
+          onClick={onReturn}
+          title="Alt+Up"
+        >
+          <MoveLeft className="h-4 w-4" />
+          <span>{t("subsession.backToParent")}</span>
+        </ControlButton>
       </div>
       {childPrompt ? (
         <div className="mt-1 text-sm text-[var(--vc-text-muted)]">
@@ -470,7 +483,7 @@ function App() {
   const isWorkspaceBootLoading =
     !hasCurrentWorkspace &&
     (workspacesStatus === "idle" || workspacesStatus === "loading");
-  const currentBranch = statusSnapshot?.git.branch?.trim() || null;
+  const currentBranch = statusSnapshot?.git?.branch?.trim() || null;
 
   return (
     <div className="flex h-screen bg-[var(--vc-bg)] text-[var(--vc-text-muted)] font-sans overflow-hidden selection:bg-[var(--vc-border-strong)] selection:text-[var(--vc-text-primary)]">
@@ -610,6 +623,7 @@ function App() {
                 />
                 <SubsessionTimelineHeader
                   childPrompt={selectedChildContext.childPrompt}
+                  onReturn={returnToParentSession}
                 />
               </>
             ) : null}

--- a/frontend/src/components/StatusBar.tsx
+++ b/frontend/src/components/StatusBar.tsx
@@ -432,19 +432,19 @@ export function StatusBar({
   const popoverId = useId();
 
   const serverTone = toneFromState(snapshot?.acp?.state);
-  const lspTone = toneFromState(snapshot?.lsp.state);
-  const mcpTone = toneFromState(snapshot?.mcp.state);
+  const lspTone = toneFromState(snapshot?.lsp?.state);
+  const mcpTone = toneFromState(snapshot?.mcp?.state);
   const overallTone = aggregateTone(serverTone, lspTone, mcpTone);
-  const mcpDetails = snapshot?.mcp.details;
+  const mcpDetails = snapshot?.mcp?.details;
   const mcpRetryAvailable = Boolean(mcpDetails?.retry_available);
 
   const counts = useMemo(() => {
     return {
       server: snapshot?.acp?.state === "failed" ? 1 : 0,
-      lsp: lspServers(snapshot?.lsp.details).filter(
+      lsp: lspServers(snapshot?.lsp?.details).filter(
         (server) => server.status === "failed",
       ).length,
-      mcp: mcpServers(snapshot?.mcp.details).filter(
+      mcp: mcpServers(snapshot?.mcp?.details).filter(
         (server) => server.status === "failed",
       ).length,
     };

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -220,6 +220,7 @@
   "subsession.childPrompt": "Delegated prompt",
   "subsession.liveWorking": "Subagent is still working...",
   "subsession.timelineTitle": "Subsession timeline",
+  "subsession.backToParent": "Back to parent",
   "review.title": "Review",
   "review.fileTree": "File Tree",
   "review.toggleFileTree": "Toggle file tree",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -220,6 +220,7 @@
   "subsession.childPrompt": "委派提示词",
   "subsession.liveWorking": "子代理仍在工作中...",
   "subsession.timelineTitle": "子会话时间线",
+  "subsession.backToParent": "返回父会话",
   "review.title": "审查",
   "review.fileTree": "文件树",
   "review.toggleFileTree": "切换文件树",

--- a/frontend/src/store.integration.test.ts
+++ b/frontend/src/store.integration.test.ts
@@ -1487,6 +1487,141 @@ describe("useAppStore integration flow", () => {
     expect(state.selectedBackgroundTaskOutputId).toBeNull();
   });
 
+  it("keeps delegated child replay run status in sync while the child is still running", async () => {
+    runtimeClientMocks.getChildSessionContextMock.mockResolvedValueOnce({
+      task: {
+        task_id: "task-child-running",
+        status: "running",
+        parent_session_id: "session-parent",
+        requested_child_session_id: "child-session",
+        delegated_prompt: "inspect child",
+        child_session_id: "child-session",
+        approval_request_id: null,
+        question_request_id: null,
+        approval_blocked: false,
+        summary_output: null,
+        error: null,
+        result_available: false,
+        cancellation_cause: null,
+      },
+      session_result: {
+        session: {
+          session: { id: "child-session", parent_id: "session-parent" },
+          status: "running",
+          turn: 1,
+          metadata: {},
+        },
+        prompt: "inspect child",
+        status: "running",
+        summary: null,
+        output: null,
+        error: null,
+        last_event_sequence: 1,
+        transcript: [
+          makeEvent(
+            1,
+            "runtime.request_received",
+            { prompt: "inspect child" },
+            "runtime",
+            "child-session",
+          ),
+        ],
+      },
+      output: null,
+    });
+    runtimeClientMocks.listSessionBackgroundTasksMock.mockResolvedValue([]);
+
+    await useAppStore.getState().selectSession("child-session");
+
+    const state = useAppStore.getState();
+    expect(state.currentSessionId).toBe("child-session");
+    expect(state.childSessionParentId).toBe("session-parent");
+    expect(state.replayStatus).toBe("success");
+    expect(state.runStatus).toBe("running");
+  });
+
+  it("allows returning to the parent session while a delegated child replay is still running", async () => {
+    const parentEvents = [
+      makeEvent(
+        1,
+        "runtime.request_received",
+        { prompt: "parent prompt" },
+        "runtime",
+        "session-parent",
+      ),
+      makeEvent(
+        2,
+        "graph.response_ready",
+        { output: "parent output" },
+        "graph",
+        "session-parent",
+      ),
+    ];
+
+    runtimeClientMocks.getChildSessionContextMock.mockResolvedValueOnce({
+      task: {
+        task_id: "task-child-running",
+        status: "running",
+        parent_session_id: "session-parent",
+        requested_child_session_id: "child-session",
+        delegated_prompt: "inspect child",
+        child_session_id: "child-session",
+        approval_request_id: null,
+        question_request_id: null,
+        approval_blocked: false,
+        summary_output: null,
+        error: null,
+        result_available: false,
+        cancellation_cause: null,
+      },
+      session_result: {
+        session: {
+          session: { id: "child-session", parent_id: "session-parent" },
+          status: "running",
+          turn: 1,
+          metadata: {},
+        },
+        prompt: "inspect child",
+        status: "running",
+        summary: null,
+        output: "child output",
+        error: null,
+        last_event_sequence: 1,
+        transcript: [
+          makeEvent(
+            1,
+            "runtime.request_received",
+            { prompt: "inspect child" },
+            "runtime",
+            "child-session",
+          ),
+        ],
+      },
+      output: "child output",
+    });
+    runtimeClientMocks.listSessionBackgroundTasksMock.mockResolvedValue([]);
+    runtimeClientMocks.getSessionReplayMock.mockResolvedValueOnce(
+      makeRuntimeResponse(
+        "session-parent",
+        "completed",
+        parentEvents,
+        "parent output",
+      ),
+    );
+
+    await useAppStore.getState().selectSession("child-session");
+    await useAppStore.getState().selectSession("session-parent");
+
+    const state = useAppStore.getState();
+    expect(runtimeClientMocks.getSessionReplayMock).toHaveBeenCalledWith(
+      "session-parent",
+    );
+    expect(state.currentSessionId).toBe("session-parent");
+    expect(state.childSessionParentId).toBeNull();
+    expect(state.runStatus).toBe("idle");
+    expect(state.currentSessionOutput).toBe("parent output");
+  });
+
   it("surfaces approval lookup failure when no pending request exists", async () => {
     const sessionId = "broken-session";
     const requestReceived = makeEvent(

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -857,7 +857,12 @@ export const useAppStore = create<AppState>()(
       },
 
       selectSession: async (sessionId: string) => {
-        if (isRunLocked(get().runStatus)) {
+        const childParentSessionId = get().childSessionParentId;
+        const allowChildParentReturn =
+          Boolean(sessionId) &&
+          childParentSessionId !== null &&
+          sessionId === childParentSessionId;
+        if (isRunLocked(get().runStatus) && !allowChildParentReturn) {
           return;
         }
 
@@ -942,6 +947,9 @@ export const useAppStore = create<AppState>()(
                 get().currentSessionEvents,
               currentSessionOutput:
                 childContext.session_result?.output ?? childContext.output,
+              runStatus: childContext.session_result?.session
+                ? runStatusForReplay(childContext.session_result.session)
+                : "idle",
               replayStatus: "success",
             });
             await get().loadBackgroundTasks();


### PR DESCRIPTION
## Summary
- add an in-context `Back to parent` action for delegated child session transcripts and keep the related localized copy in sync
- keep delegated child replay `runStatus` aligned with child session activity, and allow returning to the parent session even while the child replay is still running
- harden runtime status rendering against partial nested payloads and record the frontend fixes in `CHANGELOG.md`

## Verification
- `bun run test:run src/App.test.tsx src/store.integration.test.ts`
- `bun run build`
- browser QA with mocked runtime responses: verified the running child-session view shows the new return affordance and the parent-session path becomes reachable again after the store gate fix

## Release Notes
- no git tag should be created on this PR branch; tag the merged release commit later when cutting the release
- added `CHANGELOG.md` unreleased notes for these frontend/runtime status fixes