### PR TITLE
docs(runtime): add architecture refactor plan

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,6 +70,8 @@ VoidCode 使用 LangGraph 作为编排引擎，而不是整个产品运行时。
 
 `src/voidcode/runtime/service.py` 仍是这一控制面的主要热点。未来拆分应遵循 [`runtime/service.py` 安全拆分计划](./runtime-service-decomposition-plan.md)，先围绕已有测试保护的 background task lifecycle、provider fallback、approval resume、tool registry scoping 与 persisted runtime config replay 边界推进，并保持治理语义继续由 runtime 持有。
 
+同时，后续 runtime 重构应遵循 [`Runtime 架构重构计划`](./runtime-architecture-refactor-plan.md)：新增能力不得继续扩大 legacy compatibility、开放式 metadata 控制面或 `VoidCodeRuntime`/`SqliteSessionStore` 单体职责。旧路径应冻结、隔离并逐步删除，而不是继续获得新的 fallback 语义。
+
 ### `graph/`
 
 graph 是执行引擎和编排层，当前包含两条并行路径：

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -13,6 +13,7 @@ VoidCode 当前更重视代码的清晰性、小规模变更以及可重复的�
 
 - 符合现有的运行时 (runtime)/图 (graph)/工具 (tools) 边界。
 - 在可行的情况下保持函数短小且确定性。
+- Runtime 新行为应遵循 [`runtime-architecture-refactor-plan.md`](./runtime-architecture-refactor-plan.md)：不要新增 legacy fallback、旧 metadata key 兼容层或让客户端/graph/tool 复制 runtime 治理状态。
 - 使用 Ruff 进行格式化/代码检查，并保持 ty 类型检查清理。
 - 当行为改变时增加或更新测试。
 - 除非必要，避免引入新的依赖。

--- a/docs/runtime-architecture-refactor-plan.md
+++ b/docs/runtime-architecture-refactor-plan.md
@@ -1,0 +1,292 @@
+# Runtime 架构重构计划
+
+## 背景
+
+当前 runtime 边界方向是正确的：CLI、Web、TUI、ACP 等客户端都应通过 runtime 进入执行闭环，graph 只负责推进执行步骤，tools 只负责具体能力，storage 只保存 runtime 拥有的事实。
+
+风险在于实现正在向三个中心吸附：
+
+- `VoidCodeRuntime` 承担过多控制面和子系统实现细节。
+- `SqliteSessionStore` 同时承载 session、event、pending interaction、background task、continuation loop、memory、notification、revert 与清理语义。
+- `metadata: dict[str, object]` 正在成为隐形控制面，承担 request config、session fact、turn-local state、observability 和 legacy compatibility 的混合职责。
+
+本计划的目标不是追求文件变小，而是阻止架构继续靠特殊字段、兼容分支和横向堆叠维持。
+
+## 重构目标
+
+1. 把 runtime 收敛成稳定的内核 API，而不是功能堆叠入口。
+2. 用少数明确状态对象替代开放式 metadata 控制面。
+3. 让事件流成为客户端观测和 replay 的主轴。
+4. 让 storage 回到事实持久化职责，业务生命周期由 runtime service 层表达。
+5. 拆分 collaborator 时使用明确端口，而不是让子系统继续持有整个 `VoidCodeRuntime`。
+6. 不新增 legacy 向后兼容层；旧路径只能被隔离、冻结和删除，不能继续获得新语义。
+
+## 非目标
+
+- 不把 runtime 治理迁移到 graph、CLI、HTTP、Web/TUI、ACP、hook 或 tool 实现里。
+- 不扩展任意拓扑 multi-agent、agent marketplace、workspace-scoped MCP、通用 workflow DSL 或通用 policy DSL。
+- 不为了保持历史内部实现形状而增加新的兼容 wrapper。
+- 不为旧 metadata key 增加新的 fallback parse、best-effort migration 或静默降级逻辑。
+- 不做一次性大爆炸重写；每个阶段都必须保持主路径可运行。
+
+## 硬性原则
+
+### 不新增 legacy 兼容
+
+从本计划开始，新增能力必须走新的明确对象和端口。禁止新增以下类型的兼容层：
+
+- 新旧字段同时写入。
+- 新字段缺失时自动回退到旧字段。
+- 为旧 workflow preset、旧 metadata key 或旧 event payload 添加新的行为语义。
+- 为了旧测试或旧客户端新增长期 private wrapper。
+- 在解析失败时 best-effort 猜测用户意图。
+
+已有 legacy 路径允许短期保留，但只能做三件事：
+
+- 冻结：不再承载新功能。
+- 隔离：收束到单独 adapter/materializer。
+- 删除：在计划阶段内移除或降级为显式错误。
+
+### 类型优先
+
+开放式 `dict[str, object]` 只能用于最终 payload 边界。runtime 内部控制语义应逐步迁移到明确类型：
+
+- `RuntimeRequestContext`
+- `RuntimeSessionFacts`
+- `RuntimeTurnState`
+- `RuntimePolicyFacts`
+- `RuntimeWorkflowSelection`
+- `RuntimeToolScope`
+
+这些对象应表达“谁拥有状态”和“状态是否可持久化”，而不是只做字段搬运。
+
+### 事件是观测，不是第二状态机
+
+客户端可以从事件渲染 UI，但不应复制 runtime 状态机。runtime 应提供明确 projection，让客户端直接知道：
+
+- 当前 session 状态。
+- pending approval/question。
+- active/background child status。
+- last tool status。
+- revert marker。
+
+客户端可以容忍未知事件，但不应通过反向扫描事件来决定核心交互所有权。
+
+## 目标架构
+
+重构后的 runtime 应大致收敛为以下边界：
+
+```text
+client adapters
+  CLI / HTTP / Web / TUI / ACP
+        |
+        v
+RuntimeKernel
+  request validation
+  session lifecycle
+  run/resume/cancel facade
+        |
+        +-- RequestContextBuilder
+        +-- RuntimePolicyService
+        +-- WorkflowSelectionService
+        +-- ToolScopeResolver
+        +-- RunLoopCoordinator
+        +-- ResumeCoordinator
+        +-- BackgroundTaskService
+        +-- CapabilityManagers
+        +-- EventLog
+        +-- Repositories
+```
+
+`RuntimeKernel` 仍是唯一对外入口，但子系统不应持有整个 kernel。它们依赖小端口，例如：
+
+- `SessionRepository`
+- `EventLogRepository`
+- `PendingInteractionRepository`
+- `BackgroundTaskRepository`
+- `HookRunner`
+- `ChildRunExecutor`
+- `ToolExecutor`
+- `Clock`
+
+## 阶段计划
+
+### Phase 0: 冻结架构债入口
+
+目标：先停止继续扩大 legacy 和 metadata 债务。
+
+任务：
+
+- 将本计划作为后续 runtime 重构 PR 的约束文档。
+- 在代码审查标准里明确：新 runtime 行为不得新增 legacy fallback。
+- 列出当前 legacy metadata/workflow/event 入口，并标记 owner。
+- 对新增 runtime metadata key 建立审查规则：必须说明 owner、生命周期、持久化策略和删除条件。
+
+验收：
+
+- 文档明确“不新增 legacy 向后兼容”。
+- 后续 PR 如果新增 metadata key，必须能指向 typed owner 或计划迁移点。
+
+### Phase 1: 切分 metadata 语义
+
+目标：先建立类型对象，不急着移动所有实现。
+
+新增或整理：
+
+- `RuntimeRequestContext`：一次请求解析后的 runtime 事实，包括 agent、provider、workflow、policy、skills、tool config、mode/read_only。
+- `RuntimeSessionFacts`：可持久化并可 replay 的 session 事实。
+- `RuntimeTurnState`：本轮临时状态，包括 run id、provider attempt、retry attempt、context transform emission state。
+
+迁移策略：
+
+- 新代码只读这些对象，不直接读裸 metadata key。
+- 旧 metadata 解析集中在 builder/materializer 中。
+- 不新增旧 key fallback；遇到缺失或无效字段时显式失败或使用新对象默认值。
+
+验收：
+
+- graph 不再直接解释新增 runtime 控制 key。
+- 新 request/session/turn 状态有明确持久化边界。
+
+### Phase 2: 收缩 `VoidCodeRuntime`
+
+目标：让 `VoidCodeRuntime` 成为 facade/kernel，而不是所有子系统的实现容器。
+
+优先改造：
+
+- `RuntimeBackgroundTaskSupervisor` 不再持有整个 runtime。
+- `RuntimeRunLoopCoordinator` 不再通过 runtime 私有字段获取权限、hook、tool execution 和 config。
+- `RuntimeResumeCoordinator` 不再依赖 runtime 私有方法拼接 checkpoint/session/tool results。
+
+做法：
+
+- 为每个 coordinator 注入小接口。
+- 保持 public runtime surface 稳定。
+- 删除不再需要的 private compatibility wrapper，不新增 wrapper 过渡层。
+
+验收：
+
+- collaborator 构造参数能表达真实依赖。
+- 子系统测试可以不用实例化完整 `VoidCodeRuntime`。
+
+### Phase 3: 拆分 storage 职责
+
+目标：SQLite 仍可统一存储，但业务生命周期不再堆在 `SqliteSessionStore` 一个类里。
+
+拆分端口：
+
+- `SessionRepository`
+- `EventLogRepository`
+- `PendingInteractionRepository`
+- `BackgroundTaskRepository`
+- `ContinuationLoopRepository`
+- `MemoryRepository`
+- `NotificationRepository`
+
+约束：
+
+- repository 只做事实读写和基本一致性约束。
+- 状态机规则进入 runtime service 层或 domain object。
+- 不添加旧 schema 自动迁移 fallback。schema 不匹配继续 fail fast。
+
+验收：
+
+- background task transition 不再散落在通用 session store 中。
+- pending approval/question 不再作为 session row 的附属业务逻辑到处解析。
+
+### Phase 4: 硬化事件和客户端 projection
+
+目标：事件保持 append-only observability，客户端核心交互依赖 runtime projection。
+
+任务：
+
+- 明确 stable/shipped/experimental event 分类，代码和文档命名一致。
+- 为 session replay/debug/result 提供 pending interaction projection。
+- 前端停止本地补造 `runtime.approval_resolved` 这类权威事件。
+- 保留客户端对未知事件的容忍，但核心状态不靠客户端扫描事件倒推。
+
+验收：
+
+- Web store 不再复制 approval/question 状态机。
+- runtime 是 pending interaction ownership 的唯一来源。
+
+### Phase 5: 清理 workflow/policy/legacy preset
+
+目标：把 workflow/policy 从兼容解释层收敛为明确选择和治理事实。
+
+任务：
+
+- first-class workflow mode 只表达当前支持的字段。
+- legacy preset 不再获得新字段、新行为和新 fallback。
+- policy snapshot 只表达 runtime 治理事实，不变成通用 DSL。
+- 删除或隔离 legacy materialization 中无法解释当前产品语义的字段。
+
+验收：
+
+- 新功能不需要同时修改 workflow、legacy preset、policy、metadata、prompt guidance 多处才能生效。
+- legacy 路径缺失字段不会被静默补齐为新语义。
+
+## PR 切分建议
+
+### PR 1: 文档和守则
+
+- 新增本计划。
+- 在架构文档和 coding standards 中引用“不新增 legacy 兼容层”。
+- 不改行为。
+
+### PR 2: metadata owner inventory
+
+- 增加当前 runtime metadata key 清单。
+- 标注 request/session/turn/observability/legacy 分类。
+- 不做迁移。
+
+### PR 3: typed request context scaffold
+
+- 新增 `RuntimeRequestContext` 和 builder。
+- 让新代码路径优先消费 builder 结果。
+- 不新增旧字段 fallback。
+
+### PR 4: background task service port
+
+- 把 supervisor 对 `VoidCodeRuntime` 的依赖改成小接口。
+- 保持 public API 不变。
+- 删除被替代的 private wrapper。
+
+### PR 5: event projection hardening
+
+- 增加 pending interaction projection。
+- 前端消费 projection。
+- 移除前端本地权威事件补造。
+
+后续 PR 再处理 run loop、resume、storage repository 拆分和 workflow/policy 清理。
+
+## 验证策略
+
+每个 PR 至少运行 touched boundary 的测试。行为 PR 需要补 characterization test，文档 PR 不要求全量测试。
+
+推荐基线：
+
+```bash
+uv run pytest tests/unit/runtime/test_runtime_service_extensions.py
+uv run pytest tests/unit/runtime/test_session_storage.py
+uv run pytest tests/unit/tools/test_background_task_tools.py
+uv run pytest tests/unit/interface/test_cli_delegated_parity.py
+mise run check
+```
+
+如果只是文档变更，可以只运行：
+
+```bash
+uv run pytest tests/unit/project/test_project_metadata.py
+```
+
+## 成功标准
+
+重构完成后，应能做到：
+
+- 新 runtime 行为能从 typed request/session/turn 对象解释，而不是从散落 metadata key 解释。
+- `VoidCodeRuntime` public surface 仍稳定，但内部 collaborator 不依赖整个 runtime。
+- storage 层不再拥有高层业务状态机。
+- frontend 不复制 runtime pending/approval/question 权威状态。
+- workflow/policy 不再继续吸收 legacy 语义。
+- 新功能不需要添加兼容 fallback 才能进入主路径。

--- a/src/voidcode/runtime/prompt_assembly.py
+++ b/src/voidcode/runtime/prompt_assembly.py
@@ -427,6 +427,31 @@ def build_prompt_assembly_plan(
         seen_system_contents.add(block.content)
         sections.append(block.to_section())
 
+    def append_block(
+        content: str,
+        *,
+        source: str,
+        tier: Literal["instruction", "workspace", "task", "recent"],
+        layer: str | None,
+        metadata: Mapping[str, object] | None = None,
+        role: Literal["system", "user", "assistant", "tool"] = "system",
+        strip_content: bool = True,
+        allow_empty: bool = False,
+    ) -> None:
+        block = _normalize_prompt_context_block(
+            content,
+            source=source,
+            tier=tier,
+            layer=layer,
+            metadata=metadata,
+            role=role,
+            strip_content=strip_content,
+            allow_empty=allow_empty,
+        )
+        if block is None:
+            return
+        sections.append(block.to_section())
+
     profile_overlay = (
         get_profile_overlay(prompt_profile_name) if prompt_profile_name is not None else None
     )
@@ -560,17 +585,13 @@ def build_prompt_assembly_plan(
                     metadata=injection.metadata,
                 )
                 continue
-            sections.append(
-                PromptAssemblySection(
-                    role=cast(Literal["system", "user", "assistant", "tool"], injection.role),
-                    content=normalized,
-                    source=_metadata_source(injection.metadata, fallback="context_transform"),
-                    tier=_metadata_tier(injection.metadata, fallback="workspace"),
-                    metadata=_section_metadata(
-                        injection.metadata,
-                        layer="hook_injected_context",
-                    ),
-                )
+            append_block(
+                normalized,
+                role=cast(Literal["system", "user", "assistant", "tool"], injection.role),
+                source=_metadata_source(injection.metadata, fallback="context_transform"),
+                tier=_metadata_tier(injection.metadata, fallback="workspace"),
+                layer="hook_injected_context",
+                metadata=injection.metadata,
             )
 
     if pending_state_section is not None:
@@ -583,7 +604,14 @@ def build_prompt_assembly_plan(
                 metadata=pending_state_section.metadata,
             )
         else:
-            sections.append(pending_state_section)
+            append_block(
+                pending_state_section.content,
+                role=pending_state_section.role,
+                source=pending_state_section.source,
+                tier=pending_state_section.tier,
+                layer=None,
+                metadata=pending_state_section.metadata,
+            )
 
     append_system(
         todo_prompt_context,
@@ -621,20 +649,27 @@ def build_prompt_assembly_plan(
                 metadata=artifact_reference.metadata,
             )
             continue
-        sections.append(artifact_reference)
-
-    sections.append(
-        PromptAssemblySection(
-            role="user",
-            content=prompt,
-            source="current_user_prompt",
-            tier="task",
-            metadata={
-                "source": "current_user_prompt",
-                "tier": "task",
-                "layer": "user_request",
-            },
+        append_block(
+            artifact_reference.content,
+            role=artifact_reference.role,
+            source=artifact_reference.source,
+            tier=artifact_reference.tier,
+            layer=None,
+            metadata=artifact_reference.metadata,
         )
+
+    append_block(
+        prompt,
+        role="user",
+        source="current_user_prompt",
+        tier="task",
+        layer="user_request",
+        metadata={
+            "source": "current_user_prompt",
+            "tier": "task",
+        },
+        strip_content=False,
+        allow_empty=True,
     )
     ordered_sections = tuple(sections)
     return PromptAssemblyPlan(
@@ -688,9 +723,11 @@ def _normalize_prompt_context_block(
     layer: str | None,
     metadata: Mapping[str, object] | None,
     role: Literal["system", "user", "assistant", "tool"] = "system",
+    strip_content: bool = True,
+    allow_empty: bool = False,
 ) -> _PromptContextBlock | None:
-    normalized_content = content.strip()
-    if not normalized_content:
+    normalized_content = content.strip() if strip_content else content
+    if not normalized_content and not allow_empty:
         return None
     return _PromptContextBlock(
         role=role,

--- a/src/voidcode/runtime/prompt_assembly.py
+++ b/src/voidcode/runtime/prompt_assembly.py
@@ -327,6 +327,25 @@ class PromptAssemblySection:
 
 
 @dataclass(frozen=True, slots=True)
+class _PromptContextBlock:
+    role: Literal["system", "user", "assistant", "tool"]
+    content: str
+    source: str
+    tier: Literal["instruction", "workspace", "task", "recent"]
+    metadata: Mapping[str, object] = field(default_factory=dict)
+    layer: str | None = None
+
+    def to_section(self) -> PromptAssemblySection:
+        return PromptAssemblySection(
+            role=self.role,
+            content=self.content,
+            source=self.source,
+            tier=self.tier,
+            metadata=_section_metadata(self.metadata, layer=self.layer),
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class PromptAssemblyFragment:
     id: str
     role: Literal["system", "user", "assistant", "tool"]
@@ -396,19 +415,17 @@ def build_prompt_assembly_plan(
         layer: str | None = None,
         metadata: Mapping[str, object] | None = None,
     ) -> None:
-        normalized = content.strip()
-        if not normalized or normalized in seen_system_contents:
-            return
-        seen_system_contents.add(normalized)
-        sections.append(
-            PromptAssemblySection(
-                role="system",
-                content=normalized,
-                source=source,
-                tier=tier,
-                metadata=_section_metadata(metadata, layer=layer),
-            )
+        block = _normalize_prompt_context_block(
+            content,
+            source=source,
+            tier=tier,
+            layer=layer,
+            metadata=metadata,
         )
+        if block is None or block.content in seen_system_contents:
+            return
+        seen_system_contents.add(block.content)
+        sections.append(block.to_section())
 
     profile_overlay = (
         get_profile_overlay(prompt_profile_name) if prompt_profile_name is not None else None
@@ -661,6 +678,28 @@ def _section_metadata(
     if layer is not None and "layer" not in section_metadata:
         section_metadata["layer"] = layer
     return section_metadata
+
+
+def _normalize_prompt_context_block(
+    content: str,
+    *,
+    source: str,
+    tier: Literal["instruction", "workspace", "task", "recent"],
+    layer: str | None,
+    metadata: Mapping[str, object] | None,
+    role: Literal["system", "user", "assistant", "tool"] = "system",
+) -> _PromptContextBlock | None:
+    normalized_content = content.strip()
+    if not normalized_content:
+        return None
+    return _PromptContextBlock(
+        role=role,
+        content=normalized_content,
+        source=source,
+        tier=tier,
+        metadata={} if metadata is None else dict(metadata),
+        layer=layer,
+    )
 
 
 def _metadata_layer(metadata: Mapping[str, object], *, fallback: str) -> str:

--- a/tests/unit/runtime/test_context_window.py
+++ b/tests/unit/runtime/test_context_window.py
@@ -11,8 +11,10 @@ import pytest
 
 from voidcode.runtime.context_transforms import (
     HookPresetGuidanceTransformProvider,
+    RuntimeContextTransformInjection,
     RuntimeContextTransformRegistry,
     RuntimeContextTransformRequest,
+    RuntimeContextTransformResult,
     RuntimeFileRulesTransformProvider,
 )
 from voidcode.runtime.context_window import (
@@ -709,6 +711,131 @@ def test_assemble_provider_context_injects_pending_approval_state() -> None:
         "blocked_tool": "write_file",
         "approval_request_id": "approval-123",
     }
+
+
+def test_assemble_provider_context_skill_todo_transform_content_present() -> None:
+    assembled = assemble_provider_context(
+        prompt="continue",
+        tool_results=(),
+        session_metadata={
+            "runtime_state": {
+                "todos": {
+                    "version": 1,
+                    "revision": 1,
+                    "todos": [
+                        {
+                            "content": "implement feature",
+                            "status": "in_progress",
+                            "position": 1,
+                            "updated_at": 1,
+                        }
+                    ],
+                }
+            }
+        },
+        skill_prompt_context="skill guidance text",
+        context_transform_result=RuntimeContextTransformResult(
+            injections=(
+                RuntimeContextTransformInjection(
+                    role="system",
+                    content="transform injected",
+                    metadata={"source": "transform_test", "tier": "workspace"},
+                ),
+            )
+        ),
+        policy=_legacy_context_window_policy(max_tool_result_tokens=100),
+    )
+
+    skill_segments = [
+        s
+        for s in assembled.segments
+        if s.metadata is not None and s.metadata.get("source") == "skill_prompt"
+    ]
+    assert len(skill_segments) == 1
+    assert "skill guidance text" in (skill_segments[0].content or "")
+
+    todo_segments = [
+        s
+        for s in assembled.segments
+        if s.metadata is not None and s.metadata.get("source") == "runtime_todo_state"
+    ]
+    assert len(todo_segments) >= 1
+    todo_text = "\n".join(str(s.content) for s in todo_segments if s.content)
+    assert "implement feature" in todo_text
+
+    transform_segments = [
+        s
+        for s in assembled.segments
+        if s.metadata is not None and s.metadata.get("source") == "transform_test"
+    ]
+    assert len(transform_segments) == 1
+    assert "transform injected" in (transform_segments[0].content or "")
+
+    tiers = cast(dict[str, object], assembled.metadata.get("context_tiers", {}))
+    counts = cast(dict[str, int], tiers.get("counts", {}))
+    assert counts.get("task", 0) >= 1
+    assert counts.get("instruction", 0) >= 1
+    assert counts.get("workspace", 0) >= 1
+
+
+def test_assemble_provider_context_pressure_preserves_skill_todo_transform() -> None:
+    assembled = assemble_provider_context(
+        prompt="continue",
+        tool_results=(),
+        session_metadata={
+            "runtime_state": {
+                "todos": {
+                    "version": 1,
+                    "revision": 1,
+                    "todos": [
+                        {
+                            "content": "critical todo",
+                            "status": "in_progress",
+                            "position": 1,
+                            "updated_at": 1,
+                        }
+                    ],
+                }
+            }
+        },
+        agent_prompt_context="x" * 1000,
+        skill_prompt_context="critical skill guidance",
+        context_transform_result=RuntimeContextTransformResult(
+            injections=(
+                RuntimeContextTransformInjection(
+                    role="system",
+                    content="critical transform note",
+                    metadata={"source": "transform_pressure", "tier": "workspace"},
+                ),
+            )
+        ),
+        policy=_legacy_context_window_policy(
+            model_context_window_tokens=20,
+            context_pressure_threshold=0.5,
+        ),
+    )
+
+    assert assembled.metadata.get("context_pressure_detected") is True
+    assert assembled.metadata.get("context_overflow_detected") is True
+
+    assert any(
+        (s.metadata or {}).get("source") == "skill_prompt"
+        and s.content is not None
+        and "critical skill guidance" in s.content
+        for s in assembled.segments
+    )
+    todo_text = "\n".join(
+        str(s.content)
+        for s in assembled.segments
+        if s.metadata and s.metadata.get("source") == "runtime_todo_state" and s.content
+    )
+    assert "critical todo" in todo_text
+    assert any(
+        (s.metadata or {}).get("source") == "transform_pressure"
+        and s.content is not None
+        and "critical transform note" in s.content
+        for s in assembled.segments
+    )
 
 
 def test_assemble_provider_context_injects_pending_question_state() -> None:

--- a/tests/unit/runtime/test_prompt_assembly.py
+++ b/tests/unit/runtime/test_prompt_assembly.py
@@ -374,6 +374,68 @@ def test_prompt_stack_metadata_is_attached_to_assembled_context_without_raw_prom
     assert assembled.segments[-1].content.startswith("Please use access_token=")
 
 
+def test_build_prompt_assembly_plan_skill_todo_transform_content_appears() -> None:
+    plan = build_prompt_assembly_plan(
+        prompt="continue work",
+        runtime_instruction_precedence="runtime first",
+        agent_prompt_context="agent prompt body",
+        workflow_mode_prompt_context="workflow mode text",
+        skill_prompt_context="skill guidance for tools",
+        todo_prompt_context="active todo: finish feature",
+        context_transform_result=RuntimeContextTransformResult(
+            injections=(
+                RuntimeContextTransformInjection(
+                    role="system",
+                    content="hook injected guidance",
+                    metadata={"source": "transform_hook", "tier": "workspace"},
+                ),
+            )
+        ),
+    )
+
+    assert [section.source for section in plan.sections] == [
+        "runtime_base_safety",
+        "runtime_instruction_precedence",
+        "agent_prompt",
+        "workflow_mode_prompt",
+        "runtime_memory_usage_guidance",
+        "skill_prompt",
+        "transform_hook",
+        "runtime_todo_state",
+        "runtime_tool_policy_summary",
+        "current_user_prompt",
+    ]
+    assert [section.tier for section in plan.sections] == [
+        "instruction",
+        "instruction",
+        "instruction",
+        "instruction",
+        "instruction",
+        "instruction",
+        "workspace",
+        "task",
+        "instruction",
+        "task",
+    ]
+    skill_section = next(s for s in plan.sections if s.source == "skill_prompt")
+    assert "skill guidance for tools" in skill_section.content
+    todo_section = next(s for s in plan.sections if s.source == "runtime_todo_state")
+    assert "active todo: finish feature" in todo_section.content
+    transform_section = next(s for s in plan.sections if s.source == "transform_hook")
+    assert "hook injected guidance" in transform_section.content
+    assert plan.sections[-1].role == "user"
+    assert plan.sections[-1].content == "continue work"
+
+    fragment_payload = plan.fragment_metadata_payload()
+    fragments = cast(list[dict[str, object]], fragment_payload["fragments"])
+    skill_fragment = next(f for f in fragments if f["source"] == "skill_prompt")
+    assert skill_fragment["layer"] == "skills"
+    todo_fragment = next(f for f in fragments if f["source"] == "runtime_todo_state")
+    assert todo_fragment["layer"] == "task_state"
+    transform_fragment = next(f for f in fragments if f["source"] == "transform_hook")
+    assert transform_fragment["layer"] == "hook_injected_context"
+
+
 def test_prompt_activation_decision_records_first_activation_without_raw_prompt() -> None:
     decision = prompt_activation_decision(
         session_metadata={


### PR DESCRIPTION
Adds a runtime architecture refactor plan that freezes new legacy compatibility work, defines typed-state migration goals, and outlines phased cleanup for runtime metadata, storage responsibilities, event projections, and workflow/policy legacy paths.

Verification:
- UV_CACHE_DIR=/tmp/voidcode-uv-cache uv run pytest tests/unit/project/test_project_metadata.py