### PR TITLE
fix(runtime): preserve full reasoning output

### DIFF
--- a/src/voidcode/runtime/event_envelopes.py
+++ b/src/voidcode/runtime/event_envelopes.py
@@ -6,8 +6,6 @@ from typing import cast
 from ..acp import AcpDelegatedExecution
 from ..graph.contracts import GraphEvent
 from .events import (
-    REASONING_SESSION_PART_LIMIT,
-    REASONING_SESSION_TEXT_LIMIT_CHARS,
     RUNTIME_ACP_CONNECTED,
     RUNTIME_ACP_DELEGATED_LIFECYCLE,
     RUNTIME_ACP_DISCONNECTED,
@@ -24,7 +22,6 @@ from .events import (
     RUNTIME_MCP_SERVER_REUSED,
     RUNTIME_MCP_SERVER_STARTED,
     RUNTIME_MCP_SERVER_STOPPED,
-    RUNTIME_REASONING_DIAGNOSTIC,
     RUNTIME_REASONING_PART,
     EventEnvelope,
     runtime_reasoning_part_from_provider_stream,
@@ -189,7 +186,6 @@ def envelopes_for_mcp_events(
 class ReasoningCaptureState:
     part_count: int = 0
     text_char_count: int = 0
-    limit_diagnostic_emitted: bool = False
     stream_observed: bool = False
     reasoning_observed: bool = False
     output_diagnostic_emitted: bool = False
@@ -215,36 +211,12 @@ def renumber_events(
         if reasoning_payload is not None:
             capture_state.reasoning_observed = True
             text_char_count = reasoning_payload.get("text_char_count")
-            bounded_text = reasoning_payload.get("text")
-            next_text_count = capture_state.text_char_count + (
-                len(bounded_text) if isinstance(bounded_text, str) else 0
-            )
-            if (
-                capture_state.part_count >= REASONING_SESSION_PART_LIMIT
-                or next_text_count > REASONING_SESSION_TEXT_LIMIT_CHARS
-            ):
-                event_type = RUNTIME_REASONING_DIAGNOSTIC
-                source = "runtime"
-                diagnostic_payload: dict[str, object] = {
-                    "severity": "warning",
-                    "category": "reasoning_capture_limit",
-                    "reason": "session_reasoning_capture_limit_exceeded",
-                    "captured_part_count": capture_state.part_count,
-                    "captured_text_char_count": capture_state.text_char_count,
-                    "omitted_text_char_count": text_char_count
-                    if isinstance(text_char_count, int)
-                    else None,
-                }
-                payload = diagnostic_payload
-                if capture_state.limit_diagnostic_emitted:
-                    continue
-                capture_state.limit_diagnostic_emitted = True
-            else:
-                event_type = RUNTIME_REASONING_PART
-                source = "runtime"
-                payload = reasoning_payload
-                capture_state.part_count += 1
-                capture_state.text_char_count = next_text_count
+            event_type = RUNTIME_REASONING_PART
+            source = "runtime"
+            payload = reasoning_payload
+            capture_state.part_count += 1
+            if isinstance(text_char_count, int):
+                capture_state.text_char_count += text_char_count
         envelopes.append(
             EventEnvelope(
                 session_id=session_id,

--- a/src/voidcode/runtime/events.py
+++ b/src/voidcode/runtime/events.py
@@ -221,10 +221,7 @@ RUNTIME_REASONING_DIAGNOSTIC: Final[PrototypeAdditiveEventType] = "runtime.reaso
 RUNTIME_TURN_PROGRESS: Final[PrototypeAdditiveEventType] = "runtime.turn_progress"
 RUNTIME_STUCK_DETECTED: Final[PrototypeAdditiveEventType] = "runtime.stuck_detected"
 
-REASONING_TEXT_LIMIT_CHARS: Final[int] = 4000
 REASONING_PREVIEW_LIMIT_CHARS: Final[int] = 240
-REASONING_SESSION_TEXT_LIMIT_CHARS: Final[int] = 16_000
-REASONING_SESSION_PART_LIMIT: Final[int] = 32
 _SAFE_PROVIDER_REASONING_METADATA_KEYS: Final[frozenset[str]] = frozenset({"source"})
 POLICY_OBSERVABILITY_LIST_LIMIT: Final[int] = 32
 POLICY_OBSERVABILITY_TRACE_LIMIT: Final[int] = 16
@@ -311,18 +308,15 @@ def runtime_reasoning_part_payload(
     started_at: str | None = None,
     ended_at: str | None = None,
 ) -> dict[str, object]:
-    """Build a bounded, runtime-owned reasoning part payload."""
 
     captured_at = datetime.now(UTC).isoformat()
     text_char_count = len(text)
-    truncated = text_char_count > REASONING_TEXT_LIMIT_CHARS
-    bounded_text = text[:REASONING_TEXT_LIMIT_CHARS]
-    preview = bounded_text[:REASONING_PREVIEW_LIMIT_CHARS]
+    preview = text[:REASONING_PREVIEW_LIMIT_CHARS]
     payload: dict[str, object] = {
         "type": "reasoning",
-        "text": bounded_text,
+        "text": text,
         "text_char_count": text_char_count,
-        "truncated": truncated,
+        "truncated": False,
         "source": source,
         "visibility": "showable",
         "time": {

--- a/tests/unit/project/test_package_import.py
+++ b/tests/unit/project/test_package_import.py
@@ -1,11 +1,16 @@
 import importlib
+import tomllib
 from types import ModuleType
+
+from .._paths import REPO_ROOT
 
 
 def test_import_voidcode_exposes_version() -> None:
     voidcode = importlib.import_module("voidcode")
+    pyproject_data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    expected_version = pyproject_data["project"]["version"]
 
     assert isinstance(voidcode, ModuleType)
     version = getattr(voidcode, "__version__", None)
 
-    assert version == "0.1.0"
+    assert version == expected_version

--- a/tests/unit/project/test_project_metadata.py
+++ b/tests/unit/project/test_project_metadata.py
@@ -21,5 +21,6 @@ def test_pyproject_matches_expected_metadata() -> None:
     project_data = cast(Mapping[str, object], pyproject_data["project"])
 
     assert project_data["name"] == "voidcode"
-    assert project_data["version"] == "0.1.0"
+    assert isinstance(project_data["version"], str)
+    assert project_data["version"]
     assert project_data["description"]

--- a/tests/unit/runtime/test_runtime_events.py
+++ b/tests/unit/runtime/test_runtime_events.py
@@ -136,6 +136,17 @@ def test_reasoning_redaction_can_show_thinking_explicitly() -> None:
     assert shown["preview"] == "private chain"
 
 
+def test_runtime_reasoning_payload_preserves_full_text() -> None:
+    text = "x" * 5000
+
+    payload = runtime_reasoning_part_payload(text=text)
+
+    assert payload["text"] == text
+    assert payload["text_char_count"] == 5000
+    assert payload["truncated"] is False
+    assert payload["preview"] == text[:240]
+
+
 def test_delegated_lifecycle_payload_preserves_typed_transport_shape() -> None:
     delegated = DelegatedLifecycleEventPayload(
         session_id="child-session",

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -18945,7 +18945,7 @@ def test_runtime_does_not_persist_show_thinking_request_metadata(tmp_path: Path)
     assert "show_thinking" not in response.session.metadata
 
 
-def test_runtime_reasoning_capture_has_aggregate_limit(tmp_path: Path) -> None:
+def test_runtime_reasoning_capture_preserves_all_provider_parts(tmp_path: Path) -> None:
     reasoning_events = tuple(
         ProviderStreamEvent(kind="delta", channel="reasoning", text="x" * 4000) for _ in range(40)
     )
@@ -18989,12 +18989,11 @@ def test_runtime_reasoning_capture_has_aggregate_limit(tmp_path: Path) -> None:
         if event.event_type == "runtime.reasoning_diagnostic"
         and event.payload.get("category") == "reasoning_capture_limit"
     ]
-    assert len(reasoning_parts) == 4
-    assert len(limit_events) == 1
-    assert limit_events[0].payload["captured_text_char_count"] == 16_000
+    assert len(reasoning_parts) == 40
+    assert len(limit_events) == 0
 
 
-def test_runtime_reasoning_capture_limit_spans_provider_turns(tmp_path: Path) -> None:
+def test_runtime_reasoning_capture_preserves_parts_across_provider_turns(tmp_path: Path) -> None:
     (tmp_path / "sample.txt").write_text("sample contents", encoding="utf-8")
     first_turn_reasoning = tuple(
         ProviderStreamEvent(kind="delta", channel="reasoning", text="x" * 4000) for _ in range(3)
@@ -19055,10 +19054,8 @@ def test_runtime_reasoning_capture_limit_spans_provider_turns(tmp_path: Path) ->
         if event.event_type == "runtime.reasoning_diagnostic"
         and event.payload.get("category") == "reasoning_capture_limit"
     ]
-    assert len(reasoning_parts) == 4
-    assert len(limit_events) == 1
-    assert limit_events[0].payload["captured_part_count"] == 4
-    assert limit_events[0].payload["captured_text_char_count"] == 16_000
+    assert len(reasoning_parts) == 6
+    assert len(limit_events) == 0
 
 
 def test_runtime_reports_reasoning_output_diagnostic_for_reasoning_capable_model(

--- a/uv.lock
+++ b/uv.lock
@@ -1726,7 +1726,7 @@ wheels = [
 
 [[package]]
 name = "voidcode"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary
- remove runtime reasoning capture truncation so persisted reasoning parts preserve the full provider text while keeping preview truncation and show_thinking redaction behavior unchanged
- stop emitting `reasoning_capture_limit` diagnostics and preserve reasoning parts across provider turns
- update project metadata tests to stop hard-coding `0.1.0`, and include the resulting `uv.lock` version sync so CI stays green after the `0.1.1` release

## Verification
- `uv run pytest -n auto tests/unit/project/test_package_import.py tests/unit/project/test_project_metadata.py tests/unit/runtime/test_runtime_events.py tests/unit/runtime/test_runtime_service_extensions.py tests/integration/test_http_transport.py -q`
- `uv run pytest -n auto tests/unit/runtime/test_runtime_events.py tests/unit/runtime/test_runtime_service_extensions.py -q`