### PR TITLE
refactor(runtime): trim unused runtime metadata

### DIFF
--- a/src/voidcode/runtime/prompt_assembly.py
+++ b/src/voidcode/runtime/prompt_assembly.py
@@ -31,13 +31,6 @@ _SECRET_TEXT_PATTERNS = (
     re.compile(r"(?i)(token\s*[=:]\s*)[^\s,;]+"),
 )
 
-_TIER_PRIORITY = {
-    "instruction": 100,
-    "workspace": 200,
-    "task": 300,
-    "recent": 400,
-}
-
 _BASE_SAFETY_GUIDANCE = (
     "Base safety: follow runtime-enforced permission, approval, memory, shell, and "
     "tool policies. Prompt text describes policy intent; runtime controls remain the "
@@ -340,7 +333,6 @@ class PromptAssemblyFragment:
     source: str
     layer: str
     order: int
-    priority: int
     tier: Literal["instruction", "workspace", "task", "recent"]
     preview: str
     preview_truncated: bool
@@ -353,7 +345,6 @@ class PromptAssemblyFragment:
             "source": self.source,
             "layer": self.layer,
             "order": self.order,
-            "priority": self.priority,
             "tier": self.tier,
             "preview": self.preview,
             "preview_truncated": self.preview_truncated,
@@ -652,7 +643,6 @@ def prompt_fragments_for_sections(
                 source=section.source,
                 layer=layer,
                 order=order,
-                priority=_TIER_PRIORITY[section.tier] + order,
                 tier=section.tier,
                 preview=preview,
                 preview_truncated=truncated,

--- a/src/voidcode/runtime/task.py
+++ b/src/voidcode/runtime/task.py
@@ -28,12 +28,6 @@ type ContinuationLoopVerificationStatus = Literal[
 ]
 type ContinuationLoopStrategy = Literal["continue", "reset"]
 type SubagentExecutionMode = Literal["sync", "background"]
-type SubagentResultOwner = Literal["child_session"]
-type SubagentSummaryOwner = Literal["background_task"]
-type SubagentApprovalOwner = Literal["child_session"]
-type SubagentCancellationOwner = Literal["delegated_task"]
-type SubagentResumeOwner = Literal["child_session"]
-type SubagentRestartReconciliationOwner = Literal["runtime"]
 type SubagentExecutablePreset = str
 type DelegatedReminderStopCondition = Literal[
     "result_read",
@@ -278,37 +272,9 @@ class SubagentExecutionCorrelation:
 
 
 @dataclass(frozen=True, slots=True)
-class SubagentExecutionOwnership:
-    result_owner: SubagentResultOwner = "child_session"
-    summary_owner: SubagentSummaryOwner = "background_task"
-    approval_owner: SubagentApprovalOwner = "child_session"
-    cancellation_owner: SubagentCancellationOwner = "delegated_task"
-    resume_owner: SubagentResumeOwner = "child_session"
-
-
-@dataclass(frozen=True, slots=True)
-class SubagentExecutionLifecycle:
-    cancellation_semantics: str = (
-        "queued tasks cancel immediately; running tasks record cancellation "
-        "on the delegated task handle"
-    )
-    resume_semantics: str = (
-        "resume targets the child session id; parent sessions receive "
-        "backfilled delegated lifecycle events only"
-    )
-    restart_reconciliation_semantics: str = (
-        "runtime reconciles delegated tasks from persisted child-session truth "
-        "and backfills one waiting or terminal parent event"
-    )
-    restart_reconciliation_owner: SubagentRestartReconciliationOwner = "runtime"
-
-
-@dataclass(frozen=True, slots=True)
 class SubagentExecutionContract:
     correlation: SubagentExecutionCorrelation
     routing: SubagentRoutingIdentity | None = None
-    ownership: SubagentExecutionOwnership = field(default_factory=SubagentExecutionOwnership)
-    lifecycle: SubagentExecutionLifecycle = field(default_factory=SubagentExecutionLifecycle)
 
     @classmethod
     def from_snapshot(

--- a/tests/integration/test_read_only_slice.py
+++ b/tests/integration/test_read_only_slice.py
@@ -1363,12 +1363,10 @@ def test_provider_runtime_persists_and_injects_runtime_todo_state(tmp_path: Path
                                         {
                                             "content": "make todo runtime-owned",
                                             "status": "in_progress",
-                                            "priority": "high",
                                         },
                                         {
                                             "content": "document completed setup",
                                             "status": "completed",
-                                            "priority": "low",
                                         },
                                     ]
                                 },
@@ -1383,7 +1381,6 @@ def test_provider_runtime_persists_and_injects_runtime_todo_state(tmp_path: Path
                                         {
                                             "content": "verify latest todo context only",
                                             "status": "pending",
-                                            "priority": "medium",
                                         }
                                     ]
                                 },

--- a/tests/integration/test_tool_workflows_integration.py
+++ b/tests/integration/test_tool_workflows_integration.py
@@ -162,9 +162,9 @@ def test_todo_write_tool_persists_summary_integration(tmp_path: Path) -> None:
             tool_name="todo_write",
             arguments={
                 "todos": [
-                    {"content": "task1", "status": "pending", "priority": "high"},
-                    {"content": "task2", "status": "in_progress", "priority": "medium"},
-                    {"content": "task3", "status": "completed", "priority": "low"},
+                    {"content": "task1", "status": "pending"},
+                    {"content": "task2", "status": "in_progress"},
+                    {"content": "task3", "status": "completed"},
                 ]
             },
         ),

--- a/tests/unit/runtime/test_prompt_assembly.py
+++ b/tests/unit/runtime/test_prompt_assembly.py
@@ -313,6 +313,7 @@ def test_prompt_fragments_expose_stable_order_layers_and_bounded_redacted_previe
     assert fragment_payload["redacted"] is True
     assert fragment_payload["preview_chars"] == 240
     assert [fragment["order"] for fragment in fragments] == list(range(len(fragments)))
+    assert all("priority" not in fragment for fragment in fragments)
     assert [fragment["id"] for fragment in fragments] == [
         f"{index:03d}:{section.source}" for index, section in enumerate(plan.sections)
     ]

--- a/tests/unit/runtime/test_runtime_events.py
+++ b/tests/unit/runtime/test_runtime_events.py
@@ -242,8 +242,11 @@ def test_background_task_result_delegated_event_payload_names_are_explicit() -> 
     )
 
     payload = result.delegated_event.as_payload()
+    execution_contract = result.subagent_execution
 
     assert result.task_id == "task-1"
+    assert not hasattr(execution_contract, "ownership")
+    assert not hasattr(execution_contract, "lifecycle")
     assert payload["parent_session_id"] == "leader-session"
     assert payload["session_id"] == "child-session"
     assert payload["delegation"] == {

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -1269,7 +1269,6 @@ class _DuplicateTodoThenResultAwareTurnProvider:
             {
                 "content": "make todo runtime-owned",
                 "status": "in_progress",
-                "priority": "high",
             }
         ]
         if len(turn_request.tool_results) < 2:

--- a/tests/unit/runtime/test_session_storage.py
+++ b/tests/unit/runtime/test_session_storage.py
@@ -577,7 +577,6 @@ def test_session_storage_persists_runtime_todos_and_filters_reverted_state(
                             {
                                 "content": "persist me",
                                 "status": "in_progress",
-                                "priority": "high",
                                 "position": 1,
                                 "updated_at": 3,
                             }
@@ -614,7 +613,6 @@ def test_session_storage_persists_runtime_todos_and_filters_reverted_state(
                         {
                             "content": "persist me",
                             "status": "in_progress",
-                            "priority": "high",
                             "position": 1,
                             "updated_at": 3,
                         }

--- a/tests/unit/tools/test_tool_output_truncation.py
+++ b/tests/unit/tools/test_tool_output_truncation.py
@@ -499,14 +499,13 @@ def test_strip_redaction_sentinels_handles_nested_todo_arguments() -> None:
                 {
                     "content": {"omitted": True, "byte_count": 9, "line_count": 1},
                     "status": "pending",
-                    "priority": "high",
                 }
             ]
         },
         redacted_keys=frozenset({"content"}),
     )
 
-    assert stripped == {"todos": [{"content": "", "status": "pending", "priority": "high"}]}
+    assert stripped == {"todos": [{"content": "", "status": "pending"}]}
 
 
 def test_strip_redaction_sentinels_preserves_truncation_previews() -> None:


### PR DESCRIPTION
## Summary
- remove prompt fragment priority metadata while keeping order/tier/source observability
- drop unused subagent ownership/lifecycle contract metadata while preserving delegated event payloads
- remove obsolete todo priority fields from runtime/tool test fixtures

## Verification
- uv run pytest tests/unit/runtime/test_prompt_assembly.py::test_prompt_fragments_expose_stable_order_layers_and_bounded_redacted_previews tests/unit/runtime/test_prompt_assembly.py::test_prompt_stack_metadata_is_attached_to_assembled_context_without_raw_prompt tests/unit/runtime/test_runtime_events.py::test_background_task_result_delegated_event_payload_names_are_explicit tests/unit/runtime/test_runtime_service_extensions.py::test_runtime_todo_write_duplicate_snapshot_is_marked_unchanged tests/unit/tools/test_todo_write_tool.py tests/integration/test_tool_workflows_integration.py::test_todo_write_tool_persists_summary_integration tests/unit/runtime/test_session_storage.py::test_session_storage_persists_runtime_todos_and_filters_reverted_state tests/unit/tools/test_tool_output_truncation.py::test_strip_redaction_sentinels_handles_nested_todo_arguments tests/integration/test_read_only_slice.py::test_provider_runtime_persists_and_injects_runtime_todo_state
- QA reviewer: uv run pytest tests/unit/runtime/test_runtime_events.py tests/unit/runtime/test_session_storage.py tests/unit/tools/test_todo_write_tool.py tests/unit/runtime/test_prompt_assembly.py
- lsp_diagnostics on changed source/tests; pre-existing unrelated diagnostics remain in tests/integration/test_read_only_slice.py
- five-lane review passed: goal, QA, code quality, security, context mining
