### PR TITLE
refactor: keep it simple — remove dead code and collapse redundant patterns

### DIFF
--- a/src/voidcode/provider/deepseek.py
+++ b/src/voidcode/provider/deepseek.py
@@ -2,21 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .config import SimplifiedProviderConfig, simplified_config_to_litellm
-from .litellm_backend import LiteLLMBackendSingleAgentProvider
-from .protocol import TurnProvider
+from .simplified import SimplifiedModelProvider
 
 
 @dataclass(frozen=True, slots=True)
-class DeepSeekModelProvider:
+class DeepSeekModelProvider(SimplifiedModelProvider):
     """DeepSeek OpenAI-compatible model provider."""
 
     name: str = "deepseek"
-    config: SimplifiedProviderConfig | None = None
-
-    def provider_config(self):
-        return simplified_config_to_litellm(self.name, self.config)
-
-    def turn_provider(self) -> TurnProvider:
-        adapted_config = simplified_config_to_litellm(self.name, self.config)
-        return LiteLLMBackendSingleAgentProvider(name=self.name, config=adapted_config)

--- a/src/voidcode/provider/glm.py
+++ b/src/voidcode/provider/glm.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .config import SimplifiedProviderConfig, simplified_config_to_litellm
-from .litellm_backend import LiteLLMBackendSingleAgentProvider
-from .protocol import TurnProvider
+from .simplified import SimplifiedModelProvider
 
 
 @dataclass(frozen=True, slots=True)
-class GLMModelProvider:
+class GLMModelProvider(SimplifiedModelProvider):
     """GLM (智谱AI) Model Provider.
 
     GLM provides OpenAI-compatible API at https://open.bigmodel.cn/api/paas/v4
@@ -27,11 +25,3 @@ class GLMModelProvider:
     """
 
     name: str = "glm"
-    config: SimplifiedProviderConfig | None = None
-
-    def provider_config(self):
-        return simplified_config_to_litellm(self.name, self.config)
-
-    def turn_provider(self) -> TurnProvider:
-        adapted_config = simplified_config_to_litellm(self.name, self.config)
-        return LiteLLMBackendSingleAgentProvider(name=self.name, config=adapted_config)

--- a/src/voidcode/provider/grok.py
+++ b/src/voidcode/provider/grok.py
@@ -2,21 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .config import SimplifiedProviderConfig, simplified_config_to_litellm
-from .litellm_backend import LiteLLMBackendSingleAgentProvider
-from .protocol import TurnProvider
+from .simplified import SimplifiedModelProvider
 
 
 @dataclass(frozen=True, slots=True)
-class GrokModelProvider:
+class GrokModelProvider(SimplifiedModelProvider):
     """xAI Grok OpenAI-compatible model provider."""
 
     name: str = "grok"
-    config: SimplifiedProviderConfig | None = None
-
-    def provider_config(self):
-        return simplified_config_to_litellm(self.name, self.config)
-
-    def turn_provider(self) -> TurnProvider:
-        adapted_config = simplified_config_to_litellm(self.name, self.config)
-        return LiteLLMBackendSingleAgentProvider(name=self.name, config=adapted_config)

--- a/src/voidcode/provider/kimi.py
+++ b/src/voidcode/provider/kimi.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .config import SimplifiedProviderConfig, simplified_config_to_litellm
-from .litellm_backend import LiteLLMBackendSingleAgentProvider
-from .protocol import TurnProvider
+from .simplified import SimplifiedModelProvider
 
 
 @dataclass(frozen=True, slots=True)
-class KimiModelProvider:
+class KimiModelProvider(SimplifiedModelProvider):
     """Kimi (Moonshot AI) Model Provider.
 
     Kimi provides OpenAI-compatible API at https://api.moonshot.cn/v1 (China)
@@ -26,11 +24,3 @@ class KimiModelProvider:
     """
 
     name: str = "kimi"
-    config: SimplifiedProviderConfig | None = None
-
-    def provider_config(self):
-        return simplified_config_to_litellm(self.name, self.config)
-
-    def turn_provider(self) -> TurnProvider:
-        adapted_config = simplified_config_to_litellm(self.name, self.config)
-        return LiteLLMBackendSingleAgentProvider(name=self.name, config=adapted_config)

--- a/src/voidcode/provider/minimax.py
+++ b/src/voidcode/provider/minimax.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .config import SimplifiedProviderConfig, simplified_config_to_litellm
-from .litellm_backend import LiteLLMBackendSingleAgentProvider
-from .protocol import TurnProvider
+from .simplified import SimplifiedModelProvider
 
 
 @dataclass(frozen=True, slots=True)
-class MiniMaxModelProvider:
+class MiniMaxModelProvider(SimplifiedModelProvider):
     """MiniMax AI Model Provider.
 
     MiniMax provides OpenAI-compatible and Anthropic-compatible APIs.
@@ -27,11 +25,3 @@ class MiniMaxModelProvider:
     """
 
     name: str = "minimax"
-    config: SimplifiedProviderConfig | None = None
-
-    def provider_config(self):
-        return simplified_config_to_litellm(self.name, self.config)
-
-    def turn_provider(self) -> TurnProvider:
-        adapted_config = simplified_config_to_litellm(self.name, self.config)
-        return LiteLLMBackendSingleAgentProvider(name=self.name, config=adapted_config)

--- a/src/voidcode/provider/qwen.py
+++ b/src/voidcode/provider/qwen.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .config import SimplifiedProviderConfig, simplified_config_to_litellm
-from .litellm_backend import LiteLLMBackendSingleAgentProvider
-from .protocol import TurnProvider
+from .simplified import SimplifiedModelProvider
 
 
 @dataclass(frozen=True, slots=True)
-class QwenModelProvider:
+class QwenModelProvider(SimplifiedModelProvider):
     """Qwen (通义千问) Model Provider.
 
     Qwen provides OpenAI-compatible API at https://dashscope.aliyuncs.com/compatible-mode/v1
@@ -25,11 +23,3 @@ class QwenModelProvider:
     """
 
     name: str = "qwen"
-    config: SimplifiedProviderConfig | None = None
-
-    def provider_config(self):
-        return simplified_config_to_litellm(self.name, self.config)
-
-    def turn_provider(self) -> TurnProvider:
-        adapted_config = simplified_config_to_litellm(self.name, self.config)
-        return LiteLLMBackendSingleAgentProvider(name=self.name, config=adapted_config)

--- a/src/voidcode/provider/simplified.py
+++ b/src/voidcode/provider/simplified.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .config import SimplifiedProviderConfig, simplified_config_to_litellm
+from .litellm_backend import LiteLLMBackendSingleAgentProvider
+from .protocol import TurnProvider
+
+
+@dataclass(frozen=True, slots=True)
+class SimplifiedModelProvider:
+    name: str
+    config: SimplifiedProviderConfig | None = None
+
+    def provider_config(self):
+        return simplified_config_to_litellm(self.name, self.config)
+
+    def turn_provider(self) -> TurnProvider:
+        adapted_config = simplified_config_to_litellm(self.name, self.config)
+        return LiteLLMBackendSingleAgentProvider(name=self.name, config=adapted_config)

--- a/src/voidcode/runtime/config.py
+++ b/src/voidcode/runtime/config.py
@@ -64,6 +64,7 @@ serialize_provider_fallback_config = provider_config.serialize_provider_fallback
 serialize_provider_configs = provider_config.serialize_provider_configs
 
 RUNTIME_CONFIG_FILE_NAME = ".voidcode.json"
+DEFAULT_LOCAL_TOOLS_PATH = ".voidcode/tools"
 
 
 def _running_on_windows() -> bool:
@@ -315,7 +316,7 @@ class RuntimeToolsBuiltinConfig:
 @dataclass(frozen=True, slots=True)
 class RuntimeToolsLocalConfig:
     enabled: bool | None = None
-    path: str = ".voidcode/tools"
+    path: str = DEFAULT_LOCAL_TOOLS_PATH
 
 
 @dataclass(frozen=True, slots=True)
@@ -1483,7 +1484,7 @@ class _RuntimeToolsLocalValidationModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     enabled: bool | None = None
-    path: str = ".voidcode/tools"
+    path: str = DEFAULT_LOCAL_TOOLS_PATH
 
     @field_validator("enabled", mode="before")
     @classmethod
@@ -1496,7 +1497,7 @@ class _RuntimeToolsLocalValidationModel(BaseModel):
     def _validate_path(cls, value: object, info: ValidationInfo) -> str:
         field_path = _validation_context_field_path(info, default="tools.local")
         if value is None:
-            return ".voidcode/tools"
+            return DEFAULT_LOCAL_TOOLS_PATH
         if not isinstance(value, str) or not value.strip():
             raise ValueError(
                 f"runtime config field '{field_path}.path' must be a non-empty string when provided"

--- a/src/voidcode/runtime/events.py
+++ b/src/voidcode/runtime/events.py
@@ -98,31 +98,26 @@ type DelegatedLifecycleStatus = Literal[
 ]
 type KnownEventType = ExistingEventType | PrototypeAdditiveEventType
 
+_DELEGATED_LIFECYCLE_STATUSES: frozenset[DelegatedLifecycleStatus] = frozenset(
+    (
+        "queued",
+        "running",
+        "waiting_approval",
+        "completed",
+        "failed",
+        "cancelled",
+        "interrupted",
+    )
+)
+_EVENT_SOURCES: frozenset[EventSource] = frozenset(("runtime", "graph", "tool"))
+
 
 def _parse_delegated_routing_mode(value: object) -> Literal["sync", "background"] | None:
-    if value == "sync":
-        return "sync"
-    if value == "background":
-        return "background"
-    return None
+    return cast(Literal["sync", "background"], value) if value in ("sync", "background") else None
 
 
 def _parse_delegated_lifecycle_status(value: object) -> DelegatedLifecycleStatus | None:
-    if value == "queued":
-        return "queued"
-    if value == "running":
-        return "running"
-    if value == "waiting_approval":
-        return "waiting_approval"
-    if value == "completed":
-        return "completed"
-    if value == "failed":
-        return "failed"
-    if value == "cancelled":
-        return "cancelled"
-    if value == "interrupted":
-        return "interrupted"
-    return None
+    return cast(DelegatedLifecycleStatus, value) if value in _DELEGATED_LIFECYCLE_STATUSES else None
 
 
 RUNTIME_REQUEST_RECEIVED: Final[ExistingEventType] = "runtime.request_received"

--- a/src/voidcode/runtime/events.py
+++ b/src/voidcode/runtime/events.py
@@ -109,7 +109,7 @@ _DELEGATED_LIFECYCLE_STATUSES: frozenset[DelegatedLifecycleStatus] = frozenset(
         "interrupted",
     )
 )
-_EVENT_SOURCES: frozenset[EventSource] = frozenset(("runtime", "graph", "tool"))
+EVENT_SOURCES: frozenset[EventSource] = frozenset(("runtime", "graph", "tool"))
 
 
 def _parse_delegated_routing_mode(value: object) -> Literal["sync", "background"] | None:

--- a/src/voidcode/runtime/prompt_assembly.py
+++ b/src/voidcode/runtime/prompt_assembly.py
@@ -31,13 +31,6 @@ _SECRET_TEXT_PATTERNS = (
     re.compile(r"(?i)(token\s*[=:]\s*)[^\s,;]+"),
 )
 
-_TIER_PRIORITY = {
-    "instruction": 100,
-    "workspace": 200,
-    "task": 300,
-    "recent": 400,
-}
-
 _BASE_SAFETY_GUIDANCE = (
     "Base safety: follow runtime-enforced permission, approval, memory, shell, and "
     "tool policies. Prompt text describes policy intent; runtime controls remain the "
@@ -340,7 +333,6 @@ class PromptAssemblyFragment:
     source: str
     layer: str
     order: int
-    priority: int
     tier: Literal["instruction", "workspace", "task", "recent"]
     preview: str
     preview_truncated: bool
@@ -353,7 +345,6 @@ class PromptAssemblyFragment:
             "source": self.source,
             "layer": self.layer,
             "order": self.order,
-            "priority": self.priority,
             "tier": self.tier,
             "preview": self.preview,
             "preview_truncated": self.preview_truncated,
@@ -652,7 +643,6 @@ def prompt_fragments_for_sections(
                 source=section.source,
                 layer=layer,
                 order=order,
-                priority=_TIER_PRIORITY[section.tier] + order,
                 tier=section.tier,
                 preview=preview,
                 preview_truncated=truncated,

--- a/src/voidcode/runtime/session.py
+++ b/src/voidcode/runtime/session.py
@@ -9,6 +9,16 @@ from .policy import runtime_policy_snapshot_from_session_metadata
 type SessionStatus = Literal["idle", "running", "waiting", "completed", "failed"]
 type SessionKind = Literal["top_level", "child"]
 
+SESSION_STATUSES: frozenset[SessionStatus] = frozenset(
+    (
+        "idle",
+        "running",
+        "waiting",
+        "completed",
+        "failed",
+    )
+)
+
 _PERSISTED_STRING_LIMIT = 1_000
 _PERSISTED_LIST_LIMIT = 50
 _PERSISTED_DICT_LIMIT = 100

--- a/src/voidcode/runtime/storage.py
+++ b/src/voidcode/runtime/storage.py
@@ -22,6 +22,7 @@ from .contracts import (
 )
 from .events import (
     DELEGATED_BACKGROUND_TASK_EVENT_TYPES,
+    EVENT_SOURCES,
     RUNTIME_APPROVAL_REQUESTED,
     RUNTIME_QUESTION_REQUESTED,
     EventEnvelope,
@@ -32,6 +33,7 @@ from .paths import DB_PATH_ENV, sessions_db_path
 from .permission import OperationClass, PathScope, PendingApproval, PermissionDecision
 from .question import PendingQuestion, PendingQuestionOption, PendingQuestionPrompt
 from .session import (
+    SESSION_STATUSES,
     SessionRef,
     SessionState,
     SessionStatus,
@@ -40,6 +42,8 @@ from .session import (
     session_metadata_for_persistence,
 )
 from .task import (
+    BACKGROUND_TASK_STATUSES,
+    CONTINUATION_LOOP_STATUSES,
     BackgroundTaskRef,
     BackgroundTaskRequestSnapshot,
     BackgroundTaskState,
@@ -1138,55 +1142,27 @@ class SqliteSessionStore:
 
     @staticmethod
     def _parse_session_status(value: str) -> SessionStatus:
-        if value == "idle":
-            return "idle"
-        if value == "running":
-            return "running"
-        if value == "waiting":
-            return "waiting"
-        if value == "completed":
-            return "completed"
-        if value == "failed":
-            return "failed"
-        raise ValueError(f"invalid session status: {value}")
+        if value not in SESSION_STATUSES:
+            raise ValueError(f"invalid session status: {value}")
+        return cast(SessionStatus, value)
 
     @staticmethod
     def _parse_event_source(value: str) -> EventSource:
-        if value == "runtime":
-            return "runtime"
-        if value == "graph":
-            return "graph"
-        if value == "tool":
-            return "tool"
-        raise ValueError(f"invalid event source: {value}")
+        if value not in EVENT_SOURCES:
+            raise ValueError(f"invalid event source: {value}")
+        return cast(EventSource, value)
 
     @staticmethod
     def _parse_background_task_status(value: str) -> BackgroundTaskStatus:
-        if value == "queued":
-            return "queued"
-        if value == "running":
-            return "running"
-        if value == "completed":
-            return "completed"
-        if value == "failed":
-            return "failed"
-        if value == "cancelled":
-            return "cancelled"
-        if value == "interrupted":
-            return "interrupted"
-        raise ValueError(f"invalid background task status: {value}")
+        if value not in BACKGROUND_TASK_STATUSES:
+            raise ValueError(f"invalid background task status: {value}")
+        return cast(BackgroundTaskStatus, value)
 
     @staticmethod
     def _parse_continuation_loop_status(value: str) -> ContinuationLoopStatus:
-        if value == "active":
-            return "active"
-        if value == "completed":
-            return "completed"
-        if value == "cancelled":
-            return "cancelled"
-        if value == "exhausted":
-            return "exhausted"
-        raise ValueError(f"invalid continuation loop status: {value}")
+        if value not in CONTINUATION_LOOP_STATUSES:
+            raise ValueError(f"invalid continuation loop status: {value}")
+        return cast(ContinuationLoopStatus, value)
 
     @classmethod
     def _parse_memory_kind(cls, value: str) -> MemoryKind:

--- a/src/voidcode/runtime/task.py
+++ b/src/voidcode/runtime/task.py
@@ -27,6 +27,34 @@ type ContinuationLoopVerificationStatus = Literal[
     "failed",
 ]
 type ContinuationLoopStrategy = Literal["continue", "reset"]
+
+BACKGROUND_TASK_STATUSES: frozenset[BackgroundTaskStatus] = frozenset(
+    (
+        "queued",
+        "running",
+        "completed",
+        "failed",
+        "cancelled",
+        "interrupted",
+    )
+)
+CONTINUATION_LOOP_STATUSES: frozenset[ContinuationLoopStatus] = frozenset(
+    (
+        "active",
+        "completed",
+        "cancelled",
+        "exhausted",
+    )
+)
+CONTINUATION_LOOP_VERIFICATION_STATUSES: frozenset[ContinuationLoopVerificationStatus] = frozenset(
+    (
+        "not_required",
+        "pending",
+        "verified",
+        "failed",
+    )
+)
+CONTINUATION_LOOP_STRATEGIES: frozenset[ContinuationLoopStrategy] = frozenset(("continue", "reset"))
 type SubagentExecutionMode = Literal["sync", "background"]
 type SubagentResultOwner = Literal["child_session"]
 type SubagentSummaryOwner = Literal["background_task"]
@@ -571,24 +599,17 @@ def validate_continuation_loop_id(loop_id: str) -> str:
 
 
 def parse_continuation_loop_strategy(value: str) -> ContinuationLoopStrategy:
-    if value == "continue":
-        return "continue"
-    if value == "reset":
-        return "reset"
-    raise ValueError("continuation loop strategy must be 'continue' or 'reset'")
+    if value not in CONTINUATION_LOOP_STRATEGIES:
+        raise ValueError("continuation loop strategy must be 'continue' or 'reset'")
+    return cast(ContinuationLoopStrategy, value)
 
 
 def parse_continuation_loop_verification_status(
     value: str,
 ) -> ContinuationLoopVerificationStatus:
-    if value == "not_required":
-        return "not_required"
-    if value == "pending":
-        return "pending"
-    if value == "verified":
-        return "verified"
-    if value == "failed":
-        return "failed"
-    raise ValueError(
-        "continuation loop verification_status must be not_required, pending, verified, or failed"
-    )
+    if value not in CONTINUATION_LOOP_VERIFICATION_STATUSES:
+        raise ValueError(
+            "continuation loop verification_status must be "
+            "not_required, pending, verified, or failed"
+        )
+    return cast(ContinuationLoopVerificationStatus, value)

--- a/src/voidcode/runtime/todos.py
+++ b/src/voidcode/runtime/todos.py
@@ -8,15 +8,7 @@ TODO_STATUSES: tuple[TodoStatus, ...] = ("pending", "in_progress", "completed", 
 
 
 def _parse_todo_status(value: object) -> TodoStatus | None:
-    if value == "pending":
-        return "pending"
-    if value == "in_progress":
-        return "in_progress"
-    if value == "completed":
-        return "completed"
-    if value == "cancelled":
-        return "cancelled"
-    return None
+    return cast(TodoStatus, value) if value in TODO_STATUSES else None
 
 
 class RuntimeTodoItem(TypedDict):

--- a/src/voidcode/tools/edit.py
+++ b/src/voidcode/tools/edit.py
@@ -372,10 +372,6 @@ def _replace(
     if not content:
         raise ValueError("Content is empty; nothing to edit.")
 
-    if replace_all:
-        # For replaceAll we still need to verify at least one match exists via smart replacers
-        pass
-
     replacers = [
         SimpleReplacer,
         LineTrimmedReplacer,

--- a/tests/unit/runtime/test_prompt_assembly.py
+++ b/tests/unit/runtime/test_prompt_assembly.py
@@ -341,6 +341,9 @@ def test_prompt_fragments_expose_stable_order_layers_and_bounded_redacted_previe
         "user_request",
     ]
 
+    for fragment in fragments:
+        assert "priority" not in fragment
+
     rendered_payload = str(fragment_payload)
     assert "super-secret-token-value" not in rendered_payload
     assert "abcdefghijklmnop" not in rendered_payload


### PR DESCRIPTION
## Summary

Cleanup pass addressing redundancy and unreasonable design findings from the codebase audit. 6 atomic commits, 16 files changed, **-56 net lines** (118 insertions, 174 deletions). All 734 regression tests pass.

## P0 — Dead code removal

### `refactor(runtime): remove dead PromptAssemblyFragment.priority field`
- `PromptAssemblyFragment.priority` was computed as `_TIER_PRIORITY[tier] + order` and only emitted in `metadata_payload()` for observability. No code in `src/`, `tests/`, or `frontend/` ever read it — `order` and `tier` already encode the same ordering information.
- Removes the field, the `_TIER_PRIORITY` dict, and adds a regression guard asserting `priority` is absent from fragment metadata.

### `refactor(tools): remove dead replace_all pass stub from _replace`
- The `if replace_all: pass` block in `edit.py:_replace()` had a stale comment saying "we still need to verify at least one match exists via smart replacers" but the downstream replacer pipeline already handles this (raises `tool_diagnostic` at line 443 if no replacer finds a match). The `pass` block was a no-op with a misleading comment.

## P1 — Redundant pattern simplification

### `refactor(runtime): extract DEFAULT_LOCAL_TOOLS_PATH constant`
- The `.voidcode/tools` default path was hardcoded 3 times in `config.py` (dataclass field default, pydantic model field default, and validator fallback). Extracted into a single module-level constant.

### `refactor(runtime): simplify if/elif status parse chains to membership checks`
- 5 parse functions (`_parse_todo_status`, `_parse_delegated_lifecycle_status`, `_parse_delegated_routing_mode`, `parse_continuation_loop_strategy`, `parse_continuation_loop_verification_status`) each had 4-8 if/elif branches that compared a value to a string just to return the same string. Each is now a one-line frozenset membership check.
- Added frozenset constants alongside the Literal type definitions for background task, continuation loop, delegated lifecycle, and event source statuses.

### `refactor(runtime): simplify storage parse functions with shared status frozensets`
- Added `SESSION_STATUSES` frozenset to `session.py` and made `EVENT_SOURCES` public in `events.py`.
- Simplified `_parse_session_status`, `_parse_event_source`, `_parse_background_task_status`, and `_parse_continuation_loop_status` in `storage.py` from 6-12 line if/elif chains to 3-line frozenset membership checks.

### `refactor(provider): collapse 6 identical SimplifiedConfig provider wrappers into subclasses`
- GLM, DeepSeek, Kimi, Grok, Qwen, and MiniMax provider wrappers had byte-for-byte identical `provider_config()` and `turn_provider()` method bodies — the only difference was the `name` default and docstring.
- Extracted shared logic into `SimplifiedModelProvider` base class in `provider/simplified.py`. Each provider file is now a thin subclass that only sets the name default and keeps the provider-specific docstring.
- All imports, registry wiring, and test paths remain unchanged.

## What was NOT done (deliberately, per "keep it simple")

- **Status string → enum.StrEnum migration**: The audit found ~1,600 status string usages, but they belong to **different state machines** (TodoStatus: 4 values, SessionStatus: 5, BackgroundTaskStatus: 6, etc.) that share some values but are semantically distinct. Consolidating into one enum would be wrong, and a full multi-enum migration is too large for this PR. The if/elif parse chains (the actual code smell) were fixed instead.
- **Duplicated magic numbers** (`2000`, `4000`, `50*1024`): These are **coincidental value matches across different concepts** (output truncation vs read limit vs memory recall vs distillation limit). Merging them would create false coupling. Only `int(time.time() * 1000)` is a true idiom duplication, but extracting a shared utility for a one-liner adds more indirection than it removes.
- **`service.py` god class split** (9529 lines, 395 methods): Too large for this PR — needs dedicated planning.
- **Protocol overload** (59 Protocols, ~35 single-method): Needs careful evaluation of which are truly trivial vs which encode design intent.

## Test plan

- [x] 734 unit tests pass (provider adapters, registry, auth, prompt assembly, session storage, background task storage, continuation loop storage, runtime events, edit tool, todo write tool, runtime config, tool provider)
- [x] 2 integration tests pass (provider runtime todo state persistence, provider context live persisted replay)
- [x] LSP diagnostics clean on all changed files
- [x] Pre-commit hooks pass (ruff, ruff format, ty, trailing whitespace, end of files)