### PR TITLE
refactor(runtime): tighten background task boundary

### DIFF
--- a/src/voidcode/runtime/background_tasks.py
+++ b/src/voidcode/runtime/background_tasks.py
@@ -790,7 +790,7 @@ class RuntimeBackgroundTaskSupervisor:
                                 with self._queue_lock:
                                     self._release_slot(reserved_identity)
                             return
-                        runtime._run_background_task_worker(background_task_id)
+                        self.run_background_task_worker(background_task_id)
                     finally:
                         with self._queue_lock:
                             self._threads.pop(background_task_id, None)

--- a/src/voidcode/runtime/resume.py
+++ b/src/voidcode/runtime/resume.py
@@ -104,7 +104,9 @@ class RuntimeResumeCoordinator:
                 output=output,
                 final_session=final_session,
             )
-            self._runtime._finalize_background_task_from_session_response(session_response=response)
+            self._runtime._background_task_supervisor.finalize_background_task_from_session_response(
+                session_response=response
+            )
 
     def resume_pending_approval_response(
         self,
@@ -180,7 +182,9 @@ class RuntimeResumeCoordinator:
                 output=output,
                 final_session=final_session,
             )
-            self._runtime._finalize_background_task_from_session_response(session_response=response)
+            self._runtime._background_task_supervisor.finalize_background_task_from_session_response(
+                session_response=response
+            )
 
     def answer_pending_question_response(
         self,

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -3824,7 +3824,7 @@ class VoidCodeRuntime:
         return self._background_task_supervisor.start_background_task(validated_request)
 
     def load_background_task(self, task_id: str) -> BackgroundTaskState:
-        self._reconcile_background_tasks_if_needed()
+        self._background_task_supervisor.reconcile_background_tasks_if_needed()
         validate_background_task_id(task_id)
         task = self._session_store.load_background_task(workspace=self._workspace, task_id=task_id)
         return self._background_task_supervisor.task_with_observability(task)
@@ -3835,7 +3835,7 @@ class VoidCodeRuntime:
         *,
         emit_result_read_hook: bool = True,
     ) -> BackgroundTaskResult:
-        self._reconcile_background_tasks_if_needed()
+        self._background_task_supervisor.reconcile_background_tasks_if_needed()
         return self._background_task_supervisor.load_background_task_result(
             task_id,
             emit_result_read_hook=emit_result_read_hook,
@@ -3847,7 +3847,7 @@ class VoidCodeRuntime:
         child_session_id: str,
         emit_result_read_hook: bool = True,
     ) -> BackgroundTaskResult | None:
-        self._reconcile_background_tasks_if_needed()
+        self._background_task_supervisor.reconcile_background_tasks_if_needed()
         validated_child_session_id = validate_session_reference_id(
             child_session_id,
             field_name="child_session_id",
@@ -6142,7 +6142,9 @@ class VoidCodeRuntime:
                     workspace=self._workspace,
                     task_id=task_summary.task.id,
                 )
-                child_response = self._load_background_task_child_response(task=task)
+                child_response = (
+                    self._background_task_supervisor.load_background_task_child_response(task=task)
+                )
                 owned_request_id = (
                     self._waiting_request_id_from_response(
                         child_response,
@@ -8777,94 +8779,6 @@ class VoidCodeRuntime:
         request_kind: Literal["approval", "question"],
     ) -> str | None:
         return waiting_request_id_from_response(response, request_kind=request_kind)
-
-    def _load_background_task_child_response(
-        self,
-        *,
-        task: BackgroundTaskState,
-    ) -> RuntimeResponse | None:
-        # Compatibility wrapper for tests/callers.
-        return self._background_task_supervisor.load_background_task_child_response(task=task)
-
-    def _load_background_task_child_result(
-        self,
-        *,
-        task: BackgroundTaskState,
-    ) -> RuntimeSessionResult | None:
-        # Compatibility wrapper for tests/callers.
-        return self._background_task_supervisor.load_background_task_child_result(task=task)
-
-    def _background_task_result(self, *, task: BackgroundTaskState) -> BackgroundTaskResult:
-        # Compatibility wrapper for tests/callers.
-        return self._background_task_supervisor.background_task_result(task=task)
-
-    def _emit_background_task_parent_terminal_event(self, *, task: BackgroundTaskState) -> None:
-        # Compatibility wrapper for tests/callers.
-        self._background_task_supervisor.emit_background_task_parent_terminal_event(task=task)
-
-    def _backfill_parent_background_task_event(self, *, task: BackgroundTaskState) -> None:
-        # Compatibility wrapper for tests/callers.
-        self._background_task_supervisor.backfill_parent_background_task_event(task=task)
-
-    def _reconcile_parent_background_task_events_for_session(
-        self,
-        *,
-        parent_session_id: str,
-    ) -> None:
-        # Compatibility wrapper for tests/callers.
-        self._background_task_supervisor.reconcile_parent_background_task_events_for_session(
-            parent_session_id=parent_session_id
-        )
-
-    def _emit_background_task_waiting_approval(
-        self,
-        *,
-        task: BackgroundTaskState,
-        child_response: RuntimeResponse,
-    ) -> None:
-        # Compatibility wrapper for tests/callers.
-        self._background_task_supervisor.emit_background_task_waiting_approval(
-            task=task,
-            child_response=child_response,
-        )
-
-    def _finalize_background_task_from_session_response(
-        self,
-        *,
-        session_response: RuntimeResponse,
-    ) -> None:
-        # Compatibility wrapper for tests/callers.
-        self._background_task_supervisor.finalize_background_task_from_session_response(
-            session_response=session_response
-        )
-
-    def _run_background_task_lifecycle_hook(self, task: BackgroundTaskState) -> None:
-        # Compatibility wrapper for tests/callers.
-        self._background_task_supervisor.run_background_task_lifecycle_hook(task)
-
-    def _run_background_task_lifecycle_surface(
-        self,
-        *,
-        task: BackgroundTaskState,
-        surface: RuntimeHookSurface,
-        session_id: str,
-        extra_payload: dict[str, object] | None = None,
-    ) -> None:
-        # Compatibility wrapper for tests/callers.
-        self._background_task_supervisor.run_background_task_lifecycle_surface(
-            task=task,
-            surface=surface,
-            session_id=session_id,
-            extra_payload=extra_payload,
-        )
-
-    def _reconcile_background_tasks_if_needed(self) -> None:
-        # Compatibility wrapper for tests/callers.
-        self._background_task_supervisor.reconcile_background_tasks_if_needed()
-
-    def _run_background_task_worker(self, task_id: str) -> None:
-        # Compatibility wrapper for tests/callers.
-        self._background_task_supervisor.run_background_task_worker(task_id)
 
     def _effective_runtime_config_from_metadata(
         self, metadata: dict[str, object] | None

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -2587,7 +2587,7 @@ def test_runtime_background_task_started_hook_runs_outside_queue_lock(
         assert cast(Any, supervisor._queue_lock)._is_owned() is False
         assert worker_started.is_set() is False
 
-    monkeypatch.setattr(runtime, "_run_background_task_worker", no_op_worker)
+    monkeypatch.setattr(supervisor, "run_background_task_worker", no_op_worker)
     monkeypatch.setattr(
         supervisor,
         "run_background_task_lifecycle_surface",
@@ -2621,7 +2621,7 @@ def test_runtime_exit_waits_for_background_task_worker(
         assert release_worker.wait(timeout=2.0)
         worker_finished.set()
 
-    monkeypatch.setattr(runtime, "_run_background_task_worker", blocking_worker)
+    monkeypatch.setattr(supervisor, "run_background_task_worker", blocking_worker)
 
     supervisor._drain_background_task_queue()
     assert worker_started.wait(timeout=2.0)
@@ -2652,7 +2652,7 @@ def test_runtime_shutdown_terminalizes_unfinished_background_worker(
         worker_started.set()
         assert release_worker.wait(timeout=2.0)
 
-    monkeypatch.setattr(runtime, "_run_background_task_worker", blocking_worker)
+    monkeypatch.setattr(supervisor, "run_background_task_worker", blocking_worker)
 
     supervisor._drain_background_task_queue()
     assert worker_started.wait(timeout=2.0)
@@ -2689,7 +2689,7 @@ def test_runtime_shutdown_after_mark_running_terminalizes_task_before_worker(
         runtime._background_task_shutdown_requested = True
 
     run_mock = Mock(side_effect=AssertionError("worker must not run after shutdown"))
-    cast(Any, runtime)._run_background_task_worker = run_mock
+    cast(Any, supervisor).run_background_task_worker = run_mock
     cast(Any, supervisor).run_background_task_lifecycle_surface = request_shutdown_from_started_hook
 
     supervisor._drain_background_task_queue()
@@ -7597,7 +7597,7 @@ def test_runtime_background_task_waiting_approval_emits_parent_session_event_onc
         event.sequence for event in leader_response.events
     )
 
-    runtime._emit_background_task_waiting_approval(
+    runtime._background_task_supervisor.emit_background_task_waiting_approval(
         task=running,
         child_response=child_response,
     )
@@ -8535,7 +8535,7 @@ def test_runtime_background_task_waiting_approval_race_does_not_fail_child_task(
         "runtime.approval_requested",
     )
 
-    runtime._emit_background_task_waiting_approval(
+    runtime._background_task_supervisor.emit_background_task_waiting_approval(
         task=running,
         child_response=child_response,
     )
@@ -9111,7 +9111,7 @@ def test_runtime_background_task_worker_exits_when_task_is_cancelled_before_star
     run_mock = Mock(side_effect=AssertionError("runtime.run must not be called"))
     cast(Any, runtime).run = run_mock
 
-    runtime._run_background_task_worker("task-race-cancel")
+    runtime._background_task_supervisor.run_background_task_worker("task-race-cancel")
 
     final_task = runtime.load_background_task("task-race-cancel")
     assert final_task.status == "cancelled"
@@ -9147,7 +9147,7 @@ def test_runtime_background_task_worker_rechecks_cancel_before_dispatch(tmp_path
     run_mock = Mock(side_effect=AssertionError("runtime.run must not be called"))
     cast(Any, runtime).run = run_mock
 
-    runtime._run_background_task_worker("task-dispatch-cancel")
+    runtime._background_task_supervisor.run_background_task_worker("task-dispatch-cancel")
 
     final_task = runtime.load_background_task("task-dispatch-cancel")
     assert final_task.status == "cancelled"


### PR DESCRIPTION
## Summary
- remove `VoidCodeRuntime` private background-task compatibility wrappers
- route runtime-internal background lifecycle calls directly through `RuntimeBackgroundTaskSupervisor`
- retarget runtime boundary tests to the supervisor-owned surface

## Testing
- uv run pytest -n auto tests/unit/runtime/test_runtime_service_extensions.py -k "background or delegated or cancel or approval"
- uv run pytest -n auto tests/unit/tools/test_background_task_tools.py -k "background or cancel or output"
- uv run pytest -n auto tests/unit/interface/test_cli_delegated_parity.py
- uv run pytest -n auto tests/integration/test_read_only_slice.py -k "background or delegated"
- mise run check
