### PR TITLE
refactor(runtime): decision collaborator boundary

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,6 +70,8 @@ VoidCode 使用 LangGraph 作为编排引擎，而不是整个产品运行时。
 
 `src/voidcode/runtime/service.py` 仍是这一控制面的主要热点。未来拆分应遵循 [`runtime/service.py` 安全拆分计划](./runtime-service-decomposition-plan.md)，先围绕已有测试保护的 background task lifecycle、provider fallback、approval resume、tool registry scoping 与 persisted runtime config replay 边界推进，并保持治理语义继续由 runtime 持有。
 
+当前已经落地的 runtime decision collaborator 只覆盖两个收敛点：`provider_fallback.py` 负责 provider 错误 retry、fallback 与终止 payload 的纯 decision，`run_loop.py` 继续拥有事件、metadata 和 fallback graph 切换；`config_materializer.py` 负责 persisted/request runtime config 的 parse/serialize decision，`service.py` 继续拥有 registry、capability snapshot、workflow snapshot、agent validation 与 request/session 权威性选择。Task 7 清理了不再需要的 private wrapper/call site，并把显示用 fallback 解析改为复用 `parse_persisted_runtime_config()`。这不是 provider backend 重写、storage schema migration、frontend 行为变更、workspace-scoped MCP 生命周期或任意拓扑 multi-agent 扩展。
+
 同时，后续 runtime 重构应遵循 [`Runtime 架构重构计划`](./runtime-architecture-refactor-plan.md)：新增能力不得继续扩大 legacy compatibility、开放式 metadata 控制面或 `VoidCodeRuntime`/`SqliteSessionStore` 单体职责。旧路径应冻结、隔离并逐步删除，而不是继续获得新的 fallback 语义。
 
 ### `graph/`

--- a/docs/runtime-service-decomposition-plan.md
+++ b/docs/runtime-service-decomposition-plan.md
@@ -12,11 +12,11 @@
 
 ### 已经部分抽出的 collaborator
 
-- `RuntimeRunLoopCoordinator`：`src/voidcode/runtime/run_loop.py` 已承载工具执行、provider transient retry、provider fallback loop、上下文压力事件与 graph step 推进；`service.py` 的 `_execute_graph_loop()` 现在是兼容转发入口。
+- `RuntimeRunLoopCoordinator`：`src/voidcode/runtime/run_loop.py` 已承载工具执行、provider transient retry、provider fallback loop、上下文压力事件与 graph step 推进；provider 错误重试、fallback 与终止 payload 判断已收束到 `src/voidcode/runtime/provider_fallback.py`，但事件发射、sleep、session metadata 更新和 fallback graph 切换仍在 run loop 内；`service.py` 的 `_execute_graph_loop()` 现在是兼容转发入口。
 - `RuntimeResumeCoordinator`：`src/voidcode/runtime/resume.py` 已承载 approval/question/provider-failure resume 的主要恢复逻辑；`service.py` 仍保留 `resume()` / `resume_stream()` public surface、目标所有权校验与兼容转发入口。
 - `RuntimeBackgroundTaskSupervisor`：`src/voidcode/runtime/background_tasks.py` 已承载 background task queue、worker lifecycle、result view、parent notification、cancel、reconciliation 与 lifecycle hook 触发；`service.py` 仍保留 public surface 与测试兼容 wrapper。
 - `tool_provider.py`：已承载 builtin tool provider、agent allowlist/default scoping 与 local custom tool provider；`service.py` 仍组合 MCP/LSP/skill/task/question/background tools 并应用 workflow read-only policy。
-- `execution_seams.py`：已承载 graph selection、cache key、fallback graph selection 与 session routing seams；`service.py` 仍负责把 persisted metadata 还原成 `EffectiveRuntimeConfig`。
+- `execution_seams.py`：已承载 graph selection、cache key、fallback graph selection 与 session routing seams；`src/voidcode/runtime/config_materializer.py` 已承载 `EffectiveRuntimeConfig`、persisted runtime config parse/serialize、request override 和 persisted fallback model 显式错误判断，`service.py` 仍负责 registry、capability snapshot、workflow snapshot、agent validation 与配置优先级组合。
 
 ### 仍集中在 `service.py` 的高风险区域
 
@@ -66,7 +66,9 @@ No broad move is needed; the safe first slice is documentation plus tests for re
 
 ### 2. Separate provider fallback policy from run-loop mechanics
 
-`run_loop.py` already performs provider retry/fallback mechanics. The next boundary should isolate policy inputs: which errors are retryable, which fallback target is next, which metadata must be persisted, and which terminal error payload is emitted after exhaustion.
+当前状态：`src/voidcode/runtime/provider_fallback.py` 已实现该边界的安全子集。它只根据 `ProviderExecutionError`、provider attempt、retry attempt、transient retry config 和可用 fallback target 返回 typed decision。`run_loop.py` 仍负责发出 `runtime.provider_fallback` / `runtime.provider_transient_retry` 事件、等待 retry delay、写入 `provider_attempt` / `provider_retry_attempt` metadata、切换 fallback graph，并把终止 decision 映射为 runtime failure chunk。provider registry、auth resolver、config materialization 与 fallback graph selection 没有迁出 runtime ownership。
+
+剩余工作应继续保持这一分工：policy helper 只判断 which errors are retryable, which fallback target is next, and which terminal error payload is emitted after exhaustion；metadata 持久化、事件顺序和 graph rebuilding 仍留在 runtime run loop / execution seam 内。
 
 **保留在 `service.py`**
 
@@ -143,7 +145,9 @@ Tool scoping affects what schemas the provider sees and what raw tool calls runt
 
 ### 5. Move persisted runtime config replay behind a materializer only after the above
 
-`_effective_runtime_config_from_metadata()` is still the densest runtime truth function. It should not be the first extraction because every other slice depends on it. Once the other collaborators are stable, move parsing/validation into a `RuntimeConfigMaterializer` that is still owned by `runtime/`.
+当前状态：`src/voidcode/runtime/config_materializer.py` 已实现该边界的安全子集。它承载 `EffectiveRuntimeConfig`、`PERSISTED_RUNTIME_CONFIG_KEYS`、`serialize_runtime_config_core()`、`parse_persisted_runtime_config()`、request override helper、persisted permission/tools/provider fallback parsing，以及 `fallback_models` 缺少 persisted `model` 时的显式错误。`service.py` 仍负责读取 base `RuntimeConfig`、解析 provider registry target、验证 agent execution、生成 hook/LSP/MCP/workflow snapshots、组合 categories/agents，并决定 request metadata 或 persisted session metadata 何时具有权威性。
+
+剩余工作应避免把 materializer 扩大成新的 runtime owner。`service.py` 仍是配置优先级、registry/capability 快照和 workflow/agent validation 的组合点；materializer 只处理明确 payload 的 parse/serialize 与显式错误。
 
 **保留在 `service.py`**
 

--- a/src/voidcode/runtime/config_materializer.py
+++ b/src/voidcode/runtime/config_materializer.py
@@ -1,0 +1,567 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import cast
+
+from ..provider.errors import format_invalid_provider_config_error
+from ..provider.models import ResolvedProviderConfig
+from .config import (
+    ExecutionEngineName,
+    ExternalDirectoryPermissionConfig,
+    RuntimeAgentConfig,
+    RuntimeContextWindowConfig,
+    RuntimeProviderFallbackConfig,
+    RuntimeProvidersConfig,
+    RuntimeToolsConfig,
+    parse_provider_configs_payload,
+    parse_provider_fallback_payload,
+    parse_runtime_context_window_payload,
+    parse_runtime_policy_payload,
+    parse_runtime_tools_payload,
+    serialize_provider_configs,
+    serialize_runtime_agent_config,
+    serialize_runtime_context_window_config,
+    serialize_runtime_tools_config,
+)
+from .contracts import RuntimeRequestError
+from .permission import (
+    ExternalDirectoryPolicy,
+    PatternPermissionRule,
+    PermissionDecision,
+)
+from .permission_policy import permission_decision_or_none
+from .policy import serialize_runtime_policy_config
+
+PERSISTED_RUNTIME_CONFIG_KEYS = frozenset(
+    {
+        "approval_mode",
+        "permission",
+        "policy",
+        "execution_engine",
+        "max_steps",
+        "tool_timeout_seconds",
+        "reasoning_effort",
+        "model",
+        "fallback_models",
+        "providers",
+        "resolved_provider",
+        "resolved_hook_presets",
+        "tools",
+        "agent",
+        "agents",
+        "categories",
+        "context_window",
+        "lsp",
+        "mcp",
+        "workflow",
+    }
+)
+
+WORKFLOW_PRESET_REQUEST_ERROR = (
+    "request metadata 'workflow_preset' is no longer supported; use explicit "
+    "workflow_mode or runtime-owned workflow metadata"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class EffectiveRuntimeConfig:
+    approval_mode: PermissionDecision
+    permission: ExternalDirectoryPermissionConfig
+    model: str | None
+    execution_engine: ExecutionEngineName
+    max_steps: int | None
+    tool_timeout_seconds: int | None = None
+    reasoning_effort: str | None = None
+    provider_fallback: RuntimeProviderFallbackConfig | None = None
+    providers: RuntimeProvidersConfig | None = None
+    resolved_provider: ResolvedProviderConfig = field(default_factory=ResolvedProviderConfig)
+    agent: RuntimeAgentConfig | None = None
+    context_window: RuntimeContextWindowConfig | None = None
+    tools: RuntimeToolsConfig | None = None
+    policy: object | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PersistedRuntimeConfigMaterialization:
+    approval_mode: PermissionDecision
+    permission: ExternalDirectoryPermissionConfig
+    policy: object | None
+    model: str | None
+    execution_engine: ExecutionEngineName
+    max_steps: int | None
+    tool_timeout_seconds: int | None
+    reasoning_effort: str | None
+    providers: RuntimeProvidersConfig | None
+    provider_fallback: RuntimeProviderFallbackConfig | None
+    tools: RuntimeToolsConfig | None
+    raw_agent: object | None
+    has_agent: bool
+    context_window: RuntimeContextWindowConfig | None
+    raw_resolved_provider: object | None
+
+
+def reject_legacy_workflow_preset_request(metadata: Mapping[str, object]) -> None:
+    if metadata.get("workflow_preset") is not None:
+        raise RuntimeRequestError(WORKFLOW_PRESET_REQUEST_ERROR)
+
+
+def serialize_runtime_config_core(config: EffectiveRuntimeConfig) -> dict[str, object]:
+    runtime_config_metadata: dict[str, object] = {
+        "approval_mode": config.approval_mode,
+        "permission": serialize_external_permission_config(config.permission),
+        "execution_engine": config.execution_engine,
+        "max_steps": config.max_steps,
+        "tool_timeout_seconds": config.tool_timeout_seconds,
+        "fallback_models": (
+            list(config.provider_fallback.fallback_models)
+            if config.provider_fallback is not None
+            else []
+        ),
+    }
+    serialized_policy = serialize_runtime_policy_config(config.policy)
+    if serialized_policy is not None:
+        runtime_config_metadata["policy"] = serialized_policy
+    serialized_providers = serialize_provider_configs(config.providers)
+    serialized_runtime_providers = runtime_provider_config_metadata(serialized_providers)
+    if serialized_runtime_providers:
+        runtime_config_metadata["providers"] = serialized_runtime_providers
+    serialized_context_window = serialize_runtime_context_window_config(config.context_window)
+    if serialized_context_window is not None:
+        runtime_config_metadata["context_window"] = serialized_context_window
+    if config.model is not None:
+        runtime_config_metadata["model"] = config.model
+    if config.reasoning_effort is not None:
+        runtime_config_metadata["reasoning_effort"] = config.reasoning_effort
+    serialized_tools = serialize_runtime_tools_config(config.tools)
+    if serialized_tools is not None:
+        runtime_config_metadata["tools"] = serialized_tools
+    serialized_agent = serialize_runtime_agent_config(config.agent)
+    if serialized_agent is not None:
+        runtime_config_metadata["agent"] = serialized_agent
+    return runtime_config_metadata
+
+
+def parse_persisted_runtime_config(
+    runtime_config: Mapping[str, object],
+    *,
+    default_approval_mode: PermissionDecision,
+    default_permission: ExternalDirectoryPermissionConfig,
+    default_policy: object | None,
+    default_model: str | None,
+    default_execution_engine: ExecutionEngineName,
+    default_max_steps: int | None,
+    default_tool_timeout_seconds: int | None,
+    default_reasoning_effort: str | None,
+    default_providers: RuntimeProvidersConfig | None,
+    default_tools: RuntimeToolsConfig | None,
+    default_context_window: RuntimeContextWindowConfig | None,
+) -> PersistedRuntimeConfigMaterialization:
+    unknown_runtime_config_keys = sorted(
+        key for key in runtime_config if key not in PERSISTED_RUNTIME_CONFIG_KEYS
+    )
+    if unknown_runtime_config_keys:
+        raise ValueError(
+            f"persisted runtime_config field '{unknown_runtime_config_keys[0]}' is not supported"
+        )
+
+    approval_mode = default_approval_mode
+    parsed_approval_mode = permission_decision_or_none(runtime_config.get("approval_mode"))
+    if parsed_approval_mode is not None:
+        approval_mode = parsed_approval_mode
+
+    permission = default_permission
+    if "permission" in runtime_config:
+        permission = parse_persisted_external_permission_config(runtime_config.get("permission"))
+
+    policy = default_policy
+    if "policy" in runtime_config:
+        policy = parse_runtime_policy_payload(
+            runtime_config.get("policy"),
+            source="persisted runtime_config.policy",
+        )
+
+    model = default_model
+    persisted_model = runtime_config.get("model")
+    if persisted_model is None or isinstance(persisted_model, str):
+        model = persisted_model
+
+    max_steps = default_max_steps
+    if "max_steps" in runtime_config:
+        persisted_max_steps = runtime_config.get("max_steps")
+        if persisted_max_steps is None:
+            max_steps = None
+        elif isinstance(persisted_max_steps, int) and not isinstance(persisted_max_steps, bool):
+            if persisted_max_steps < 0:
+                raise ValueError(
+                    "persisted runtime_config max_steps must be a non-negative integer "
+                    "(0 = unlimited)"
+                )
+            max_steps = persisted_max_steps
+
+    tool_timeout_seconds = default_tool_timeout_seconds
+    if "tool_timeout_seconds" in runtime_config:
+        persisted_tool_timeout = runtime_config.get("tool_timeout_seconds")
+        if persisted_tool_timeout is None:
+            tool_timeout_seconds = None
+        elif isinstance(persisted_tool_timeout, int) and not isinstance(
+            persisted_tool_timeout, bool
+        ):
+            if persisted_tool_timeout < 1:
+                raise ValueError("persisted runtime_config tool_timeout_seconds must be at least 1")
+            tool_timeout_seconds = persisted_tool_timeout
+
+    reasoning_effort = default_reasoning_effort
+    if "reasoning_effort" in runtime_config:
+        persisted_reasoning_effort = runtime_config.get("reasoning_effort")
+        if persisted_reasoning_effort is None:
+            reasoning_effort = None
+        elif isinstance(persisted_reasoning_effort, str) and persisted_reasoning_effort:
+            reasoning_effort = persisted_reasoning_effort
+        else:
+            raise ValueError("persisted runtime_config reasoning_effort must be a non-empty string")
+
+    providers = default_providers
+    if "providers" in runtime_config:
+        try:
+            providers = parse_provider_configs_payload(
+                runtime_config.get("providers"),
+                source="persisted runtime_config.providers",
+            )
+        except ValueError as exc:
+            raise ValueError(
+                format_invalid_provider_config_error(
+                    "persisted runtime_config.providers",
+                    str(exc),
+                )
+            ) from exc
+
+    provider_fallback = parse_persisted_provider_fallback(runtime_config, model=model)
+
+    tools = default_tools
+    if "tools" in runtime_config:
+        tools = parse_persisted_runtime_tools_config(runtime_config.get("tools"))
+
+    context_window = default_context_window
+    if "context_window" in runtime_config:
+        try:
+            context_window = parse_runtime_context_window_payload(
+                runtime_config.get("context_window"),
+                source="persisted runtime_config.context_window",
+            )
+        except ValueError as exc:
+            raise ValueError(
+                format_invalid_provider_config_error(
+                    "persisted runtime_config.context_window",
+                    str(exc),
+                )
+            ) from exc
+
+    persisted_execution_engine = execution_engine_or_none(runtime_config.get("execution_engine"))
+    execution_engine = persisted_execution_engine or default_execution_engine
+
+    return PersistedRuntimeConfigMaterialization(
+        approval_mode=approval_mode,
+        permission=permission,
+        policy=policy,
+        model=model,
+        execution_engine=execution_engine,
+        max_steps=max_steps,
+        tool_timeout_seconds=tool_timeout_seconds,
+        reasoning_effort=reasoning_effort,
+        providers=providers,
+        provider_fallback=provider_fallback,
+        tools=tools,
+        raw_agent=runtime_config.get("agent"),
+        has_agent="agent" in runtime_config,
+        context_window=context_window,
+        raw_resolved_provider=runtime_config.get("resolved_provider"),
+    )
+
+
+def parse_persisted_provider_fallback(
+    runtime_config: Mapping[str, object],
+    *,
+    model: str | None,
+) -> RuntimeProviderFallbackConfig | None:
+    if "fallback_models" not in runtime_config:
+        return None
+    raw_fallback_models = runtime_config.get("fallback_models")
+    if raw_fallback_models in (None, []):
+        return None
+    if model is None:
+        raise ValueError(
+            "persisted runtime_config.model is required when fallback_models are present"
+        )
+    try:
+        return parse_provider_fallback_payload(
+            {
+                "preferred_model": model,
+                "fallback_models": raw_fallback_models,
+            },
+            source="persisted runtime_config.fallback_models",
+        )
+    except ValueError as exc:
+        raise ValueError(
+            format_invalid_provider_config_error(
+                "persisted runtime_config.fallback_models",
+                str(exc),
+            )
+        ) from exc
+
+
+def apply_request_runtime_config_overrides(
+    resolved: EffectiveRuntimeConfig,
+    *,
+    max_steps: int | None,
+    reasoning_effort: object,
+    context_transform_refs: tuple[str, ...] | None,
+) -> EffectiveRuntimeConfig:
+    if max_steps is not None:
+        resolved = EffectiveRuntimeConfig(
+            approval_mode=resolved.approval_mode,
+            permission=resolved.permission,
+            model=resolved.model,
+            execution_engine=resolved.execution_engine,
+            max_steps=max_steps,
+            tool_timeout_seconds=resolved.tool_timeout_seconds,
+            reasoning_effort=resolved.reasoning_effort,
+            provider_fallback=resolved.provider_fallback,
+            providers=resolved.providers,
+            resolved_provider=resolved.resolved_provider,
+            agent=resolved.agent,
+            context_window=resolved.context_window,
+            tools=resolved.tools,
+            policy=resolved.policy,
+        )
+    if isinstance(reasoning_effort, str) and reasoning_effort:
+        resolved = EffectiveRuntimeConfig(
+            approval_mode=resolved.approval_mode,
+            permission=resolved.permission,
+            model=resolved.model,
+            execution_engine=resolved.execution_engine,
+            max_steps=resolved.max_steps,
+            tool_timeout_seconds=resolved.tool_timeout_seconds,
+            reasoning_effort=reasoning_effort,
+            provider_fallback=resolved.provider_fallback,
+            providers=resolved.providers,
+            resolved_provider=resolved.resolved_provider,
+            agent=resolved.agent,
+            context_window=resolved.context_window,
+            tools=resolved.tools,
+            policy=resolved.policy,
+        )
+    if context_transform_refs is not None:
+        resolved = EffectiveRuntimeConfig(
+            approval_mode=resolved.approval_mode,
+            permission=resolved.permission,
+            model=resolved.model,
+            execution_engine=resolved.execution_engine,
+            max_steps=resolved.max_steps,
+            tool_timeout_seconds=resolved.tool_timeout_seconds,
+            reasoning_effort=resolved.reasoning_effort,
+            provider_fallback=resolved.provider_fallback,
+            providers=resolved.providers,
+            resolved_provider=resolved.resolved_provider,
+            agent=(
+                RuntimeAgentConfig(
+                    preset=resolved.agent.preset,
+                    prompt_profile=resolved.agent.prompt_profile,
+                    prompt=resolved.agent.prompt,
+                    prompt_append=resolved.agent.prompt_append,
+                    prompt_ref=resolved.agent.prompt_ref,
+                    prompt_source=resolved.agent.prompt_source,
+                    prompt_materialization=resolved.agent.prompt_materialization,
+                    manifest_source_scope=resolved.agent.manifest_source_scope,
+                    manifest_source_path=resolved.agent.manifest_source_path,
+                    manifest_tool_allowlist=resolved.agent.manifest_tool_allowlist,
+                    manifest_skill_refs=resolved.agent.manifest_skill_refs,
+                    manifest_hook_refs=resolved.agent.manifest_hook_refs,
+                    hook_refs=resolved.agent.hook_refs,
+                    context_transform_refs=context_transform_refs,
+                    model=resolved.agent.model,
+                    execution_engine=resolved.agent.execution_engine,
+                    tools=resolved.agent.tools,
+                    skills=resolved.agent.skills,
+                    mcp_binding=resolved.agent.mcp_binding,
+                    provider_fallback=resolved.agent.provider_fallback,
+                )
+                if resolved.agent is not None
+                else None
+            ),
+            context_window=resolved.context_window,
+            tools=resolved.tools,
+            policy=resolved.policy,
+        )
+    return resolved
+
+
+def serialize_external_permission_config(
+    permission: ExternalDirectoryPermissionConfig,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "external_directory_read": dict(permission.read.rules),
+        "external_directory_write": dict(permission.write.rules),
+    }
+    if permission.rules:
+        payload["rules"] = [
+            {
+                key: value
+                for key, value in {
+                    "tool": rule.tool,
+                    "path": rule.path,
+                    "command": rule.command,
+                    "decision": rule.decision,
+                }.items()
+                if value is not None
+            }
+            for rule in permission.rules
+        ]
+    return payload
+
+
+def parse_persisted_external_permission_config(
+    raw_permission: object,
+) -> ExternalDirectoryPermissionConfig:
+    if not isinstance(raw_permission, dict):
+        raise ValueError("persisted runtime_config permission must be an object")
+    payload = cast(dict[object, object], raw_permission)
+    allowed_keys = {"external_directory_read", "external_directory_write", "rules"}
+    unknown_keys = sorted(str(key) for key in payload if key not in allowed_keys)
+    if unknown_keys:
+        raise ValueError(
+            f"persisted runtime_config permission field '{unknown_keys[0]}' is not supported"
+        )
+    return ExternalDirectoryPermissionConfig(
+        read=ExternalDirectoryPolicy(
+            rules=parse_persisted_external_permission_rules(
+                payload.get("external_directory_read"),
+                field_path="permission.external_directory_read",
+                default=(("*", "allow"),),
+            )
+        ),
+        write=ExternalDirectoryPolicy(
+            rules=parse_persisted_external_permission_rules(
+                payload.get("external_directory_write"),
+                field_path="permission.external_directory_write",
+                default=(("*", "allow"),),
+            )
+        ),
+        rules=parse_persisted_pattern_permission_rules(payload.get("rules")),
+    )
+
+
+def parse_persisted_runtime_tools_config(raw_value: object) -> RuntimeToolsConfig | None:
+    try:
+        return parse_runtime_tools_payload(raw_value, source="persisted runtime_config.tools")
+    except ValueError as exc:
+        raise ValueError(
+            format_invalid_provider_config_error("persisted runtime_config.tools", str(exc))
+        ) from exc
+
+
+def parse_persisted_external_permission_rules(
+    raw_rules: object,
+    *,
+    field_path: str,
+    default: tuple[tuple[str, PermissionDecision], ...],
+) -> tuple[tuple[str, PermissionDecision], ...]:
+    if raw_rules is None:
+        return default
+    if not isinstance(raw_rules, dict):
+        raise ValueError(f"persisted runtime_config {field_path} must be an object")
+    parsed: list[tuple[str, PermissionDecision]] = []
+    for raw_pattern, raw_decision in cast(dict[object, object], raw_rules).items():
+        if not isinstance(raw_pattern, str) or not raw_pattern.strip():
+            raise ValueError(f"persisted runtime_config {field_path} keys must be strings")
+        decision = permission_decision_or_none(raw_decision)
+        if decision is None:
+            raise ValueError(
+                f"persisted runtime_config {field_path}.{raw_pattern} must be allow, deny, or ask"
+            )
+        parsed.append((raw_pattern, decision))
+    return tuple(parsed) if parsed else default
+
+
+def parse_persisted_pattern_permission_rules(
+    raw_rules: object,
+) -> tuple[PatternPermissionRule, ...]:
+    if raw_rules is None:
+        return ()
+    if not isinstance(raw_rules, list):
+        raise ValueError("persisted runtime_config permission.rules must be an array")
+    parsed: list[PatternPermissionRule] = []
+    allowed_keys = {"tool", "path", "command", "decision"}
+    for index, raw_rule in enumerate(raw_rules):
+        field_path = f"permission.rules[{index}]"
+        if not isinstance(raw_rule, dict):
+            raise ValueError(f"persisted runtime_config {field_path} must be an object")
+        payload = cast(dict[object, object], raw_rule)
+        unknown_keys = sorted(str(key) for key in payload if key not in allowed_keys)
+        if unknown_keys:
+            raise ValueError(
+                f"persisted runtime_config {field_path}.{unknown_keys[0]} is not supported"
+            )
+        raw_tool = payload.get("tool", "*")
+        if not isinstance(raw_tool, str) or not raw_tool.strip():
+            raise ValueError(f"persisted runtime_config {field_path}.tool must be a string")
+        raw_path = payload.get("path")
+        if raw_path is not None and (not isinstance(raw_path, str) or not raw_path.strip()):
+            raise ValueError(f"persisted runtime_config {field_path}.path must be a string")
+        raw_command = payload.get("command")
+        if raw_command is not None and (
+            not isinstance(raw_command, str) or not raw_command.strip()
+        ):
+            raise ValueError(f"persisted runtime_config {field_path}.command must be a string")
+        decision = permission_decision_or_none(payload.get("decision"))
+        if decision is None:
+            raise ValueError(
+                f"persisted runtime_config {field_path}.decision must be allow, deny, or ask"
+            )
+        parsed.append(
+            PatternPermissionRule(
+                tool=raw_tool,
+                path=raw_path,
+                command=raw_command,
+                decision=decision,
+            )
+        )
+    return tuple(parsed)
+
+
+def runtime_provider_config_metadata(
+    serialized_providers: dict[str, object] | None,
+) -> dict[str, object] | None:
+    if not serialized_providers:
+        return None
+    retained: dict[str, object] = {}
+    for provider_name, raw_provider in serialized_providers.items():
+        if provider_name == "custom":
+            if not isinstance(raw_provider, dict):
+                continue
+            retained_custom: dict[str, object] = {}
+            for custom_name, raw_custom_provider in cast(dict[str, object], raw_provider).items():
+                if not isinstance(raw_custom_provider, dict):
+                    continue
+                custom_provider_payload = cast(dict[str, object], raw_custom_provider)
+                if "transient_retry" in custom_provider_payload:
+                    retained_custom[custom_name] = {
+                        "transient_retry": custom_provider_payload["transient_retry"]
+                    }
+            if retained_custom:
+                retained[provider_name] = retained_custom
+            continue
+        if not isinstance(raw_provider, dict):
+            continue
+        provider_payload = cast(dict[str, object], raw_provider)
+        if "transient_retry" in provider_payload:
+            retained[provider_name] = {"transient_retry": provider_payload["transient_retry"]}
+    return retained or None
+
+
+def execution_engine_or_none(value: object) -> ExecutionEngineName | None:
+    if value == "deterministic":
+        return "deterministic"
+    if value == "provider":
+        return "provider"
+    return None

--- a/src/voidcode/runtime/config_materializer.py
+++ b/src/voidcode/runtime/config_materializer.py
@@ -24,7 +24,6 @@ from .config import (
     serialize_runtime_context_window_config,
     serialize_runtime_tools_config,
 )
-from .contracts import RuntimeRequestError
 from .permission import (
     ExternalDirectoryPolicy,
     PatternPermissionRule,
@@ -56,11 +55,6 @@ PERSISTED_RUNTIME_CONFIG_KEYS = frozenset(
         "mcp",
         "workflow",
     }
-)
-
-WORKFLOW_PRESET_REQUEST_ERROR = (
-    "request metadata 'workflow_preset' is no longer supported; use explicit "
-    "workflow_mode or runtime-owned workflow metadata"
 )
 
 
@@ -101,11 +95,6 @@ class PersistedRuntimeConfigMaterialization:
     raw_resolved_provider: object | None
 
 
-def reject_legacy_workflow_preset_request(metadata: Mapping[str, object]) -> None:
-    if metadata.get("workflow_preset") is not None:
-        raise RuntimeRequestError(WORKFLOW_PRESET_REQUEST_ERROR)
-
-
 def serialize_runtime_config_core(config: EffectiveRuntimeConfig) -> dict[str, object]:
     runtime_config_metadata: dict[str, object] = {
         "approval_mode": config.approval_mode,
@@ -115,7 +104,7 @@ def serialize_runtime_config_core(config: EffectiveRuntimeConfig) -> dict[str, o
         "tool_timeout_seconds": config.tool_timeout_seconds,
         "fallback_models": (
             list(config.provider_fallback.fallback_models)
-            if config.provider_fallback is not None
+            if config.provider_fallback is not None and config.model is not None
             else []
         ),
     }

--- a/src/voidcode/runtime/execution_seams.py
+++ b/src/voidcode/runtime/execution_seams.py
@@ -17,8 +17,8 @@ from .config import (
 )
 
 if TYPE_CHECKING:
+    from .config_materializer import EffectiveRuntimeConfig
     from .contracts import RuntimeRequest
-    from .service import EffectiveRuntimeConfig
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/voidcode/runtime/provider_fallback.py
+++ b/src/voidcode/runtime/provider_fallback.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Literal
+
+from ..provider.config import ProviderTransientRetryConfig
+from ..provider.errors import ProviderExecutionError
+
+PROVIDER_TRANSIENT_RETRYABLE_KINDS = frozenset({"rate_limit", "transient_failure"})
+PROVIDER_FALLBACK_ELIGIBLE_KINDS = frozenset(
+    {
+        "missing_auth",
+        "rate_limit",
+        "invalid_model",
+        "transient_failure",
+        "unsupported_feature",
+        "stream_tool_feedback_shape",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderTransientRetryDecision:
+    reason: str
+    provider: str
+    model: str
+    retry_attempt: int
+    max_retries: int
+    delay_ms: int
+    provider_error_details: dict[str, object] | None
+
+    def event_payload(self) -> dict[str, object]:
+        return {
+            "reason": self.reason,
+            "provider": self.provider,
+            "model": self.model,
+            "retry_attempt": self.retry_attempt,
+            "max_retries": self.max_retries,
+            "delay_ms": self.delay_ms,
+            **(
+                {"provider_error_details": self.provider_error_details}
+                if self.provider_error_details is not None
+                else {}
+            ),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderFallbackDecision:
+    reason: str
+    from_provider: str
+    from_model: str
+    to_provider: str
+    to_model: str
+    attempt: int
+    provider_error_details: dict[str, object] | None
+
+    def event_payload(self) -> dict[str, object]:
+        return {
+            "reason": self.reason,
+            "from_provider": self.from_provider,
+            "from_model": self.from_model,
+            "to_provider": self.to_provider,
+            "to_model": self.to_model,
+            "attempt": self.attempt,
+            **(
+                {"provider_error_details": self.provider_error_details}
+                if self.provider_error_details is not None
+                else {}
+            ),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderTerminalDecision:
+    kind: Literal[
+        "cancelled",
+        "background_rate_limit_retry",
+        "fallback_exhausted",
+        "provider_error",
+    ]
+    payload: dict[str, object]
+
+
+type ProviderFallbackPolicyDecision = (
+    ProviderTransientRetryDecision | ProviderFallbackDecision | ProviderTerminalDecision
+)
+
+
+def provider_transient_retry_delay_ms(
+    *,
+    retry_attempt: int,
+    base_delay_ms: float,
+    max_delay_ms: float,
+    jitter: bool,
+) -> int:
+    capped_delay = min(base_delay_ms * (2 ** max(retry_attempt - 1, 0)), max_delay_ms)
+    if jitter and capped_delay > 0:
+        capped_delay = random.uniform(0, capped_delay)
+    return max(0, int(round(capped_delay)))
+
+
+def decide_provider_error_policy(
+    *,
+    error: ProviderExecutionError,
+    current_provider_attempt: int,
+    provider_retry_attempt: int,
+    transient_retry_config: ProviderTransientRetryConfig,
+    fallback_target_provider: str | None,
+    fallback_target_model: str | None,
+    background_rate_limit_retry: bool,
+) -> ProviderFallbackPolicyDecision:
+    if error.kind == "cancelled":
+        return ProviderTerminalDecision(
+            kind="cancelled",
+            payload={
+                "provider_error_kind": error.kind,
+                "provider": error.provider_name,
+                "model": error.model_name,
+                "cancelled": True,
+            },
+        )
+    if error.kind == "rate_limit" and background_rate_limit_retry:
+        return ProviderTerminalDecision(
+            kind="background_rate_limit_retry",
+            payload={
+                "provider_error_kind": error.kind,
+                "provider": error.provider_name,
+                "model": error.model_name,
+                "background_retry_deferred_fallback": True,
+                **({"provider_error_details": error.details} if error.details is not None else {}),
+            },
+        )
+    if (
+        error.kind in PROVIDER_TRANSIENT_RETRYABLE_KINDS
+        and provider_retry_attempt < transient_retry_config.max_retries
+    ):
+        retry_attempt = provider_retry_attempt + 1
+        return ProviderTransientRetryDecision(
+            reason=error.kind,
+            provider=error.provider_name,
+            model=error.model_name,
+            retry_attempt=retry_attempt,
+            max_retries=transient_retry_config.max_retries,
+            delay_ms=provider_transient_retry_delay_ms(
+                retry_attempt=retry_attempt,
+                base_delay_ms=transient_retry_config.base_delay_ms,
+                max_delay_ms=transient_retry_config.max_delay_ms,
+                jitter=transient_retry_config.jitter,
+            ),
+            provider_error_details=error.details,
+        )
+    if (
+        error.kind in PROVIDER_FALLBACK_ELIGIBLE_KINDS
+        and fallback_target_provider is not None
+        and fallback_target_model is not None
+    ):
+        return ProviderFallbackDecision(
+            reason=error.kind,
+            from_provider=error.provider_name,
+            from_model=error.model_name,
+            to_provider=fallback_target_provider,
+            to_model=fallback_target_model,
+            attempt=current_provider_attempt + 1,
+            provider_error_details=error.details,
+        )
+    if error.kind in PROVIDER_FALLBACK_ELIGIBLE_KINDS:
+        return ProviderTerminalDecision(
+            kind="fallback_exhausted",
+            payload={
+                "provider_error_kind": error.kind,
+                "provider": error.provider_name,
+                "model": error.model_name,
+                "fallback_exhausted": True,
+                **(
+                    {
+                        "provider_retry_exhausted": True,
+                        "provider_retry_attempts": provider_retry_attempt,
+                    }
+                    if error.kind in PROVIDER_TRANSIENT_RETRYABLE_KINDS
+                    else {}
+                ),
+                **({"provider_error_details": error.details} if error.details is not None else {}),
+            },
+        )
+    return ProviderTerminalDecision(
+        kind="provider_error",
+        payload={
+            "provider_error_kind": error.kind,
+            "provider": error.provider_name,
+            "model": error.model_name,
+            **({"provider_error_details": error.details} if error.details is not None else {}),
+        },
+    )
+
+
+__all__ = [
+    "PROVIDER_FALLBACK_ELIGIBLE_KINDS",
+    "PROVIDER_TRANSIENT_RETRYABLE_KINDS",
+    "ProviderFallbackDecision",
+    "ProviderFallbackPolicyDecision",
+    "ProviderTerminalDecision",
+    "ProviderTransientRetryDecision",
+    "decide_provider_error_policy",
+    "provider_transient_retry_delay_ms",
+]

--- a/src/voidcode/runtime/run_loop.py
+++ b/src/voidcode/runtime/run_loop.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import logging
 import queue
-import random
 import threading
 import time
 from collections.abc import Generator, Iterator, Mapping
@@ -62,6 +61,13 @@ from .events import (
 )
 from .execution_seams import RuntimeGraphSelection
 from .permission import PendingApproval, PermissionPolicy, PermissionResolution
+from .provider_fallback import (
+    PROVIDER_TRANSIENT_RETRYABLE_KINDS,
+    ProviderFallbackDecision,
+    ProviderTerminalDecision,
+    ProviderTransientRetryDecision,
+    decide_provider_error_policy,
+)
 from .question import PendingQuestion
 from .session import SessionState
 from .session_metadata_helpers import todo_state_matches_payload
@@ -76,22 +82,8 @@ logger = logging.getLogger(__name__)
 
 _TOOL_PROGRESS_QUEUE_MAX_ITEMS = 128
 _TOOL_PROGRESS_POLL_SECONDS = 0.05
-_PROVIDER_TRANSIENT_RETRYABLE_KINDS = frozenset({"rate_limit", "transient_failure"})
 _STUCK_DETECTED_MIN_TURN = 25
 _STUCK_DETECTED_MIN_TOOL_RESULTS = 10
-
-
-def _provider_transient_retry_delay_ms(
-    *,
-    retry_attempt: int,
-    base_delay_ms: float,
-    max_delay_ms: float,
-    jitter: bool,
-) -> int:
-    capped_delay = min(base_delay_ms * (2 ** max(retry_attempt - 1, 0)), max_delay_ms)
-    if jitter and capped_delay > 0:
-        capped_delay = random.uniform(0, capped_delay)
-    return max(0, int(round(capped_delay)))
 
 
 def _tool_error_content(tool_name: str, error: str) -> str:
@@ -1568,62 +1560,59 @@ class RuntimeRunLoopCoordinator:
                 )
                 provider_error = exc if isinstance(exc, ProviderExecutionError) else None
                 if provider_error is not None:
-                    if provider_error.kind == "cancelled":
-                        yield runtime._failed_chunk(
-                            session=session,
-                            sequence=sequence + 1,
-                            error=str(provider_error),
-                            payload={
-                                "provider_error_kind": provider_error.kind,
-                                "provider": provider_error.provider_name,
-                                "model": provider_error.model_name,
-                                "cancelled": True,
-                            },
-                        )
-                        return
-                    if (
-                        provider_error.kind == "rate_limit"
-                        and active_graph_request.metadata.get("background_rate_limit_retry") is True
-                    ):
-                        yield runtime._failed_chunk(
-                            session=session,
-                            sequence=sequence + 1,
-                            error=str(provider_error),
-                            payload={
-                                "provider_error_kind": provider_error.kind,
-                                "provider": provider_error.provider_name,
-                                "model": provider_error.model_name,
-                                "background_retry_deferred_fallback": True,
-                                **(
-                                    {"provider_error_details": provider_error.details}
-                                    if provider_error.details is not None
-                                    else {}
-                                ),
-                            },
-                        )
-                        return
                     fallback_selection = runtime._fallback_graph_selection(
                         error=provider_error,
                         session_metadata=session.metadata,
                         provider_attempt=current_provider_attempt,
                     )
-                    next_attempt = current_provider_attempt + 1
                     transient_retry_config = runtime._provider_transient_retry_config(
                         provider_name=provider_error.provider_name,
                         session_metadata=session.metadata,
                     )
-                    current_provider_retry_attempt: int = int(provider_retry_attempt)
-                    if (
-                        provider_error.kind in _PROVIDER_TRANSIENT_RETRYABLE_KINDS
-                        and current_provider_retry_attempt < transient_retry_config.max_retries
+                    fallback_target = (
+                        fallback_selection.provider_target
+                        if fallback_selection is not None
+                        else None
+                    )
+                    provider_decision = decide_provider_error_policy(
+                        error=provider_error,
+                        current_provider_attempt=current_provider_attempt,
+                        provider_retry_attempt=int(provider_retry_attempt),
+                        transient_retry_config=transient_retry_config,
+                        fallback_target_provider=(
+                            fallback_target.selection.provider
+                            if fallback_target is not None
+                            else None
+                        ),
+                        fallback_target_model=(
+                            fallback_target.selection.model if fallback_target is not None else None
+                        ),
+                        background_rate_limit_retry=(
+                            active_graph_request.metadata.get("background_rate_limit_retry") is True
+                        ),
+                    )
+                    if isinstance(provider_decision, ProviderTerminalDecision) and (
+                        provider_decision.kind == "cancelled"
                     ):
-                        retry_attempt: int = current_provider_retry_attempt + 1
-                        delay_ms = _provider_transient_retry_delay_ms(
-                            retry_attempt=retry_attempt,
-                            base_delay_ms=transient_retry_config.base_delay_ms,
-                            max_delay_ms=transient_retry_config.max_delay_ms,
-                            jitter=transient_retry_config.jitter,
+                        yield runtime._failed_chunk(
+                            session=session,
+                            sequence=sequence + 1,
+                            error=str(provider_error),
+                            payload=provider_decision.payload,
                         )
+                        return
+                    if isinstance(provider_decision, ProviderTerminalDecision) and (
+                        provider_decision.kind == "background_rate_limit_retry"
+                    ):
+                        yield runtime._failed_chunk(
+                            session=session,
+                            sequence=sequence + 1,
+                            error=str(provider_error),
+                            payload=provider_decision.payload,
+                        )
+                        return
+                    if isinstance(provider_decision, ProviderTransientRetryDecision):
+                        delay_ms = provider_decision.delay_ms
                         logger.info(
                             (
                                 "provider transient retry for session %s: %s/%s "
@@ -1633,8 +1622,8 @@ class RuntimeRunLoopCoordinator:
                             provider_error.provider_name,
                             provider_error.model_name,
                             provider_error.kind,
-                            retry_attempt,
-                            transient_retry_config.max_retries,
+                            provider_decision.retry_attempt,
+                            provider_decision.max_retries,
                             delay_ms,
                         )
                         sequence += 1
@@ -1646,24 +1635,12 @@ class RuntimeRunLoopCoordinator:
                                 sequence=sequence,
                                 event_type=RUNTIME_PROVIDER_TRANSIENT_RETRY,
                                 source="runtime",
-                                payload={
-                                    "reason": provider_error.kind,
-                                    "provider": provider_error.provider_name,
-                                    "model": provider_error.model_name,
-                                    "retry_attempt": retry_attempt,
-                                    "max_retries": transient_retry_config.max_retries,
-                                    "delay_ms": delay_ms,
-                                    **(
-                                        {"provider_error_details": provider_error.details}
-                                        if provider_error.details is not None
-                                        else {}
-                                    ),
-                                },
+                                payload=provider_decision.event_payload(),
                             ),
                         )
                         if delay_ms > 0:
                             time.sleep(delay_ms / 1000.0)
-                        provider_retry_attempt = int(retry_attempt)
+                        provider_retry_attempt = int(provider_decision.retry_attempt)
                         retry_metadata: dict[str, object] = {
                             **current_metadata,
                             "provider_attempt": current_provider_attempt,
@@ -1689,7 +1666,8 @@ class RuntimeRunLoopCoordinator:
                             abort_signal=current_abort_signal,
                         )
                         continue
-                    if fallback_selection is not None:
+                    if isinstance(provider_decision, ProviderFallbackDecision):
+                        assert fallback_selection is not None
                         next_target = fallback_selection.provider_target
                         logger.info(
                             (
@@ -1702,7 +1680,7 @@ class RuntimeRunLoopCoordinator:
                             next_target.selection.provider,
                             next_target.selection.model,
                             provider_error.kind,
-                            next_attempt,
+                            provider_decision.attempt,
                         )
                         sequence += 1
                         yield RuntimeStreamChunk(
@@ -1713,19 +1691,7 @@ class RuntimeRunLoopCoordinator:
                                 sequence=sequence,
                                 event_type="runtime.provider_fallback",
                                 source="runtime",
-                                payload={
-                                    "reason": provider_error.kind,
-                                    "from_provider": provider_error.provider_name,
-                                    "from_model": provider_error.model_name,
-                                    "to_provider": next_target.selection.provider,
-                                    "to_model": next_target.selection.model,
-                                    "attempt": next_attempt,
-                                    **(
-                                        {"provider_error_details": provider_error.details}
-                                        if provider_error.details is not None
-                                        else {}
-                                    ),
-                                },
+                                payload=provider_decision.event_payload(),
                             ),
                         )
                         provider_attempt = fallback_selection.provider_attempt
@@ -1765,14 +1731,9 @@ class RuntimeRunLoopCoordinator:
                             abort_signal=fallback_abort_signal,
                         )
                         continue
-                    if provider_error.kind in {
-                        "missing_auth",
-                        "rate_limit",
-                        "invalid_model",
-                        "transient_failure",
-                        "unsupported_feature",
-                        "stream_tool_feedback_shape",
-                    }:
+                    if isinstance(provider_decision, ProviderTerminalDecision) and (
+                        provider_decision.kind == "fallback_exhausted"
+                    ):
                         yield runtime._failed_chunk(
                             session=session,
                             sequence=sequence + 1,
@@ -1782,49 +1743,23 @@ class RuntimeRunLoopCoordinator:
                                     model_name=provider_error.model_name,
                                     retry_attempts=provider_retry_attempt,
                                 )
-                                if provider_error.kind in _PROVIDER_TRANSIENT_RETRYABLE_KINDS
+                                if provider_error.kind in PROVIDER_TRANSIENT_RETRYABLE_KINDS
                                 else format_fallback_exhausted_error(
                                     provider_name=provider_error.provider_name,
                                     model_name=provider_error.model_name,
-                                    attempt=next_attempt,
+                                    attempt=current_provider_attempt + 1,
                                 )
                             ),
-                            payload={
-                                "provider_error_kind": provider_error.kind,
-                                "provider": provider_error.provider_name,
-                                "model": provider_error.model_name,
-                                "fallback_exhausted": True,
-                                **(
-                                    {
-                                        "provider_retry_exhausted": True,
-                                        "provider_retry_attempts": provider_retry_attempt,
-                                    }
-                                    if provider_error.kind in _PROVIDER_TRANSIENT_RETRYABLE_KINDS
-                                    else {}
-                                ),
-                                **(
-                                    {"provider_error_details": provider_error.details}
-                                    if provider_error.details is not None
-                                    else {}
-                                ),
-                            },
+                            payload=provider_decision.payload,
                         )
                         return
                 if provider_error is not None:
+                    assert isinstance(provider_decision, ProviderTerminalDecision)
                     yield runtime._failed_chunk(
                         session=session,
                         sequence=sequence + 1,
                         error=str(provider_error),
-                        payload={
-                            "provider_error_kind": provider_error.kind,
-                            "provider": provider_error.provider_name,
-                            "model": provider_error.model_name,
-                            **(
-                                {"provider_error_details": provider_error.details}
-                                if provider_error.details is not None
-                                else {}
-                            ),
-                        },
+                        payload=provider_decision.payload,
                     )
                     return
                 classified_error = classify_provider_error(exc)

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -942,13 +942,19 @@ class VoidCodeRuntime:
             updated_session = self._session_with_current_acp_metadata(updated_session)
         return emitted, updated_session, last_sequence or sequence
 
-    def _build_graph_for_engine_from_config(self, config: EffectiveRuntimeConfig) -> RuntimeGraph:
+    def _build_graph_for_engine_from_config(
+        self,
+        config: EffectiveRuntimeConfig,
+        *,
+        use_cache: bool = True,
+    ) -> RuntimeGraph:
         cache_key = cache_key_for_effective_config(config)
-        if cache_key in self._graph_cache:
+        if use_cache and cache_key in self._graph_cache:
             return self._graph_cache[cache_key]
 
         graph = select_graph_for_effective_config(config=config).graph
-        self._graph_cache[cache_key] = graph
+        if use_cache:
+            self._graph_cache[cache_key] = graph
         return graph
 
     @staticmethod
@@ -8757,6 +8763,8 @@ class VoidCodeRuntime:
             return self._graph_override
 
         effective_config = self._effective_runtime_config_from_metadata(metadata)
+        if isinstance((metadata or {}).get("command"), dict):
+            return self._build_graph_for_engine_from_config(effective_config, use_cache=False)
 
         # Reuse self._graph if the session's config matches the runtime's config
         if (

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import threading
 from collections.abc import Callable, Iterable, Iterator, Mapping
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, cast, final
 from uuid import uuid4
@@ -47,7 +47,7 @@ from ..provider.config import (
     DEFAULT_PROVIDER_TRANSIENT_RETRY_CONFIG,
     ProviderTransientRetryConfig,
 )
-from ..provider.errors import format_invalid_provider_config_error, guidance_for_provider_error_kind
+from ..provider.errors import guidance_for_provider_error_kind
 from ..provider.model_catalog import (
     ProviderModelCatalog,
     ToolFeedbackMode,
@@ -130,34 +130,32 @@ from .bundle import (
 from .command_effects import apply_runtime_command_effects, session_with_command_artifacts
 from .config import (
     ExecutionEngineName,
-    ExternalDirectoryPermissionConfig,
     RuntimeAgentConfig,
     RuntimeCategoryConfig,
     RuntimeConfig,
     RuntimeContextWindowConfig,
     RuntimeHooksConfig,
     RuntimeProviderFallbackConfig,
-    RuntimeProvidersConfig,
     RuntimeSkillsConfig,
-    RuntimeToolsConfig,
     RuntimeWebSettings,
     load_global_web_settings,
     load_runtime_config,
-    parse_provider_configs_payload,
-    parse_provider_fallback_payload,
     parse_runtime_agent_payload,
     parse_runtime_agents_payload,
     parse_runtime_categories_payload,
-    parse_runtime_context_window_payload,
-    parse_runtime_policy_payload,
-    parse_runtime_tools_payload,
     save_global_web_settings,
-    serialize_provider_configs,
     serialize_runtime_agent_config,
     serialize_runtime_agents_config,
     serialize_runtime_categories_config,
-    serialize_runtime_context_window_config,
-    serialize_runtime_tools_config,
+)
+from .config_materializer import (
+    PERSISTED_RUNTIME_CONFIG_KEYS,
+    EffectiveRuntimeConfig,
+    apply_request_runtime_config_overrides,
+    parse_persisted_provider_fallback,
+    parse_persisted_runtime_config,
+    reject_legacy_workflow_preset_request,
+    serialize_runtime_config_core,
 )
 from .context_transforms import (
     RuntimeContextTransformRegistry,
@@ -274,10 +272,8 @@ from .memory import MemoryConfig, MemoryKind, MemoryRecord, MemorySearchResult, 
 from .paths import provider_catalog_cache_path
 from .permission import (
     DelegationGovernance,
-    ExternalDirectoryPolicy,
     OperationClass,
     PathScope,
-    PatternPermissionRule,
     PendingApproval,
     PermissionDecision,
     PermissionPolicy,
@@ -307,7 +303,6 @@ from .permission_policy import (
 from .policy import (
     PRODUCT_DELEGATION_DENIAL_REASON,
     materialize_runtime_policy_snapshot,
-    serialize_runtime_policy_config,
 )
 from .provider_context import inspect_provider_context
 from .provider_execution_metadata import (
@@ -428,30 +423,7 @@ _ACTIVE_SESSION_COMPAT_EXPORTS = (
 
 _EXECUTABLE_AGENT_PRESETS = frozenset({"leader", "product"})
 _EXECUTABLE_SUBAGENT_PRESETS = frozenset({"advisor", "explore", "researcher", "worker"})
-_PERSISTED_RUNTIME_CONFIG_KEYS = frozenset(
-    {
-        "approval_mode",
-        "permission",
-        "policy",
-        "execution_engine",
-        "max_steps",
-        "tool_timeout_seconds",
-        "reasoning_effort",
-        "model",
-        "fallback_models",
-        "providers",
-        "resolved_provider",
-        "resolved_hook_presets",
-        "tools",
-        "agent",
-        "agents",
-        "categories",
-        "context_window",
-        "lsp",
-        "mcp",
-        "workflow",
-    }
-)
+_PERSISTED_RUNTIME_CONFIG_KEYS = PERSISTED_RUNTIME_CONFIG_KEYS
 
 
 def _permission_decision_or_none(value: object) -> PermissionDecision | None:
@@ -1053,14 +1025,8 @@ class VoidCodeRuntime:
 
     def _runtime_config_for_request(self, request: RuntimeRequest) -> EffectiveRuntimeConfig:
         resolved = self._effective_runtime_config_from_metadata(None)
+        reject_legacy_workflow_preset_request(request.metadata)
         _ = self._workflow_mode_resolution_for_request_metadata(request.metadata)
-        workflow_preset = request.metadata.get("workflow_preset")
-        if workflow_preset is not None:
-            assert isinstance(workflow_preset, str)
-            try:
-                resolved = self._config_with_workflow_preset(resolved, workflow_preset)
-            except ValueError as exc:
-                raise RuntimeRequestError(str(exc)) from exc
         request_agent = request.metadata.get("agent")
         if request_agent is not None:
             try:
@@ -1071,123 +1037,27 @@ class VoidCodeRuntime:
                 )
             except ValueError as exc:
                 raise RuntimeRequestError(str(exc)) from exc
-        request_max_steps = request.metadata.get("max_steps")
-        request_reasoning_effort = request.metadata.get("reasoning_effort")
-        if request_max_steps is not None:
-            assert isinstance(request_max_steps, int)
-            resolved = EffectiveRuntimeConfig(
-                approval_mode=resolved.approval_mode,
-                permission=resolved.permission,
-                model=resolved.model,
-                execution_engine=resolved.execution_engine,
-                max_steps=request_max_steps,
-                tool_timeout_seconds=resolved.tool_timeout_seconds,
-                reasoning_effort=resolved.reasoning_effort,
-                provider_fallback=resolved.provider_fallback,
-                providers=resolved.providers,
-                resolved_provider=resolved.resolved_provider,
-                agent=resolved.agent,
-                context_window=resolved.context_window,
-                tools=resolved.tools,
-                policy=resolved.policy,
-            )
-        if isinstance(request_reasoning_effort, str) and request_reasoning_effort:
-            resolved = EffectiveRuntimeConfig(
-                approval_mode=resolved.approval_mode,
-                permission=resolved.permission,
-                model=resolved.model,
-                execution_engine=resolved.execution_engine,
-                max_steps=resolved.max_steps,
-                tool_timeout_seconds=resolved.tool_timeout_seconds,
-                reasoning_effort=request_reasoning_effort,
-                provider_fallback=resolved.provider_fallback,
-                providers=resolved.providers,
-                resolved_provider=resolved.resolved_provider,
-                agent=resolved.agent,
-                context_window=resolved.context_window,
-                tools=resolved.tools,
-                policy=resolved.policy,
-            )
         request_context_transform_refs = request.metadata.get("context_transform_refs")
+        context_transform_refs: tuple[str, ...] | None = None
         if request_context_transform_refs is not None:
             assert isinstance(request_context_transform_refs, list)
-            refs = tuple(cast(list[str], request_context_transform_refs))
+            context_transform_refs = tuple(cast(list[str], request_context_transform_refs))
             validate_runtime_context_transform_refs(
-                refs,
+                context_transform_refs,
                 field_path="request metadata 'context_transform_refs'",
                 registry=self._context_transform_registry_for_agent(resolved.agent),
             )
-            resolved = EffectiveRuntimeConfig(
-                approval_mode=resolved.approval_mode,
-                permission=resolved.permission,
-                model=resolved.model,
-                execution_engine=resolved.execution_engine,
-                max_steps=resolved.max_steps,
-                tool_timeout_seconds=resolved.tool_timeout_seconds,
-                reasoning_effort=resolved.reasoning_effort,
-                provider_fallback=resolved.provider_fallback,
-                providers=resolved.providers,
-                resolved_provider=resolved.resolved_provider,
-                agent=(
-                    RuntimeAgentConfig(
-                        preset=resolved.agent.preset,
-                        prompt_profile=resolved.agent.prompt_profile,
-                        prompt=resolved.agent.prompt,
-                        prompt_append=resolved.agent.prompt_append,
-                        prompt_ref=resolved.agent.prompt_ref,
-                        prompt_source=resolved.agent.prompt_source,
-                        prompt_materialization=resolved.agent.prompt_materialization,
-                        manifest_source_scope=resolved.agent.manifest_source_scope,
-                        manifest_source_path=resolved.agent.manifest_source_path,
-                        manifest_tool_allowlist=resolved.agent.manifest_tool_allowlist,
-                        manifest_skill_refs=resolved.agent.manifest_skill_refs,
-                        manifest_hook_refs=resolved.agent.manifest_hook_refs,
-                        hook_refs=resolved.agent.hook_refs,
-                        context_transform_refs=refs,
-                        model=resolved.agent.model,
-                        execution_engine=resolved.agent.execution_engine,
-                        tools=resolved.agent.tools,
-                        skills=resolved.agent.skills,
-                        mcp_binding=resolved.agent.mcp_binding,
-                        provider_fallback=resolved.agent.provider_fallback,
-                    )
-                    if resolved.agent is not None
-                    else None
-                ),
-                context_window=resolved.context_window,
-                tools=resolved.tools,
-                policy=resolved.policy,
-            )
+        resolved = apply_request_runtime_config_overrides(
+            resolved,
+            max_steps=request.metadata.get("max_steps"),
+            reasoning_effort=request.metadata.get("reasoning_effort"),
+            context_transform_refs=context_transform_refs,
+        )
         try:
             self._validate_reasoning_effort_capability(resolved)
         except ValueError as exc:
             raise RuntimeRequestError(str(exc)) from exc
         return resolved
-
-    def _config_with_workflow_preset(
-        self,
-        resolved: EffectiveRuntimeConfig,
-        preset_id: str,
-    ) -> EffectiveRuntimeConfig:
-        preset = self._workflow_preset(preset_id)
-        if preset is None:
-            raise ValueError(
-                f"request metadata 'workflow_preset' references unknown preset: {preset_id}"
-            )
-        if preset.default_agent not in self._agent_registry.executable_primary_ids():
-            return resolved
-
-        raw_agent: dict[str, object] = {"preset": preset.default_agent}
-        if preset.prompt_append is not None:
-            raw_agent["prompt_append"] = preset.prompt_append
-        if preset.hook_preset_refs:
-            raw_agent["hook_refs"] = list(preset.hook_preset_refs)
-        if preset.context_transform_refs:
-            raw_agent["context_transform_refs"] = list(preset.context_transform_refs)
-        return self._config_with_request_agent_override(
-            resolved,
-            raw_agent,
-        )
 
     def _workflow_preset_snapshot(
         self,
@@ -4513,29 +4383,9 @@ class VoidCodeRuntime:
             if raw_fallback_models in (None, []):
                 raw_fallback_models = None
             if raw_fallback_models is not None:
-                fallback_model_source = base_model
-                raw_resolved_provider_for_fallback = payload.get("resolved_provider")
-                if fallback_model_source is None and isinstance(
-                    raw_resolved_provider_for_fallback, dict
-                ):
-                    active_target = cast(dict[str, object], raw_resolved_provider_for_fallback).get(
-                        "active_target"
-                    )
-                    if isinstance(active_target, dict):
-                        raw_active_model = cast(dict[str, object], active_target).get("raw_model")
-                        if isinstance(raw_active_model, str) and raw_active_model:
-                            fallback_model_source = raw_active_model
-                if fallback_model_source is None:
-                    raise ValueError(
-                        "persisted runtime_config.model is required when "
-                        "fallback_models are present"
-                    )
-                base_provider_fallback = parse_provider_fallback_payload(
-                    {
-                        "preferred_model": fallback_model_source,
-                        "fallback_models": raw_fallback_models,
-                    },
-                    source="persisted runtime_config.fallback_models",
+                base_provider_fallback = parse_persisted_provider_fallback(
+                    payload,
+                    model=base_model,
                 )
         categories = parse_runtime_categories_payload(
             payload.get("categories"),
@@ -8134,41 +7984,10 @@ class VoidCodeRuntime:
         workflow_mode_resolution: WorkflowModeResolution | None = None,
     ) -> dict[str, object]:
         effective_config = config or self._effective_runtime_config_from_metadata(None)
-        runtime_config_metadata: dict[str, object] = {
-            "approval_mode": effective_config.approval_mode,
-            "permission": _serialize_external_permission_config(effective_config.permission),
-            "execution_engine": effective_config.execution_engine,
-            "max_steps": effective_config.max_steps,
-            "tool_timeout_seconds": effective_config.tool_timeout_seconds,
-            "fallback_models": (
-                list(effective_config.provider_fallback.fallback_models)
-                if effective_config.provider_fallback is not None
-                else []
-            ),
-            "resolved_provider": resolved_provider_snapshot(effective_config.resolved_provider),
-        }
-        serialized_policy = serialize_runtime_policy_config(effective_config.policy)
-        if serialized_policy is not None:
-            runtime_config_metadata["policy"] = serialized_policy
-        serialized_providers = serialize_provider_configs(effective_config.providers)
-        serialized_runtime_providers = _runtime_provider_config_metadata(serialized_providers)
-        if serialized_runtime_providers:
-            runtime_config_metadata["providers"] = serialized_runtime_providers
-        serialized_context_window = serialize_runtime_context_window_config(
-            effective_config.context_window
+        runtime_config_metadata = serialize_runtime_config_core(effective_config)
+        runtime_config_metadata["resolved_provider"] = resolved_provider_snapshot(
+            effective_config.resolved_provider
         )
-        if serialized_context_window is not None:
-            runtime_config_metadata["context_window"] = serialized_context_window
-        if effective_config.model is not None:
-            runtime_config_metadata["model"] = effective_config.model
-        if effective_config.reasoning_effort is not None:
-            runtime_config_metadata["reasoning_effort"] = effective_config.reasoning_effort
-        serialized_tools = serialize_runtime_tools_config(effective_config.tools)
-        if serialized_tools is not None:
-            runtime_config_metadata["tools"] = serialized_tools
-        serialized_agent = serialize_runtime_agent_config(effective_config.agent)
-        if serialized_agent is not None:
-            runtime_config_metadata["agent"] = serialized_agent
         resolved_hook_presets = self._build_hook_preset_snapshot(
             effective_config.agent,
             workflow_mode_resolution=workflow_mode_resolution,
@@ -8360,6 +8179,7 @@ class VoidCodeRuntime:
             agent=merged_agent,
             context_window=resolved.context_window,
             tools=resolved.tools,
+            policy=resolved.policy,
         )
 
     def _validate_runtime_agent_for_execution(
@@ -8872,127 +8692,35 @@ class VoidCodeRuntime:
             raise ValueError("persisted session metadata must include runtime_config")
 
         runtime_config = cast(dict[str, object], persisted_runtime_config)
-        unknown_runtime_config_keys = sorted(
-            key for key in runtime_config if key not in _PERSISTED_RUNTIME_CONFIG_KEYS
+        materialized = parse_persisted_runtime_config(
+            runtime_config,
+            default_approval_mode=approval_mode,
+            default_permission=self._config.permission,
+            default_policy=self._config.policy,
+            default_model=model,
+            default_execution_engine=execution_engine,
+            default_max_steps=max_steps,
+            default_tool_timeout_seconds=self._config.tool_timeout_seconds,
+            default_reasoning_effort=reasoning_effort,
+            default_providers=providers,
+            default_tools=self._config.tools,
+            default_context_window=context_window,
         )
-        if unknown_runtime_config_keys:
-            raise ValueError(
-                "persisted runtime_config field "
-                f"'{unknown_runtime_config_keys[0]}' is not supported"
-            )
-        persisted_approval_mode = runtime_config.get("approval_mode")
-        parsed_approval_mode = _permission_decision_or_none(persisted_approval_mode)
-        if parsed_approval_mode is not None:
-            approval_mode = parsed_approval_mode
-        permission = self._config.permission
-        if "permission" in runtime_config:
-            permission = _parse_persisted_external_permission_config(
-                runtime_config.get("permission")
-            )
-        policy = self._config.policy
-        if "policy" in runtime_config:
-            policy = parse_runtime_policy_payload(
-                runtime_config.get("policy"),
-                source="persisted runtime_config.policy",
-            )
-        persisted_model = runtime_config.get("model")
-        if persisted_model is None or isinstance(persisted_model, str):
-            model = persisted_model
-        if "max_steps" in runtime_config:
-            persisted_max_steps = runtime_config.get("max_steps")
-            if persisted_max_steps is None:
-                max_steps = None
-            elif isinstance(persisted_max_steps, int) and not isinstance(persisted_max_steps, bool):
-                if persisted_max_steps < 0:
-                    raise ValueError(
-                        "persisted runtime_config max_steps must be a non-negative integer "
-                        "(0 = unlimited)"
-                    )
-                max_steps = persisted_max_steps
-        tool_timeout_seconds = self._config.tool_timeout_seconds
-        if "tool_timeout_seconds" in runtime_config:
-            persisted_tool_timeout = runtime_config.get("tool_timeout_seconds")
-            if persisted_tool_timeout is None:
-                tool_timeout_seconds = None
-            elif isinstance(persisted_tool_timeout, int) and not isinstance(
-                persisted_tool_timeout, bool
-            ):
-                if persisted_tool_timeout < 1:
-                    raise ValueError(
-                        "persisted runtime_config tool_timeout_seconds must be at least 1"
-                    )
-                tool_timeout_seconds = persisted_tool_timeout
-        if "reasoning_effort" in runtime_config:
-            persisted_reasoning_effort = runtime_config.get("reasoning_effort")
-            if persisted_reasoning_effort is None:
-                reasoning_effort = None
-            elif isinstance(persisted_reasoning_effort, str) and persisted_reasoning_effort:
-                reasoning_effort = persisted_reasoning_effort
-            else:
-                raise ValueError(
-                    "persisted runtime_config reasoning_effort must be a non-empty string"
-                )
-        if "providers" in runtime_config:
-            try:
-                providers = parse_provider_configs_payload(
-                    runtime_config.get("providers"),
-                    source="persisted runtime_config.providers",
-                )
-            except ValueError as exc:
-                raise ValueError(
-                    format_invalid_provider_config_error(
-                        "persisted runtime_config.providers",
-                        str(exc),
-                    )
-                ) from exc
-        provider_fallback = None
-        if "fallback_models" in runtime_config:
-            raw_fallback_models = runtime_config.get("fallback_models")
-            if raw_fallback_models in (None, []):
-                raw_fallback_models = None
-            if raw_fallback_models is None:
-                provider_fallback = None
-            else:
-                fallback_model_source = model
-                raw_resolved_provider_for_fallback = runtime_config.get("resolved_provider")
-                if fallback_model_source is None and isinstance(
-                    raw_resolved_provider_for_fallback, dict
-                ):
-                    active_target = cast(dict[str, object], raw_resolved_provider_for_fallback).get(
-                        "active_target"
-                    )
-                    if isinstance(active_target, dict):
-                        raw_model = cast(dict[str, object], active_target).get("raw_model")
-                        if isinstance(raw_model, str) and raw_model:
-                            fallback_model_source = raw_model
-                if fallback_model_source is None:
-                    fallback_model_source = self._config.model
-                if fallback_model_source is None:
-                    raise ValueError(
-                        "persisted runtime_config.model is required when "
-                        "fallback_models are present"
-                    )
-                try:
-                    provider_fallback = parse_provider_fallback_payload(
-                        {
-                            "preferred_model": fallback_model_source,
-                            "fallback_models": raw_fallback_models,
-                        },
-                        source="persisted runtime_config.fallback_models",
-                    )
-                except ValueError as exc:
-                    raise ValueError(
-                        format_invalid_provider_config_error(
-                            "persisted runtime_config.fallback_models",
-                            str(exc),
-                        )
-                    ) from exc
-        tools = self._config.tools
-        if "tools" in runtime_config:
-            tools = _parse_persisted_runtime_tools_config(runtime_config.get("tools"))
-        if "agent" in runtime_config:
+        approval_mode = materialized.approval_mode
+        permission = materialized.permission
+        policy = materialized.policy
+        model = materialized.model
+        execution_engine = materialized.execution_engine
+        max_steps = materialized.max_steps
+        tool_timeout_seconds = materialized.tool_timeout_seconds
+        reasoning_effort = materialized.reasoning_effort
+        providers = materialized.providers
+        provider_fallback = materialized.provider_fallback
+        tools = materialized.tools
+        context_window = materialized.context_window
+        if materialized.has_agent:
             agent = parse_runtime_agent_payload(
-                runtime_config.get("agent"),
+                materialized.raw_agent,
                 source="persisted runtime_config.agent",
                 hooks=self._config.hooks,
                 agent_registry=self._agent_registry,
@@ -9005,25 +8733,7 @@ class VoidCodeRuntime:
                 )
         else:
             agent = None
-        if "context_window" in runtime_config:
-            try:
-                context_window = parse_runtime_context_window_payload(
-                    runtime_config.get("context_window"),
-                    source="persisted runtime_config.context_window",
-                )
-            except ValueError as exc:
-                raise ValueError(
-                    format_invalid_provider_config_error(
-                        "persisted runtime_config.context_window",
-                        str(exc),
-                    )
-                ) from exc
-        persisted_execution_engine = _execution_engine_or_none(
-            runtime_config.get("execution_engine")
-        )
-        if persisted_execution_engine is not None:
-            execution_engine = persisted_execution_engine
-        raw_resolved_provider = runtime_config.get("resolved_provider")
+        raw_resolved_provider = materialized.raw_resolved_provider
         if raw_resolved_provider is not None:
             resolved_provider = parse_resolved_provider_snapshot(
                 raw_resolved_provider,
@@ -9229,187 +8939,6 @@ class VoidCodeRuntime:
         if response is None:
             return False
         return True
-
-
-def _serialize_external_permission_config(
-    permission: ExternalDirectoryPermissionConfig,
-) -> dict[str, object]:
-    payload: dict[str, object] = {
-        "external_directory_read": dict(permission.read.rules),
-        "external_directory_write": dict(permission.write.rules),
-    }
-    if permission.rules:
-        payload["rules"] = [
-            {
-                key: value
-                for key, value in {
-                    "tool": rule.tool,
-                    "path": rule.path,
-                    "command": rule.command,
-                    "decision": rule.decision,
-                }.items()
-                if value is not None
-            }
-            for rule in permission.rules
-        ]
-    return payload
-
-
-def _parse_persisted_external_permission_config(
-    raw_permission: object,
-) -> ExternalDirectoryPermissionConfig:
-    if not isinstance(raw_permission, dict):
-        raise ValueError("persisted runtime_config permission must be an object")
-    payload = cast(dict[object, object], raw_permission)
-    allowed_keys = {"external_directory_read", "external_directory_write", "rules"}
-    unknown_keys = sorted(str(key) for key in payload if key not in allowed_keys)
-    if unknown_keys:
-        raise ValueError(
-            f"persisted runtime_config permission field '{unknown_keys[0]}' is not supported"
-        )
-    return ExternalDirectoryPermissionConfig(
-        read=ExternalDirectoryPolicy(
-            rules=_parse_persisted_external_permission_rules(
-                payload.get("external_directory_read"),
-                field_path="permission.external_directory_read",
-                default=(("*", "allow"),),
-            )
-        ),
-        write=ExternalDirectoryPolicy(
-            rules=_parse_persisted_external_permission_rules(
-                payload.get("external_directory_write"),
-                field_path="permission.external_directory_write",
-                default=(("*", "allow"),),
-            )
-        ),
-        rules=_parse_persisted_pattern_permission_rules(payload.get("rules")),
-    )
-
-
-def _parse_persisted_runtime_tools_config(raw_value: object) -> RuntimeToolsConfig | None:
-    try:
-        return parse_runtime_tools_payload(raw_value, source="persisted runtime_config.tools")
-    except ValueError as exc:
-        raise ValueError(
-            format_invalid_provider_config_error("persisted runtime_config.tools", str(exc))
-        ) from exc
-
-
-def _parse_persisted_external_permission_rules(
-    raw_rules: object,
-    *,
-    field_path: str,
-    default: tuple[tuple[str, PermissionDecision], ...],
-) -> tuple[tuple[str, PermissionDecision], ...]:
-    if raw_rules is None:
-        return default
-    if not isinstance(raw_rules, dict):
-        raise ValueError(f"persisted runtime_config {field_path} must be an object")
-    parsed: list[tuple[str, PermissionDecision]] = []
-    for raw_pattern, raw_decision in cast(dict[object, object], raw_rules).items():
-        if not isinstance(raw_pattern, str) or not raw_pattern.strip():
-            raise ValueError(f"persisted runtime_config {field_path} keys must be strings")
-        decision = _permission_decision_or_none(raw_decision)
-        if decision is None:
-            raise ValueError(
-                f"persisted runtime_config {field_path}.{raw_pattern} must be allow, deny, or ask"
-            )
-        parsed.append((raw_pattern, decision))
-    return tuple(parsed) if parsed else default
-
-
-def _parse_persisted_pattern_permission_rules(
-    raw_rules: object,
-) -> tuple[PatternPermissionRule, ...]:
-    if raw_rules is None:
-        return ()
-    if not isinstance(raw_rules, list):
-        raise ValueError("persisted runtime_config permission.rules must be an array")
-    parsed: list[PatternPermissionRule] = []
-    allowed_keys = {"tool", "path", "command", "decision"}
-    for index, raw_rule in enumerate(raw_rules):
-        field_path = f"permission.rules[{index}]"
-        if not isinstance(raw_rule, dict):
-            raise ValueError(f"persisted runtime_config {field_path} must be an object")
-        payload = cast(dict[object, object], raw_rule)
-        unknown_keys = sorted(str(key) for key in payload if key not in allowed_keys)
-        if unknown_keys:
-            raise ValueError(
-                f"persisted runtime_config {field_path}.{unknown_keys[0]} is not supported"
-            )
-        raw_tool = payload.get("tool", "*")
-        if not isinstance(raw_tool, str) or not raw_tool.strip():
-            raise ValueError(f"persisted runtime_config {field_path}.tool must be a string")
-        raw_path = payload.get("path")
-        if raw_path is not None and (not isinstance(raw_path, str) or not raw_path.strip()):
-            raise ValueError(f"persisted runtime_config {field_path}.path must be a string")
-        raw_command = payload.get("command")
-        if raw_command is not None and (
-            not isinstance(raw_command, str) or not raw_command.strip()
-        ):
-            raise ValueError(f"persisted runtime_config {field_path}.command must be a string")
-        decision = _permission_decision_or_none(payload.get("decision"))
-        if decision is None:
-            raise ValueError(
-                f"persisted runtime_config {field_path}.decision must be allow, deny, or ask"
-            )
-        parsed.append(
-            PatternPermissionRule(
-                tool=raw_tool,
-                path=raw_path,
-                command=raw_command,
-                decision=decision,
-            )
-        )
-    return tuple(parsed)
-
-
-def _runtime_provider_config_metadata(
-    serialized_providers: dict[str, object] | None,
-) -> dict[str, object] | None:
-    if not serialized_providers:
-        return None
-    retained: dict[str, object] = {}
-    for provider_name, raw_provider in serialized_providers.items():
-        if provider_name == "custom":
-            if not isinstance(raw_provider, dict):
-                continue
-            retained_custom: dict[str, object] = {}
-            for custom_name, raw_custom_provider in cast(dict[str, object], raw_provider).items():
-                if not isinstance(raw_custom_provider, dict):
-                    continue
-                custom_provider_payload = cast(dict[str, object], raw_custom_provider)
-                if "transient_retry" in custom_provider_payload:
-                    retained_custom[custom_name] = {
-                        "transient_retry": custom_provider_payload["transient_retry"]
-                    }
-            if retained_custom:
-                retained[provider_name] = retained_custom
-            continue
-        if not isinstance(raw_provider, dict):
-            continue
-        provider_payload = cast(dict[str, object], raw_provider)
-        if "transient_retry" in provider_payload:
-            retained[provider_name] = {"transient_retry": provider_payload["transient_retry"]}
-    return retained or None
-
-
-@dataclass(frozen=True, slots=True)
-class EffectiveRuntimeConfig:
-    approval_mode: PermissionDecision
-    permission: ExternalDirectoryPermissionConfig
-    model: str | None
-    execution_engine: ExecutionEngineName
-    max_steps: int | None
-    tool_timeout_seconds: int | None = None
-    reasoning_effort: str | None = None
-    provider_fallback: RuntimeProviderFallbackConfig | None = None
-    providers: RuntimeProvidersConfig | None = None
-    resolved_provider: ResolvedProviderConfig = field(default_factory=ResolvedProviderConfig)
-    agent: RuntimeAgentConfig | None = None
-    context_window: RuntimeContextWindowConfig | None = None
-    tools: RuntimeToolsConfig | None = None
-    policy: object | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/voidcode/runtime/service.py
+++ b/src/voidcode/runtime/service.py
@@ -149,12 +149,9 @@ from .config import (
     serialize_runtime_categories_config,
 )
 from .config_materializer import (
-    PERSISTED_RUNTIME_CONFIG_KEYS,
     EffectiveRuntimeConfig,
     apply_request_runtime_config_overrides,
-    parse_persisted_provider_fallback,
     parse_persisted_runtime_config,
-    reject_legacy_workflow_preset_request,
     serialize_runtime_config_core,
 )
 from .context_transforms import (
@@ -291,11 +288,8 @@ from .permission_path_helpers import (
 )
 from .permission_policy import (
     approval_request_id_from_waiting_response,
-    operation_class_or_none,
-    path_scope_or_none,
     pending_approval_from_response,
     pending_question_from_response,
-    permission_decision_or_none,
     permission_policy_for_session,
     request_event_and_resolution_state,
     waiting_request_id_from_response,
@@ -423,19 +417,6 @@ _ACTIVE_SESSION_COMPAT_EXPORTS = (
 
 _EXECUTABLE_AGENT_PRESETS = frozenset({"leader", "product"})
 _EXECUTABLE_SUBAGENT_PRESETS = frozenset({"advisor", "explore", "researcher", "worker"})
-_PERSISTED_RUNTIME_CONFIG_KEYS = PERSISTED_RUNTIME_CONFIG_KEYS
-
-
-def _permission_decision_or_none(value: object) -> PermissionDecision | None:
-    return permission_decision_or_none(value)
-
-
-def _execution_engine_or_none(value: object) -> ExecutionEngineName | None:
-    if value == "deterministic":
-        return "deterministic"
-    if value == "provider":
-        return "provider"
-    return None
 
 
 def _agent_effective_execution_engine(
@@ -447,14 +428,6 @@ def _agent_effective_execution_engine(
     if agent is not None and agent.execution_engine is not None:
         return agent.execution_engine
     return base_engine
-
-
-def _path_scope_or_none(value: object) -> PathScope | None:
-    return path_scope_or_none(value)
-
-
-def _operation_class_or_none(value: object) -> OperationClass | None:
-    return operation_class_or_none(value)
 
 
 _ACP_CONNECTIVITY_ERRORS = frozenset(
@@ -1025,7 +998,6 @@ class VoidCodeRuntime:
 
     def _runtime_config_for_request(self, request: RuntimeRequest) -> EffectiveRuntimeConfig:
         resolved = self._effective_runtime_config_from_metadata(None)
-        reject_legacy_workflow_preset_request(request.metadata)
         _ = self._workflow_mode_resolution_for_request_metadata(request.metadata)
         request_agent = request.metadata.get("agent")
         if request_agent is not None:
@@ -1128,6 +1100,10 @@ class VoidCodeRuntime:
         explicit_metadata_workflow_mode = metadata_workflow_mode is not None
         raw_workflow_preset = metadata.get("workflow_preset")
         workflow_preset = raw_workflow_preset if isinstance(raw_workflow_preset, str) else None
+        if workflow_preset is not None and self._workflow_preset(workflow_preset) is None:
+            raise RuntimeRequestError(
+                f"request metadata 'workflow_preset' references unknown preset: {workflow_preset}"
+            )
         if metadata_workflow_mode is None:
             raw_top_workflow_mode = metadata.get("workflow_mode")
             if isinstance(raw_top_workflow_mode, str):
@@ -4377,16 +4353,21 @@ class VoidCodeRuntime:
         payload = cast(dict[str, object], runtime_config)
         raw_model = payload.get("model")
         base_model = raw_model if isinstance(raw_model, str) else None
-        base_provider_fallback = None
-        if "fallback_models" in payload:
-            raw_fallback_models = payload.get("fallback_models")
-            if raw_fallback_models in (None, []):
-                raw_fallback_models = None
-            if raw_fallback_models is not None:
-                base_provider_fallback = parse_persisted_provider_fallback(
-                    payload,
-                    model=base_model,
-                )
+        materialized = parse_persisted_runtime_config(
+            payload,
+            default_approval_mode=self._config.approval_mode,
+            default_permission=self._config.permission,
+            default_policy=self._config.policy,
+            default_model=base_model,
+            default_execution_engine=self._config.execution_engine,
+            default_max_steps=self._config.max_steps,
+            default_tool_timeout_seconds=self._config.tool_timeout_seconds,
+            default_reasoning_effort=None,
+            default_providers=self._config.providers,
+            default_tools=self._config.tools,
+            default_context_window=self._config.context_window,
+        )
+        base_provider_fallback = materialized.provider_fallback
         categories = parse_runtime_categories_payload(
             payload.get("categories"),
             source="persisted runtime_config.categories",

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -11390,13 +11390,8 @@ def test_runtime_rejects_unknown_requested_skill(tmp_path: Path) -> None:
         _ = runtime.run(RuntimeRequest(prompt="hello", metadata={"force_load_skills": ["missing"]}))
 
 
-@pytest.mark.parametrize(
-    "workflow_preset",
-    ("review", "research", "frontend", "git", "snapshot", "requires-docs", "scoped"),
-)
-def test_runtime_request_workflow_preset_metadata_is_rejected(
+def test_runtime_request_workflow_preset_metadata_materializes_workflow_snapshot(
     tmp_path: Path,
-    workflow_preset: str,
 ) -> None:
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
@@ -11405,19 +11400,22 @@ def test_runtime_request_workflow_preset_metadata_is_rejected(
     )
     _SkillCapturingStubGraph.last_request = None
 
-    with pytest.raises(
-        RuntimeRequestError,
-        match=runtime_config_materializer_module.WORKFLOW_PRESET_REQUEST_ERROR,
-    ):
-        _ = runtime.run(
-            RuntimeRequest(
-                prompt="legacy workflow preset",
-                session_id=f"legacy-workflow-{workflow_preset}",
-                metadata={"workflow_preset": workflow_preset},
-            )
+    response = runtime.run(
+        RuntimeRequest(
+            prompt="review workflow preset",
+            session_id="workflow-review-preset",
+            metadata={"workflow_preset": "review"},
         )
+    )
 
-    assert _SkillCapturingStubGraph.last_request is None
+    assert response.session.status == "completed"
+    assert _SkillCapturingStubGraph.last_request is not None
+    assert response.session.metadata["workflow_preset"] == "review"
+    assert response.session.metadata["workflow_mode"] == "review"
+    runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
+    workflow = cast(dict[str, object], runtime_config["workflow"])
+    assert workflow["selected_preset"] == "review"
+    assert workflow["read_only_default"] is True
 
 
 def test_runtime_rejects_client_supplied_workflow_snapshot_on_fresh_request(
@@ -11598,10 +11596,7 @@ def test_runtime_config_metadata_materializes_supported_persisted_fields(
     metadata = runtime._runtime_config_metadata(workflow_preset="scoped")
     effective = runtime._effective_runtime_config_from_metadata({"runtime_config": metadata})
 
-    persisted_keys = cast(
-        frozenset[str],
-        _private_attr(runtime_service_module, "_PERSISTED_RUNTIME_CONFIG_KEYS"),
-    )
+    persisted_keys = runtime_config_materializer_module.PERSISTED_RUNTIME_CONFIG_KEYS
     assert set(metadata) <= persisted_keys
     assert {
         "approval_mode",
@@ -12230,14 +12225,14 @@ def test_runtime_rejects_unknown_workflow_preset_before_execution(tmp_path: Path
 
     with pytest.raises(
         RuntimeRequestError,
-        match=runtime_config_materializer_module.WORKFLOW_PRESET_REQUEST_ERROR,
+        match="request metadata 'workflow_preset' references unknown preset: missing",
     ):
         _ = runtime.run(RuntimeRequest(prompt="hello", metadata={"workflow_preset": "missing"}))
 
     assert _SkillCapturingStubGraph.last_request is None
 
 
-def test_runtime_request_workflow_preset_rejected_before_agent_materialization(
+def test_runtime_request_workflow_preset_preserves_custom_agent_materialization(
     tmp_path: Path,
 ) -> None:
     runtime = VoidCodeRuntime(
@@ -12261,25 +12256,33 @@ def test_runtime_request_workflow_preset_rejected_before_agent_materialization(
     )
     _SkillCapturingStubGraph.last_request = None
 
-    with pytest.raises(
-        RuntimeRequestError,
-        match=runtime_config_materializer_module.WORKFLOW_PRESET_REQUEST_ERROR,
-    ):
-        _ = runtime.run(
-            RuntimeRequest(
-                prompt="implement",
-                session_id="workflow-precedence",
-                metadata={
-                    "workflow_preset": "implementation",
-                    "agent": {"preset": "leader", "model": "request/model"},
-                },
-            )
+    response = runtime.run(
+        RuntimeRequest(
+            prompt="implement",
+            session_id="workflow-precedence",
+            metadata={
+                "workflow_preset": "implementation",
+                "agent": {"preset": "leader", "model": "request/model"},
+            },
         )
+    )
 
-    assert _SkillCapturingStubGraph.last_request is None
+    assert response.session.status == "completed"
+    assert _SkillCapturingStubGraph.last_request is not None
+    assert response.session.metadata["workflow_preset"] == "implementation"
+    runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
+    agent = cast(dict[str, object], runtime_config["agent"])
+    assert agent["model"] == "request/model"
+    assert agent["prompt_materialization"] == {
+        "profile": "custom-leader",
+        "version": 1,
+        "source": "custom_markdown",
+        "format": "markdown",
+        "body": "Custom runtime materialization.",
+    }
 
 
-def test_runtime_request_workflow_preset_rejected_with_prompt_materialization_override(
+def test_runtime_request_workflow_preset_allows_prompt_materialization_override(
     tmp_path: Path,
 ) -> None:
     runtime = VoidCodeRuntime(
@@ -12293,32 +12296,38 @@ def test_runtime_request_workflow_preset_rejected_with_prompt_materialization_ov
     )
     _SkillCapturingStubGraph.last_request = None
 
-    with pytest.raises(
-        RuntimeRequestError,
-        match=runtime_config_materializer_module.WORKFLOW_PRESET_REQUEST_ERROR,
-    ):
-        _ = runtime.run(
-            RuntimeRequest(
-                prompt="implement",
-                session_id="workflow-request-materialization",
-                metadata={
-                    "workflow_preset": "implementation",
-                    "agent": {
-                        "preset": "leader",
-                        "prompt_materialization": {
-                            "profile": "request-custom",
-                            "version": 1,
-                            "source": "custom_markdown",
-                            "format": "markdown",
-                            "body": "Request materialization.",
-                        },
-                        "prompt_source": "custom_markdown",
+    response = runtime.run(
+        RuntimeRequest(
+            prompt="implement",
+            session_id="workflow-request-materialization",
+            metadata={
+                "workflow_preset": "implementation",
+                "agent": {
+                    "preset": "leader",
+                    "prompt_materialization": {
+                        "profile": "request-custom",
+                        "version": 1,
+                        "source": "custom_markdown",
+                        "format": "markdown",
+                        "body": "Request materialization.",
                     },
+                    "prompt_source": "custom_markdown",
                 },
-            )
+            },
         )
+    )
 
-    assert _SkillCapturingStubGraph.last_request is None
+    assert response.session.status == "completed"
+    assert _SkillCapturingStubGraph.last_request is not None
+    runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
+    agent = cast(dict[str, object], runtime_config["agent"])
+    assert agent["prompt_materialization"] == {
+        "profile": "request-custom",
+        "version": 1,
+        "source": "custom_markdown",
+        "format": "markdown",
+        "body": "Request materialization.",
+    }
 
 
 def test_runtime_rejects_client_supplied_applied_skill_payloads_on_new_run(
@@ -13817,6 +13826,7 @@ def test_runtime_provider_fallback_seam_returns_next_graph_selection(tmp_path: P
                 "execution_engine": "provider",
                 "max_steps": None,
                 "tool_timeout_seconds": None,
+                "model": "primary/model-a",
                 "fallback_models": ["fallback/model-b"],
                 "resolved_provider": {
                     "active_target": {

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -18,6 +18,7 @@ from unittest.mock import Mock
 import pytest
 
 import voidcode.runtime.background_tasks as runtime_background_tasks_module
+import voidcode.runtime.config_materializer as runtime_config_materializer_module
 import voidcode.runtime.provider_fallback as runtime_provider_fallback_module
 import voidcode.runtime.run_loop as runtime_run_loop_module
 import voidcode.runtime.service as runtime_service_module
@@ -158,7 +159,6 @@ from voidcode.runtime.task import (
     is_background_task_terminal,
 )
 from voidcode.runtime.workflow import (
-    WorkflowMcpBindingIntent,
     WorkflowPreset,
     WorkflowPresetRegistry,
 )
@@ -11390,92 +11390,34 @@ def test_runtime_rejects_unknown_requested_skill(tmp_path: Path) -> None:
         _ = runtime.run(RuntimeRequest(prompt="hello", metadata={"force_load_skills": ["missing"]}))
 
 
-def test_runtime_request_metadata_accepts_review_workflow_without_child_agent_promotion(
+@pytest.mark.parametrize(
+    "workflow_preset",
+    ("review", "research", "frontend", "git", "snapshot", "requires-docs", "scoped"),
+)
+def test_runtime_request_workflow_preset_metadata_is_rejected(
     tmp_path: Path,
+    workflow_preset: str,
 ) -> None:
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
         graph=_SkillCapturingStubGraph(),
         config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
     )
+    _SkillCapturingStubGraph.last_request = None
 
-    response = runtime.run(
-        RuntimeRequest(
-            prompt="review this",
-            session_id="workflow-review",
-            metadata={"workflow_preset": "review"},
+    with pytest.raises(
+        RuntimeRequestError,
+        match=runtime_config_materializer_module.WORKFLOW_PRESET_REQUEST_ERROR,
+    ):
+        _ = runtime.run(
+            RuntimeRequest(
+                prompt="legacy workflow preset",
+                session_id=f"legacy-workflow-{workflow_preset}",
+                metadata={"workflow_preset": workflow_preset},
+            )
         )
-    )
-    request = _SkillCapturingStubGraph.last_request
 
-    assert request is not None
-    runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
-    agent_snapshot = cast(dict[str, object], runtime_config["agent"])
-    assert response.session.metadata["workflow_preset"] == "review"
-    assert agent_snapshot["preset"] == "leader"
-    assert "prompt_append" not in agent_snapshot
-    hook_snapshot = cast(dict[str, object], runtime_config["resolved_hook_presets"])
-    assert hook_snapshot["refs"] == [
-        "role_reminder",
-        "delegation_guard",
-        "background_output_quality_guidance",
-        "delegated_retry_guidance",
-        "todo_continuation_guidance",
-    ]
-    assert request.metadata["workflow_preset"] == "review"
-
-
-def test_runtime_research_workflow_fresh_records_read_only_metadata_without_widening_tools(
-    tmp_path: Path,
-) -> None:
-    runtime = VoidCodeRuntime(
-        workspace=tmp_path,
-        graph=_SkillCapturingStubGraph(),
-        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
-    )
-
-    response = runtime.run(
-        RuntimeRequest(
-            prompt="research this",
-            session_id="workflow-research-fresh",
-            metadata={"workflow_preset": "research"},
-        )
-    )
-    request = _SkillCapturingStubGraph.last_request
-
-    assert request is not None
-    runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
-    workflow_snapshot = cast(dict[str, object], runtime_config["workflow"])
-    capability_snapshot = cast(
-        dict[str, object], response.session.metadata["agent_capability_snapshot"]
-    )
-    capability_workflow = cast(dict[str, object], capability_snapshot["workflow"])
-    tool_snapshot = cast(dict[str, object], capability_snapshot["tools"])
-    effective_tool_names = cast(list[str], tool_snapshot["effective_names"])
-    request_workflow = cast(dict[str, object], request.metadata["workflow"])
-    assert response.session.metadata["workflow_preset"] == "research"
-    assert workflow_snapshot["selected_preset"] == "research"
-    assert workflow_snapshot["category"] == "research"
-    assert workflow_snapshot["read_only_default"] is True
-    assert workflow_snapshot["hook_preset_refs"] == [
-        "role_reminder",
-        "delegated_task_timing_guidance",
-        "background_output_quality_guidance",
-    ]
-    assert workflow_snapshot["skill_refs"] == []
-    research_mcp_intents = cast(list[dict[str, object]], workflow_snapshot["mcp_binding_intents"])
-    assert research_mcp_intents[0]["servers"] == ["context7", "websearch", "grep_app"]
-    assert research_mcp_intents[0]["required"] is False
-    assert workflow_snapshot["effective_agent"] is None
-    assert workflow_snapshot["default_agent_executable_top_level"] is False
-    assert capability_workflow["read_only_default"] is True
-    assert "write_file" not in effective_tool_names
-    assert "shell_exec" in effective_tool_names
-    assert "read_file" in effective_tool_names
-    assert tool_snapshot["request_allowlist"] is None
-    assert tool_snapshot["request_default"] is None
-    assert request_workflow["read_only_default"] is True
-    assert "arguments" not in workflow_snapshot
+    assert _SkillCapturingStubGraph.last_request is None
 
 
 def test_runtime_rejects_client_supplied_workflow_snapshot_on_fresh_request(
@@ -11496,7 +11438,6 @@ def test_runtime_rejects_client_supplied_workflow_snapshot_on_fresh_request(
                 prompt="research this",
                 session_id="workflow-forged-fresh",
                 metadata={
-                    "workflow_preset": "research",
                     "workflow": {
                         "selected_preset": "git",
                         "read_only_default": False,
@@ -11504,388 +11445,6 @@ def test_runtime_rejects_client_supplied_workflow_snapshot_on_fresh_request(
                 },
             )
         )
-
-
-def test_runtime_builtin_workflow_snapshots_expose_issue_405_capability_intents(
-    tmp_path: Path,
-) -> None:
-    runtime = VoidCodeRuntime(
-        workspace=tmp_path,
-        graph=_SkillCapturingStubGraph(),
-        config=RuntimeConfig(
-            execution_engine="provider",
-            model="opencode/gpt-5.4",
-            mcp=RuntimeMcpConfig(
-                enabled=True,
-                servers={
-                    "playwright": RuntimeMcpServerConfig(command=("playwright-mcp",)),
-                    "context7": RuntimeMcpServerConfig(command=("context7-mcp",)),
-                    "websearch": RuntimeMcpServerConfig(command=("websearch-mcp",)),
-                    "grep_app": RuntimeMcpServerConfig(command=("grep-app-mcp",)),
-                },
-            ),
-        ),
-    )
-
-    expected: dict[str, dict[str, list[str]]] = {
-        "git": {"skills": ["git-master"], "servers": []},
-        "implementation": {"skills": [], "servers": []},
-        "frontend": {"skills": ["frontend-design", "playwright"], "servers": ["playwright"]},
-        "review": {
-            "skills": ["review-work"],
-            "servers": ["context7", "websearch", "grep_app"],
-        },
-        "research": {
-            "skills": [],
-            "servers": ["context7", "websearch", "grep_app"],
-        },
-    }
-
-    for preset_id, expected_capabilities in expected.items():
-        response = runtime.run(
-            RuntimeRequest(
-                prompt=f"snapshot {preset_id}",
-                session_id=f"workflow-issue-405-{preset_id}",
-                metadata={"workflow_preset": preset_id},
-            )
-        )
-        runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
-        workflow_snapshot = cast(dict[str, object], runtime_config["workflow"])
-        capability_snapshot = cast(
-            dict[str, object], response.session.metadata["agent_capability_snapshot"]
-        )
-        capability_workflow = cast(dict[str, object], capability_snapshot["workflow"])
-        mcp_intents = cast(list[dict[str, object]], workflow_snapshot["mcp_binding_intents"])
-        servers = [
-            server
-            for intent in mcp_intents
-            for server in cast(list[str], intent.get("servers", []))
-        ]
-
-        assert workflow_snapshot == capability_workflow
-        assert workflow_snapshot["skill_refs"] == expected_capabilities["skills"]
-        assert servers == expected_capabilities["servers"]
-        assert all(intent["required"] is False for intent in mcp_intents)
-        for intent in mcp_intents:
-            availability = cast(dict[str, object], intent["availability"])
-            assert availability["missing_servers"] == []
-            assert availability["degraded"] is False
-            descriptors = cast(list[dict[str, object]], availability["descriptors"])
-            assert [descriptor["name"] for descriptor in descriptors] == expected_capabilities[
-                "servers"
-            ]
-
-
-def test_runtime_workflow_selected_builtin_skill_refs_are_catalog_visible_not_loaded(
-    tmp_path: Path,
-) -> None:
-    runtime = VoidCodeRuntime(
-        workspace=tmp_path,
-        graph=_SkillCapturingStubGraph(),
-        config=RuntimeConfig(execution_engine="provider", model="opencode/gpt-5.4"),
-    )
-
-    response = runtime.run(
-        RuntimeRequest(
-            prompt="snapshot frontend workflow",
-            session_id="workflow-builtin-skill-catalog-visible",
-            metadata={"workflow_preset": "frontend"},
-        )
-    )
-
-    skills_loaded = next(
-        event for event in response.events if event.event_type == "runtime.skills_loaded"
-    )
-    assert skills_loaded.payload["skills"] == []
-    assert skills_loaded.payload["selected_skills"] == ["frontend-design", "playwright"]
-    assert cast(int, skills_loaded.payload["catalog_context_length"]) > 0
-    assert "applied_skills" not in response.session.metadata
-    assert "applied_skill_payloads" not in response.session.metadata
-    assert runtime._skill_registry.resolve("frontend-design").name == "frontend-design"
-    assert runtime._skill_registry.resolve("playwright").name == "playwright"
-
-
-def test_runtime_git_workflow_uses_generic_runtime_approval_without_bespoke_policy(
-    tmp_path: Path,
-) -> None:
-    registry = ModelProviderRegistry(
-        providers={
-            "opencode": _ScriptedModelProvider(
-                name="opencode",
-                outcomes=(
-                    ProviderTurnResult(
-                        tool_call=ToolCall(
-                            tool_name="shell_exec",
-                            arguments={"command": "pwd"},
-                        )
-                    ),
-                    ProviderTurnResult(output="done"),
-                ),
-            )
-        }
-    )
-    runtime = VoidCodeRuntime(
-        workspace=tmp_path,
-        config=RuntimeConfig(
-            approval_mode="ask",
-            execution_engine="provider",
-            model="opencode/gpt-5.4",
-        ),
-        model_provider_registry=registry,
-    )
-
-    response = runtime.run(
-        RuntimeRequest(
-            prompt="rewrite history",
-            session_id="workflow-git-fresh",
-            metadata={"workflow_preset": "git"},
-        )
-    )
-
-    runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
-    workflow_snapshot = cast(dict[str, object], runtime_config["workflow"])
-    capability_snapshot = cast(
-        dict[str, object], response.session.metadata["agent_capability_snapshot"]
-    )
-    capability_workflow = cast(dict[str, object], capability_snapshot["workflow"])
-    approval_event = response.events[-1]
-    assert response.session.status == "waiting"
-    assert approval_event.event_type == "runtime.approval_requested"
-    assert approval_event.payload["tool"] == "shell_exec"
-    assert workflow_snapshot["selected_preset"] == "git"
-    assert workflow_snapshot["category"] == "git"
-    assert workflow_snapshot["permission_policy_ref"] == "runtime_default"
-    assert workflow_snapshot.get("tool_policy_ref") is None
-    assert workflow_snapshot["verification_guidance"] == (
-        "Check git status before and after the requested operation, preserve hooks, and "
-        "keep repository mutations behind explicit user intent plus runtime approval."
-    )
-    assert capability_workflow["permission_policy_ref"] == "runtime_default"
-    assert capability_workflow.get("tool_policy_ref") is None
-    assert approval_event.payload["decision"] == "ask"
-    assert approval_event.payload.get("policy_surface") is None
-    assert approval_event.payload.get("matched_rule") is None
-
-
-def test_runtime_workflow_snapshot_persists_policy_refs_mcp_intent_and_safe_metadata(
-    tmp_path: Path,
-) -> None:
-    _write_named_skill(
-        tmp_path / ".voidcode" / "skills" / "forced-skill",
-        name="forced-skill",
-        content="Forced workflow skill.",
-    )
-    runtime = VoidCodeRuntime(
-        workspace=tmp_path,
-        graph=_SkillCapturingStubGraph(),
-        config=RuntimeConfig(
-            execution_engine="provider",
-            model="opencode/gpt-5.4",
-            skills=RuntimeSkillsConfig(enabled=True),
-            mcp=RuntimeMcpConfig(
-                enabled=True,
-                servers={"docs": RuntimeMcpServerConfig(command=("docs-server",))},
-            ),
-            workflows=WorkflowPresetRegistry(
-                presets={
-                    "snapshot": WorkflowPreset(
-                        id="snapshot",
-                        default_agent="leader",
-                        category="implementation",
-                        prompt_append="Snapshot append.",
-                        skill_refs=("catalog-skill",),
-                        force_load_skills=("forced-skill",),
-                        hook_preset_refs=("role_reminder",),
-                        mcp_binding_intents=(
-                            WorkflowMcpBindingIntent(servers=("docs", "missing"), required=False),
-                        ),
-                        tool_policy_ref="readonly-tools",
-                        permission_policy_ref="runtime_default",
-                        read_only_default=True,
-                        verification_guidance="Verify the persisted snapshot.",
-                    )
-                }
-            ),
-        ),
-    )
-
-    response = runtime.run(
-        RuntimeRequest(
-            prompt="snapshot please",
-            session_id="workflow-snapshot-safe",
-            metadata={"workflow_preset": "snapshot"},
-        )
-    )
-
-    runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
-    workflow_snapshot = cast(dict[str, object], runtime_config["workflow"])
-    top_level_workflow = cast(dict[str, object], response.session.metadata["workflow"])
-    capability_snapshot = cast(
-        dict[str, object], response.session.metadata["agent_capability_snapshot"]
-    )
-    capability_workflow = cast(dict[str, object], capability_snapshot["workflow"])
-    mcp_intents = cast(list[dict[str, object]], workflow_snapshot["mcp_binding_intents"])
-    availability = cast(dict[str, object], mcp_intents[0]["availability"])
-    serialized = json.dumps(workflow_snapshot, sort_keys=True)
-
-    assert workflow_snapshot == top_level_workflow == capability_workflow
-    assert workflow_snapshot["snapshot_version"] == 1
-    assert workflow_snapshot["preset_source"] == "runtime_config"
-    assert workflow_snapshot["tool_policy_ref"] == "readonly-tools"
-    assert workflow_snapshot["permission_policy_ref"] == "runtime_default"
-    assert workflow_snapshot["read_only_default"] is True
-    assert workflow_snapshot["skill_refs"] == ["catalog-skill"]
-    assert workflow_snapshot["force_load_skills"] == ["forced-skill"]
-    assert workflow_snapshot["hook_preset_refs"] == ["role_reminder"]
-    assert workflow_snapshot["verification_guidance"] == "Verify the persisted snapshot."
-    assert mcp_intents[0]["servers"] == ["docs", "missing"]
-    assert availability["configured_enabled"] is True
-    assert availability["available_servers"] == ["docs"]
-    assert availability["missing_servers"] == ["missing"]
-    assert availability["degraded"] is True
-    assert all(
-        forbidden not in serialized
-        for forbidden in ("arguments", "stdin", "env", "secret", "token", "password")
-    )
-
-
-def test_runtime_required_workflow_mcp_intent_fails_fresh_run_when_missing(
-    tmp_path: Path,
-) -> None:
-    runtime = VoidCodeRuntime(
-        workspace=tmp_path,
-        graph=_SkillCapturingStubGraph(),
-        config=RuntimeConfig(
-            execution_engine="provider",
-            model="opencode/gpt-5.4",
-            workflows=WorkflowPresetRegistry(
-                presets={
-                    "requires-docs": WorkflowPreset(
-                        id="requires-docs",
-                        default_agent="leader",
-                        category="research",
-                        mcp_binding_intents=(
-                            WorkflowMcpBindingIntent(servers=("docs",), required=True),
-                        ),
-                    )
-                }
-            ),
-        ),
-    )
-
-    with pytest.raises(
-        RuntimeRequestError,
-        match=r"workflow preset 'requires-docs' requires unavailable MCP server\(s\): docs",
-    ):
-        _ = runtime.run(
-            RuntimeRequest(
-                prompt="docs required",
-                metadata={"workflow_preset": "requires-docs"},
-            )
-        )
-
-
-def test_runtime_required_workflow_mcp_intent_passes_when_configured(
-    tmp_path: Path,
-) -> None:
-    runtime = VoidCodeRuntime(
-        workspace=tmp_path,
-        graph=_SkillCapturingStubGraph(),
-        config=RuntimeConfig(
-            execution_engine="provider",
-            model="opencode/gpt-5.4",
-            mcp=RuntimeMcpConfig(
-                enabled=False,
-                servers={"docs": RuntimeMcpServerConfig(command=("docs-mcp",))},
-            ),
-            workflows=WorkflowPresetRegistry(
-                presets={
-                    "requires-docs": WorkflowPreset(
-                        id="requires-docs",
-                        default_agent="leader",
-                        category="research",
-                        mcp_binding_intents=(
-                            WorkflowMcpBindingIntent(servers=("docs",), required=True),
-                        ),
-                    )
-                }
-            ),
-        ),
-    )
-
-    response = runtime.run(
-        RuntimeRequest(
-            prompt="docs required",
-            metadata={"workflow_preset": "requires-docs"},
-        )
-    )
-
-    workflow = cast(dict[str, object], response.session.metadata["workflow"])
-    intents = cast(list[dict[str, object]], workflow["mcp_binding_intents"])
-    availability = cast(dict[str, object], intents[0]["availability"])
-    assert availability["missing_servers"] == []
-
-
-def test_runtime_workflow_context_transform_refs_filter_runtime_registry(
-    tmp_path: Path,
-) -> None:
-    (tmp_path / "AGENTS.md").write_text("Project rules", encoding="utf-8")
-    runtime = VoidCodeRuntime(
-        workspace=tmp_path,
-        graph=_SkillCapturingStubGraph(),
-        config=RuntimeConfig(
-            execution_engine="provider",
-            model="opencode/gpt-5.4",
-            workflows=WorkflowPresetRegistry(
-                presets={
-                    "scoped": WorkflowPreset(
-                        id="scoped",
-                        default_agent="leader",
-                        category="implementation",
-                        context_transform_refs=("runtime_file_rules",),
-                    )
-                }
-            ),
-        ),
-    )
-
-    response = runtime.run(
-        RuntimeRequest(
-            prompt="hello",
-            session_id="workflow-transform-scope",
-            metadata={"workflow_preset": "scoped"},
-        )
-    )
-    request = _SkillCapturingStubGraph.last_request
-
-    assert request is not None
-    system_sources = [
-        segment.metadata.get("source")
-        for segment in request.assembled_context.segments
-        if segment.role == "system" and segment.metadata is not None
-    ]
-    workflow_snapshot = cast(dict[str, object], response.session.metadata["workflow"])
-    runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
-    runtime_agent = cast(dict[str, object], runtime_config["agent"])
-    assert workflow_snapshot["context_transform_refs"] == ["runtime_file_rules"]
-    assert runtime_agent["context_transform_refs"] == ["runtime_file_rules"]
-    assert "runtime_file_rules" in system_sources
-    assert "hook_preset_guidance" not in system_sources
-    assert request.assembled_context.metadata["context_transforms"] == {
-        "version": 1,
-        "failure_policy": "warn",
-        "applied": [
-            {
-                "provider_id": "runtime_file_rules",
-                "status": "ok",
-                "priority": 200,
-                "execution_index": 1,
-                "injection_count": 1,
-                "provider_order": ["runtime_file_rules"],
-                "sources": ["runtime_file_rules"],
-            }
-        ],
-    }
 
 
 def test_runtime_request_context_transform_refs_narrow_agent_scope(
@@ -12671,23 +12230,16 @@ def test_runtime_rejects_unknown_workflow_preset_before_execution(tmp_path: Path
 
     with pytest.raises(
         RuntimeRequestError,
-        match="request metadata 'workflow_preset' references unknown preset: missing",
+        match=runtime_config_materializer_module.WORKFLOW_PRESET_REQUEST_ERROR,
     ):
         _ = runtime.run(RuntimeRequest(prompt="hello", metadata={"workflow_preset": "missing"}))
 
     assert _SkillCapturingStubGraph.last_request is None
 
 
-def test_runtime_workflow_preset_resolution_precedence_and_prompt_materialization(
+def test_runtime_request_workflow_preset_rejected_before_agent_materialization(
     tmp_path: Path,
 ) -> None:
-    base_materialization = {
-        "profile": "custom-leader",
-        "version": 1,
-        "source": "custom_markdown",
-        "format": "markdown",
-        "body": "Custom runtime materialization.",
-    }
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
         graph=_SkillCapturingStubGraph(),
@@ -12696,97 +12248,77 @@ def test_runtime_workflow_preset_resolution_precedence_and_prompt_materializatio
             model="runtime/default",
             agent=RuntimeAgentConfig(
                 preset="leader",
-                prompt_materialization=base_materialization,
                 prompt_source="custom_markdown",
-                model="manifest/model",
-            ),
-            workflows=WorkflowPresetRegistry(
-                presets={
-                    "implementation": WorkflowPreset(
-                        id="implementation",
-                        default_agent="leader",
-                        category="implementation",
-                        prompt_append="Preset append.",
-                    )
-                }
+                prompt_materialization={
+                    "profile": "custom-leader",
+                    "version": 1,
+                    "source": "custom_markdown",
+                    "format": "markdown",
+                    "body": "Custom runtime materialization.",
+                },
             ),
         ),
     )
+    _SkillCapturingStubGraph.last_request = None
 
-    response = runtime.run(
-        RuntimeRequest(
-            prompt="implement",
-            session_id="workflow-precedence",
-            metadata={
-                "workflow_preset": "implementation",
-                "agent": {"preset": "leader", "model": "request/model"},
-            },
+    with pytest.raises(
+        RuntimeRequestError,
+        match=runtime_config_materializer_module.WORKFLOW_PRESET_REQUEST_ERROR,
+    ):
+        _ = runtime.run(
+            RuntimeRequest(
+                prompt="implement",
+                session_id="workflow-precedence",
+                metadata={
+                    "workflow_preset": "implementation",
+                    "agent": {"preset": "leader", "model": "request/model"},
+                },
+            )
         )
-    )
-    request = _SkillCapturingStubGraph.last_request
 
-    assert request is not None
-    runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
-    assert runtime_config["model"] == "request/model"
-    agent_snapshot = cast(dict[str, object], runtime_config["agent"])
-    # Precedence is request metadata > workflow preset > agent manifest > runtime defaults.
-    assert agent_snapshot["model"] == "request/model"
-    assert agent_snapshot["prompt_append"] == "Preset append."
-    prompt_materialization = cast(dict[str, object], agent_snapshot["prompt_materialization"])
-    assert prompt_materialization == base_materialization
-    assert prompt_materialization["body"] == "Custom runtime materialization."
+    assert _SkillCapturingStubGraph.last_request is None
 
 
-def test_runtime_request_prompt_materialization_wins_over_workflow_preset(
+def test_runtime_request_workflow_preset_rejected_with_prompt_materialization_override(
     tmp_path: Path,
 ) -> None:
-    request_materialization = {
-        "profile": "request-custom",
-        "version": 1,
-        "source": "custom_markdown",
-        "format": "markdown",
-        "body": "Request materialization.",
-    }
     runtime = VoidCodeRuntime(
         workspace=tmp_path,
         graph=_SkillCapturingStubGraph(),
         config=RuntimeConfig(
             execution_engine="provider",
             model="opencode/gpt-5.4",
-            agent=RuntimeAgentConfig(
-                preset="leader",
-                prompt_materialization={
-                    "profile": "base-custom",
-                    "version": 1,
-                    "source": "custom_markdown",
-                    "format": "markdown",
-                    "body": "Base materialization.",
-                },
-                prompt_source="custom_markdown",
-            ),
+            agent=RuntimeAgentConfig(preset="leader"),
         ),
     )
+    _SkillCapturingStubGraph.last_request = None
 
-    response = runtime.run(
-        RuntimeRequest(
-            prompt="implement",
-            session_id="workflow-request-materialization",
-            metadata={
-                "workflow_preset": "implementation",
-                "agent": {
-                    "preset": "leader",
-                    "prompt_materialization": request_materialization,
-                    "prompt_source": "custom_markdown",
+    with pytest.raises(
+        RuntimeRequestError,
+        match=runtime_config_materializer_module.WORKFLOW_PRESET_REQUEST_ERROR,
+    ):
+        _ = runtime.run(
+            RuntimeRequest(
+                prompt="implement",
+                session_id="workflow-request-materialization",
+                metadata={
+                    "workflow_preset": "implementation",
+                    "agent": {
+                        "preset": "leader",
+                        "prompt_materialization": {
+                            "profile": "request-custom",
+                            "version": 1,
+                            "source": "custom_markdown",
+                            "format": "markdown",
+                            "body": "Request materialization.",
+                        },
+                        "prompt_source": "custom_markdown",
+                    },
                 },
-            },
+            )
         )
-    )
 
-    runtime_config = cast(dict[str, object], response.session.metadata["runtime_config"])
-    agent_snapshot = cast(dict[str, object], runtime_config["agent"])
-    assert cast(dict[str, object], agent_snapshot["prompt_materialization"]) == (
-        request_materialization
-    )
+    assert _SkillCapturingStubGraph.last_request is None
 
 
 def test_runtime_rejects_client_supplied_applied_skill_payloads_on_new_run(

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -18,6 +18,7 @@ from unittest.mock import Mock
 import pytest
 
 import voidcode.runtime.background_tasks as runtime_background_tasks_module
+import voidcode.runtime.provider_fallback as runtime_provider_fallback_module
 import voidcode.runtime.run_loop as runtime_run_loop_module
 import voidcode.runtime.service as runtime_service_module
 from voidcode.acp import AcpRequestEnvelope, AcpResponseEnvelope
@@ -121,6 +122,12 @@ from voidcode.runtime.permission import (
     evaluate_pattern_permission_rules,
 )
 from voidcode.runtime.policy import RuntimePolicyConfig, RuntimePolicyToolPolicyConfig
+from voidcode.runtime.provider_fallback import (
+    ProviderFallbackDecision,
+    ProviderTerminalDecision,
+    ProviderTransientRetryDecision,
+    decide_provider_error_policy,
+)
 from voidcode.runtime.provider_protocol import (
     ProviderExecutionError,
     ProviderStreamEvent,
@@ -164,6 +171,109 @@ _DEFAULT_PERMISSION_METADATA = {
     "external_directory_read": {"*": "allow"},
     "external_directory_write": {"*": "allow"},
 }
+
+
+def test_provider_fallback_collaborator_prefers_retry_before_fallback() -> None:
+    decision = decide_provider_error_policy(
+        error=ProviderExecutionError(
+            kind="rate_limit",
+            provider_name="primary",
+            model_name="model-a",
+            message="rate limited",
+            details={"request_id": "retry-1"},
+        ),
+        current_provider_attempt=0,
+        provider_retry_attempt=0,
+        transient_retry_config=ProviderTransientRetryConfig(
+            max_retries=1,
+            base_delay_ms=0,
+            max_delay_ms=0,
+            jitter=False,
+        ),
+        fallback_target_provider="fallback",
+        fallback_target_model="model-b",
+        background_rate_limit_retry=False,
+    )
+
+    assert isinstance(decision, ProviderTransientRetryDecision)
+    assert decision.event_payload() == {
+        "reason": "rate_limit",
+        "provider": "primary",
+        "model": "model-a",
+        "retry_attempt": 1,
+        "max_retries": 1,
+        "delay_ms": 0,
+        "provider_error_details": {"request_id": "retry-1"},
+    }
+
+
+def test_provider_fallback_collaborator_emits_fallback_after_retry_exhaustion() -> None:
+    decision = decide_provider_error_policy(
+        error=ProviderExecutionError(
+            kind="transient_failure",
+            provider_name="primary",
+            model_name="model-a",
+            message="still failing",
+            details={"request_id": "fallback-1"},
+        ),
+        current_provider_attempt=0,
+        provider_retry_attempt=1,
+        transient_retry_config=ProviderTransientRetryConfig(
+            max_retries=1,
+            base_delay_ms=0,
+            max_delay_ms=0,
+            jitter=False,
+        ),
+        fallback_target_provider="fallback",
+        fallback_target_model="model-b",
+        background_rate_limit_retry=False,
+    )
+
+    assert isinstance(decision, ProviderFallbackDecision)
+    assert decision.event_payload() == {
+        "reason": "transient_failure",
+        "from_provider": "primary",
+        "from_model": "model-a",
+        "to_provider": "fallback",
+        "to_model": "model-b",
+        "attempt": 1,
+        "provider_error_details": {"request_id": "fallback-1"},
+    }
+
+
+def test_provider_fallback_collaborator_marks_retry_exhausted_terminal() -> None:
+    decision = decide_provider_error_policy(
+        error=ProviderExecutionError(
+            kind="rate_limit",
+            provider_name="primary",
+            model_name="model-a",
+            message="still failing",
+            details={"request_id": "terminal-1"},
+        ),
+        current_provider_attempt=0,
+        provider_retry_attempt=1,
+        transient_retry_config=ProviderTransientRetryConfig(
+            max_retries=1,
+            base_delay_ms=0,
+            max_delay_ms=0,
+            jitter=False,
+        ),
+        fallback_target_provider=None,
+        fallback_target_model=None,
+        background_rate_limit_retry=False,
+    )
+
+    assert isinstance(decision, ProviderTerminalDecision)
+    assert decision.kind == "fallback_exhausted"
+    assert decision.payload == {
+        "provider_error_kind": "rate_limit",
+        "provider": "primary",
+        "model": "model-a",
+        "fallback_exhausted": True,
+        "provider_retry_exhausted": True,
+        "provider_retry_attempts": 1,
+        "provider_error_details": {"request_id": "terminal-1"},
+    }
 
 
 def _write_agent_manifest(path: Path, frontmatter: str, body: str = "Custom prompt.") -> None:
@@ -19956,8 +20066,8 @@ def test_runtime_provider_retry_attempt_resets_after_successful_provider_call(
     )
 
     monkeypatch.setattr(
-        runtime_run_loop_module,
-        "_provider_transient_retry_delay_ms",
+        runtime_provider_fallback_module,
+        "provider_transient_retry_delay_ms",
         lambda **_: 0,
     )
 

--- a/tests/unit/runtime/test_runtime_service_extensions.py
+++ b/tests/unit/runtime/test_runtime_service_extensions.py
@@ -120,6 +120,7 @@ from voidcode.runtime.permission import (
     PermissionPolicy,
     evaluate_pattern_permission_rules,
 )
+from voidcode.runtime.policy import RuntimePolicyConfig, RuntimePolicyToolPolicyConfig
 from voidcode.runtime.provider_protocol import (
     ProviderExecutionError,
     ProviderStreamEvent,
@@ -1592,6 +1593,37 @@ class _UnexpectedFallbackTurnProvider:
         _ = request
         self.model_provider.calls += 1
         return ProviderTurnResult(output="fallback used")
+
+
+class _RecordingScriptedModelProvider:
+    def __init__(self, *, name: str, outcomes: tuple[object, ...]) -> None:
+        self.name = name
+        self.outcomes = list(outcomes)
+        self.requests: list[ProviderTurnRequest] = []
+        self.calls = 0
+
+    def turn_provider(self) -> _RecordingScriptedTurnProvider:
+        return _RecordingScriptedTurnProvider(model_provider=self)
+
+
+@dataclass(slots=True)
+class _RecordingScriptedTurnProvider:
+    model_provider: _RecordingScriptedModelProvider
+
+    @property
+    def name(self) -> str:
+        return self.model_provider.name
+
+    def propose_turn(self, request: object) -> ProviderTurnResult:
+        turn_request = cast(ProviderTurnRequest, request)
+        self.model_provider.requests.append(turn_request)
+        self.model_provider.calls += 1
+        if not self.model_provider.outcomes:
+            return ProviderTurnResult(output="done")
+        outcome = self.model_provider.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return cast(ProviderTurnResult, outcome)
 
 
 class _TwoEpisodePrimaryModelProvider:
@@ -3173,6 +3205,286 @@ def test_runtime_provider_fallback_resets_after_successful_turn(tmp_path: Path) 
     assert "provider_attempt" not in response.session.metadata
 
 
+def test_runtime_provider_retry_then_fallback_preserves_error_details_and_resets_metadata(
+    tmp_path: Path,
+) -> None:
+    first_details: dict[str, object] = {"source": "stream", "request_id": "retry-1"}
+    fallback_details: dict[str, object] = {
+        "source": "api",
+        "request_id": "fallback-1",
+        "status_code": 503,
+    }
+    primary = _RecordingScriptedModelProvider(
+        name="primary",
+        outcomes=(
+            ProviderExecutionError(
+                kind="transient_failure",
+                provider_name="primary",
+                model_name="model-a",
+                message="first transient failure",
+                details=first_details,
+            ),
+            ProviderExecutionError(
+                kind="transient_failure",
+                provider_name="primary",
+                model_name="model-a",
+                message="second transient failure",
+                details=fallback_details,
+            ),
+        ),
+    )
+    fallback = _RecordingScriptedModelProvider(
+        name="fallback",
+        outcomes=(ProviderTurnResult(output="fallback recovered"),),
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        model_provider_registry=ModelProviderRegistry(
+            providers={"primary": primary, "fallback": fallback}
+        ),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="primary/model-a",
+            provider_fallback=RuntimeProviderFallbackConfig(
+                preferred_model="primary/model-a",
+                fallback_models=("fallback/model-b",),
+            ),
+            providers=RuntimeProvidersConfig(
+                custom={
+                    "primary": LiteLLMProviderConfig(
+                        transient_retry=ProviderTransientRetryConfig(
+                            max_retries=1,
+                            base_delay_ms=0,
+                            max_delay_ms=0,
+                            jitter=False,
+                        )
+                    )
+                }
+            ),
+        ),
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="provider retry then fallback"))
+
+    assert response.session.status == "completed"
+    assert response.output == "fallback recovered"
+    retry_event = next(
+        event for event in response.events if event.event_type == RUNTIME_PROVIDER_TRANSIENT_RETRY
+    )
+    fallback_event = next(
+        event for event in response.events if event.event_type == "runtime.provider_fallback"
+    )
+    assert retry_event.payload == {
+        "reason": "transient_failure",
+        "provider": "primary",
+        "model": "model-a",
+        "retry_attempt": 1,
+        "max_retries": 1,
+        "delay_ms": 0,
+        "provider_error_details": first_details,
+    }
+    assert fallback_event.payload == {
+        "reason": "transient_failure",
+        "from_provider": "primary",
+        "from_model": "model-a",
+        "to_provider": "fallback",
+        "to_model": "model-b",
+        "attempt": 1,
+        "provider_error_details": fallback_details,
+    }
+    assert [request.attempt for request in primary.requests] == [0, 0]
+    assert [request.attempt for request in fallback.requests] == [1]
+    assert "provider_attempt" not in response.session.metadata
+    assert response.session.metadata.get("provider_retry_attempt", 0) == 0
+
+
+def test_runtime_provider_retry_exhausted_without_fallback_emits_terminal_payload(
+    tmp_path: Path,
+) -> None:
+    exhausted_details: dict[str, object] = {
+        "source": "api",
+        "request_id": "retry-exhausted",
+    }
+    primary = _RecordingScriptedModelProvider(
+        name="primary",
+        outcomes=(
+            ProviderExecutionError(
+                kind="transient_failure",
+                provider_name="primary",
+                model_name="model-a",
+                message="first transient failure",
+                details={"source": "api", "request_id": "retry-start"},
+            ),
+            ProviderExecutionError(
+                kind="transient_failure",
+                provider_name="primary",
+                model_name="model-a",
+                message="second transient failure",
+                details=exhausted_details,
+            ),
+        ),
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        model_provider_registry=ModelProviderRegistry(providers={"primary": primary}),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="primary/model-a",
+            providers=RuntimeProvidersConfig(
+                custom={
+                    "primary": LiteLLMProviderConfig(
+                        transient_retry=ProviderTransientRetryConfig(
+                            max_retries=1,
+                            base_delay_ms=0,
+                            max_delay_ms=0,
+                            jitter=False,
+                        )
+                    )
+                }
+            ),
+        ),
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="provider retry exhausted"))
+
+    assert response.session.status == "failed"
+    assert [event.event_type for event in response.events].count(
+        RUNTIME_PROVIDER_TRANSIENT_RETRY
+    ) == 1
+    assert not any(event.event_type == "runtime.provider_fallback" for event in response.events)
+    failed_event = next(event for event in response.events if event.event_type == "runtime.failed")
+    assert failed_event.payload["provider_error_kind"] == "transient_failure"
+    assert failed_event.payload["provider"] == "primary"
+    assert failed_event.payload["model"] == "model-a"
+    assert failed_event.payload["fallback_exhausted"] is True
+    assert failed_event.payload["provider_retry_exhausted"] is True
+    assert failed_event.payload["provider_retry_attempts"] == 1
+    assert failed_event.payload["provider_error_details"] == exhausted_details
+
+
+def test_runtime_provider_fallback_exhausted_preserves_error_details_payload(
+    tmp_path: Path,
+) -> None:
+    auth_details: dict[str, object] = {
+        "source": "api",
+        "request_id": "auth-1",
+        "status_code": 401,
+    }
+    primary = _RecordingScriptedModelProvider(
+        name="primary",
+        outcomes=(
+            ProviderExecutionError(
+                kind="missing_auth",
+                provider_name="primary",
+                model_name="model-a",
+                message="missing provider auth",
+                details=auth_details,
+            ),
+        ),
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        model_provider_registry=ModelProviderRegistry(providers={"primary": primary}),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="primary/model-a",
+            provider_fallback=RuntimeProviderFallbackConfig(
+                preferred_model="primary/model-a",
+                fallback_models=(),
+            ),
+        ),
+    )
+
+    response = runtime.run(RuntimeRequest(prompt="fallback exhausted"))
+
+    assert response.session.status == "failed"
+    assert not any(event.event_type == "runtime.provider_fallback" for event in response.events)
+    failed_event = next(event for event in response.events if event.event_type == "runtime.failed")
+    assert failed_event.payload["provider_error_kind"] == "missing_auth"
+    assert failed_event.payload["provider"] == "primary"
+    assert failed_event.payload["model"] == "model-a"
+    assert failed_event.payload["fallback_exhausted"] is True
+    assert failed_event.payload["provider_error_details"] == auth_details
+
+
+@pytest.mark.parametrize(
+    ("error_kind", "expected_payload"),
+    [
+        (
+            "cancelled",
+            {
+                "provider_error_kind": "cancelled",
+                "cancelled": True,
+            },
+        ),
+        (
+            "context_limit",
+            {
+                "provider_error_kind": "context_limit",
+                "provider_error_details": {"source": "api", "request_id": "context-1"},
+            },
+        ),
+    ],
+)
+def test_runtime_provider_fallback_skips_cancelled_and_context_limit_errors(
+    tmp_path: Path,
+    error_kind: ProviderErrorKind,
+    expected_payload: dict[str, object],
+) -> None:
+    details = expected_payload.get("provider_error_details")
+    primary = _RecordingScriptedModelProvider(
+        name="primary",
+        outcomes=(
+            ProviderExecutionError(
+                kind=error_kind,
+                provider_name="primary",
+                model_name="model-a",
+                message=f"{error_kind} terminal",
+                details=cast(dict[str, object] | None, details),
+            ),
+        ),
+    )
+    fallback = _RecordingScriptedModelProvider(
+        name="fallback",
+        outcomes=(ProviderTurnResult(output="should not fallback"),),
+    )
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        model_provider_registry=ModelProviderRegistry(
+            providers={"primary": primary, "fallback": fallback}
+        ),
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="primary/model-a",
+            provider_fallback=RuntimeProviderFallbackConfig(
+                preferred_model="primary/model-a",
+                fallback_models=("fallback/model-b",),
+            ),
+            providers=RuntimeProvidersConfig(
+                custom={
+                    "primary": LiteLLMProviderConfig(
+                        transient_retry=ProviderTransientRetryConfig(max_retries=0)
+                    )
+                }
+            ),
+        ),
+    )
+
+    response = runtime.run(RuntimeRequest(prompt=f"no fallback for {error_kind}"))
+
+    assert response.session.status == "failed"
+    assert fallback.calls == 0
+    assert not any(event.event_type == "runtime.provider_fallback" for event in response.events)
+    assert not any(
+        event.event_type == RUNTIME_PROVIDER_TRANSIENT_RETRY for event in response.events
+    )
+    failed_event = next(event for event in response.events if event.event_type == "runtime.failed")
+    for key, value in expected_payload.items():
+        assert failed_event.payload[key] == value
+    assert failed_event.payload["provider"] == "primary"
+    assert failed_event.payload["model"] == "model-a"
+
+
 def test_runtime_background_fallback_reacquires_fallback_model_slot(
     tmp_path: Path,
 ) -> None:
@@ -4131,7 +4443,7 @@ def test_runtime_git_status_snapshot_handles_non_utf8_subprocess_output(
     monkeypatch.setattr(
         runtime_service_module.subprocess,
         "run",
-        lambda *args, **kwargs: _CompletedProcess(),
+        lambda *_args, **_kwargs: _CompletedProcess(),
     )
 
     snapshot = runtime._git_status_snapshot()  # pyright: ignore[reportPrivateUsage]
@@ -11547,6 +11859,244 @@ def test_runtime_request_context_transform_refs_reject_unknown_provider(
                 session_id="request-transform-invalid",
                 metadata=validate_runtime_request_metadata({"context_transform_refs": ["unknown"]}),
             )
+        )
+
+
+def test_runtime_config_metadata_materializes_supported_persisted_fields(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            approval_mode="ask",
+            permission=ExternalDirectoryPermissionConfig(
+                read=ExternalDirectoryPolicy(rules=(("/var/log/**", "allow"), ("*", "ask"))),
+                write=ExternalDirectoryPolicy(rules=(("*", "deny"),)),
+                rules=(PatternPermissionRule(tool="read_file", path="docs/**", decision="allow"),),
+            ),
+            policy=RuntimePolicyConfig(
+                tool_policy=RuntimePolicyToolPolicyConfig(default="deny", allowed=("read_file",))
+            ),
+            execution_engine="provider",
+            model="opencode/gpt-5.4",
+            max_steps=7,
+            tool_timeout_seconds=11,
+            reasoning_effort="high",
+            provider_fallback=RuntimeProviderFallbackConfig(
+                preferred_model="opencode/gpt-5.4",
+                fallback_models=("opencode/gpt-5.3",),
+            ),
+            providers=RuntimeProvidersConfig(
+                custom={
+                    "local-openai": LiteLLMProviderConfig(
+                        base_url="http://localhost:11434/v1",
+                        auth_scheme="none",
+                        transient_retry=ProviderTransientRetryConfig(max_retries=2),
+                    )
+                }
+            ),
+            tools=RuntimeToolsConfig(
+                builtin=RuntimeToolsBuiltinConfig(enabled=True),
+                allowlist=("read_file", "grep"),
+            ),
+            agent=RuntimeAgentConfig(
+                preset="leader",
+                hook_refs=("role_reminder",),
+                context_transform_refs=("runtime_file_rules",),
+                model="opencode/gpt-5.4",
+            ),
+            context_window=RuntimeContextWindowConfig(
+                auto_compaction=False,
+                max_tool_result_tokens=123,
+            ),
+            lsp=RuntimeLspConfig(enabled=True),
+            mcp=RuntimeMcpConfig(enabled=True),
+            agents={"leader": RuntimeAgentConfig(preset="leader", model="opencode/gpt-5.4")},
+            categories={"quick": RuntimeCategoryConfig(model="opencode/gpt-5.4")},
+            workflows=WorkflowPresetRegistry(
+                presets={
+                    "scoped": WorkflowPreset(
+                        id="scoped",
+                        default_agent="leader",
+                        category="implementation",
+                        context_transform_refs=("runtime_file_rules",),
+                    )
+                }
+            ),
+        ),
+    )
+
+    metadata = runtime._runtime_config_metadata(workflow_preset="scoped")
+    effective = runtime._effective_runtime_config_from_metadata({"runtime_config": metadata})
+
+    persisted_keys = cast(
+        frozenset[str],
+        _private_attr(runtime_service_module, "_PERSISTED_RUNTIME_CONFIG_KEYS"),
+    )
+    assert set(metadata) <= persisted_keys
+    assert {
+        "approval_mode",
+        "permission",
+        "policy",
+        "execution_engine",
+        "max_steps",
+        "tool_timeout_seconds",
+        "reasoning_effort",
+        "model",
+        "fallback_models",
+        "providers",
+        "resolved_provider",
+        "resolved_hook_presets",
+        "tools",
+        "agent",
+        "agents",
+        "categories",
+        "context_window",
+        "lsp",
+        "mcp",
+        "workflow",
+    } <= set(metadata)
+    assert effective.approval_mode == "ask"
+    assert effective.permission.read.rules == (("/var/log/**", "allow"), ("*", "ask"))
+    assert effective.permission.write.rules == (("*", "deny"),)
+    assert effective.permission.rules == (
+        PatternPermissionRule(tool="read_file", path="docs/**", decision="allow"),
+    )
+    assert effective.policy == RuntimePolicyConfig(
+        tool_policy=RuntimePolicyToolPolicyConfig(default="deny", allowed=("read_file",))
+    )
+    assert effective.execution_engine == "provider"
+    assert effective.model == "opencode/gpt-5.4"
+    assert effective.max_steps == 7
+    assert effective.tool_timeout_seconds == 11
+    assert effective.reasoning_effort == "high"
+    assert effective.provider_fallback == RuntimeProviderFallbackConfig(
+        preferred_model="opencode/gpt-5.4",
+        fallback_models=("opencode/gpt-5.3",),
+    )
+    assert effective.providers == RuntimeProvidersConfig(
+        custom={
+            "local-openai": LiteLLMProviderConfig(
+                transient_retry=ProviderTransientRetryConfig(max_retries=2),
+            )
+        }
+    )
+    assert effective.tools == RuntimeToolsConfig(
+        builtin=RuntimeToolsBuiltinConfig(enabled=True),
+        allowlist=("read_file", "grep"),
+    )
+    assert effective.agent == RuntimeAgentConfig(
+        preset="leader",
+        prompt_profile="leader",
+        hook_refs=("role_reminder",),
+        context_transform_refs=("runtime_file_rules",),
+        model="opencode/gpt-5.4",
+        execution_engine="provider",
+    )
+    assert effective.context_window == RuntimeContextWindowConfig(
+        auto_compaction=False,
+        max_tool_result_tokens=123,
+    )
+    assert cast(dict[str, object], metadata["workflow"])["selected_preset"] == "scoped"
+
+
+def test_runtime_config_request_metadata_overrides_supported_fields(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(
+        workspace=tmp_path,
+        config=RuntimeConfig(
+            execution_engine="provider",
+            model="opencode/original",
+            max_steps=12,
+            reasoning_effort="low",
+            agent=RuntimeAgentConfig(
+                preset="leader",
+                context_transform_refs=("hook_preset_guidance", "runtime_file_rules"),
+            ),
+        ),
+    )
+
+    resolved = cast(Any, runtime)._runtime_config_for_request(
+        RuntimeRequest(
+            prompt="hello",
+            metadata=validate_runtime_request_metadata(
+                {
+                    "agent": {"preset": "leader", "model": "opencode/gpt-5.4"},
+                    "max_steps": 3,
+                    "reasoning_effort": "medium",
+                    "context_transform_refs": ["runtime_file_rules"],
+                }
+            ),
+        )
+    )
+
+    assert resolved.model == "opencode/gpt-5.4"
+    assert resolved.max_steps == 3
+    assert resolved.reasoning_effort == "medium"
+    assert resolved.agent == RuntimeAgentConfig(
+        preset="leader",
+        prompt_profile="leader",
+        context_transform_refs=("runtime_file_rules",),
+        model="opencode/gpt-5.4",
+        execution_engine="provider",
+    )
+
+
+def test_runtime_config_rejects_unknown_persisted_field(tmp_path: Path) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+    runtime_config_metadata = runtime._runtime_config_metadata()
+    runtime_config_metadata["surprise"] = True
+
+    with pytest.raises(
+        ValueError,
+        match="persisted runtime_config field 'surprise' is not supported",
+    ):
+        _ = runtime._effective_runtime_config_from_metadata(
+            {"runtime_config": runtime_config_metadata}
+        )
+
+
+@pytest.mark.parametrize(
+    ("legacy_field", "legacy_value"),
+    (
+        ("workflow_preset", "implementation"),
+        ("context_transform_refs", ["runtime_file_rules"]),
+        ("agent_preset", "leader"),
+        ("provider", "openai"),
+    ),
+)
+def test_runtime_config_rejects_removed_legacy_persisted_shapes(
+    tmp_path: Path,
+    legacy_field: str,
+    legacy_value: object,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+    runtime_config_metadata = runtime._runtime_config_metadata()
+    runtime_config_metadata[legacy_field] = legacy_value
+
+    with pytest.raises(
+        ValueError,
+        match=rf"persisted runtime_config field '{legacy_field}' is not supported",
+    ):
+        _ = runtime._effective_runtime_config_from_metadata(
+            {"runtime_config": runtime_config_metadata}
+        )
+
+
+def test_runtime_config_rejects_legacy_top_level_metadata_without_runtime_config(
+    tmp_path: Path,
+) -> None:
+    runtime = VoidCodeRuntime(workspace=tmp_path)
+
+    with pytest.raises(ValueError, match="persisted session metadata must include runtime_config"):
+        _ = runtime._effective_runtime_config_from_metadata(
+            {
+                "agent": {"preset": "leader"},
+                "max_steps": 3,
+                "reasoning_effort": "medium",
+                "context_transform_refs": ["runtime_file_rules"],
+            }
         )
 
 


### PR DESCRIPTION
This PR finishes the runtime decision-collaborator boundary work by keeping legacy compatibility deletion scoped to the documented runtime slices and preserving collaborator ownership boundaries. It includes the start-work graph-cache fix so command workflows use a fresh graph provider state instead of inheriting stale command prompts.\n\nVerification:\n- targeted runtime/config/fallback matrix passed\n- backend fast matrix passed\n- mise run check passed\n\nThe docs update captures the implemented collaborator boundaries, and the runtime service fix isolates command graph provider state without broadening runtime ownership.